### PR TITLE
fix(channels): handle feishu [post] mssage type

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -527,7 +527,11 @@ class FeishuChannel(BaseChannel):
                 if text:
                     text_parts.append(text)
             elif msg_type == "post":
-                text_parts.extend(self._parse_post_content(content_raw))
+                parsed_post = self._parse_post_content(content_raw)
+                if parsed_post:
+                    text_parts.extend(parsed_post)
+                else:
+                    text_parts.append("[post]")
             elif msg_type == "image":
                 image_key = extract_json_key(
                     content_raw,


### PR DESCRIPTION
## Description

feat(feishu): add support for parsing 'post' message type

Extract title and content from Feishu post messages, handling both direct and nested structure formats. Convert post elements (text, links, mentions, images) into plain text representation for downstream processing.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [x] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feishu "post" messages now include parsed titles and rich-text content so posts appear alongside other message types.
* **Bug Fixes**
  * Improved parsing robustness with safe fallback and error logging when post content cannot be extracted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->