### PR TITLE
fix(cli): remove redundant provider validation in config key command

### DIFF
--- a/src/copaw/cli/providers_cmd.py
+++ b/src/copaw/cli/providers_cmd.py
@@ -397,9 +397,6 @@ def config_cmd() -> None:
 @click.argument("provider_id", required=False, default=None)
 def config_key_cmd(provider_id: str | None) -> None:
     """Configure a provider's API key."""
-    if provider_id is not None and provider_id not in PROVIDERS:
-        click.echo(click.style(f"Unknown provider: {provider_id}", fg="red"))
-        raise SystemExit(1)
     configure_provider_api_key_interactive(provider_id)
 
 


### PR DESCRIPTION
## Description

As title says

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]
