### PR TITLE
fix: workspace content textarea

### DIFF
--- a/console/src/pages/Agent/Workspace/index.module.less
+++ b/console/src/pages/Agent/Workspace/index.module.less
@@ -194,6 +194,13 @@
 .editorContent {
   padding: 16px;
   height: calc(100% - 96px);
+
+  textarea {
+    font-family: monospace;
+    font-size: 13px;
+    resize: vertical;
+    height: 100%;
+  }
 }
 
 .contentLabel {


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

编辑内容区域高度过小

修复前
<img width="1639" height="1218" alt="修复前" src="https://github.com/user-attachments/assets/19f4b201-e51e-43ff-a4f5-73dbb0649ac1" />
修复后
<img width="1639" height="1220" alt="修复后" src="https://github.com/user-attachments/assets/f95e7ff1-c4ef-47aa-85cf-3ea73f6e4239" />



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]
