### PR TITLE
fix: request contentType

### DIFF
--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -1,9 +1,6 @@
 import { getApiUrl, getApiToken } from "./config";
 
-function buildHeaders(
-  method?: string,
-  extra?: HeadersInit,
-): Headers {
+function buildHeaders(method?: string, extra?: HeadersInit): Headers {
   // Normalize extra to a Headers instance for consistent handling
   const headers = extra instanceof Headers ? extra : new Headers(extra);
 


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

前端 HTTP 客户端的全局配置问题，导致所有 GET 请求都带了不合适的 Content-Type: application/json 请求头。在某些网络环境（经过网关）下会触发 504 错误。

本机或同 VPC 直接访问 IP → FastAPI/Uvicorn 比较宽松，忽略错误的 Content-Type
经过网关 + 域名 → 网关可能对请求头更严格，或者触发了某些中间件处理逻辑

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]
