### PR TITLE
fix(install): avoid uv parallel install lock failures on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -123,6 +123,11 @@ function Ensure-Uv {
 
 Ensure-Uv
 
+# On Windows, uv parallel wheel installs can intermittently fail with
+# file-lock "Access Denied" errors. Force serial install for reliability.
+$env:UV_CONCURRENT_INSTALLS = "1"
+Write-Info "Set UV_CONCURRENT_INSTALLS=1 for stable package installation on Windows"
+
 # ── Step 2: Create / update virtual environment ──────────────────────────────
 if (Test-Path $CopawVenv) {
     Write-Info "Existing environment found, upgrading..."


### PR DESCRIPTION
## Summary
- set `UV_CONCURRENT_INSTALLS=1` in `scripts/install.ps1` before any `uv pip install` call
- keep install flow unchanged, only enforce serial wheel installation on Windows

## Why
Issue reports show intermittent `Access Denied (os error -2147024891)` while `uv pip install` runs in parallel on Windows. Serial install avoids Windows file-lock races and makes installer behavior stable.

## Issue Mapping
Fixes #301

## Validation
- code review: only installer env var setup added; no behavior changes outside install concurrency
- local shell verification of diff and script flow
- note: `pwsh` binary is not available in this execution environment, so I could not run PowerShell parser/runtime checks here
