### PR TITLE
fix(dingtalk): add message deduplication to prevent duplicate replies

### DIFF
--- a/src/copaw/app/channels/dingtalk/handler.py
+++ b/src/copaw/app/channels/dingtalk/handler.py
@@ -94,10 +94,7 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
             return
         self._inflight_message_ids.discard(msg_id)
         self._processed_message_ids[msg_id] = None
-        while (
-            len(self._processed_message_ids)
-            > DINGTALK_PROCESSED_IDS_MAX
-        ):
+        while len(self._processed_message_ids) > DINGTALK_PROCESSED_IDS_MAX:
             self._processed_message_ids.popitem(last=False)
 
     def _emit_native_threadsafe(self, native: dict) -> None:
@@ -204,7 +201,10 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
             logger.exception("failed to fetch richText download url(s)")
         return content
 
-    async def process(self, callback: CallbackMessage) -> tuple[int, str]:
+    async def process(  # pylint: disable=too-many-branches,too-many-statements
+        self,
+        callback: CallbackMessage,
+    ) -> tuple[int, str]:
         try:
             incoming_message = ChatbotMessage.from_dict(callback.data)
 

--- a/tests/test_dingtalk_dedup.py
+++ b/tests/test_dingtalk_dedup.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 """Tests for DingTalk message deduplication in handler."""
+# pylint: disable=protected-access,redefined-outer-name
 
 import asyncio
 from collections import OrderedDict
@@ -55,6 +57,7 @@ class TestDingTalkDedup:
         fake_msg.to_dict = lambda: cb.data
 
         import dingtalk_stream
+
         with patch(
             "copaw.app.channels.dingtalk.handler.ChatbotMessage.from_dict",
             return_value=fake_msg,
@@ -87,6 +90,7 @@ class TestDingTalkDedup:
         fake_msg.to_dict = lambda: cb.data
 
         import dingtalk_stream
+
         with patch(
             "copaw.app.channels.dingtalk.handler.ChatbotMessage.from_dict",
             return_value=fake_msg,
@@ -119,8 +123,7 @@ class TestDingTalkDedup:
             handler._mark_completed(f"msg_{i}")
 
         assert (
-            len(handler._processed_message_ids)
-            == DINGTALK_PROCESSED_IDS_MAX
+            len(handler._processed_message_ids) == DINGTALK_PROCESSED_IDS_MAX
         )
         assert "msg_0" not in handler._processed_message_ids
         newest = f"msg_{DINGTALK_PROCESSED_IDS_MAX + 99}"
@@ -173,5 +176,6 @@ class TestDingTalkDedup:
         from copaw.app.channels.dingtalk.handler import (
             DINGTALK_PROCESSED_IDS_MAX,
         )
+
         assert DINGTALK_PROCESSED_IDS_MAX >= 1024
         assert DINGTALK_PROCESSED_IDS_MAX <= 10000


### PR DESCRIPTION
## Summary

Fix DingTalk channel sending duplicate replies when agent processing takes >60 seconds.

Closes #85

## Root Cause

DingTalk Stream SDK retries callbacks when the handler does not respond within ~60s. The `DingTalkChannelHandler.process()` method had no deduplication mechanism, so retried callbacks were processed as new messages, resulting in duplicate replies to users.

## Solution

Add `msgId`-based message deduplication to `DingTalkChannelHandler`, following the same pattern already used by `FeishuChannel` (which uses `_processed_message_ids` OrderedDict).

### Key Design Decisions (informed by Codex gpt-5.3-codex code review):

**Two-phase dedup** to handle both concurrent and sequential duplicates correctly:

1. **Inflight set** (`_inflight_message_ids`): Prevents concurrent processing of the same message when a retry arrives while the original is still being handled.

2. **Completed cache** (`_processed_message_ids`): OrderedDict with FIFO eviction (cap: 2048 entries) prevents re-processing of already-finished messages.

**Failure-safe**: On processing failure, the msgId is removed from the inflight set so DingTalk retries can succeed. Only on successful completion is the ID moved to the completed cache.

**Robust ID extraction**: Dedicated `_extract_msg_id()` static method with multiple attribute/dict key fallbacks (`msgId`, `msg_id`) and explicit `None`/empty-string checks (not relying on truthiness).

## Changes

- **`src/copaw/app/channels/dingtalk/handler.py`**
  - Added `_extract_msg_id()` static method
  - Added `_mark_completed()` helper
  - Added `_inflight_message_ids` set and `_processed_message_ids` OrderedDict
  - Added dedup check at top of `process()`
  - Added cleanup in success/failure paths
  - Added `DINGTALK_PROCESSED_IDS_MAX = 2048` constant

- **`tests/test_dingtalk_dedup.py`** — 12 unit tests covering:
  - Initialization state
  - Completed dedup rejection
  - Inflight concurrent rejection
  - `_mark_completed` transitions
  - Max size eviction (FIFO)
  - `_extract_msg_id` from attribute, callback.data, missing, whitespace
  - Failure cleanup (inflight removal)
  - Constant bounds validation

## Testing

```
12 passed in 1.84s
```

## Backward Compatibility

✅ Fully backward compatible — no config changes, no API changes. Existing DingTalk setups get automatic dedup protection.