### PR TITLE
fix(deps): use stable agentscope release by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "CoPaw is a **personal assistant** that runs in your own environme
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "agentscope==1.0.16.dev0",
+    "agentscope==1.0.16",
     "agentscope-runtime==1.1.0",
     "discord-py>=2.3",
     "dingtalk-stream>=0.24.3",


### PR DESCRIPTION
## Summary
- replace `agentscope==1.0.16.dev0` with stable `agentscope==1.0.16` in project dependencies

## Why
Some mirrors/proxies skip pre-release artifacts, causing `pip install copaw` failures when default dependency pins include dev builds.

## Issue Mapping
Fixes #47

## Validation
- `python -m pip install --dry-run --no-deps --no-cache-dir "agentscope==1.0.16" "reme-ai==0.3.0.0"`
- `python - <<'PY' ...` toml assertion to ensure `agentscope==1.0.16` is present and `.dev0` pin removed
