### PR TITLE
fix(agents): normalize tool_choice None to auto when tools exist

### DIFF
--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -46,6 +46,16 @@ from ..constant import (
 logger = logging.getLogger(__name__)
 
 
+def normalize_reasoning_tool_choice(
+    tool_choice: Literal["auto", "none", "required"] | None,
+    has_tools: bool,
+) -> Literal["auto", "none", "required"] | None:
+    """Normalize tool_choice for reasoning to reduce provider variance."""
+    if tool_choice is None and has_tools:
+        return "auto"
+    return tool_choice
+
+
 class CoPawAgent(ReActAgent):
     """CoPaw Agent with integrated tools, skills, and memory management.
 
@@ -269,8 +279,10 @@ class CoPawAgent(ReActAgent):
         tool_choice: Literal["auto", "none", "required"] | None = None,
     ) -> Msg:
         """Ensure a stable default tool-choice behavior across providers."""
-        if tool_choice is None and self.toolkit.get_json_schemas():
-            tool_choice = "auto"
+        tool_choice = normalize_reasoning_tool_choice(
+            tool_choice=tool_choice,
+            has_tools=bool(self.toolkit.get_json_schemas()),
+        )
 
         return await super()._reasoning(tool_choice=tool_choice)
 

--- a/tests/test_react_agent_tool_choice.py
+++ b/tests/test_react_agent_tool_choice.py
@@ -1,53 +1,27 @@
 # -*- coding: utf-8 -*-
 import pytest
-from agentscope.agent import ReActAgent
-from agentscope.message import Msg
-from agentscope.tool import Toolkit
 
-from copaw.agents.react_agent import CoPawAgent
+from copaw.agents.react_agent import normalize_reasoning_tool_choice
 
 
-def _dummy_tool() -> str:
-    """Dummy tool for testing tool schema presence."""
-    return "ok"
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("register_tool", "tool_choice_in", "expected"),
+    ("tool_choice_in", "has_tools", "expected"),
     [
-        (True, None, "auto"),
-        (False, None, None),
-        (True, "required", "required"),
-        (True, "none", "none"),
+        (None, True, "auto"),
+        (None, False, None),
+        ("required", True, "required"),
+        ("none", True, "none"),
     ],
 )
-async def test_reasoning_tool_choice_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-    register_tool: bool,
+def test_normalize_reasoning_tool_choice(
     tool_choice_in: str | None,
+    has_tools: bool,
     expected: str | None,
 ) -> None:
-    captured: dict[str, str | None] = {"tool_choice": None}
-
-    async def _fake_parent_reasoning(
-        self,
-        tool_choice: str | None = None,
-    ) -> Msg:
-        captured["tool_choice"] = tool_choice
-        return Msg("assistant", "ok", "assistant")
-
-    monkeypatch.setattr(ReActAgent, "_reasoning", _fake_parent_reasoning)
-
-    agent = CoPawAgent.__new__(CoPawAgent)
-    object.__setattr__(agent, "_module_dict", {})
-    agent.toolkit = Toolkit()
-    if register_tool:
-        agent.toolkit.register_tool_function(_dummy_tool)
-
-    msg = await CoPawAgent._reasoning.__wrapped__(  # type: ignore[attr-defined]
-        agent,
-        tool_choice=tool_choice_in,
+    assert (
+        normalize_reasoning_tool_choice(
+            tool_choice=tool_choice_in,
+            has_tools=has_tools,
+        )
+        == expected
     )
-    assert msg.get_text_content() == "ok"
-    assert captured["tool_choice"] == expected


### PR DESCRIPTION
## Summary
- Add a compatibility fallback in `CoPawAgent._reasoning`: when `tool_choice` is `None` and tools are available, pass `"auto"` to parent reasoning.
- Keep explicit `tool_choice` values (`required` / `none`) unchanged.
- Add regression tests to verify fallback behavior and explicit-value passthrough.

## Root Cause
`ReActAgent.reply` initializes `tool_choice` as `None`. Most providers treat omitted `tool_choice` as auto, but provider/gateway behavior can vary. CoPaw had no explicit normalization at agent layer.

## Fix
Override `_reasoning` in `CoPawAgent` to normalize:
- `None` + non-empty tool schemas -> `"auto"`
- otherwise keep original value

## Verification (Local)
Executed locally:

```bash
PYTHONPATH=src pytest -q tests/test_react_agent_tool_choice.py
```

Result:
- `4 passed`

## Additional Validation (OpenAI-compatible gateway)
Using a real OpenAI-compatible endpoint, we validated:
- with tools and omitted `tool_choice`, models can still return `tool_calls`
- with `tool_choice="auto"`, behavior is equivalent
- with `tool_choice="none"`, no tool call is returned

## Issue
Closes #344
