### PR TITLE
docs(channels): document python-socks for feishu socks proxy

### DIFF
--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -201,7 +201,7 @@ Find `channels.feishu`（default as `~/.copaw/config.json`） in `config.json`. 
 }
 ```
 
-Other fields (encrypt_key, verification_token, media_dir) are optional; with WebSocket mode you can omit them (defaults apply). Then `pip install lark-oapi` and run `copaw app`.
+Other fields (encrypt_key, verification_token, media_dir) are optional; with WebSocket mode you can omit them (defaults apply). Then `pip install lark-oapi` and run `copaw app`. If your environment uses a SOCKS proxy, also install `python-socks` (for example, `pip install python-socks`), otherwise you may see: `python-socks is required to use a SOCKS proxy`.
 
 > **Note:** You can also fill in **App ID** and **App Secret** in the Console UI, but you must restart the copaw service before continuing with the long-connection configuration.
 > ![console](https://img.alicdn.com/imgextra/i1/O1CN01JInbHT1ei5MdfkMGv_!!6000000003904-2-tps-4082-2126.png)

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -197,7 +197,7 @@
 }
 ```
 
-其他字段（encrypt_key、verification_token、media_dir）可选，WebSocket 模式可不填，有默认值。依赖：`pip install lark-oapi`，然后 `copaw app`。
+其他字段（encrypt_key、verification_token、media_dir）可选，WebSocket 模式可不填，有默认值。依赖：`pip install lark-oapi`，然后 `copaw app`。如果你使用 SOCKS 代理联网，还需安装 `python-socks`（例如 `pip install python-socks`），否则可能报错：`python-socks is required to use a SOCKS proxy`。
 
 > 注: **App ID** 和 **App Secret** 信息也可以在Console前端填写，但需重启copaw服务，才能继续配置长链接的操作。
 > ![console](https://img.alicdn.com/imgextra/i2/O1CN01k7UVrP1E2hZBAn0oF_!!6000000000294-2-tps-4082-2126.png)


### PR DESCRIPTION
## Description

Add explicit Feishu channel docs guidance for SOCKS proxy environments:

- If users use a SOCKS proxy, they also need `python-socks`.
- Include the common runtime error string for faster troubleshooting.

**Related Issue:** Fixes #53

**Security Considerations:** Documentation-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Docs review only:

- Updated both zh/en Feishu sections under channels docs.
- Verified wording matches the reported error: `python-socks is required to use a SOCKS proxy`.

## Additional Notes

This PR intentionally contains only docs changes for #53.
