### PR TITLE
fix(qq): sanitize outgoing URLs to avoid API 400

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import threading
 import time
 from typing import Any, Dict, List, Optional
@@ -61,6 +62,18 @@ MAX_QUICK_DISCONNECT_COUNT = 3
 
 DEFAULT_API_BASE = "https://api.sgroup.qq.com"
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
+_URL_PATTERN = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+
+
+def _sanitize_qq_text(text: str) -> tuple[str, bool]:
+    """QQ API disallows URL links in plain messages.
+
+    Return the sanitized text and whether any URL was removed.
+    """
+    if not text:
+        return "", False
+    sanitized, count = _URL_PATTERN.subn("[链接已省略]", text)
+    return sanitized, count > 0
 
 
 def _get_api_base() -> str:
@@ -375,6 +388,10 @@ class QQChannel(BaseChannel):
         """
         if not self.enabled or not text.strip():
             return
+        text = text.strip()
+        text, had_url = _sanitize_qq_text(text)
+        if had_url:
+            logger.info("qq send: stripped URL content for API compatibility")
         meta = meta or {}
         message_type = meta.get("message_type")
         msg_id = meta.get("message_id")
@@ -401,7 +418,7 @@ class QQChannel(BaseChannel):
                     self._http,
                     token,
                     sender_id,
-                    text.strip(),
+                    text,
                     msg_id,
                 )
             elif message_type == "group" and group_openid:
@@ -409,7 +426,7 @@ class QQChannel(BaseChannel):
                     self._http,
                     token,
                     group_openid,
-                    text.strip(),
+                    text,
                     msg_id,
                 )
             elif channel_id:
@@ -417,7 +434,7 @@ class QQChannel(BaseChannel):
                     self._http,
                     token,
                     channel_id,
-                    text.strip(),
+                    text,
                     msg_id,
                 )
             else:
@@ -425,7 +442,7 @@ class QQChannel(BaseChannel):
                     self._http,
                     token,
                     sender_id,
-                    text.strip(),
+                    text,
                     msg_id,
                 )
         except Exception:

--- a/tests/channels/test_qq_url_sanitize.py
+++ b/tests/channels/test_qq_url_sanitize.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from copaw.app.channels.qq.channel import _sanitize_qq_text
+
+
+def test_sanitize_qq_text_replaces_http_and_https_urls() -> None:
+    text = "请看 https://example.com 和 http://a.b/c?q=1"
+    sanitized, had_url = _sanitize_qq_text(text)
+
+    assert had_url is True
+    assert "http://" not in sanitized
+    assert "https://" not in sanitized
+    assert sanitized.count("[链接已省略]") == 2
+
+
+def test_sanitize_qq_text_keeps_plain_text_unchanged() -> None:
+    text = "这是普通消息，没有链接"
+    sanitized, had_url = _sanitize_qq_text(text)
+
+    assert had_url is False
+    assert sanitized == text


### PR DESCRIPTION
## Summary
- add `_sanitize_qq_text` to remove `http://` / `https://` URLs from outgoing QQ text
- apply sanitization in `QQChannel.send` before all send paths (c2c/group/guild)
- add unit tests for URL replacement and no-op behavior on plain text

## Why
QQ message APIs reject plain text containing URLs (`不允许发送url`) and currently fail the whole send operation. Sanitizing keeps delivery reliable.

## Issue Mapping
Fixes #303

## Validation
- `PYTHONPATH=src pytest -q tests/channels/test_qq_url_sanitize.py`
- `python -m compileall src/copaw/app/channels/qq/channel.py tests/channels/test_qq_url_sanitize.py`
