### PR TITLE
fix(providers): bound ollama list_models timeout to avoid hangs

### DIFF
--- a/src/copaw/providers/ollama_manager.py
+++ b/src/copaw/providers/ollama_manager.py
@@ -9,6 +9,7 @@ or a manifest.json. Ollama remains the single source of truth for its models.
 from __future__ import annotations
 
 import logging
+import math
 import os
 from datetime import datetime
 from typing import List, Optional, Union
@@ -59,6 +60,15 @@ def _ensure_ollama():
     return ollama
 
 
+def _warn_timeout_fallback(raw: str) -> None:
+    logger.warning(
+        "Invalid %s=%r, fallback to %.1fs",
+        _OLLAMA_LIST_TIMEOUT_ENV,
+        raw,
+        _DEFAULT_OLLAMA_LIST_TIMEOUT_SECONDS,
+    )
+
+
 def _get_ollama_list_timeout_seconds() -> float:
     """Resolve list_models timeout seconds from environment.
 
@@ -71,21 +81,11 @@ def _get_ollama_list_timeout_seconds() -> float:
     try:
         timeout = float(raw)
     except ValueError:
-        logger.warning(
-            "Invalid %s=%r, fallback to %.1fs",
-            _OLLAMA_LIST_TIMEOUT_ENV,
-            raw,
-            _DEFAULT_OLLAMA_LIST_TIMEOUT_SECONDS,
-        )
+        _warn_timeout_fallback(raw)
         return _DEFAULT_OLLAMA_LIST_TIMEOUT_SECONDS
 
-    if timeout <= 0:
-        logger.warning(
-            "Non-positive %s=%r, fallback to %.1fs",
-            _OLLAMA_LIST_TIMEOUT_ENV,
-            raw,
-            _DEFAULT_OLLAMA_LIST_TIMEOUT_SECONDS,
-        )
+    if not math.isfinite(timeout) or timeout <= 0:
+        _warn_timeout_fallback(raw)
         return _DEFAULT_OLLAMA_LIST_TIMEOUT_SECONDS
 
     return timeout

--- a/tests/test_ollama_manager_timeout.py
+++ b/tests/test_ollama_manager_timeout.py
@@ -9,6 +9,7 @@ from copaw.providers import ollama_manager
 def _make_fake_ollama(timeout_box: dict, response: dict):
     class _FakeClient:
         def __init__(self, *, timeout=None, **kwargs):
+            _ = kwargs
             timeout_box["timeout"] = timeout
 
         def list(self):
@@ -67,3 +68,45 @@ def test_list_models_falls_back_on_invalid_env_timeout(monkeypatch) -> None:
     ollama_manager.OllamaModelManager.list_models()
 
     assert timeout_box["timeout"] == 10.0
+
+
+def test_list_models_falls_back_on_non_positive_env_timeout(
+    monkeypatch,
+) -> None:
+    timeout_box: dict = {}
+    fake_ollama = _make_fake_ollama(timeout_box, {"models": []})
+
+    monkeypatch.setattr(
+        ollama_manager,
+        "_ensure_ollama",
+        lambda: fake_ollama,
+    )
+
+    for timeout_value in ("0", "-1"):
+        monkeypatch.setenv(
+            "COPAW_OLLAMA_LIST_TIMEOUT_SECONDS",
+            timeout_value,
+        )
+        ollama_manager.OllamaModelManager.list_models()
+        assert timeout_box["timeout"] == 10.0
+
+
+def test_list_models_falls_back_on_non_finite_env_timeout(
+    monkeypatch,
+) -> None:
+    timeout_box: dict = {}
+    fake_ollama = _make_fake_ollama(timeout_box, {"models": []})
+
+    monkeypatch.setattr(
+        ollama_manager,
+        "_ensure_ollama",
+        lambda: fake_ollama,
+    )
+
+    for timeout_value in ("nan", "inf", "-inf"):
+        monkeypatch.setenv(
+            "COPAW_OLLAMA_LIST_TIMEOUT_SECONDS",
+            timeout_value,
+        )
+        ollama_manager.OllamaModelManager.list_models()
+        assert timeout_box["timeout"] == 10.0


### PR DESCRIPTION
## Summary

Fixes a hang path in provider loading when Ollama host is unreachable.

- add bounded timeout for `OllamaModelManager.list_models()` via `ollama.Client(timeout=...)`
- default timeout: **10 seconds**
- allow override via env var: `COPAW_OLLAMA_LIST_TIMEOUT_SECONDS`
- invalid/non-positive env values fall back to default
- add regression tests for default timeout, env override, and invalid fallback

## Root Cause

`load_providers_json()` is called by multiple APIs (including settings/model related APIs) and always runs `sync_ollama_models()`.

`sync_ollama_models()` called `OllamaModelManager.list_models()`, which previously used `ollama.list()` with SDK default timeout `None` (unbounded). If `OLLAMA_HOST` is unreachable, request handling can block for a long time and appear as UI freeze.

## Reproduction

1. Set unreachable Ollama host, e.g. `OLLAMA_HOST=http://192.0.2.1:11434`
2. Call APIs that trigger provider loading (`/api/models`, `/api/models/active`, or chat pre-check path)
3. Request can stall for a long time due to unbounded ollama SDK call

## Validation

Local checks run:

- `PYTHONPATH=src pytest -q` → `7 passed`
- `pre-commit run --all-files` → all hooks passed
- timeout behavior check with `COPAW_OLLAMA_LIST_TIMEOUT_SECONDS=0.2` against unreachable host shows bounded return (`~0.339s` in local run)

## Impact

- prevents long/unbounded request hangs caused by unreachable Ollama host
- keeps existing failure behavior (Ollama sync failure is swallowed by `sync_ollama_models`, so app stays available)

Closes #413
