### PR TITLE
fix(agents): convert local image urls to base64 blocks

### DIFF
--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -31,7 +31,7 @@ def _is_allowed_media_path(path: str) -> bool:
     try:
         resolved = Path(path).expanduser().resolve()
         root = _ALLOWED_MEDIA_ROOT.resolve()
-        return resolved.is_file() and str(resolved).startswith(str(root))
+        return resolved.is_file() and resolved.is_relative_to(root)
     except Exception:
         return False
 
@@ -42,13 +42,17 @@ def _extract_local_path_from_url(url: str) -> Optional[str]:
 
     if parsed.scheme == "file":
         try:
-            return urllib.request.url2pathname(parsed.path)
+            local_path = urllib.request.url2pathname(parsed.path)
+            candidate = Path(local_path).expanduser()
+            if candidate.is_file():
+                return str(candidate)
+            return None
         except Exception:
             return None
 
     if parsed.scheme == "" and parsed.netloc == "":
         candidate = Path(url).expanduser()
-        if candidate.exists():
+        if candidate.is_file():
             return str(candidate)
 
     return None

--- a/tests/agents/utils/test_message_processing.py
+++ b/tests/agents/utils/test_message_processing.py
@@ -3,9 +3,11 @@ import base64
 import asyncio
 
 from copaw.agents.utils.message_processing import (
+    _is_allowed_media_path,
     _process_single_file_block,
     _update_block_with_local_path,
 )
+from copaw.constant import WORKING_DIR
 
 
 def test_update_image_block_uses_base64_source(tmp_path):
@@ -49,3 +51,15 @@ def test_process_single_file_block_rejects_plain_local_path_outside_media_root(
     )
 
     assert result is None
+
+
+def test_is_allowed_media_path_rejects_same_prefix_not_child():
+    media_root = WORKING_DIR / "media"
+    media_root.mkdir(parents=True, exist_ok=True)
+
+    evil_dir = WORKING_DIR / "media_evil"
+    evil_dir.mkdir(parents=True, exist_ok=True)
+    evil_file = evil_dir / "bad.png"
+    evil_file.write_bytes(b"bad")
+
+    assert _is_allowed_media_path(str(evil_file)) is False


### PR DESCRIPTION
## Summary
- Fix image preprocessing so local image files are not sent to OpenAI-compatible endpoints as `file://...` URLs.
- Convert downloaded local image blocks to `base64` source (`media_type` + `data`) in message preprocessing.
- Keep existing behavior for audio/video/file blocks unchanged.
- Add regression tests for image base64 conversion and audio URL behavior.

## Root Cause
`src/copaw/agents/utils/message_processing.py` rewrote downloaded image blocks to:
- `{"type": "url", "url": "file://..."}`

Then runtime conversion passed it directly to model `image_url`, and OpenAI-compatible APIs rejected local file URLs with:
- `InternalError.Algo.InvalidParameter: The provided URL does not appear to be valid`

## Fix
- For `block_type == "image"`, `_update_block_with_local_path` now writes:
  - `{"type": "base64", "media_type": "image/*", "data": "..."}`
- Runtime message conversion already supports image base64 and turns it into `data:image/...;base64,...`, so no further API-side adaptation is required.

## Validation
### Local checks
- `ruff check src/copaw/agents/utils/message_processing.py tests/agents/utils/test_message_processing.py`
- `PYTHONPATH=src pytest -q tests/agents/utils/test_message_processing.py`

### Real endpoint checks (one-api, OpenAI-compatible)
- Model `qwen3.5`:
  - `data:image/...` input: ✅ success (HTTP 200)
  - `file://...` input: ❌ fails with `InvalidParameter` (HTTP 400)
- Model `qwen3.5-plus`:
  - `data:image/...` input: ✅ success (HTTP 200)
  - `file://...` input: ❌ fails with `InvalidParameter` (HTTP 400)

### CoPaw conversion observed
- Post-processing image block source type: `base64`
- Runtime payload prefix: `data:image/png;base64,...`

Closes #318
