### PR TITLE
fix(llamacpp): return actionable errors when backend init fails

### DIFF
--- a/src/copaw/local_models/backends/llamacpp_backend.py
+++ b/src/copaw/local_models/backends/llamacpp_backend.py
@@ -79,7 +79,26 @@ class LlamaCppBackend(LocalBackend):
         if chat_format is not None:
             init_kwargs["chat_format"] = chat_format
 
-        self._llm = Llama(**init_kwargs)
+        try:
+            self._llm = Llama(**init_kwargs)
+        except AssertionError as e:
+            # llama-cpp-python sometimes raises a bare AssertionError when
+            # context creation fails, which would otherwise surface as a
+            # cryptic empty error message to end users.
+            raise RuntimeError(
+                "Failed to initialize llama.cpp model context. "
+                f"model_path={model_path!r}, n_ctx={n_ctx}, "
+                f"n_gpu_layers={n_gpu_layers}. "
+                "The model file may be incompatible/corrupted or system "
+                "resources are insufficient. Try a smaller GGUF model, "
+                "reducing n_ctx, or adjusting n_gpu_layers.",
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to initialize llama.cpp backend. "
+                f"model_path={model_path!r}, n_ctx={n_ctx}, "
+                f"n_gpu_layers={n_gpu_layers}. Original error: {e}",
+            ) from e
         self._model_path = model_path
         logger.info("Model loaded successfully: %s", model_path)
 


### PR DESCRIPTION
## Summary
- catch bare `AssertionError` during llama.cpp model initialization
- rethrow with actionable context (model path, n_ctx, n_gpu_layers)
- add a clear fallback message for other backend init exceptions

## Why
In real usage, llama-cpp can fail with an empty `AssertionError`, which becomes an opaque unknown error in CoPaw. This change makes failures diagnosable and easier to fix.

Closes #183

## Validation
- `python -m compileall src/copaw/local_models/backends/llamacpp_backend.py`
