### PR TITLE
fix(feishu): resolve cron send target via receive_id fallbacks

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -1347,13 +1347,23 @@ class FeishuChannel(BaseChannel):
                 if len(suffix) >= 4:
                     async with self._receive_id_lock:
                         for _, v in self._receive_id_store.items():
-                            if v[0] and str(v[0]).endswith(suffix):
+                            # v = (receive_id_type, receive_id)
+                            if v[1] and str(v[1]).endswith(suffix):
                                 logger.info(
                                     "feishu _get_receive_for_send: "
                                     "fallback match by suffix %s",
                                     suffix,
                                 )
                                 return v
+            # Cron dispatch may carry the target open_id in merged meta even
+            # when session-key lookup misses.
+            meta_user_id = str(m.get("user_id") or "").strip()
+            if meta_user_id.startswith("ou_"):
+                logger.info(
+                    "feishu _get_receive_for_send: fallback open_id from "
+                    "meta.user_id",
+                )
+                return ("open_id", meta_user_id)
             logger.warning(
                 "feishu _get_receive_for_send: no store entry for "
                 "session_key=%s (user must have chatted first or add "

--- a/tests/channels/test_feishu_receive_id_resolution.py
+++ b/tests/channels/test_feishu_receive_id_resolution.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from copaw.app.channels.feishu.channel import FeishuChannel
+
+
+async def _dummy_process(_request: Any) -> AsyncIterator[Any]:
+    if False:
+        yield None
+
+
+@pytest.mark.asyncio
+async def test_get_receive_for_send_matches_suffix_against_receive_id() -> None:
+    channel = FeishuChannel(
+        process=_dummy_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="",
+    )
+    channel._receive_id_store["k1"] = ("open_id", "ou_abc123xyz9876")
+
+    recv = await channel._get_receive_for_send(
+        "feishu:sw:nickname#9876",
+        meta={},
+    )
+
+    assert recv == ("open_id", "ou_abc123xyz9876")
+
+
+@pytest.mark.asyncio
+async def test_get_receive_for_send_fallbacks_to_meta_user_open_id() -> None:
+    channel = FeishuChannel(
+        process=_dummy_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="",
+    )
+
+    recv = await channel._get_receive_for_send(
+        "feishu:sw:missing_session_key",
+        meta={"user_id": "ou_meta_open_id"},
+    )
+
+    assert recv == ("open_id", "ou_meta_open_id")


### PR DESCRIPTION
## Summary
- fix Feishu session-key suffix fallback to match against stored `receive_id` (not `receive_id_type`)
- add fallback to `meta.user_id` when it carries an `open_id` (`ou_*`) and store lookup misses
- add async regression tests for both fallback paths

## Why
Cron proactive messages can fail when the short session key cannot be resolved from store. The existing suffix fallback compared the wrong tuple field and could never match real open_id/chat_id values.

## Issue Mapping
Fixes #350

## Validation
- `PYTHONPATH=src pytest -q tests/channels/test_feishu_receive_id_resolution.py`
- `python -m compileall src/copaw/app/channels/feishu/channel.py tests/channels/test_feishu_receive_id_resolution.py`
