### PR TITLE
[fix] Strip ANSI sequences and enable tool result truncation

### DIFF
--- a/src/copaw/agents/hooks/memory_compaction.py
+++ b/src/copaw/agents/hooks/memory_compaction.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Default max length for tool result text truncation during compaction
-_DEFAULT_COMPACT_TOOL_RESULT_MAX_LENGTH = 10000
+_DEFAULT_COMPACT_TOOL_RESULT_MAX_LENGTH = 5000
 
 
 def _truncate_tool_result_texts(
@@ -92,12 +92,10 @@ class MemoryCompactionHook:
         """Whether to truncate tool result texts.
 
         Controlled by environment variable ENABLE_TRUNCATE_TOOL_RESULT_TEXTS.
-        Default is False (disabled).
+        Default is True (enabled) to prevent memory bloat from large outputs.
         """
-        return os.environ.get(
-            "ENABLE_TRUNCATE_TOOL_RESULT_TEXTS",
-            "false",
-        ).lower() in ("true", "1", "yes")
+        env_value = os.environ.get("ENABLE_TRUNCATE_TOOL_RESULT_TEXTS", "true")
+        return env_value.lower() in ("true", "1", "yes")
 
     async def __call__(
         self,

--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -12,6 +12,7 @@ from agentscope.tool import ToolResponse
 from agentscope.message import TextBlock
 
 from copaw.constant import WORKING_DIR
+from copaw.agents.utils.ansi_utils import strip_ansi_sequences
 
 
 # pylint: disable=too-many-branches
@@ -97,6 +98,11 @@ async def execute_shell_command(
             except ProcessLookupError:
                 stdout_str = ""
                 stderr_str = stderr_suffix
+
+        # Strip ANSI escape sequences to reduce memory bloat
+        # These are terminal control codes for colors, cursor movement, etc.
+        stdout_str = strip_ansi_sequences(stdout_str)
+        stderr_str = strip_ansi_sequences(stderr_str)
 
         # Format the response in a human-friendly way
         if returncode == 0:

--- a/src/copaw/agents/utils/ansi_utils.py
+++ b/src/copaw/agents/utils/ansi_utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""ANSI escape sequence utilities for cleaning terminal output."""
+
+import re
+
+# Regex pattern to match ANSI escape sequences
+# Matches ESC followed by any number of parameter bytes and final byte
+_ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]")
+
+
+def strip_ansi_sequences(text: str) -> str:
+    """Remove ANSI escape sequences from text.
+
+    This cleans terminal output that contains color codes, cursor movements,
+    and other control sequences that bloat the output when stored in memory.
+
+    Args:
+        text: Text potentially containing ANSI escape sequences
+
+    Returns:
+        Cleaned text with all ANSI sequences removed
+
+    Example:
+        >>> strip_ansi_sequences("\\x1b[32mHello\\x1b[0m World")
+        'Hello World'
+    """
+    if not text:
+        return text
+    return _ANSI_ESCAPE_PATTERN.sub("", text)

--- a/tests/test_ansi_utils.py
+++ b/tests/test_ansi_utils.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Tests for ANSI escape sequence utilities."""
+
+import pytest
+
+from copaw.agents.utils.ansi_utils import strip_ansi_sequences
+
+
+class TestStripAnsiSequences:
+    """Test cases for strip_ansi_sequences function."""
+
+    def test_empty_string(self) -> None:
+        """Test empty string returns empty."""
+        assert strip_ansi_sequences("") == ""
+
+    def test_none_input(self) -> None:
+        """Test None input returns None."""
+        assert strip_ansi_sequences(None) is None  # type: ignore
+
+    def test_plain_text(self) -> None:
+        """Test plain text without ANSI codes is unchanged."""
+        text = "Hello World"
+        assert strip_ansi_sequences(text) == text
+
+    def test_color_codes(self) -> None:
+        """Test removal of color ANSI codes."""
+        # Green text
+        text = "\x1b[32mHello\x1b[0m World"
+        assert strip_ansi_sequences(text) == "Hello World"
+
+        # Red text
+        text = "\x1b[31mError\x1b[0m"
+        assert strip_ansi_sequences(text) == "Error"
+
+        # Multiple colors
+        text = "\x1b[32mSuccess\x1b[0m: \x1b[33mWarning\x1b[0m"
+        assert strip_ansi_sequences(text) == "Success: Warning"
+
+    def test_cursor_movement(self) -> None:
+        """Test removal of cursor movement codes."""
+        # Clear line
+        text = "Loading...\x1b[2KDone"
+        assert strip_ansi_sequences(text) == "Loading...Done"
+
+        # Cursor up and clear
+        text = "\x1b[1A\x1b[KHello"
+        assert strip_ansi_sequences(text) == "Hello"
+
+    def test_spinner_animation_output(self) -> None:
+        """Test typical spinner/progress output from CLI tools."""
+        # Simulated spinner frames
+        text = "\x1b[?25l◐ Processing\x1b[1D\x1b[0K◓ Processing\x1b[1D\x1b[0KDone"
+        result = strip_ansi_sequences(text)
+        assert "\x1b" not in result
+
+    def test_real_world_npx_output(self) -> None:
+        """Test with realistic npx/skills output containing many escape codes."""
+        text = (
+            "\x1b[38;5;250m███████╗██╗  ██╗██╗██╗\x1b[0m\n"
+            "\x1b[?25l│\n"
+            "◇  Source: test\n"
+            "\x1b[?25h"
+        )
+        result = strip_ansi_sequences(text)
+        assert "\x1b" not in result
+        assert "███████" in result or "Source" in result
+
+    def test_multiple_escape_types(self) -> None:
+        """Test mixed ANSI escape sequence types."""
+        text = "\x1b[1m\x1b[31mBold Red\x1b[0m\x1b[2K"
+        assert strip_ansi_sequences(text) == "Bold Red"


### PR DESCRIPTION
## Summary

Fixes #84

This PR addresses memory bloat caused by unmanaged tool outputs accumulating in memory without compression.

### Changes

1. **Add ANSI stripping utility** ()
   - New  function to remove terminal escape codes
   - Handles color codes, cursor movements, and other control sequences

2. **Strip ANSI from shell command output** ()
   - Apply ANSI stripping to stdout/stderr before returning
   - Prevents memory bloat from terminal animations (spinners, progress bars, etc.)

3. **Enable tool result truncation by default** ()
   - `ENABLE_TRUNCATE_TOOL_RESULT_TEXTS` default changed from `false` to `true`
   - Reduce `DEFAULT_COMPACT_TOOL_RESULT_MAX_LENGTH` from 10000 to 5000

### Problem Solved

Before this fix:
- Tool outputs with ANSI sequences (e.g., npx skills install) could exceed 200KB for a single command
- 246 tool records accumulated in memory without compression
- Token limit exceeded errors (170k, 144k, even 450k+ tokens)

### Test Plan

- [x] Added unit tests for `strip_ansi_sequences()`
- [x] Manually tested with local CoPaw instance