### PR TITLE
fix(runner): normalize upstream 5xx model errors

### DIFF
--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -40,10 +40,12 @@ def _normalize_user_facing_exception(exc: Exception) -> Exception:
         )
     )
     if exc_type in {"InternalServerError", "APIStatusError"} and is_upstream_5xx:
-        return RuntimeError(
+        wrapped = RuntimeError(
             "Upstream model service returned a temporary server error (5xx). "
             "Please retry later or switch endpoint/model.",
         )
+        wrapped.__cause__ = exc
+        return wrapped
     return exc
 
 
@@ -193,7 +195,7 @@ class AgentRunner(Runner):
                 e.args = (
                     (f"{e.args[0]}{suffix}" if e.args else suffix.strip()),
                 ) + e.args[1:]
-            raise
+            raise e
         finally:
             if agent is not None:
                 await self.session.save_session_state(

--- a/tests/runner/test_runner_server_error_normalization.py
+++ b/tests/runner/test_runner_server_error_normalization.py
@@ -17,6 +17,7 @@ def test_normalize_upstream_5xx_exception() -> None:
 
     assert isinstance(normalized, RuntimeError)
     assert "server error" in str(normalized).lower()
+    assert normalized.__cause__ is exc
 
 
 def test_keep_non_5xx_exception_unchanged() -> None:


### PR DESCRIPTION
## Summary
- add runner-side normalization for upstream `InternalServerError` / `APIStatusError` with 5xx codes
- rewrite to a concise actionable runtime message for end users
- add unit tests for 5xx mapping and passthrough behavior

## Why
Current behavior surfaces raw upstream 5xx exceptions as `Unknown agent error`, which is noisy and not actionable for users.

## Issue Mapping
Fixes #217

## Validation
- `PYTHONPATH=src pytest -q tests/runner/test_runner_server_error_normalization.py`
- `python -m compileall src/copaw/app/runner/runner.py tests/runner/test_runner_server_error_normalization.py`
