### PR TITLE
fix(formatter): strip messages[*].name for strict OpenAI-compatible APIs

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -37,6 +37,34 @@ _CHAT_MODEL_FORMATTER_MAP: dict[Type[ChatModelBase], Type[FormatterBase]] = {
 }
 
 
+def _strip_message_name_fields(payload: object) -> object:
+    """Remove top-level ``messages[*].name`` for strict OpenAI-compatible APIs.
+
+    Some OpenAI-compatible backends reject any extra keys under message
+    objects. Removing top-level ``name`` keeps payloads schema-safe while
+    preserving function/tool names under ``tool_calls``.
+    """
+
+    def _strip_in_messages(messages: object) -> None:
+        if not isinstance(messages, list):
+            return
+        for msg in messages:
+            if isinstance(msg, dict):
+                msg.pop("name", None)
+
+    if isinstance(payload, dict):
+        _strip_in_messages(payload.get("messages"))
+        return payload
+
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                _strip_in_messages(item.get("messages"))
+        return payload
+
+    return payload
+
+
 def _get_formatter_for_chat_model(
     chat_model_class: Type[ChatModelBase],
 ) -> Type[FormatterBase]:
@@ -79,7 +107,8 @@ def _create_file_block_support_formatter(
             tool messages.
             """
             msgs = _sanitize_tool_messages(msgs)
-            return await super()._format(msgs)
+            payload = await super()._format(msgs)
+            return _strip_message_name_fields(payload)
 
         @staticmethod
         def convert_tool_result_to_string(

--- a/tests/agents/test_model_factory_message_name.py
+++ b/tests/agents/test_model_factory_message_name.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from copaw.agents.model_factory import _strip_message_name_fields
+
+
+def test_strip_message_name_fields_for_single_payload() -> None:
+    payload = {
+        "model": "demo",
+        "messages": [
+            {"role": "system", "name": "system", "content": "rules"},
+            {"role": "user", "name": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "name": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": "{}",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+    out = _strip_message_name_fields(payload)
+    assert out is payload
+    assert "name" not in payload["messages"][0]
+    assert "name" not in payload["messages"][1]
+    assert "name" not in payload["messages"][2]
+    assert (
+        payload["messages"][2]["tool_calls"][0]["function"]["name"]
+        == "write_file"
+    )
+
+
+def test_strip_message_name_fields_for_batch_payload() -> None:
+    payloads = [
+        {
+            "messages": [{"role": "user", "name": "user", "content": "a"}],
+        },
+        {
+            "messages": [{"role": "assistant", "name": "assistant"}],
+        },
+    ]
+
+    out = _strip_message_name_fields(payloads)
+    assert out is payloads
+    assert "name" not in payloads[0]["messages"][0]
+    assert "name" not in payloads[1]["messages"][0]


### PR DESCRIPTION
## Summary
- sanitize formatter output by removing top-level `name` fields from `messages[*]`
- keep tool/function names untouched under `tool_calls[].function.name`
- add regression tests for single and batched payload formatting

## Why
Some strict OpenAI-compatible backends reject extra keys in message objects (`messages.*.name`). This causes 400 validation failures even for normal chats.

## Issue Mapping
Fixes #312

## Validation
- `PYTHONPATH=src pytest -q tests/agents/test_model_factory_message_name.py`
- `python -m compileall src/copaw/agents/model_factory.py tests/agents/test_model_factory_message_name.py`
