### PR TITLE
disable discover models

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -152,33 +152,33 @@ export function ProviderConfigModal({
 
       // Auto-discover models from /models endpoint so users don't need
       // to enter model IDs manually.
-      try {
-        const discovered = await api.discoverModels(provider.id, {
-          api_key: values.api_key,
-          base_url: values.base_url,
-          chat_model: values.chat_model,
-        });
-        if (discovered.success) {
-          if (discovered.added_count > 0) {
-            message.success(
-              t("models.autoDiscoveredAndAdded", {
-                count: discovered.models.length,
-                added: discovered.added_count,
-              }),
-            );
-          } else if (discovered.models.length > 0) {
-            message.info(
-              t("models.autoDiscoveredNoNew", {
-                count: discovered.models.length,
-              }),
-            );
-          }
-        } else {
-          message.warning(discovered.message || t("models.autoDiscoverFailed"));
-        }
-      } catch {
-        message.warning(t("models.autoDiscoverFailed"));
-      }
+      // try {
+      //   const discovered = await api.discoverModels(provider.id, {
+      //     api_key: values.api_key,
+      //     base_url: values.base_url,
+      //     chat_model: values.chat_model,
+      //   });
+      //   if (discovered.success) {
+      //     if (discovered.added_count > 0) {
+      //       message.success(
+      //         t("models.autoDiscoveredAndAdded", {
+      //           count: discovered.models.length,
+      //           added: discovered.added_count,
+      //         }),
+      //       );
+      //     } else if (discovered.models.length > 0) {
+      //       message.info(
+      //         t("models.autoDiscoveredNoNew", {
+      //           count: discovered.models.length,
+      //         }),
+      //       );
+      //     }
+      //   } else {
+      //     message.warning(discovered.message || t("models.autoDiscoverFailed"));
+      //   }
+      // } catch {
+      //   message.warning(t("models.autoDiscoverFailed"));
+      // }
 
       await onSaved();
       setFormDirty(false);

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -37,10 +37,11 @@ export function RemoteModelManageModal({
   const [discovering, setDiscovering] = useState(false);
   const [testingModelId, setTestingModelId] = useState<string | null>(null);
   const [form] = Form.useForm();
-  const canDiscover =
-    provider.id === "ollama" || provider.needs_base_url
-      ? !!provider.current_base_url
-      : !!provider.current_api_key;
+  // const canDiscover =
+  //   provider.id === "ollama" || provider.needs_base_url
+  //     ? !!provider.current_base_url
+  //     : !!provider.current_api_key;
+  const canDiscover = false;
 
   // For custom providers ALL models are deletable.
   // For built-in providers only extra_models are deletable.


### PR DESCRIPTION
## Description

Chat model functionality is not supported by all models

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Removed Features**
  * Automatic model discovery has been disabled. Model detection and configuration now require manual setup instead of automatic detection after saving provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->