### PR TITLE
fix(console) Optimize Web console missing message

### DIFF
--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode }) => {
     build: {
       // Output to CoPaw's console directory,
       // so we don't need to copy files manually after build.
-      outDir: "../src/copaw/console",
+      outDir: path.resolve(__dirname, "../src/copaw/console"),
       emptyOutDir: true,
     },
   };

--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -208,7 +208,7 @@ def read_root():
         "message": (
             "CoPaw Web Console is not available. "
             "If you installed CoPaw from source code, please run "
-            "`npm ci && npm run build` in the CoPaw's `console` "
+            "`npm ci && npm run build` in CoPaw's `console/` "
             "directory, and restart CoPaw to enable the web console."
         ),
     }

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -63,8 +63,7 @@ Once `copaw app` is running, open `http://127.0.0.1:8088/` in your browser to
 access the **Console** — a web UI for chat, channels, cron, skills, models,
 and more. See [Console](./console) for a full walkthrough.
 
-If the frontend was not built, the root URL returns `{"message": "CoPaw Web Console is not available. ..."}`
-but the API still works.
+If the frontend was not built, the root URL returns a JSON message like `{"message": "CoPaw Web Console is not available."}` but the API still works.
 
 **To build the frontend:** in the project's `console/` directory run
 `npm ci && npm run build` (output in `src/copaw/console/`). Docker images and pip

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -57,7 +57,7 @@ copaw app --log-level debug           # 详细日志
 `copaw app` 启动后，在浏览器打开 `http://127.0.0.1:8088/` 即可进入 **控制台** ——
 一个用于对话、频道、定时任务、技能、模型等的 Web 管理界面。详见 [控制台](./console)。
 
-若未构建前端，根路径返回 `{"message": "CoPaw Web Console is not available. ..."}`，API 仍可正常使用。
+若未构建前端，根路径会返回类似 `{"message": "CoPaw Web Console is not available."}` 的提示信息（实际文案可能调整），API 仍可正常使用。
 
 **构建方式：** 在项目 `console/` 目录下执行 `npm ci && npm run build`，产物在
 `src/copaw/console/`。Docker 镜像或 pip 安装包已内置控制台，无需单独构建。


### PR DESCRIPTION
## Description

When building CoPaw from source (`pip install -e .`), the web console is not built. And the webpage only displays a `Hello World` message, which is confusing.

This PR optimizes the message, and points the npm build output path to `src/copaw/console` to avoid copying after the build process.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed web console build output location and ensured the output directory is cleaned before each build.

* **Bug Fixes**
  * Replaced generic root response with a clearer message explaining how to build and enable the web console when the frontend is not available.

* **Documentation**
  * Updated docs to reflect the new console build path and revised setup guidance for including the frontend in packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->