### PR TITLE
[Docs]: add Telegram channel documentation and doc link

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -33,6 +33,7 @@ const CHANNEL_DOC_URLS: Partial<Record<ChannelKey, string>> = {
     "https://copaw.agentscope.io/docs/channels/#iMessage%E4%BB%85-macOS",
   discord: "https://copaw.agentscope.io/docs/channels/#Discord",
   qq: "https://copaw.agentscope.io/docs/channels/#QQ",
+  telegram: "https://copaw.agentscope.io/docs/channels/#Telegram",
 };
 
 export function ChannelDrawer({

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -410,6 +410,61 @@ You can also fill them in the Console UI.
 
 ---
 
+## Telegram
+
+### Get Telegram bot credentials
+
+1. Open Telegram and search for `@BotFather` to add a Bot (make sure it is the official @BotFather with a blue verified badge).
+2. Open the chat with @BotFather and follow the instructions to create a new bot
+
+   ![Create bot](https://img.alicdn.com/imgextra/i1/O1CN01wVVmbY1qkcxBn8Oc0_!!6000000005534-0-tps-817-1279.jpg)
+
+3. Create the bot name in the dialog and copy the bot_token
+
+   ![Copy token](https://img.alicdn.com/imgextra/i3/O1CN01KUMvBW1UnuF599tNX_!!6000000002563-0-tps-1209-1237.jpg)
+
+### Configure the Bot
+
+You can configure via the Console UI or by editing `~/.copaw/config.json`.
+
+**Method 1:** Configure in the Console
+
+Go to **Control → Channels**, click **Telegram**, and enter the **Bot Token** you obtained.
+
+![Console](https://img.alicdn.com/imgextra/i4/O1CN01utJvvg1dmNSiFOOJi_!!6000000003778-0-tps-1920-993.jpg)
+
+**Method 2:** Edit `~/.copaw/config.json`
+
+Find `channels.telegram` in `config.json` and fill in the fields, for example:
+
+```json
+"telegram": {
+    "enabled": true,
+    "bot_prefix": "[BOT]",
+    "bot_token": "your Bot Token",
+    "http_proxy": "",
+    "http_proxy_auth": ""
+}
+```
+
+If you need a proxy to access the Telegram API (e.g. for network restrictions):
+
+- **http_proxy** — e.g. `http://127.0.0.1:7890`
+- **http_proxy_auth** — `username:password` if the proxy requires auth, otherwise leave empty
+
+### Notes
+
+The Telegram whitelist mechanism is still under construction. It is recommended to deploy for personal use only and avoid exposing your bot username publicly.
+
+It is recommended to configure the following in `@BotFather`:
+
+```
+/setprivacy -> ENABLED    # Restrict bot reply permissions
+/setjoingroups -> DISABLED # Block group invitations
+```
+
+---
+
 ## Appendix
 
 ### Config overview
@@ -421,6 +476,7 @@ You can also fill them in the Console UI.
 | iMessage | imessage   | db_path, poll_sec (macOS only)                                          |
 | Discord  | discord    | bot_token; optional http_proxy, http_proxy_auth                         |
 | QQ       | qq         | app_id, client_secret                                                   |
+| Telegram | telegram   | bot_token; optional http_proxy, http_proxy_auth                         |
 
 Field details and structure are in the tables above and [Config & working dir](./config).
 
@@ -438,6 +494,7 @@ done). **✗** = not supported (not possible on this channel).
 | Discord  | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
 | iMessage | ✓         | ✗          | ✗          | ✗          | ✗         | ✓         | ✗          | ✗          | ✗          | ✗         |
 | QQ       | ✓         | 🚧         | 🚧         | 🚧         | 🚧        | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
+| Telegram | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
 
 Notes:
 
@@ -452,6 +509,7 @@ Notes:
   possible on this channel).
 - **QQ**: Receiving attachments as multimodal and sending real media are 🚧;
   currently text + link-only.
+- **Telegram**: Attachments are parsed as files on receive and can be opened in the corresponding format (image / voice / video / file) within the Telegram chat interface.
 
 ### Changing config via HTTP
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -402,6 +402,61 @@
 
 ---
 
+## Telegram
+
+### 获取 Telegram 机器人凭证
+
+1. 打开 Telegram 并搜索 `@BotFather` 添加 Bot（注意需要是官方 @BotFather，有蓝色认证标识）。
+2. 打开与 @BotFather 的聊天，根据对话中的指引创建新机器人
+
+   ![创建机器人](https://img.alicdn.com/imgextra/i1/O1CN01wVVmbY1qkcxBn8Oc0_!!6000000005534-0-tps-817-1279.jpg)
+
+3. 在对话框中创建 bot_name，复制 bot_token
+
+   ![复制token](https://img.alicdn.com/imgextra/i3/O1CN01KUMvBW1UnuF599tNX_!!6000000002563-0-tps-1209-1237.jpg)
+
+### 绑定 Bot
+
+可以在console前端配置，或者修改`~/.copaw/config.json`。
+
+**方法1**: 在console前端配置
+
+从"控制→频道"找到**Telegram**，点击后填入刚刚获取的**Bot Token**
+
+![console](https://img.alicdn.com/imgextra/i4/O1CN01utJvvg1dmNSiFOOJi_!!6000000003778-0-tps-1920-993.jpg)
+
+**方法2**: 修改`~/.copaw/config.json`
+
+在 `config.json` 里找到 `channels.telegram`，填入对应信息，例如：
+
+```json
+"telegram": {
+    "enabled": true,
+    "bot_prefix": "[BOT]",
+    "bot_token": "你的 Bot Token",
+    "http_proxy": "",
+    "http_proxy_auth": ""
+}
+```
+
+国内网络访问 Telegram API 可能需代理。如需代理：
+
+- **http_proxy** — 例如 `http://127.0.0.1:7890`
+- **http_proxy_auth** — 若代理需鉴权，填 `用户名:密码`，否则留空
+
+### 备注
+
+目前telegram白名单机制仍在施工中，推荐个人场景部署，不暴露username到公共环境中。
+
+建议在 `@BotFather` 设置：
+
+```
+/setprivacy -> ENABLED # 设置bot回复权限
+/setjoingroups -> DISABLED # 拦截Group邀请
+```
+
+---
+
 ## 附录
 
 ### 配置总览
@@ -413,6 +468,7 @@
 | iMessage | imessage | db_path, poll_sec（仅 macOS）                                       |
 | Discord  | discord  | bot_token；可选 http_proxy, http_proxy_auth                         |
 | QQ       | qq       | app_id, client_secret                                               |
+| Telegram | telegram | bot_token；可选 http_proxy, http_proxy_auth                         |
 
 各频道字段与完整结构见上文表格及 [配置与工作目录](./config)。
 
@@ -428,6 +484,7 @@
 | Discord  | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
 | iMessage | ✓        | ✗        | ✗        | ✗        | ✗        | ✓        | ✗        | ✗        | ✗        | ✗        |
 | QQ       | ✓        | 🚧       | 🚧       | 🚧       | 🚧       | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
+| Telegram | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
 
 说明：
 
@@ -436,6 +493,7 @@
 - **Discord**：接收时附件会解析为图片 / 视频 / 音频 / 文件并传入 Agent；回复时真实附件发送为 🚧 施工中，当前仅以链接形式附在文本中。
 - **iMessage**：基于本地 imsg + 数据库轮询，仅支持文本收发；平台/实现限制，无法支持附件（✗）。
 - **QQ**：接收侧附件解析为多模态、发送侧真实媒体均为 🚧 施工中，当前仅文本 + 链接形式。
+- **Telegram**：接收时附件会解析为文件并传入，可在telegram对话界面以对应格式打开（图片 / 语音 / 视频 / 文件）
 
 ### 通过 HTTP 修改配置
 


### PR DESCRIPTION
## Description

Add Telegram related channel documentation and doc link.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [x] Tests pass locally (`pytest` or as relevant)
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

N/A

## Additional Notes

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Telegram channel integration guide (credential retrieval, Console and config.json setup examples, proxy guidance, privacy/whitelist notes, and multimodal messaging capabilities).
  * Telegram now appears in channel configuration and multimodal support tables and the documentation index for quick access.
  * Notes: Telegram attachments are parsed as files and opened in-chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->