### PR TITLE
fix(model_factory): support providers without API key like Ollama

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -260,8 +260,9 @@ def _create_remote_model_instance(
     Returns:
         Configured chat model instance
     """
-    # Get configuration from llm_cfg or fall back to environment
-    if llm_cfg and llm_cfg.api_key:
+    # Get configuration from llm_cfg or fall back to environment.
+    # Some providers (e.g. Ollama) only need a base_url, no api_key.
+    if llm_cfg and (llm_cfg.api_key or llm_cfg.base_url):
         model_name = llm_cfg.model or "qwen3-max"
         api_key = llm_cfg.api_key
         base_url = llm_cfg.base_url

--- a/tests/test_ollama_no_apikey.py
+++ b/tests/test_ollama_no_apikey.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for issue #165: Ollama (no API key) model creation."""
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from agentscope.model import OpenAIChatModel
+
+from copaw.agents.model_factory import (
+    _create_remote_model_instance,
+    _create_formatter_instance,
+    create_model_and_formatter,
+)
+from copaw.providers.models import ResolvedModelConfig
+
+
+def test_ollama_no_apikey_uses_base_url():
+    """Providers with base_url but no api_key should not fall back to DashScope."""
+    cfg = ResolvedModelConfig(
+        model="qwen3:0.6b",
+        base_url="http://localhost:11434/v1",
+        api_key="",
+        is_local=False,
+    )
+    model = _create_remote_model_instance(cfg, OpenAIChatModel)
+
+    assert model.model_name == "qwen3:0.6b", (
+        f"Expected qwen3:0.6b, got {model.model_name}"
+    )
+    assert "localhost:11434" in str(model.client._base_url), (
+        f"Expected Ollama base_url, got {model.client._base_url}"
+    )
+    print("✅ PASS — Ollama config with base_url but no api_key works")
+
+
+def test_dashscope_fallback_still_works():
+    """When both api_key and base_url are empty, should still fall back to DashScope."""
+    cfg = ResolvedModelConfig(
+        model="",
+        base_url="",
+        api_key="",
+        is_local=False,
+    )
+    model = _create_remote_model_instance(cfg, OpenAIChatModel)
+
+    assert model.model_name == "qwen3-max", (
+        f"Expected DashScope fallback model qwen3-max, got {model.model_name}"
+    )
+    print("✅ PASS — DashScope fallback still works when no config")
+
+
+def test_none_config_falls_back():
+    """None config should fall back to DashScope."""
+    model = _create_remote_model_instance(None, OpenAIChatModel)
+
+    assert model.model_name == "qwen3-max", (
+        f"Expected DashScope fallback, got {model.model_name}"
+    )
+    print("✅ PASS — None config falls back to DashScope")
+
+
+def test_apikey_provider_still_works():
+    """Providers with api_key (e.g. Kimi, DashScope) should still work."""
+    cfg = ResolvedModelConfig(
+        model="kimi-k2.5",
+        base_url="https://api.moonshot.cn/v1",
+        api_key="sk-test-key",
+        is_local=False,
+    )
+    model = _create_remote_model_instance(cfg, OpenAIChatModel)
+
+    assert model.model_name == "kimi-k2.5", (
+        f"Expected kimi-k2.5, got {model.model_name}"
+    )
+    assert "moonshot" in str(model.client._base_url), (
+        f"Expected Kimi base_url, got {model.client._base_url}"
+    )
+    print("✅ PASS — API key provider still works correctly")
+
+
+def test_full_pipeline_with_ollama_config():
+    """Full create_model_and_formatter with Ollama-like config."""
+    cfg = ResolvedModelConfig(
+        model="qwen3:0.6b",
+        base_url="http://localhost:11434/v1",
+        api_key="",
+        is_local=False,
+    )
+    model, formatter = create_model_and_formatter(cfg)
+
+    assert model.model_name == "qwen3:0.6b"
+    assert formatter is not None
+    print("✅ PASS — Full pipeline works with Ollama config")
+
+
+if __name__ == "__main__":
+    test_ollama_no_apikey_uses_base_url()
+    test_dashscope_fallback_still_works()
+    test_none_config_falls_back()
+    test_apikey_provider_still_works()
+    test_full_pipeline_with_ollama_config()
+    print("\nAll tests passed!")


### PR DESCRIPTION
## Summary

- **Bug**: Ollama model configured as active LLM but falls back to DashScope, causing 401 error
- **Root cause**: `_create_remote_model_instance()` in `model_factory.py` only checks `api_key` to determine valid config
- **Fix**: Also check `base_url` — providers like Ollama only need a base_url, no api_key

Fixes #165

## Problem

When a user configures an Ollama model as the active LLM via the Web UI, the model creation path in `_create_remote_model_instance()` checks `if llm_cfg and llm_cfg.api_key:`. Since Ollama doesn't require an API key (`api_key=""`), this condition is always `False`, causing the code to fall back to DashScope with a hardcoded `qwen3-max` model. Without `DASHSCOPE_API_KEY` set, this results in a 401 authentication error.

**Before fix (main branch):**

```
Resolved config: model=qwen3:0.6b, base_url=http://localhost:11434/v1, api_key='', is_local=False

WARNING: No active LLM configured — falling back to DASHSCOPE_API_KEY env var
openai.AuthenticationError: Error code: 401 - You didn't provide an API key
```

<img width="1430" height="1103" alt="image" src="https://github.com/user-attachments/assets/6aba52ac-3ba3-4585-9219-8b3624d27f47" />

* 401 authentication error when using Ollama on main branch*

## Changes

- `src/copaw/agents/model_factory.py` — Change condition from `llm_cfg.api_key` to `llm_cfg.api_key or llm_cfg.base_url`

**After fix (fix branch):**

```
Resolved config: model=qwen3:0.6b, base_url=http://localhost:11434/v1, api_key='', is_local=False

model_name: qwen3:0.6b
base_url: http://localhost:11434/v1/
✅ PASS — Model correctly points to Ollama, not DashScope
```

<img width="1274" height="1105" alt="image" src="https://github.com/user-attachments/assets/2d259560-4114-42dd-afae-47f813863de5" />

*Successful response from Ollama model on fix branch*

## Test plan

- [x] New test: `test_ollama_no_apikey_uses_base_url` — Ollama config creates model with correct base_url
- [x] New test: `test_dashscope_fallback_still_works` — Empty config still falls back to DashScope
- [x] New test: `test_none_config_falls_back` — None config falls back correctly
- [x] New test: `test_apikey_provider_still_works` — API key providers (Kimi, DashScope) unaffected
- [x] New test: `test_full_pipeline_with_ollama_config` — Full create_model_and_formatter pipeline works

All tests pass: `python tests/test_ollama_no_apikey.py`

## Effect on User Experience

**Before:** Configuring Ollama as active LLM in Web UI results in `AGENT_UNKNOWN_ERROR` with 401 authentication error. Ollama is completely unusable.

**After:** Ollama model is correctly created with the configured base_url. Users can use Ollama models without needing any API key.