### PR TITLE
fix(cron): preserve channel context for scheduled dispatch

### DIFF
--- a/src/copaw/app/crons/executor.py
+++ b/src/copaw/app/crons/executor.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 from typing import Any, Dict
 
+from ..channels.schema import DEFAULT_CHANNEL
 from .models import CronJobSpec
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ class CronExecutor:
         - task_type agent: ask agent with prompt, send reply to channel (
             stream_query + send_event)
         """
+        dispatch_channel = self._resolve_dispatch_channel(job)
         target_user_id = job.dispatch.target.user_id
         target_session_id = job.dispatch.target.session_id
         dispatch_meta: Dict[str, Any] = dict(job.dispatch.meta or {})
@@ -29,7 +31,7 @@ class CronExecutor:
             "cron execute: job_id=%s channel=%s task_type=%s "
             "target_user_id=%s target_session_id=%s",
             job.id,
-            job.dispatch.channel,
+            dispatch_channel,
             job.task_type,
             target_user_id[:40] if target_user_id else "",
             target_session_id[:40] if target_session_id else "",
@@ -39,11 +41,11 @@ class CronExecutor:
             logger.info(
                 "cron send_text: job_id=%s channel=%s len=%s",
                 job.id,
-                job.dispatch.channel,
+                dispatch_channel,
                 len(job.text or ""),
             )
             await self._channel_manager.send_text(
-                channel=job.dispatch.channel,
+                channel=dispatch_channel,
                 user_id=target_user_id,
                 session_id=target_session_id,
                 text=job.text.strip(),
@@ -55,17 +57,18 @@ class CronExecutor:
         logger.info(
             "cron agent: job_id=%s channel=%s stream_query then send_event",
             job.id,
-            job.dispatch.channel,
+            dispatch_channel,
         )
         assert job.request is not None
         req: Dict[str, Any] = job.request.model_dump(mode="json")
         req["user_id"] = target_user_id or "cron"
         req["session_id"] = target_session_id or f"cron:{job.id}"
+        req["channel"] = dispatch_channel
 
         async def _run() -> None:
             async for event in self._runner.stream_query(req):
                 await self._channel_manager.send_event(
-                    channel=job.dispatch.channel,
+                    channel=dispatch_channel,
                     user_id=target_user_id,
                     session_id=target_session_id,
                     event=event,
@@ -73,3 +76,17 @@ class CronExecutor:
                 )
 
         await asyncio.wait_for(_run(), timeout=job.runtime.timeout_seconds)
+
+    @staticmethod
+    def _resolve_dispatch_channel(job: CronJobSpec) -> str:
+        """Resolve dispatch channel with fallback to request.channel."""
+        channel = (job.dispatch.channel or "").strip().lower()
+        if channel and channel != DEFAULT_CHANNEL:
+            return channel
+
+        request_channel = ""
+        if job.request is not None:
+            raw = job.request.model_dump(mode="json")
+            request_channel = str(raw.get("channel") or "").strip().lower()
+
+        return request_channel or channel or DEFAULT_CHANNEL

--- a/src/copaw/app/crons/models.py
+++ b/src/copaw/app/crons/models.py
@@ -56,6 +56,12 @@ class DispatchSpec(BaseModel):
     mode: Literal["stream", "final"] = Field(default="stream")
     meta: Dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("channel")
+    @classmethod
+    def normalize_channel(cls, v: str) -> str:
+        channel = (v or "").strip().lower()
+        return channel or DEFAULT_CHANNEL
+
 
 class JobRuntimeSpec(BaseModel):
     max_concurrency: int = Field(default=1, ge=1)
@@ -103,6 +109,16 @@ class CronJobSpec(BaseModel):
                 raise ValueError("task_type is agent but request is missing")
             # Keep request.user_id and request.session_id in sync with target
             target = self.dispatch.target
+            req_raw = self.request.model_dump(mode="json")
+            req_channel = str(req_raw.get("channel") or "").strip().lower()
+            if (
+                req_channel
+                and (
+                    not self.dispatch.channel
+                    or self.dispatch.channel == DEFAULT_CHANNEL
+                )
+            ):
+                self.dispatch.channel = req_channel
             self.request = self.request.model_copy(
                 update={
                     "user_id": target.user_id,


### PR DESCRIPTION
## Summary
- normalize cron dispatch channel values (`strip + lowercase`) at model validation
- when creating agent jobs, if `dispatch.channel` is still default, backfill it from `request.channel`
- in executor, resolve dispatch channel with fallback logic and pass channel through to `runner.stream_query`

## Why
Some scheduled jobs end up being dispatched to `console` even when created from another channel context. This change keeps channel routing consistent and avoids accidental fallback to console.

Closes #141

## Validation
- `python -m compileall src/copaw/app/crons/models.py src/copaw/app/crons/executor.py`
