### PR TITLE
ci: add PR labeler workflow for first-time contributors

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -18,10 +18,10 @@ jobs:
             const author = context.payload.pull_request.user.login;
 
             const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${author}`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${author} is:closed`,
             });
 
-            const isFirstTime = searchResult.total_count <= 1;
+            const isFirstTime = searchResult.total_count === 0;
 
             if (isFirstTime) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`.github/workflows/pr-label.yml`) that automatically labels PRs with `first-time-contributor` when the author has no prior PRs in the repo.
- Uses `pull_request_target` so it works for PRs from forks.
- The workflow file is named `pr-label.yml` so additional labeling jobs can be added later.

## Test plan
- Open a PR from an account that has never contributed to the repo and verify the `first-time-contributor` label is applied.
- Open a PR from an existing contributor and verify no label is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that detects first-time contributors and applies a "first-time-contributor" label to qualifying pull requests, improving visibility for new contributors and streamlining PR moderation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->