### PR TITLE
fix: Telegram show typing

### DIFF
--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -239,6 +239,7 @@ class TelegramChannel(BaseChannel):
             Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
         )
         self._show_typing = show_typing
+        self._typing_tasks: dict[str, asyncio.Task] = {}
         self._task: Optional[asyncio.Task] = None
         self._application = None
         if self.enabled and self._bot_token:
@@ -319,6 +320,7 @@ class TelegramChannel(BaseChannel):
                 "meta": meta,
             }
             if self._enqueue is not None:
+                self._start_typing(chat_id)
                 self._enqueue(native)
             else:
                 logger.warning("telegram: _enqueue not set, message dropped")
@@ -432,6 +434,30 @@ class TelegramChannel(BaseChannel):
                 chat_id,
             )
 
+    def _start_typing(self, chat_id: str) -> None:
+        """Start the typing indicator loop for a chat."""
+        if not self._show_typing:
+            return
+        self._stop_typing(chat_id)
+        self._typing_tasks[chat_id] = asyncio.create_task(
+            self._typing_loop(chat_id),
+        )
+
+    def _stop_typing(self, chat_id: str) -> None:
+        """Stop the typing indicator for a chat."""
+        task = self._typing_tasks.pop(chat_id, None)
+        if task and not task.done():
+            task.cancel()
+
+    async def _typing_loop(self, chat_id: str) -> None:
+        """Repeatedly send 'typing' action every 4s until cancelled."""
+        try:
+            while self._application:
+                await self._send_chat_action(chat_id, "typing")
+                await asyncio.sleep(4)
+        except asyncio.CancelledError:
+            pass
+
     async def send(
         self,
         to_handle: str,
@@ -450,8 +476,7 @@ class TelegramChannel(BaseChannel):
         bot = self._application.bot
         if not bot:
             return
-        if self._show_typing:
-            asyncio.create_task(self._send_chat_action(chat_id, "typing"))
+        self._stop_typing(chat_id)
         chunks = self._chunk_text(text)
         for chunk in chunks:
             try:
@@ -479,6 +504,7 @@ class TelegramChannel(BaseChannel):
         bot = self._application.bot
         if not bot:
             return
+        self._stop_typing(chat_id)
 
         part_type = getattr(part, "type", None)
         try:
@@ -598,6 +624,8 @@ class TelegramChannel(BaseChannel):
     async def stop(self) -> None:
         if not self.enabled:
             return
+        for cid in list(self._typing_tasks):
+            self._stop_typing(cid)
         if self._task:
             self._task.cancel()
             try:


### PR DESCRIPTION
## Description

Typing was fired once right before send(), making it invisible to users.
Now starts a 4s typing loop on message receipt and cancels it on reply.

**Related Issue:** Fixes https://github.com/agentscope-ai/CoPaw/issues/387

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

- [x] Send message to bot, verify "typing..." appears immediately
- [x] Verify typing persists during long agent processing (>5s)
- [x] Verify typing disappears when reply arrives
- [x] Verify `show_typing=False` disables the indicator


## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Telegram: Added automatic typing indicator that displays while the bot is actively processing messages and preparing responses
  * The typing status automatically activates upon message receipt and deactivates before sending, providing users with real-time visibility into bot activity and improving the conversational experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->