### PR TITLE
fix(agents): avoid file URI for local image sources

### DIFF
--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -30,8 +30,34 @@ def _is_allowed_media_path(path: str) -> bool:
         resolved = Path(path).expanduser().resolve()
         root = _ALLOWED_MEDIA_ROOT.resolve()
         return resolved.is_file() and resolved.is_relative_to(root)
-    except Exception:
+    except Exception as e:
+        logger.debug("Error checking allowed media path '%s': %s", path, e)
         return False
+
+
+def _looks_like_windows_abs_path(
+    url: str,
+    parsed: urllib.parse.ParseResult,
+) -> bool:
+    """True when url is like C:\\foo\\bar (urlparse sees scheme='c')."""
+    return (
+        len(parsed.scheme) == 1
+        and len(url) > 2
+        and url[1] == ":"
+        and url[2] in ("/", "\\")
+    )
+
+
+def _looks_like_local_path_reference(
+    url: str,
+    parsed: urllib.parse.ParseResult,
+) -> bool:
+    """True when URL should be treated as local path input."""
+    return (
+        parsed.scheme == "file"
+        or (parsed.scheme == "" and parsed.netloc == "")
+        or _looks_like_windows_abs_path(url, parsed)
+    )
 
 
 def _extract_local_path_from_url(url: str) -> Optional[str]:
@@ -45,13 +71,26 @@ def _extract_local_path_from_url(url: str) -> Optional[str]:
             if candidate.is_file():
                 return str(candidate)
             return None
-        except Exception:
+        except Exception as e:
+            logger.debug(
+                "Error extracting local path from file URL '%s': %s",
+                url,
+                e,
+            )
             return None
 
-    if parsed.scheme == "" and parsed.netloc == "":
-        candidate = Path(url).expanduser()
-        if candidate.is_file():
-            return str(candidate)
+    if _looks_like_local_path_reference(url, parsed):
+        try:
+            candidate = Path(url).expanduser()
+            if candidate.is_file():
+                return str(candidate)
+        except Exception as e:
+            logger.debug(
+                "Error extracting local path from plain path '%s': %s",
+                url,
+                e,
+            )
+            return None
 
     return None
 
