### PR TITLE
fix: normalize custom provider/model ids before persistence

### DIFF
--- a/src/copaw/providers/store.py
+++ b/src/copaw/providers/store.py
@@ -342,6 +342,9 @@ def create_custom_provider(
     if not name:
         raise ValueError("Provider name cannot be empty.")
 
+    if not provider_id:
+        raise ValueError("Provider id cannot be empty.")
+
     err = validate_custom_provider_id(provider_id)
     if err:
         raise ValueError(err)


### PR DESCRIPTION
## Summary
- trim provider_id/model_id/model_name values before saving custom providers and models
- reject empty provider/model identifiers early with clear validation errors
- normalize active model slot values before persistence

## Validation
- python -m compileall src/copaw/providers/store.py

Closes #229