### PR TITLE
fix(channels): correct iMessage bot_prefix filtering

### DIFF
--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -124,13 +124,17 @@ class IMessageChannel(BaseChannel):
         if self._enqueue is not None:
             self._enqueue(request)
 
-    def _should_skip_incoming_text(self, text: Any) -> bool:
+    def should_skip_incoming_text(self, text: Any) -> bool:
         """Return True when incoming message should be ignored."""
         if not text:
             return True
         if self.bot_prefix and not str(text).startswith(self.bot_prefix):
             return True
         return False
+
+    def _should_skip_incoming_text(self, text: Any) -> bool:
+        """Backward-compatible alias for older callers/tests."""
+        return self.should_skip_incoming_text(text)
 
     def _watcher_loop(self) -> None:
         logger.info(
@@ -166,7 +170,7 @@ ORDER BY m.ROWID ASC
                         if r["is_from_me"] == 1:
                             continue
                         text = r["text"]
-                        if self._should_skip_incoming_text(text):
+                        if self.should_skip_incoming_text(text):
                             continue
                         sender = (r["sender"] or "").strip()
                         if not sender:

--- a/tests/channels/test_imessage_channel.py
+++ b/tests/channels/test_imessage_channel.py
@@ -1,86 +1,18 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import annotations
 
-import sys
-import types
 from typing import Any, AsyncIterator
+
+from copaw.app.channels.imessage.channel import IMessageChannel
 
 
 async def _dummy_process(_: Any) -> AsyncIterator[Any]:
-    if False:
-        yield None
+    for event in ():
+        yield event
 
 
-def _install_agentscope_runtime_stub() -> None:
-    if "agentscope_runtime.engine.schemas.agent_schemas" in sys.modules:
-        return
-
-    runtime_module = types.ModuleType("agentscope_runtime")
-    engine_module = types.ModuleType("agentscope_runtime.engine")
-    schemas_module = types.ModuleType("agentscope_runtime.engine.schemas")
-    agent_schemas_module = types.ModuleType(
-        "agentscope_runtime.engine.schemas.agent_schemas",
-    )
-
-    class _RunStatus:
-        Completed = "completed"
-
-    class _MessageType:
-        MESSAGE = "message"
-
-    class _ContentType:
-        TEXT = "text"
-        IMAGE = "image"
-        VIDEO = "video"
-        AUDIO = "audio"
-        FILE = "file"
-        REFUSAL = "refusal"
-
-    class _BaseContent:
-        def __init__(self, type: str, **kwargs: Any):
-            self.type = type
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    class TextContent(_BaseContent):
-        pass
-
-    class ImageContent(_BaseContent):
-        pass
-
-    class VideoContent(_BaseContent):
-        pass
-
-    class AudioContent(_BaseContent):
-        pass
-
-    class FileContent(_BaseContent):
-        pass
-
-    class RefusalContent(_BaseContent):
-        pass
-
-    agent_schemas_module.RunStatus = _RunStatus
-    agent_schemas_module.MessageType = _MessageType
-    agent_schemas_module.ContentType = _ContentType
-    agent_schemas_module.TextContent = TextContent
-    agent_schemas_module.ImageContent = ImageContent
-    agent_schemas_module.VideoContent = VideoContent
-    agent_schemas_module.AudioContent = AudioContent
-    agent_schemas_module.FileContent = FileContent
-    agent_schemas_module.RefusalContent = RefusalContent
-
-    sys.modules["agentscope_runtime"] = runtime_module
-    sys.modules["agentscope_runtime.engine"] = engine_module
-    sys.modules["agentscope_runtime.engine.schemas"] = schemas_module
-    sys.modules[
-        "agentscope_runtime.engine.schemas.agent_schemas"
-    ] = agent_schemas_module
-
-
-def _build_channel(bot_prefix: str) -> Any:
-    _install_agentscope_runtime_stub()
-    from copaw.app.channels.imessage.channel import IMessageChannel
-
+def _build_channel(bot_prefix: str) -> IMessageChannel:
     return IMessageChannel(
         process=_dummy_process,
         enabled=True,
@@ -92,20 +24,20 @@ def _build_channel(bot_prefix: str) -> Any:
 
 def test_should_skip_empty_message() -> None:
     channel = _build_channel("@bot")
-    assert channel._should_skip_incoming_text("")
-    assert channel._should_skip_incoming_text(None)
+    assert channel.should_skip_incoming_text("")
+    assert channel.should_skip_incoming_text(None)
 
 
 def test_should_skip_message_without_prefix_when_prefix_configured() -> None:
     channel = _build_channel("@bot")
-    assert channel._should_skip_incoming_text("hello")
+    assert channel.should_skip_incoming_text("hello")
 
 
 def test_should_accept_message_with_prefix_when_prefix_configured() -> None:
     channel = _build_channel("@bot")
-    assert not channel._should_skip_incoming_text("@bot hello")
+    assert not channel.should_skip_incoming_text("@bot hello")
 
 
 def test_should_accept_any_non_empty_message_when_prefix_empty() -> None:
     channel = _build_channel("")
-    assert not channel._should_skip_incoming_text("hello")
+    assert not channel.should_skip_incoming_text("hello")


### PR DESCRIPTION
## Summary

This PR fixes inverted `bot_prefix` filtering in the iMessage channel.

In `IMessageChannel._watcher_loop`, incoming messages were previously skipped when they **started with** `bot_prefix`, which is opposite to expected behavior when `bot_prefix` is configured as an incoming command trigger.

## Root Cause

Previous logic:

```python
if not text or str(text).startswith(self.bot_prefix):
    continue
```

When `bot_prefix` was configured (e.g. `@bot`), valid trigger messages were skipped, while non-prefixed messages were processed.

## Changes

- Added a dedicated helper: `IMessageChannel._should_skip_incoming_text`.
- Updated polling loop to call this helper.
- New behavior:
  - skip empty message text
  - if `bot_prefix` is non-empty, skip messages that do **not** start with `bot_prefix`
  - keep processing when prefix matches

## Tests

Added `tests/channels/test_imessage_channel.py` covering:

- empty message is skipped
- non-prefixed message is skipped when `bot_prefix` is configured
- prefixed message is accepted when `bot_prefix` is configured
- any non-empty message is accepted when `bot_prefix` is empty

Local verification:

```bash
PYTHONPATH=src pytest -q
# 8 passed
```

## Runtime Verification (macOS iMessage)

Verified on a local macOS environment with iMessage DB access:

- iMessage watcher starts successfully.
- Non-prefixed inbound message (`hello`) did not enter processing.
- Prefixed inbound message (`@bot 你好`) entered processing (`recv ... text='@bot 你好'`) and reached agent runner.

## Impact

- Fixes iMessage `bot_prefix` trigger semantics.
- No behavior changes for channels other than iMessage.

Closes #404
