### PR TITLE
fix(providers): correct OpenAI model IDs - replace gpt-5-chat with gpt-5, add gpt-5.2

### DIFF
--- a/src/copaw/providers/registry.py
+++ b/src/copaw/providers/registry.py
@@ -42,7 +42,8 @@ ALIYUN_CODINGPLAN_MODELS: List[ModelInfo] = [
 ]
 
 OPENAI_MODELS: List[ModelInfo] = [
-    ModelInfo(id="gpt-5-chat", name="GPT-5 Chat"),
+    ModelInfo(id="gpt-5.2", name="GPT-5.2"),
+    ModelInfo(id="gpt-5", name="GPT-5"),
     ModelInfo(id="gpt-5-mini", name="GPT-5 Mini"),
     ModelInfo(id="gpt-5-nano", name="GPT-5 Nano"),
     ModelInfo(id="gpt-4.1", name="GPT-4.1"),


### PR DESCRIPTION
## Problem

The OpenAI provider model list (added in #138) includes `gpt-5-chat` as a default model ID. However, **`gpt-5-chat` is not a valid OpenAI API model ID** — calling the Chat Completions API with this model returns a `model_not_found` error.

According to the [OpenAI Models documentation](https://developers.openai.com/api/docs/models):
- `gpt-5-chat` does not exist in the OpenAI API
- The ChatGPT-specific variant `gpt-5-chat-latest` is listed under "ChatGPT models — not recommended for API use"
- The correct API model ID for GPT-5 is simply `gpt-5`

> **Note**: `gpt-5-chat` **is** a valid model on Azure OpenAI (Preview, no registration required) per the [Azure OpenAI Models documentation](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure), so the Azure OpenAI model list is **not changed**.

## Changes

- Replace `gpt-5-chat` → `gpt-5` in `OPENAI_MODELS` only
- Add `gpt-5.2` (OpenAI's current flagship model) to `OPENAI_MODELS`
- `AZURE_OPENAI_MODELS` is unchanged (gpt-5-chat is valid on Azure)

## Updated OpenAI model list

gpt-5.2, gpt-5, gpt-5-mini, gpt-5-nano, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, o3, o4-mini, gpt-4o, gpt-4o-mini

## Reference

- OpenAI available models: https://developers.openai.com/api/docs/models
- Azure OpenAI available models: https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI integration now includes GPT-5.2 and GPT-5, replacing the previous GPT-5 Chat option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->