### PR TITLE
docs(contributing): require local pre-commit gate before PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,14 +28,25 @@
 
 ## Checklist
 
-- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
-- [ ] Tests pass locally (`pytest` or as relevant)
+- [ ] I ran `pre-commit run --all-files` locally and it passes
+- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
+- [ ] I ran tests locally (`pytest` or as relevant) and they pass
 - [ ] Documentation updated (if needed)
 - [ ] Ready for review
 
 ## Testing
 
 [How to test these changes]
+
+## Local Verification Evidence
+
+```bash
+pre-commit run --all-files
+# paste summary result
+
+pytest
+# paste summary result
+```
 
 ## Additional Notes
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,7 +35,7 @@ jobs:
           pre-commit run --all-files > pre-commit.log 2>&1 || true
           cat pre-commit.log
           if grep -q Failed pre-commit.log; then
-            echo -e "\e[41m  [**FAIL**] Please install pre-commit and format your code first. \e[0m"
+            echo -e "\e[41m  [**FAIL**] pre-commit checks failed. Run 'pre-commit run --all-files' locally, commit any auto-fixes, then push again. \e[0m"
             exit 1
           fi
           echo -e "\e[46m  ********************************Passed******************************** \e[0m"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,16 +67,16 @@ docs(skills): document Skills Hub import
 
 ### 4. Code and Quality
 
-- **Pre-commit:** Install and run pre-commit for consistent style and checks:
+- **Required local gate (must pass before push/PR):**
   ```bash
   pip install -e ".[dev]"
   pre-commit install
   pre-commit run --all-files
-  ```
-- **Tests:** Run tests before submitting:
-  ```bash
   pytest
   ```
+- **If pre-commit modifies files:** Commit those changes, then rerun
+  `pre-commit run --all-files` until it passes cleanly.
+- **CI policy:** Pull requests with failing pre-commit checks are not merge-ready.
 - **Frontend formatting:** If your changes involve the `console` or `website` directories, run the formatter before committing:
   ```bash
   cd console && npm run format

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -67,16 +67,16 @@ docs(skills): document Skills Hub import
 
 ### 4. 代码和质量
 
-- **Pre-commit：** 安装并运行 pre-commit 以保持一致的风格和检查：
+- **本地必跑门禁（push/提 PR 前必须通过）：**
   ```bash
   pip install -e ".[dev]"
   pre-commit install
   pre-commit run --all-files
-  ```
-- **测试：** 提交前运行测试：
-  ```bash
   pytest
   ```
+- **如果 pre-commit 自动修改了文件：** 先提交这些修改，再重复执行
+  `pre-commit run --all-files`，直到无修改且通过。
+- **CI 策略：** pre-commit 检查失败的 PR 视为未就绪（not merge-ready）。
 - **前端代码格式化：** 如果你的修改涉及到 `console` 或 `website` 目录，请在提交前运行格式化：
   ```bash
   cd console && npm run format


### PR DESCRIPTION
## Summary

This PR tightens contributor guidance and PR checks to reduce avoidable CI failures caused by skipping local pre-commit validation.

## Problem

Contributors can still open PRs without running the same local checks as CI. In practice, this leads to repeated failures in `Pre-commit Checks` (e.g. auto-fixes not committed, lint warnings in tests), which slows review and iteration.

## Changes

1. `CONTRIBUTING.md`
- Reframed quality section as a **required local gate** before push/PR.
- Explicitly requires running both:
  - `pre-commit run --all-files`
  - `pytest`
- Added instructions to commit auto-fixes and rerun until clean.
- Clarified CI policy: failing pre-commit means PR is not merge-ready.

2. `CONTRIBUTING_zh.md`
- Same strengthening in Chinese for consistency.

3. `.github/PULL_REQUEST_TEMPLATE.md`
- Changed checklist from optional/CI fallback language to explicit local execution.
- Added checkbox for handling pre-commit auto-fixes.
- Added **Local Verification Evidence** section to encourage command/result reporting.

4. `.github/workflows/pre-commit.yml`
- Improved failure message to tell contributors exactly what to do locally:
  run pre-commit, commit auto-fixes, push again.

## Validation

```bash
pre-commit run --all-files
PYTHONPATH=src pytest -q
```

Both passed locally.
