### PR TITLE
Add a doc link to the channel card of the console

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -24,8 +24,16 @@ interface ChannelDrawerProps {
   onSubmit: (values: SingleChannelConfig) => void;
 }
 
-// DingTalk doc URL
-const dingtalkDocUrl = "https://copaw.agentscope.io/docs/channels";
+// Doc URLs per channel (anchors on https://copaw.agentscope.io/docs/channels)
+const CHANNEL_DOC_URLS: Partial<Record<ChannelKey, string>> = {
+  dingtalk:
+    "https://copaw.agentscope.io/docs/channels/#%E9%92%89%E9%92%89%E6%8E%A8%E8%8D%90",
+  feishu: "https://copaw.agentscope.io/docs/channels/#%E9%A3%9E%E4%B9%A6",
+  imessage:
+    "https://copaw.agentscope.io/docs/channels/#iMessage%E4%BB%85-macOS",
+  discord: "https://copaw.agentscope.io/docs/channels/#Discord",
+  qq: "https://copaw.agentscope.io/docs/channels/#QQ",
+};
 
 export function ChannelDrawer({
   open,
@@ -163,15 +171,15 @@ export function ChannelDrawer({
               ? `${activeLabel} ${t("channels.settings")}`
               : t("channels.channelSettings")}
           </span>
-          {activeKey === "dingtalk" && (
+          {activeKey && CHANNEL_DOC_URLS[activeKey] && (
             <Button
               type="text"
               size="small"
               icon={<LinkOutlined />}
-              onClick={() => window.open(dingtalkDocUrl, "_blank")}
+              onClick={() => window.open(CHANNEL_DOC_URLS[activeKey], "_blank")}
               className={styles.dingtalkDocBtn}
             >
-              DingTalk Doc
+              {activeLabel} Doc
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Documentation button now supports channel-specific links with dynamic labels.
  * Button visibility optimized to display only when documentation is available for the selected channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->