### PR TITLE
fix(deps): replace pre-release agentscope pin with stable 1.0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "CoPaw is a **personal assistant** that runs in your own environme
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "agentscope==1.0.16.dev0",
+    "agentscope==1.0.16",
     "agentscope-runtime==1.1.0",
     "discord-py>=2.3",
     "dingtalk-stream>=0.24.3",


### PR DESCRIPTION
## Summary

Fix dependency pin to avoid pre-release-only install failures on common PyPI mirrors/proxies.

Closes #47

## Root Cause

`pyproject.toml` pinned:
- `agentscope==1.0.16.dev0` (pre-release)

Many mirrors/proxies do not include or allow pre-release packages, causing `pip install copaw` to fail.

## Change

- Replace `agentscope==1.0.16.dev0` with stable `agentscope==1.0.16`.
- Keep `reme-ai==0.3.0.0` unchanged (already stable on PyPI).

## Verification

- Dry-run resolution with stable constraints:

```bash
python -m pip install --dry-run --no-deps --no-cache-dir \
  "agentscope==1.0.16" "reme-ai==0.3.0.0"
```

Observed result:
- Would install `agentscope-1.0.16`
- Would install `reme_ai-0.3.0.0`

- Pre-commit check on changed file passed.
