### PR TITLE
fix(envs): store env vars under COPAW_WORKING_DIR

### DIFF
--- a/src/copaw/envs/store.py
+++ b/src/copaw/envs/store.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 import shutil
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 from typing import Optional
 
 from ..constant import WORKING_DIR
@@ -39,8 +42,12 @@ def _migrate_legacy_envs(path: Path) -> None:
         return
     if not _LEGACY_ENVS_JSON.is_file():
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(_LEGACY_ENVS_JSON, path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        shutil.copyfile(_LEGACY_ENVS_JSON, path)
+        path.chmod(0o600)
+    except OSError:
+        logger.warning("Failed to migrate legacy envs.json to %s", path)
 
 
 def get_envs_json_path() -> Path:


### PR DESCRIPTION
## Description

Persist environment variables in the user workspace instead of package installation directories.

Changes:
- Default env store moved to `${COPAW_WORKING_DIR}/envs.json` (or `COPAW_ENVS_FILE` override)
- Added one-time migration: if legacy `site-packages/.../envs.json` exists and new file does not, copy it automatically

This makes env configuration survive package upgrades and typical Docker/container restarts where only workspace is mounted.

**Related Issue:** Fixes #236

**Security Considerations:** No new exposure; file remains local and now follows the workspace persistence boundary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `python -m compileall src/copaw/envs/store.py`
- `git diff --check`

## Additional Notes

This PR focuses on env vars persistence. Provider/model persistence is handled separately.
