### PR TITLE
fix(workspace): enlarge default editor area

### DIFF
--- a/console/src/pages/Agent/Workspace/index.module.less
+++ b/console/src/pages/Agent/Workspace/index.module.less
@@ -30,9 +30,7 @@
 }
 
 .fileListPanel {
-  width: clamp(280px, 28vw, 360px);
-  min-width: 260px;
-  max-width: 42vw;
+  width: clamp(260px, 28vw, 360px);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description

Improve workspace editing usability by giving the editor pane more default space and increasing the textarea's initial height.

Changes:
- Shrink file list panel default width (`clamp(280px, 28vw, 360px)`) to free room for editor content
- Increase textarea default height and minimum height for easier editing

The editor remains resizable (`resize: vertical`) as before.

**Related Issue:** Fixes #234

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `npx prettier --check src/pages/Agent/Workspace/index.module.less`
- `npm run build` (in `console/`)
- `git diff --check`

## Additional Notes

None.
