### PR TITLE
docs: serve install scripts from copaw.agentscope.io

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
     paths:
       - "website/**"
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
       - ".github/workflows/deploy-website.yml"
   workflow_dispatch:
 
@@ -45,6 +47,12 @@ jobs:
         env:
           VITE_BASE_PATH: "/"
         run: pnpm run build
+
+      # Copy installation scripts so they are served from the website
+      # (e.g. copaw.agentscope.io/install.sh) instead of raw.githubusercontent.com,
+      # which may be blocked by some firewalls.
+      - name: Copy installation scripts to dist
+        run: cp scripts/install.sh scripts/install.ps1 website/dist/
 
       # 404.html fallback for unknown paths (real routes from build script).
       - name: 404 fallback for GitHub Pages

--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ No Python required — the installer handles everything:
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.sh | bash
+curl -fsSL https://copaw.agentscope.io/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.ps1 | iex
+irm https://copaw.agentscope.io/install.ps1 | iex
 ```
 
 Then open a new terminal and run:

--- a/README_zh.md
+++ b/README_zh.md
@@ -93,13 +93,13 @@ copaw app
 **macOS / Linux：**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.sh | bash
+curl -fsSL https://copaw.agentscope.io/install.sh | bash
 ```
 
 **Windows（PowerShell）：**
 
 ```powershell
-irm https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.ps1 | iex
+irm https://copaw.agentscope.io/install.ps1 | iex
 ```
 
 然后打开新终端并运行：

--- a/website/public/docs/quickstart.en.md
+++ b/website/public/docs/quickstart.en.md
@@ -21,7 +21,7 @@ No Python required — the installer handles everything automatically using [uv]
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.sh | bash
+curl -fsSL https://copaw.agentscope.io/install.sh | bash
 ```
 
 Then open a new terminal (or `source ~/.zshrc` / `source ~/.bashrc`).
@@ -29,7 +29,7 @@ Then open a new terminal (or `source ~/.zshrc` / `source ~/.bashrc`).
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.ps1 | iex
+irm https://copaw.agentscope.io/install.ps1 | iex
 ```
 
 Then open a new terminal (the installer adds CoPaw to your PATH automatically).

--- a/website/public/docs/quickstart.zh.md
+++ b/website/public/docs/quickstart.zh.md
@@ -21,7 +21,7 @@
 **macOS / Linux：**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.sh | bash
+curl -fsSL https://copaw.agentscope.io/install.sh | bash
 ```
 
 然后打开新终端（或执行 `source ~/.zshrc` / `source ~/.bashrc`）。
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/
 **Windows（PowerShell）：**
 
 ```powershell
-irm https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.ps1 | iex
+irm https://copaw.agentscope.io/install.ps1 | iex
 ```
 
 然后打开新终端（安装脚本会自动将 CoPaw 加入 PATH）。

--- a/website/src/components/QuickStart.tsx
+++ b/website/src/components/QuickStart.tsx
@@ -8,12 +8,12 @@ import { t, type Lang } from "../i18n";
 const COMMANDS = {
   pip: ["pip install copaw", "copaw init --defaults", "copaw app"],
   unix: [
-    "curl -fsSL https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.sh | bash",
+    "curl -fsSL https://copaw.agentscope.io/install.sh | bash",
     "copaw init --defaults",
     "copaw app",
   ],
   windows: [
-    "irm https://raw.githubusercontent.com/agentscope-ai/CoPaw/master/scripts/install.ps1 | iex",
+    "irm https://copaw.agentscope.io/install.ps1 | iex",
     "copaw init --defaults",
     "copaw app",
   ],


### PR DESCRIPTION
## Description

Use `copaw.agentscope.io` to host the installation scripts.

- Copy scripts to website/dist/ during deploy workflow
- Trigger website redeploy when install scripts change
- Update all install URLs in READMEs, website docs, and QuickStart component

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [x] Tests pass locally (`pytest` or as relevant)
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Once the website is updated and deployed, the one-click install commands should work. 

## Additional Notes

N/A
