### PR TITLE
fix: accept provider names as aliases in CLI model management

### DIFF
--- a/src/copaw/cli/providers_cmd.py
+++ b/src/copaw/cli/providers_cmd.py
@@ -29,9 +29,6 @@ def _resolve_provider_id(identifier: str) -> str:
     if not raw:
         raise ValueError("Provider id is required.")
 
-    if raw in PROVIDERS:
-        return raw
-
     lowered = raw.lower()
     if lowered in PROVIDERS:
         return lowered


### PR DESCRIPTION
## Summary
- add provider resolution helper that accepts provider id/name with case-insensitive matching
- apply alias resolution to config-key, add-model, remove-model, and remove-provider commands
- improve error messages with guidance to list available providers

## Validation
- python -m compileall src/copaw/cli/providers_cmd.py

Closes #95