### PR TITLE
fix: expand environment variables in COPAW_WORKING_DIR

### DIFF
--- a/src/copaw/constant.py
+++ b/src/copaw/constant.py
@@ -2,8 +2,9 @@
 import os
 from pathlib import Path
 
+_WORKING_DIR_RAW = os.environ.get("COPAW_WORKING_DIR", "~/.copaw")
 WORKING_DIR = (
-    Path(os.environ.get("COPAW_WORKING_DIR", "~/.copaw"))
+    Path(os.path.expandvars(_WORKING_DIR_RAW))
     .expanduser()
     .resolve()
 )


### PR DESCRIPTION
## Summary
- expand shell-style environment variables in COPAW_WORKING_DIR before path resolution
- keep existing home-directory expansion behavior
- improve Windows compatibility for paths like %USERPROFILE%\.copaw

## Validation
- python -m compileall src/copaw/constant.py

Closes #114