### PR TITLE
fix(console): hide revoke action when no api key is set

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -85,8 +85,10 @@ export function ProviderConfigModal({
 
   const isActiveLlmProvider =
     activeModels?.active_llm?.provider_id === provider.id;
+  const canRevoke = Boolean(provider.current_api_key);
 
   const handleRevoke = () => {
+    if (!canRevoke) return;
     const confirmContent = isActiveLlmProvider
       ? t("models.revokeConfirmContent", { name: provider.name })
       : t("models.revokeConfirmSimple", { name: provider.name });
@@ -128,7 +130,7 @@ export function ProviderConfigModal({
       footer={
         <div className={styles.modalFooter}>
           <div className={styles.modalFooterLeft}>
-            {provider.has_api_key && (
+            {canRevoke && (
               <Button danger size="small" onClick={handleRevoke}>
                 {t("models.revokeAuthorization")}
               </Button>


### PR DESCRIPTION
## Description

Fix the provider settings modal so the **Revoke Authorization** button is only shown when a real API key is present.

For providers like Ollama (commonly used without API keys), the previous UI showed a revoke action that could not change state, which looked broken.

**Related Issue:** Fixes #235

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `npx prettier --check src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx`
- `git diff --check`

## Additional Notes

None.
