### PR TITLE
fix: stop displaying masked API key fragments in settings UI

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -220,6 +220,7 @@
     "baseURL": "Base URL",
     "apiKey": "API Key",
     "currentKey": "Current: {{key}}",
+    "apiKeyAlreadyConfigured": "API key already configured. Leave blank to keep it unchanged.",
     "startsWith": "Starts with \"{{prefix}}\"",
     "optionalSelfHosted": "Optional for self-hosted services",
     "leaveBlankKeep": "Leave blank to keep current key",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -220,6 +220,7 @@
     "baseURL": "基础 URL",
     "apiKey": "API 密钥",
     "currentKey": "当前密钥：{{key}}",
+    "apiKeyAlreadyConfigured": "API Key 已配置，留空将保持不变。",
     "startsWith": "以 \"{{prefix}}\" 开头",
     "optionalSelfHosted": "自托管服务可选",
     "leaveBlankKeep": "留空以保持当前密钥",

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -35,7 +35,7 @@ export function ProviderConfigModal({
 
   const apiKeyExtra = useMemo(() => {
     if (provider.current_api_key) {
-      return t("models.currentKey", { key: provider.current_api_key });
+      return t("models.apiKeyAlreadyConfigured");
     }
     if (provider.api_key_prefix) {
       return t("models.startsWith", { prefix: provider.api_key_prefix });


### PR DESCRIPTION
## Summary
- remove masked API key fragment from provider settings helper text
- replace it with a generic configured-state hint
- add localized text for the new helper message

## Validation
- cd console && npm run build

Closes #223