### PR TITLE
fix(shell): reduce garbled non-UTF8 command output

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -14,6 +14,21 @@ from agentscope.message import TextBlock
 from copaw.constant import WORKING_DIR
 
 
+def _decode_output_bytes(data: bytes) -> str:
+    """Decode subprocess output with UTF-8-first fallback strategy."""
+    encodings = []
+    preferred = locale.getpreferredencoding(False)
+    for enc in ("utf-8", preferred, "gb18030", "latin-1"):
+        if enc and enc not in encodings:
+            encodings.append(enc)
+    for encoding in encodings:
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
 # pylint: disable=too-many-branches
 async def execute_shell_command(
     command: str,
@@ -58,9 +73,8 @@ async def execute_shell_command(
         try:
             await asyncio.wait_for(proc.wait(), timeout=timeout)
             stdout, stderr = await proc.communicate()
-            encoding = locale.getpreferredencoding(False) or "utf-8"
-            stdout_str = stdout.decode(encoding, errors="replace").strip("\n")
-            stderr_str = stderr.decode(encoding, errors="replace").strip("\n")
+            stdout_str = _decode_output_bytes(stdout).strip("\n")
+            stderr_str = _decode_output_bytes(stderr).strip("\n")
             returncode = proc.returncode
 
         except asyncio.TimeoutError:
@@ -83,13 +97,8 @@ async def execute_shell_command(
                     await proc.wait()
 
                 stdout, stderr = await proc.communicate()
-                encoding = locale.getpreferredencoding(False) or "utf-8"
-                stdout_str = stdout.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
-                stderr_str = stderr.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
+                stdout_str = _decode_output_bytes(stdout).strip("\n")
+                stderr_str = _decode_output_bytes(stderr).strip("\n")
                 if stderr_str:
                     stderr_str += f"\n{stderr_suffix}"
                 else:

--- a/tests/tools/test_shell_decode_output.py
+++ b/tests/tools/test_shell_decode_output.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import locale
+
+from copaw.agents.tools.shell import _decode_output_bytes
+
+
+def test_decode_output_bytes_prefers_utf8() -> None:
+    data = "中文输出".encode("utf-8")
+    assert _decode_output_bytes(data) == "中文输出"
+
+
+def test_decode_output_bytes_falls_back_to_preferred_encoding(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(locale, "getpreferredencoding", lambda _: "gb18030")
+    text = "中文输出"
+    data = text.encode("gb18030")
+    assert _decode_output_bytes(data) == text


### PR DESCRIPTION
## Summary
- add `_decode_output_bytes` with UTF-8-first decoding and fallback encodings
- use the decoder in both normal and timeout paths of `execute_shell_command`
- add tests for UTF-8 and preferred-encoding fallback behavior

## Why
Chinese output can become garbled when command output encoding and locale encoding differ. A resilient decode path significantly reduces mojibake.

## Issue Mapping
Fixes #298
Relates to #164

## Validation
- `PYTHONPATH=src pytest -q tests/tools/test_shell_decode_output.py`
- `python -m compileall src/copaw/agents/tools/shell.py tests/tools/test_shell_decode_output.py`
