### PR TITLE
feat(website): add semantic icons to docs sidebar

### DIFF
--- a/website/src/pages/Docs.tsx
+++ b/website/src/pages/Docs.tsx
@@ -504,7 +504,11 @@ export function Docs({ config, lang, onLangClick }: DocsProps) {
                                 activeSlug === cs ? "var(--bg)" : "transparent",
                             }}
                           >
-                            <ChildIcon size={14} strokeWidth={1.5} aria-hidden />
+                            <ChildIcon
+                              size={14}
+                              strokeWidth={1.5}
+                              aria-hidden
+                            />
                             {DOC_TITLES[lang][ct] ?? ct}
                             {activeSlug === cs && (
                               <ChevronRight


### PR DESCRIPTION
## Summary

Replace the uniform `BookOpen` icon in the docs sidebar with context-appropriate icons for each section, making navigation more intuitive at a glance.

## Changes

- Replaced the single `BookOpen` icon with 15 distinct semantic icons from `lucide-react`
- Added a `DOC_SLUG_ICONS` mapping table for clean, maintainable icon assignment
- Child entries under **Memory** (`compact`, `commands`) now also show dedicated icons

## Icon Mapping

| Section | Icon | Rationale |
|---|---|---|
| Introduction | `Rocket` | Project launch / starting point |
| Quick Start | `Zap` | Speed and quick actions |
| Console | `Terminal` | Terminal/console interface |
| Channels | `MessageSquare` | Messaging channels |
| Skills | `Wrench` | Tools and capabilities |
| MCP | `Plug` | Plugin/extension protocol |
| Memory | `Brain` | Cognition and memory |
| Compaction | `Archive` | Compression/archiving |
| Commands | `Command` | Keyboard/system commands |
| Heartbeat | `Activity` | Activity waveform |
| Config | `Settings` | Configuration settings |
| CLI | `Terminal` | Command-line interface |
| FAQ | `CircleHelp` | Help and questions |
| Community | `Users` | Community and feedback |
| Contributing | `GitBranch` | Open source branching |
