### PR TITLE
fix: remove failed user messages from memory to prevent session poisoning

### DIFF
--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -150,11 +150,38 @@ class AgentRunner(Runner):
                 await agent.interrupt()
             raise
         except Exception as e:
+            # Dump before cleanup so the debug file captures the full
+            # memory state including the message that caused the error.
             debug_dump_path = write_query_error_dump(
                 request=request,
                 exc=e,
                 locals_=locals(),
             )
+
+            # Remove the user messages that were added to memory before the
+            # error.  Without this, the malformed content (e.g. a bad image
+            # URI) is persisted by save_session_state in the finally block
+            # and poisons every subsequent request in this session.
+            if agent is not None and msgs:
+                try:
+                    msg_ids = [
+                        m.id for m in (
+                            msgs if isinstance(msgs, list) else [msgs]
+                        )
+                        if hasattr(m, "id")
+                    ]
+                    if msg_ids:
+                        await agent.memory.delete(msg_ids)
+                        logger.info(
+                            "Removed %d failed msg(s) from memory: %s",
+                            len(msg_ids),
+                            msg_ids,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to remove msgs from memory",
+                        exc_info=True,
+                    )
             path_hint = (
                 f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
             )


### PR DESCRIPTION
## Summary

Related: #557

When `query_handler` raises an exception (e.g. a DashScope 400 from a malformed image URI), the user's input message has already been added to agent memory by `ReActAgent.reply()`. The `finally` block then calls `save_session_state()`, persisting the poisoned memory to disk. Every subsequent request in the same session replays the bad message and fails again — the session is permanently broken until the user runs `/start`.

This PR removes the failed user messages from memory in the `except` block before the session state is saved, so a single error does not permanently break the session.

## Changes

- In `runner.py` `query_handler`: on exception, delete the current request's `msgs` from `agent.memory` by their IDs before re-raising
- Wrapped in try/except so a failure to clean up memory does not mask the original error

## How it works

```
ReActAgent.reply(msg)
  → self.memory.add(msg)     # msg is in memory now
  → LLM call fails           # exception
  → propagates to runner

runner.query_handler except block:
  → agent.memory.delete([msg.id])  # ← NEW: remove the poisoned message
  → raise

runner.query_handler finally block:
  → save_session_state()     # saves clean memory (without the bad msg)
```

## Testing

- Send image via Telegram → 400 error → send text in same session → works (was broken before)
- Normal text conversation → no change in behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery: when processing fails, the app now captures memory state before cleanup and removes the affected user messages from session memory to prevent malformed content from persisting. Deletion issues are logged but do not mask the original error, improving stability and observability during failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->