### PR TITLE
fix(local-models): parse Codex-style channel tags to avoid template breakage

### DIFF
--- a/src/copaw/local_models/chat_model.py
+++ b/src/copaw/local_models/chat_model.py
@@ -19,8 +19,10 @@ from agentscope.message import TextBlock, ToolUseBlock, ThinkingBlock
 
 from .backends.base import LocalBackend
 from .tag_parser import (
+    extract_channel_tags_from_text,
     extract_thinking_from_text,
     parse_tool_calls_from_text,
+    text_contains_channel_tag,
     text_contains_think_tag,
     text_contains_tool_call_tag,
 )
@@ -175,6 +177,19 @@ class LocalChatModel(ChatModelBase):
             effective_thinking = accumulated_thinking
             effective_text = accumulated_text
 
+            if effective_text and text_contains_channel_tag(effective_text):
+                parsed_channel = extract_channel_tags_from_text(effective_text)
+                if parsed_channel.thinking:
+                    effective_thinking = (
+                        f"{effective_thinking}\n{parsed_channel.thinking}"
+                        if effective_thinking
+                        else parsed_channel.thinking
+                    ).strip()
+                effective_text = parsed_channel.remaining_text
+                # Keep silent until a final channel appears.
+                if parsed_channel.has_open_tag and not effective_text:
+                    effective_text = ""
+
             if (
                 not effective_thinking
                 and effective_text
@@ -273,6 +288,19 @@ class LocalChatModel(ChatModelBase):
             # Reasoning/thinking content
             thinking = message.get("reasoning_content") or ""
             text = message.get("content") or ""
+
+            # Some local coding models emit Codex-style channel tags
+            # (<|channel|>analysis/final...). Extract them so control tags
+            # never leak into conversation history.
+            if text and text_contains_channel_tag(text):
+                parsed_channel = extract_channel_tags_from_text(text)
+                if parsed_channel.thinking:
+                    thinking = (
+                        f"{thinking}\n{parsed_channel.thinking}"
+                        if thinking
+                        else parsed_channel.thinking
+                    ).strip()
+                text = parsed_channel.remaining_text
 
             # Fallback: if backend didn't return structured
             # reasoning_content but the text contains <think> tags,

--- a/src/copaw/local_models/tag_parser.py
+++ b/src/copaw/local_models/tag_parser.py
@@ -26,6 +26,11 @@ THINK_END = "</think>"
 TOOL_CALL_START = "<tool_call>"
 TOOL_CALL_END = "</tool_call>"
 
+# Tags used by some local coding models (Codex-like format).
+CHANNEL_TAG = "<|channel|>"
+MESSAGE_TAG = "<|message|>"
+END_TAG = "<|end|>"
+
 # Regex to find a complete <think>...</think> block (non-greedy).
 _THINK_RE = re.compile(
     r"<think>(.*?)</think>",
@@ -37,6 +42,14 @@ _TOOL_CALL_RE = re.compile(
     r"<tool_call>\s*(.*?)\s*</tool_call>",
     re.DOTALL,
 )
+
+_CHANNEL_RE = re.compile(
+    r"<\|channel\|>\s*(analysis|final)\s*<\|message\|>(.*?)(?="
+    r"(?:<\|end\|>|<\|start\|>|<\|channel\|>|$))",
+    re.DOTALL | re.IGNORECASE,
+)
+
+_CONTROL_TAG_RE = re.compile(r"<\|[^>]+\|>")
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -81,6 +94,15 @@ class TextWithToolCalls:
     has_open_tag: bool = False
     # Raw text accumulated after the unclosed <tool_call> tag.
     partial_tool_text: str = ""
+
+
+@dataclass
+class TextWithChannelTags:
+    """Result of extracting ``<|channel|>`` style segments from text."""
+
+    thinking: str = ""
+    remaining_text: str = ""
+    has_open_tag: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +193,62 @@ def extract_thinking_from_text(text: str) -> TextWithThinking:
 def text_contains_tool_call_tag(text: str) -> bool:
     """Fast substring check for a ``<tool_call>`` tag."""
     return TOOL_CALL_START in text
+
+
+def text_contains_channel_tag(text: str) -> bool:
+    """Fast substring check for Codex-style ``<|channel|>`` tags."""
+    return CHANNEL_TAG in text
+
+
+def _strip_control_tags(text: str) -> str:
+    return _CONTROL_TAG_RE.sub("", text).strip()
+
+
+def extract_channel_tags_from_text(text: str) -> TextWithChannelTags:
+    """Extract Codex-style ``analysis/final`` channel blocks from *text*."""
+    if not text:
+        return TextWithChannelTags(remaining_text="")
+
+    matches = list(_CHANNEL_RE.finditer(text))
+    if not matches:
+        has_open_tag = (
+            CHANNEL_TAG in text
+            and MESSAGE_TAG in text
+            and END_TAG not in text
+        )
+        return TextWithChannelTags(
+            remaining_text=_strip_control_tags(text),
+            has_open_tag=has_open_tag,
+        )
+
+    thinking_parts: list[str] = []
+    final_parts: list[str] = []
+    for m in matches:
+        role = (m.group(1) or "").strip().lower()
+        content = (m.group(2) or "").strip()
+        if not content:
+            continue
+        if role == "analysis":
+            thinking_parts.append(content)
+        elif role == "final":
+            final_parts.append(content)
+
+    prefix = text[: matches[0].start()]
+    suffix = text[matches[-1].end() :]
+    extra_text = _strip_control_tags("\n".join([prefix, suffix]).strip())
+
+    remaining_parts = list(final_parts)
+    if extra_text:
+        remaining_parts.append(extra_text)
+
+    has_open_tag = text.count(CHANNEL_TAG) > text.count(END_TAG)
+    return TextWithChannelTags(
+        thinking="\n".join(thinking_parts).strip(),
+        remaining_text="\n".join(
+            p for p in remaining_parts if p and p.strip()
+        ).strip(),
+        has_open_tag=has_open_tag,
+    )
 
 
 def parse_tool_calls_from_text(text: str) -> TextWithToolCalls:


### PR DESCRIPTION
## Summary
- parse `<|channel|>analysis/final` blocks emitted by some local coding models
- route `analysis` content into thinking and keep only `final` in visible text
- strip control tags from streamed/non-streamed responses so they never pollute conversation history

## Why
Some local models return Codex-style control tags directly in content. Those tags can leak into history and trigger downstream template/tool-call errors.

Closes #176

## Validation
- `python -m compileall src/copaw/local_models/tag_parser.py src/copaw/local_models/chat_model.py`
