### PR TITLE
fix: wrap install.ps1 in scriptblock for irm | iex compatibility

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,7 +4,11 @@
 #
 # Installs CoPaw into ~/.copaw with a uv-managed Python environment.
 # Users do NOT need Python pre-installed — uv handles everything.
+#
+# The entire script is wrapped in & { ... } @args so that `irm | iex` works
+# correctly (param() is only valid inside a scriptblock/function/file scope).
 
+& {
 param(
     [string]$Version = "",
     [switch]$FromSource,
@@ -321,3 +325,5 @@ Write-Host ""
 Write-Host "To upgrade later, re-run this installer."
 Write-Host "To uninstall, run: " -NoNewline
 Write-Host "copaw uninstall" -ForegroundColor White
+
+} @args


### PR DESCRIPTION
## Description

param() is only valid at the top of a script file, function, or scriptblock — not inside an Invoke-Expression call. Wrapping the entire script body in `& { ... } @args` makes `irm | iex` work while preserving argument pass-through for direct .ps1 execution.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [x] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]
