### PR TITLE
fix(app): add explicit MIME mappings for static assets

### DIFF
--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name,unused-argument
+import mimetypes
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -32,6 +33,14 @@ from ..envs import load_envs_into_environ
 
 # Apply log level on load so reload child process gets same level as CLI.
 logger = setup_logger(os.environ.get(LOG_LEVEL_ENV, "info"))
+
+# Ensure static assets are served with browser-compatible MIME types across
+# platforms (notably Windows may miss .js/.mjs mappings).
+mimetypes.init()
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/wasm", ".wasm")
 
 # Load persisted env vars into os.environ at module import time
 # so they are available before the lifespan starts.


### PR DESCRIPTION
## Summary

Split from #127: static MIME mapping fix only.

This PR adds explicit MIME mappings for common static asset extensions at app startup.

## Why

Some environments (notably part of Windows setups) may miss MIME mappings for module assets, causing strict module MIME checks to fail and resulting in blank console page.

## Changes

- `src/copaw/app/_app.py`
  - initialize `mimetypes`
  - add explicit mappings for `.js`, `.mjs`, `.css`, `.wasm`

## Verification

- `python -m compileall src/copaw/app/_app.py`

## Issue Mapping

- Fixes #88
