### PR TITLE
fix(tools): make shell execution robust on Windows

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -5,6 +5,10 @@
 
 import asyncio
 import locale
+import os
+import shlex
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -12,6 +16,52 @@ from agentscope.tool import ToolResponse
 from agentscope.message import TextBlock
 
 from copaw.constant import WORKING_DIR
+
+
+def _normalize_command(cmd: str) -> tuple[str, str | None]:
+    """Normalize shell wrappers for cross-platform execution."""
+    if os.name != "nt":
+        return cmd, None
+
+    # LLMs often emit Linux-style wrappers on Windows. If bash is not
+    # available, unwrap `bash -lc "..."` and run the inner command directly.
+    if cmd.strip().lower().startswith("bash -lc") and shutil.which("bash") is None:
+        try:
+            parts = shlex.split(cmd, posix=True)
+            if len(parts) >= 3 and parts[0].lower() == "bash" and parts[1] == "-lc":
+                return (
+                    parts[2],
+                    "bash is unavailable on Windows, executed inner command directly.",
+                )
+        except ValueError:
+            pass
+
+    return cmd, None
+
+
+def _run_shell_command_sync(
+    cmd: str,
+    cwd: Path,
+    timeout: int,
+) -> tuple[int, bytes, bytes, str | None]:
+    """Execute command in a worker thread for compatibility."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(cwd),
+            timeout=timeout,
+            check=False,
+        )
+        return proc.returncode, proc.stdout or b"", proc.stderr or b"", None
+    except subprocess.TimeoutExpired as exc:
+        timeout_msg = (
+            f"⚠️ TimeoutError: The command execution exceeded the timeout of {timeout} seconds. "
+            "Please consider increasing the timeout value if this command requires more time to complete."
+        )
+        return -1, exc.stdout or b"", exc.stderr or b"", timeout_msg
 
 
 # pylint: disable=too-many-branches
@@ -43,71 +93,57 @@ async def execute_shell_command(
 
     cmd = (command or "").strip()
 
-    # Set working directory
-    working_dir = cwd if cwd is not None else WORKING_DIR
+    notices: list[str] = []
+
+    # Set and validate working directory
+    try:
+        working_dir = Path(cwd).expanduser() if cwd is not None else WORKING_DIR
+    except Exception:
+        working_dir = WORKING_DIR
+        notices.append("Invalid cwd provided, fallback to default working directory.")
+
+    if not working_dir.exists() or not working_dir.is_dir():
+        notices.append(
+            f"Provided cwd does not exist or is not a directory: {working_dir}. "
+            f"Fallback to {WORKING_DIR}.",
+        )
+        working_dir = WORKING_DIR
+
+    cmd, normalize_notice = _normalize_command(cmd)
+    if normalize_notice:
+        notices.append(normalize_notice)
 
     try:
-        proc = await asyncio.create_subprocess_shell(
+        returncode, stdout, stderr, timeout_msg = await asyncio.to_thread(
+            _run_shell_command_sync,
             cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            bufsize=0,
-            cwd=str(working_dir),
+            working_dir,
+            timeout,
         )
 
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=timeout)
-            stdout, stderr = await proc.communicate()
-            encoding = locale.getpreferredencoding(False) or "utf-8"
-            stdout_str = stdout.decode(encoding, errors="replace").strip("\n")
-            stderr_str = stderr.decode(encoding, errors="replace").strip("\n")
-            returncode = proc.returncode
-
-        except asyncio.TimeoutError:
-            # Handle timeout
-            stderr_suffix = (
-                f"⚠️ TimeoutError: The command execution exceeded "
-                f"the timeout of {timeout} seconds. "
-                f"Please consider increasing the timeout value if this command "
-                f"requires more time to complete."
-            )
-            returncode = -1
-            try:
-                proc.terminate()
-                # Wait a bit for graceful termination
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=1)
-                except asyncio.TimeoutError:
-                    # Force kill if graceful termination fails
-                    proc.kill()
-                    await proc.wait()
-
-                stdout, stderr = await proc.communicate()
-                encoding = locale.getpreferredencoding(False) or "utf-8"
-                stdout_str = stdout.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
-                stderr_str = stderr.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
-                if stderr_str:
-                    stderr_str += f"\n{stderr_suffix}"
-                else:
-                    stderr_str = stderr_suffix
-            except ProcessLookupError:
-                stdout_str = ""
-                stderr_str = stderr_suffix
+        encoding = locale.getpreferredencoding(False) or "utf-8"
+        stdout_str = stdout.decode(encoding, errors="replace").strip("\n")
+        stderr_str = stderr.decode(encoding, errors="replace").strip("\n")
+        if timeout_msg:
+            if stderr_str:
+                stderr_str += f"\n{timeout_msg}"
+            else:
+                stderr_str = timeout_msg
 
         # Format the response in a human-friendly way
+        notice_prefix = ""
+        if notices:
+            notice_prefix = "\n".join(f"[notice] {n}" for n in notices) + "\n\n"
+
         if returncode == 0:
             # Success case: just show the output
             if stdout_str:
-                response_text = stdout_str
+                response_text = f"{notice_prefix}{stdout_str}"
             else:
-                response_text = "Command executed successfully (no output)."
+                response_text = f"{notice_prefix}Command executed successfully (no output)."
         else:
             # Error case: show detailed information
-            response_parts = [f"Command failed with exit code {returncode}."]
+            response_parts = [f"{notice_prefix}Command failed with exit code {returncode}."]
             if stdout_str:
                 response_parts.append(f"\n[stdout]\n{stdout_str}")
             if stderr_str:
@@ -124,11 +160,15 @@ async def execute_shell_command(
         )
 
     except Exception as e:
+        detail = str(e) or repr(e)
         return ToolResponse(
             content=[
                 TextBlock(
                     type="text",
-                    text=f"Error: Shell command execution failed due to \n{e}",
+                    text=(
+                        "Error: Shell command execution failed due to\n"
+                        f"{e.__class__.__name__}: {detail}"
+                    ),
                 ),
             ],
         )


### PR DESCRIPTION
## Summary
- fix `execute_shell_command` on Windows by replacing the unstable asyncio subprocess path with a thread-backed `subprocess.run` execution path
- keep async tool behavior (`await asyncio.to_thread(...)`) while avoiding `NotImplementedError` failures observed in chat tool calls
- add safer command execution handling:
  - normalize Linux-style `bash -lc` wrapper usage for Windows fallback
  - validate/fallback invalid `cwd` to default working directory
  - return clearer exception details in error output

## Why
In Windows environments, shell tool calls intermittently returned:
`Error: Shell command execution failed due to\nNotImplementedError: NotImplementedError()`
This prevented agent tasks from using command execution reliably.

## Validation
- `python -m compileall src/copaw/agents/tools/shell.py`
- manual smoke test:
  - `execute_shell_command('bash -lc "pwd"', cwd='C:/Users/youdo/.copaw')`
  - returns current working directory output successfully