### PR TITLE
fix(formatter): send text-only messages as plain strings

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -37,6 +37,49 @@ _CHAT_MODEL_FORMATTER_MAP: dict[Type[ChatModelBase], Type[FormatterBase]] = {
 }
 
 
+def _downgrade_text_only_message_content(payload: object) -> object:
+    """Convert text-only content arrays to plain strings for compatibility.
+
+    Some OpenAI-compatible backends only accept string content for text
+    messages. This keeps multimodal content arrays unchanged and only rewrites
+    arrays composed of ``{"type": "text", "text": ...}`` blocks.
+    """
+
+    def _rewrite_messages(messages: object) -> None:
+        if not isinstance(messages, list):
+            return
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list) or not content:
+                continue
+            if not all(
+                isinstance(block, dict) and block.get("type") == "text"
+                for block in content
+            ):
+                continue
+            texts: list[str] = []
+            for block in content:
+                text = block.get("text")
+                if text is None:
+                    continue
+                texts.append(str(text))
+            msg["content"] = "".join(texts)
+
+    if isinstance(payload, dict):
+        _rewrite_messages(payload.get("messages"))
+        return payload
+
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                _rewrite_messages(item.get("messages"))
+        return payload
+
+    return payload
+
+
 def _get_formatter_for_chat_model(
     chat_model_class: Type[ChatModelBase],
 ) -> Type[FormatterBase]:
@@ -79,7 +122,8 @@ def _create_file_block_support_formatter(
             tool messages.
             """
             msgs = _sanitize_tool_messages(msgs)
-            return await super()._format(msgs)
+            payload = await super()._format(msgs)
+            return _downgrade_text_only_message_content(payload)
 
         @staticmethod
         def convert_tool_result_to_string(

--- a/tests/agents/test_model_factory_text_content_compat.py
+++ b/tests/agents/test_model_factory_text_content_compat.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from copaw.agents.model_factory import _downgrade_text_only_message_content
+
+
+def test_downgrade_text_only_content_blocks_to_string() -> None:
+    payload = {
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "line1"},
+                    {"type": "text", "text": "\nline2"},
+                ],
+            },
+        ],
+    }
+
+    out = _downgrade_text_only_message_content(payload)
+    assert out is payload
+    assert payload["messages"][0]["content"] == "line1\nline2"
+
+
+def test_keep_multimodal_content_array_unchanged() -> None:
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": "https://example.com/a.png"},
+                ],
+            },
+        ],
+    }
+
+    out = _downgrade_text_only_message_content(payload)
+    assert out is payload
+    assert isinstance(payload["messages"][0]["content"], list)
+    assert payload["messages"][0]["content"][1]["type"] == "image_url"


### PR DESCRIPTION
## Summary
- post-process formatter payload to convert text-only content arrays into plain strings
- keep multimodal message arrays unchanged
- add regression tests for both downgrade and multimodal preservation

## Why
Some older/strict OpenAI-compatible servers validate `SystemMessage.content` as string-only and reject array-form content with 422.

## Issue Mapping
Fixes #306

## Validation
- `PYTHONPATH=src pytest -q tests/agents/test_model_factory_text_content_compat.py`
- `python -m compileall src/copaw/agents/model_factory.py tests/agents/test_model_factory_text_content_compat.py`
