### PR TITLE
fix: stop idle browser to reclaim accumulated Chrome renderer processes

### DIFF
--- a/src/copaw/agents/tools/browser_control.py
+++ b/src/copaw/agents/tools/browser_control.py
@@ -10,6 +10,7 @@ wait_for, pdf, close. Uses refs from snapshot for ref-based actions.
 """
 
 import asyncio
+import atexit
 import json
 import logging
 import subprocess
@@ -39,7 +40,61 @@ _state: dict[str, Any] = {
     "headless": True,
     "current_page_id": None,
     "page_counter": 0,  # monotonic counter for page_N ids, avoids reuse after close
+    "last_activity_time": 0.0,  # monotonic timestamp of last browser activity
+    "_idle_task": None,  # background asyncio.Task for idle watchdog
 }
+
+# Stop the browser after this many seconds of inactivity (default 30 minutes).
+_BROWSER_IDLE_TIMEOUT = 1800.0
+
+
+def _touch_activity() -> None:
+    """Record the current time as the last browser activity timestamp."""
+    _state["last_activity_time"] = time.monotonic()
+
+
+async def _idle_watchdog(idle_seconds: float = _BROWSER_IDLE_TIMEOUT) -> None:
+    """Background task: stop the browser after it has been idle for *idle_seconds*.
+
+    This reclaims Chrome renderer processes that accumulate when pages are
+    opened during agent tasks but never explicitly closed.
+    """
+    try:
+        while True:
+            await asyncio.sleep(60)  # check every minute
+            if _state["browser"] is None:
+                return
+            idle = time.monotonic() - _state.get("last_activity_time", 0.0)
+            if idle >= idle_seconds:
+                logger.info(
+                    "Browser idle for %.0fs (limit %.0fs), stopping to release resources",
+                    idle,
+                    idle_seconds,
+                )
+                await _action_stop()
+                return
+    except asyncio.CancelledError:
+        pass
+
+
+def _atexit_cleanup() -> None:
+    """Best-effort browser cleanup registered with :func:`atexit`.
+
+    Playwright child processes are cleaned up by the OS when the parent
+    exits, but this gives Playwright a chance to flush any pending I/O and
+    close Chrome gracefully before the process disappears.
+    """
+    if _state.get("browser") is None:
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        if not loop.is_running() and not loop.is_closed():
+            loop.run_until_complete(_action_stop())
+    except Exception:
+        pass
+
+
+atexit.register(_atexit_cleanup)
 
 
 def _tool_response(text: str) -> ToolResponse:
@@ -504,6 +559,7 @@ def _attach_context_listeners(context) -> None:
 async def _ensure_browser() -> bool:
     """Start browser if not running. Return True if ready, False on failure."""
     if _state["browser"] is not None and _state["context"] is not None:
+        _touch_activity()
         return True
     try:
         async_playwright = _ensure_playwright_async()
@@ -514,9 +570,27 @@ async def _ensure_browser() -> bool:
         _state["playwright"] = pw
         _state["browser"] = pw_browser
         _state["context"] = context
+        _touch_activity()
+        _start_idle_watchdog()
         return True
     except Exception:
         return False
+
+
+def _start_idle_watchdog() -> None:
+    """Cancel any existing idle watchdog and start a fresh one."""
+    old_task = _state.get("_idle_task")
+    if old_task and not old_task.done():
+        old_task.cancel()
+    _state["_idle_task"] = asyncio.ensure_future(_idle_watchdog())
+
+
+def _cancel_idle_watchdog() -> None:
+    """Cancel the idle watchdog, if running."""
+    task = _state.get("_idle_task")
+    if task and not task.done():
+        task.cancel()
+    _state["_idle_task"] = None
 
 
 async def _action_start(headed: bool = False) -> ToolResponse:
@@ -524,6 +598,7 @@ async def _action_start(headed: bool = False) -> ToolResponse:
     # but browser is already running headless, restart with headed
     if _state["browser"] is not None:
         if headed and _state["headless"]:
+            _cancel_idle_watchdog()
             try:
                 await _state["browser"].close()
                 if _state["playwright"] is not None:
@@ -543,6 +618,7 @@ async def _action_start(headed: bool = False) -> ToolResponse:
                 _state["pending_file_choosers"].clear()
                 _state["current_page_id"] = None
                 _state["page_counter"] = 0
+                _state["last_activity_time"] = 0.0
         else:
             return _tool_response(
                 json.dumps(
@@ -571,6 +647,8 @@ async def _action_start(headed: bool = False) -> ToolResponse:
         _state["playwright"] = pw
         _state["browser"] = pw_browser
         _state["context"] = context
+        _touch_activity()
+        _start_idle_watchdog()
         msg = (
             "Browser started (visible window)"
             if _state["headless"] is False
@@ -594,6 +672,7 @@ async def _action_start(headed: bool = False) -> ToolResponse:
 
 
 async def _action_stop() -> ToolResponse:
+    _cancel_idle_watchdog()
     if _state["browser"] is None:
         return _tool_response(
             json.dumps(
@@ -627,6 +706,7 @@ async def _action_stop() -> ToolResponse:
         _state["pending_file_choosers"].clear()
         _state["current_page_id"] = None
         _state["page_counter"] = 0
+        _state["last_activity_time"] = 0.0
         _state["headless"] = True  # next start defaults to background
     return _tool_response(
         json.dumps(


### PR DESCRIPTION
When agent tasks open pages via the browser tool but do not explicitly close them, Chrome renderer processes accumulate in the background. One stuck renderer was observed consuming 42 % CPU for 200+ minutes.

Changes:
- Add `_BROWSER_IDLE_TIMEOUT` (default 30 min) and `last_activity_time` tracking in `_state`.
- Add `_idle_watchdog()` async background task: checks every 60 s and calls `_action_stop()` once the browser has been idle for the timeout period, releasing all open pages and renderer processes.
- `_start_idle_watchdog()` / `_cancel_idle_watchdog()` helpers manage the task lifecycle; watchdog starts when the browser starts (via `_action_start` or `_ensure_browser`) and is cancelled on stop.
- `_touch_activity()` is called from `_ensure_browser()` so every browser action resets the idle timer without per-action boilerplate.
- Add `_atexit_cleanup()` registered via `atexit.register()` as a best-effort graceful shutdown when the Python process exits.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]