@@ -87,12 +126,20 @@ async def _process_single_file_block(
     elif isinstance(source, dict) and source.get("type") == "url":
         url = source.get("url", "")
         if url:
-            local_path = _extract_local_path_from_url(url)
-            if local_path and not _is_allowed_media_path(local_path):
-                logger.warning(
-                    "Rejected local media path outside allowed media dir",
-                )
-                return None
+            parsed = urllib.parse.urlparse(url)
+            if _looks_like_local_path_reference(url, parsed):
+                local_path = _extract_local_path_from_url(url)
+                if not local_path:
+                    logger.warning(
+                        "Rejected local media path that is not a regular file",
+                    )
+                    return None
+                if not _is_allowed_media_path(local_path):
+                    logger.warning(
+                        "Rejected local media path outside allowed media dir",
+                    )
+                    return None
+                return str(Path(local_path).expanduser().resolve())
             local_path = await download_file_from_url(
                 url,
                 filename,

--- a/tests/agents/utils/test_message_processing.py
+++ b/tests/agents/utils/test_message_processing.py
@@ -73,6 +73,15 @@ def test_process_single_file_block_accepts_plain_local_path_inside_media_root(
     inside_file.parent.mkdir(parents=True, exist_ok=True)
     inside_file.write_bytes(b"ok")
 
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("download_file_from_url should not be called")
+
+    monkeypatch.setattr(
+        message_processing,
+        "download_file_from_url",
+        _should_not_be_called,
+    )
+
     result = asyncio.run(
         message_processing._process_single_file_block(
             source={"type": "url", "url": str(inside_file)},
@@ -107,3 +116,84 @@ def test_extract_local_path_from_file_url(tmp_path):
     )
 
     assert result == str(image_path)
+
+
+def test_extract_local_path_from_plain_path(tmp_path):
+    image_path = tmp_path / "plain.png"
+    image_path.write_bytes(b"img")
+
+    result = message_processing._extract_local_path_from_url(str(image_path))
+
+    assert result == str(image_path)
+
+
+def test_extract_local_path_returns_none_for_remote_and_invalid_urls():
+    assert (
+        message_processing._extract_local_path_from_url(
+            "https://example.com/image.png",
+        )
+        is None
+    )
+    assert (
+        message_processing._extract_local_path_from_url(
+            "http://example.com/image.png",
+        )
+        is None
+    )
+    assert (
+        message_processing._extract_local_path_from_url("not a url://") is None
+    )
+
+
+def test_extract_local_path_supports_windows_absolute_path(monkeypatch):
+    windows_path = r"C:\tmp\sample.png"
+
+    original_is_file = Path.is_file
+
+    def _fake_is_file(self):
+        if str(self) == windows_path:
+            return True
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", _fake_is_file)
+
+    result = message_processing._extract_local_path_from_url(windows_path)
+
+    assert result == windows_path
+
+
+def test_process_single_file_block_rejects_local_directory_paths(
+    tmp_path,
+    monkeypatch,
+):
+    media_root = tmp_path / "media"
+    media_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(message_processing, "_ALLOWED_MEDIA_ROOT", media_root)
+
+    media_dir = media_root / "telegram"
+    media_dir.mkdir(parents=True, exist_ok=True)
+
+    async def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("download_file_from_url should not be called")
+
+    monkeypatch.setattr(
+        message_processing,
+        "download_file_from_url",
+        _should_not_be_called,
+    )
+
+    plain_result = asyncio.run(
+        message_processing._process_single_file_block(
+            source={"type": "url", "url": str(media_dir)},
+            filename=None,
+        ),
+    )
+    file_url_result = asyncio.run(
+        message_processing._process_single_file_block(
+            source={"type": "url", "url": media_dir.as_uri()},
+            filename=None,
+        ),
+    )
+
+    assert plain_result is None
+    assert file_url_result is None


### PR DESCRIPTION
## Summary
- Fix image preprocessing to avoid writing local image paths as `file://...` URLs.
- Keep image source as an absolute local path string (`source.type = "url"`, `url = /abs/path/...`) so downstream OpenAI-compatible formatters can correctly detect local files.
- Keep audio behavior unchanged (still `file://...` + `media_type`).
- Harden local media root checks for local-path URL inputs (`file://` and plain paths).
- Add regression tests for image source normalization and local-path allowlist behavior.

## Why This Change
PR #340 converted images to base64 blocks, but maintainers requested avoiding base64 persistence in message context due to context pollution risk.

This PR follows the direction discussed in #584:
- do **not** persist image payloads as base64 in message context
- fix local-path compatibility so strict URL validation models (e.g. qwen3.5-plus) do not receive invalid `file://` web URLs.

## Root Cause
In `src/copaw/agents/utils/message_processing.py`, `_update_block_with_local_path` converted image local paths to:
- `{"type": "url", "url": "file:///..."}`

Downstream formatting logic can treat `file:///...` as a URL string instead of a local file path and fail strict endpoint validation.

## Implementation Details
- Added `_extract_local_path_from_url` to normalize `file://` and plain local paths.
- Updated `_process_single_file_block` to apply allowlist checks to both `file://` and plain local-path inputs.
- Updated `_is_allowed_media_path` to use robust subpath checking (`is_relative_to`) instead of string prefix matching.
- Updated `_update_block_with_local_path` for `image` blocks to emit absolute local path strings (not `file://`).

## Validation
- `ruff check src/copaw/agents/utils/message_processing.py tests/agents/utils/test_message_processing.py`
- `PYTHONPATH=src pytest -q tests/agents/utils/test_message_processing.py`
- `pre-commit run --all-files`

Test file added:
- `tests/agents/utils/test_message_processing.py`
  - image uses local absolute path source (not `file://`)
  - audio keeps `file://` behavior
  - reject plain local path outside media root
  - accept plain local path inside media root
  - reject prefix-confusable path (`media_evil`)
  - file-url local path extraction

## Notes
- Local full `pytest` currently reports one unrelated existing failure:
  - `tests/test_memory_compaction_hook.py::test_compaction_triggers_on_total_context_budget`
  - Error: `FakeMemoryManager.compact_memory() got an unexpected keyword argument 'messages'`

Closes #584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of local media paths to ensure files reside inside the allowed media directory.
  * Images are now preserved as canonical absolute local paths (no file:// prefix) when displayed.
  * Audio files continue to be exposed as file URLs with correct media-type metadata.

* **Tests**
  * Added unit tests covering path validation, URL↔local-path conversion, and image/audio handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->