### PR TITLE
fix(channels): handle dict tool arguments in renderer

### DIFF
--- a/src/copaw/app/channels/renderer.py
+++ b/src/copaw/app/channels/renderer.py
@@ -114,6 +114,8 @@ class MessageRenderer:
                             )
                         except TypeError:
                             args_str = str(args)
+                    # Prevent code fence breakout in markdown renderers.
+                    args_str = args_str.replace("```", "``\\`")
                     args_preview = (
                         args_str[:200] + "..."
                         if len(args_str) > 200


### PR DESCRIPTION
## Description

Fix renderer crash when tool-call arguments are dicts by converting them to a safe string before truncation. This prevents TypeError during message rendering.

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- pre-commit run --all-files

## Additional Notes

N/A
