### PR TITLE
fix(tool): fix execute_shell_command encoding issue on Windows

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -129,8 +129,8 @@ async def execute_shell_command(
 
 def smart_decode(data: bytes) -> str:
     try:
-        return data.decode("utf-8").strip("\n")
+        return data.decode("utf-8").strip("\r\n")
     except UnicodeDecodeError:
         pass
 
-    return data.decode(locale.getpreferredencoding(False), errors="replace").strip("\n")
+    return data.decode(locale.getpreferredencoding(False), errors="replace").strip("\r\n")


### PR DESCRIPTION
## Description

Windows 环境下使用 Windows Terminal 等终端启动 copaw, execute_shell_command 工具会出现输出乱码问题。原因是使用 locale.getpreferredencoding() 返回的系统编码（cp936/GBK）去解码 UTF-8 输出的内容。新增 smart_decode 函数，优先尝试 UTF-8，解码失败时回退到系统编码，兼容传统 CMD 终端。

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ x] Ready for review

## Testing

在 Windows 中文环境使用 Windows Terminal 启动 copaw, 让 agent 使用 execute_shell_command  执行 dir ,观察目录两个字会不会变成乱码

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal improvement: centralized handling and decoding of command output and error streams, applied uniformly across success and timeout/error cases. No changes to user-facing behavior; existing output trimming and error handling remain intact. These tweaks reduce duplicated logic and make command execution handling more robust without impacting functionality visible to end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->