### PR TITLE
fix: use bare absolute path instead of file:// URI for local media blocks

### DIFF
--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -120,28 +120,33 @@ def _media_type_from_path(path: str) -> str:
     }.get(ext, "audio/octet-stream")
 
 
+
+
 def _update_block_with_local_path(
     block: dict,
     block_type: str,
     local_path: str,
 ) -> dict:
     """Update block with downloaded local path."""
+    resolved = str(Path(local_path).resolve())
     if block_type == "file":
         block["source"] = local_path
         if not block.get("filename"):
             block["filename"] = os.path.basename(local_path)
+    elif block_type == "audio":
+        # Audio needs media_type for formats mimetypes doesn't know (e.g. .amr).
+        block["source"] = {
+            "type": "url",
+            "url": resolved,
+            "media_type": _media_type_from_path(local_path),
+        }
     else:
-        if block_type == "audio":
-            block["source"] = {
-                "type": "url",
-                "url": Path(local_path).as_uri(),
-                "media_type": _media_type_from_path(local_path),
-            }
-        else:
-            block["source"] = {
-                "type": "url",
-                "url": Path(local_path).as_uri(),
-            }
+        # Store bare absolute path; each provider's formatter handles
+        # the conversion (DashScope adds file://, OpenAI reads to base64, etc.)
+        block["source"] = {
+            "type": "url",
+            "url": resolved,
+        }
     return block
 
 


### PR DESCRIPTION
## Summary

Fixes #557 (supersedes #558 which used a different approach)

`_update_block_with_local_path()` used `Path.as_uri()` producing `file:///` URIs. DashScope's `_is_accessible_local_file()` calls `os.path.isfile("file:///...")` which returns `False`, so the URI is sent as-is to the API — causing a 400 error. This also poisons the session: the malformed message is persisted to memory before the error, breaking all subsequent requests until `/start`.

## Root Cause

```python
# Before (broken)
source.url = Path(local_path).as_uri()   # "file:///Users/.../xxx.jpg"
os.path.isfile("file:///Users/.../xxx.jpg")  # False → sent as web URL → 400

# After (fixed)
source.url = str(Path(local_path).resolve())  # "/Users/.../xxx.jpg"
os.path.isfile("/Users/.../xxx.jpg")           # True → formatter handles it
```

## Approach

Store bare absolute paths instead of `file:///` URIs. Each provider's formatter already handles the conversion:

- DashScope: `_is_accessible_local_file()` → `True` → prepends `file://`
- OpenAI: `os.path.exists()` → `True` → reads file and converts to base64
- Anthropic, Gemini, etc.: similar local file detection in their formatters

This keeps memory and session state lightweight (just a path string, no base64 blobs) and delegates format conversion to the framework's formatter layer where it belongs.

## Changes

One file, minimal diff:
- All `Path(local_path).as_uri()` → `str(Path(local_path).resolve())`
- Audio blocks: same change, `media_type` preserved for formats `mimetypes` doesn't know (e.g. `.amr`)
- Removed unused `_read_as_base64_source()` from earlier iteration

## Testing

Tested locally with Telegram channel + DashScope provider:
- Send image → agent processes and replies correctly (was 400 before)
- Send image + caption → works
- Send text after image in same session → works (no session poisoning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced audio and media file handling in message processing with improved path resolution and source formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->