### PR TITLE
fix(runner): inject local timezone context for relative dates

### DIFF
--- a/src/copaw/app/runner/utils.py
+++ b/src/copaw/app/runner/utils.py
@@ -27,7 +27,7 @@ def _build_local_time_context() -> list[str]:
         utc_offset = "UTC"
 
     return [
-        f"- 当前本地时间: {now.strftime('%Y-%m-%d %H:%M:%S')}",
+        f"- 当前本地日期: {now.strftime('%Y-%m-%d')}",
         f"- 当前本地时区: {timezone_name} ({utc_offset})",
         "- 日期解释规则: 处理“今天/明天/昨天/本周”等相对日期时，必须基于上述本地时区和时间。",
     ]

--- a/tests/test_runner_env_context.py
+++ b/tests/test_runner_env_context.py
@@ -4,7 +4,7 @@ import re
 from copaw.app.runner.utils import build_env_context
 
 
-def test_build_env_context_includes_local_time_timezone_rules() -> None:
+def test_build_env_context_includes_local_date_timezone_rules() -> None:
     context = build_env_context(
         session_id="s1",
         user_id="u1",
@@ -14,9 +14,10 @@ def test_build_env_context_includes_local_time_timezone_rules() -> None:
     )
 
     assert re.search(
-        r"- 当前本地时间: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}",
+        r"- 当前本地日期: \d{4}-\d{2}-\d{2}",
         context,
     )
+    assert "- 当前本地时间:" not in context
     assert "- 当前本地时区:" in context
     assert re.search(r"UTC(?:[+-]\d{2}:\d{2})?", context)
     assert "日期解释规则" in context


### PR DESCRIPTION
## Summary

Fixes timezone drift for relative date reasoning (`今天/明天/昨天`) by injecting host-local date context into the runtime env prompt.

## Problem

`build_env_context` originally injected session/user/channel/workdir only, without deterministic date/timezone anchors.
When the model did not proactively call `get_current_time`, relative dates could be interpreted against a non-local default timezone (often UTC), causing weekday/date mistakes (issue #617).

## Design Reference

This change aligns with Codex-style environment context design:
- inject `current_date`
- inject `timezone`

Reference implementation:
- `openai/codex`: `codex-rs/core/src/codex.rs` (`local_time_context`)
- `openai/codex`: `codex-rs/core/src/environment_context.rs` (`<current_date>`, `<timezone>`)

## Solution

- Add local date/timezone context into `src/copaw/app/runner/utils.py` env context:
  - current local **date** (`YYYY-MM-DD`)
  - local timezone name + UTC offset
  - explicit rule for relative-date interpretation
- Keep existing context fields/hints unchanged.
- Add tests in `tests/test_runner_env_context.py` to verify:
  - date + timezone + rule are present
  - time-of-day is not injected
  - original fields/hints still exist

## Validation

- `pre-commit run --files src/copaw/app/runner/utils.py tests/test_runner_env_context.py`
- `pytest -q tests/test_runner_env_context.py tests/test_mcp_resilience.py`

Both passed locally.

Closes #617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment context now appends local date, timezone name, and UTC offset information for richer time-aware context.

* **Tests**
  * Added tests validating the local time-related context is included correctly, original context fields remain intact, and hint behavior toggles as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->