### PR TITLE
fix(feishu): support post (rich text) messages and fix local image pa…

### DIFF
--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -6,6 +6,7 @@ This module handles:
 - Message content manipulation
 - Message validation
 """
+
 import logging
 import os
 import urllib.parse
@@ -138,9 +139,15 @@ def _update_block_with_local_path(
                 "media_type": _media_type_from_path(local_path),
             }
         else:
+            # Use the raw local path (not a file:// URI) so the OpenAI
+            # formatter (_to_openai_image_url) can detect it as a local
+            # file via os.path.exists() and encode it as base64.
+            # Converting to a file:// URI causes the formatter to treat it
+            # as a web URL and pass it unchanged to the provider (e.g.
+            # DashScope/Qwen), which rejects it with an invalid-URL error.
             block["source"] = {
                 "type": "url",
-                "url": Path(local_path).as_uri(),
+                "url": local_path,
             }
     return block
 

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -602,6 +602,84 @@ class FeishuChannel(BaseChannel):
                         text_parts.append("[audio: download failed]")
                 else:
                     text_parts.append("[audio: missing key]")
+            elif msg_type == "post":
+                # Feishu "post" is rich text: mixed text + images.
+                # Two possible structures from Feishu clients:
+                # 1) Unwrapped: {"title": "...", "content": [[...]]}
+                # 2) Wrapped:   {"zh_cn": {"title": "...", "content": [[...]]}}
+                try:
+                    post_data = json.loads(content_raw) if content_raw else {}
+                except (json.JSONDecodeError, Exception):
+                    logger.exception(
+                        "feishu post: failed to parse content_raw"
+                    )
+                    post_data = {}
+                if "content" in post_data:
+                    lang_content = post_data
+                else:
+                    lang_content = post_data.get("zh_cn") or next(
+                        (v for v in post_data.values() if isinstance(v, dict)),
+                        {},
+                    )
+                if isinstance(lang_content, dict):
+                    title = (lang_content.get("title") or "").strip()
+                    if title:
+                        text_parts.append(title)
+                    paragraphs = lang_content.get("content") or []
+                    for paragraph in paragraphs:
+                        if not isinstance(paragraph, list):
+                            continue
+                        para_texts: List[str] = []
+                        for elem in paragraph:
+                            if not isinstance(elem, dict):
+                                continue
+                            tag = elem.get("tag", "")
+                            if tag == "text":
+                                t = (elem.get("text") or "").strip()
+                                if t:
+                                    para_texts.append(t)
+                            elif tag == "img":
+                                image_key = elem.get("image_key", "")
+                                if image_key:
+                                    if para_texts:
+                                        text_parts.append(" ".join(para_texts))
+                                        para_texts = []
+                                    url_or_path = (
+                                        await self._download_image_resource(
+                                            message_id,
+                                            image_key,
+                                        )
+                                    )
+                                    if url_or_path:
+                                        content_parts.append(
+                                            ImageContent(
+                                                type=ContentType.IMAGE,
+                                                image_url=url_or_path,
+                                            ),
+                                        )
+                                    else:
+                                        text_parts.append(
+                                            "[image: download failed]",
+                                        )
+                            elif tag == "a":
+                                link_text = (elem.get("text") or "").strip()
+                                href = (elem.get("href") or "").strip()
+                                if link_text and href:
+                                    para_texts.append(f"{link_text}({href})")
+                                elif link_text:
+                                    para_texts.append(link_text)
+                                elif href:
+                                    para_texts.append(href)
+                            elif tag == "at":
+                                user_name = (
+                                    elem.get("user_name")
+                                    or elem.get("userName")
+                                    or ""
+                                ).strip()
+                                if user_name:
+                                    para_texts.append(f"@{user_name}")
+                        if para_texts:
+                            text_parts.append(" ".join(para_texts))
             else:
                 text_parts.append(f"[{msg_type}]")
 


### PR DESCRIPTION
## Description

1. **Post (rich text) message support: ** Feishu post messages (mixed image + text sent together) were silently dropped — the handler fell into the else branch and replaced the entire content with [post]. This PR parses the post JSON structure, downloads embedded images via _download_image_resource, and reconstructs both text_parts and content_parts correctly. Handles both the unwrapped format {"title": ..., "content": [...]} and the language-wrapped format {"zh_cn": {...}} seen in different Feishu clients.

2. **Local image path encoding:** When Feishu downloaded an image to a local path (e.g. ~/.copaw/media/img.webp), the path was converted to a file:// URI via Path.as_uri(). The agentscope OpenAI formatter treats any URL with a scheme as a remote URL and passes it unchanged to the LLM provider. DashScope/Qwen rejects file:// URIs with a 400 InternalError.Algo.InvalidParameter. Fix: keep the raw absolute path for image/video blocks so the formatter detects it via os.path.exists() and encodes it as a base64 data URL before the API call. Audio blocks retain file:// + media_type as required by the qwen-omni audio pipeline.

[Describe what this PR does and why]

**Related Issue:** Fixes #549 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ x ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Send local picture messages and mixed messages with both pictures and text. The response performance is correct.

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Feishu rich post messages: parses titles, paragraphs, images (auto-downloaded), hyperlinks, and user mentions into text and media parts.

* **Bug Fixes**
  * Improved local file path handling so non-audio local attachments are recognized and encoded correctly for downstream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->