### PR TITLE
fix(runner): surface model timeout errors with actionable guidance

### DIFF
--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -26,10 +26,12 @@ def _normalize_user_facing_exception(exc: Exception) -> Exception:
     """Rewrite known upstream timeout errors into actionable messages."""
     exc_type = type(exc).__name__
     if exc_type in {"APITimeoutError", "ReadTimeout", "ConnectTimeout"}:
-        return RuntimeError(
+        wrapped = RuntimeError(
             "Model request timed out. Please retry, shorten your prompt, "
             "or switch to a more stable endpoint/model.",
         )
+        wrapped.__cause__ = exc
+        return wrapped
     return exc
 
 
@@ -179,7 +181,7 @@ class AgentRunner(Runner):
                 e.args = (
                     (f"{e.args[0]}{suffix}" if e.args else suffix.strip()),
                 ) + e.args[1:]
-            raise
+            raise e
         finally:
             if agent is not None:
                 await self.session.save_session_state(

--- a/tests/runner/test_runner_exception_normalization.py
+++ b/tests/runner/test_runner_exception_normalization.py
@@ -14,6 +14,7 @@ def test_normalize_timeout_exception_to_runtime_error() -> None:
 
     assert isinstance(normalized, RuntimeError)
     assert "timed out" in str(normalized).lower()
+    assert normalized.__cause__ is exc
 
 
 def test_keep_unknown_exception_unchanged() -> None:


### PR DESCRIPTION
## Summary
- add `_normalize_user_facing_exception` in runner
- map upstream timeout exceptions (`APITimeoutError`, `ReadTimeout`, `ConnectTimeout`) to a clear actionable runtime error message
- add unit tests for timeout mapping and non-timeout passthrough

## Why
Users currently see opaque `AGENT_UNKNOWN_ERROR` wrappers on model timeouts. A normalized message improves triage and recovery without changing execution flow.

## Issue Mapping
Fixes #351

## Validation
- `PYTHONPATH=src pytest -q tests/runner/test_runner_exception_normalization.py`
- `python -m compileall src/copaw/app/runner/runner.py tests/runner/test_runner_exception_normalization.py`
