### PR TITLE
fix: accept URL-based MCP configs in JSON import

### DIFF
--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -32,7 +32,9 @@ function normalizeClientData(key: string, rawData: any) {
       : "stdio");
 
   const command =
-    transport === "stdio" ? (rawData.command ?? "").toString() : "";
+    (rawData.command ?? rawData.url ?? rawData.baseUrl ?? "")
+      .toString()
+      .trim();
 
   return {
     name: rawData.name || key,
@@ -130,6 +132,11 @@ function MCPPage() {
           }
         });
       }
+
+      // Filter invalid entries so we don't trigger backend validation failures.
+      clientsToCreate = clientsToCreate.filter(
+        ({ data }) => typeof data.command === "string" && data.command.length > 0,
+      );
 
       // Create all clients
       let allSuccess = true;


### PR DESCRIPTION
## Summary
- support url/baseUrl aliases when importing MCP client JSON definitions
- map URL-style definitions to command so request payloads stay schema-compliant
- filter invalid entries without command to avoid backend 422 errors

## Validation
- cd console && npm run build

Closes #201