### PR TITLE
fix: handle unknown provider IDs and non-blocking model test

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -415,6 +415,7 @@
     "discoverModels": "Discover Models",
     "discoverModelsFailed": "Failed to discover models",
     "modelTestFailed": "Model validation failed, please check if the model ID is correct",
+    "modelTestFailedConfirm": "Model connection test failed: {{message}}. Do you still want to add this model?",
     "autoDiscoveredAndAdded": "Auto-discovered {{count}} models and added {{added}} new model(s)",
     "autoDiscoveredNoNew": "Auto-discovered {{count}} models; model list is already up to date",
     "autoDiscoverFailed": "Automatic model discovery failed; you can add models manually"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -415,6 +415,7 @@
     "discoverModels": "自动获取模型",
     "discoverModelsFailed": "自动获取模型失败",
     "modelTestFailed": "模型验证失败，请检查模型ID是否正确",
+    "modelTestFailedConfirm": "模型连接测试失败：{{message}}。是否仍要添加此模型？",
     "autoDiscoveredAndAdded": "已自动获取 {{count}} 个模型，并新增 {{added}} 个到可选列表",
     "autoDiscoveredNoNew": "已自动获取 {{count}} 个模型，当前列表已是最新",
     "autoDiscoverFailed": "自动获取模型失败，可在模型管理中手动添加"

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -51,6 +51,14 @@ export function RemoteModelManageModal({
       : (provider.extra_models || []).map((m) => m.id),
   );
 
+  const doAddModel = async (id: string, name: string) => {
+    await api.addModel(provider.id, { id, name });
+    message.success(t("models.modelAdded", { name }));
+    form.resetFields();
+    setAdding(false);
+    onSaved();
+  };
+
   const handleAddModel = async () => {
     try {
       const values = await form.validateFields();
@@ -64,16 +72,35 @@ export function RemoteModelManageModal({
       });
 
       if (!testResult.success) {
-        message.error(testResult.message || t("models.modelTestFailed"));
+        // Test failed – ask user whether to proceed anyway
+        setSaving(false);
+        Modal.confirm({
+          title: t("models.testConnectionFailed"),
+          content: t("models.modelTestFailedConfirm", {
+            message: testResult.message || t("models.modelTestFailed"),
+          }),
+          okText: t("models.addModel"),
+          cancelText: t("models.cancel"),
+          onOk: async () => {
+            setSaving(true);
+            try {
+              await doAddModel(id, name);
+            } catch (error) {
+              const errMsg =
+                error instanceof Error
+                  ? error.message
+                  : t("models.modelAddFailed");
+              message.error(errMsg);
+            } finally {
+              setSaving(false);
+            }
+          },
+        });
         return;
       }
 
       // Step 2: If test passed, add the model
-      await api.addModel(provider.id, { id, name });
-      message.success(t("models.modelAdded", { name }));
-      form.resetFields();
-      setAdding(false);
-      onSaved();
+      await doAddModel(id, name);
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) return;
       const errMsg =

--- a/src/copaw/cli/providers_cmd.py
+++ b/src/copaw/cli/providers_cmd.py
@@ -12,6 +12,7 @@ from ..providers import (
     add_model,
     create_custom_provider,
     delete_custom_provider,
+    get_provider,
     is_builtin,
     list_providers,
     load_providers_json,
@@ -62,7 +63,22 @@ def configure_provider_api_key_interactive(
             "Select provider to configure API key:",
         )
 
-    defn = PROVIDERS[provider_id]
+    defn = get_provider(provider_id)
+    if defn is None:
+        available = ", ".join(d.id for d in list_providers())
+        click.echo(
+            click.style(
+                f"Error: unknown provider '{provider_id}'. "
+                f"Available providers: {available}",
+                fg="red",
+            ),
+        )
+        click.echo(
+            "To add a custom provider, first run:\n"
+            f"  copaw models add-provider {provider_id} "
+            f'-n "My Provider"',
+        )
+        raise SystemExit(1)
 
     # Local providers (llamacpp, mlx) don't need API key configuration
     if defn.is_local:


### PR DESCRIPTION
## Summary
Fixes #568

- **CLI**: `copaw models config-key <unknown-id>` now shows a clear error with available providers and a hint to use `add-provider`, instead of crashing with `KeyError`
- **Frontend**: When adding a model, if the connection test fails (e.g. for DeepSeek, Doubao), a confirmation dialog is shown instead of hard-blocking the addition — users can choose to proceed anyway

## Test plan
- [x] Run `copaw models config-key nonexistent` — should show error message listing available providers
- [x] Run `copaw models config-key openai` — should work as before
- [x] In the console UI, add a model to a custom provider whose test fails — should show confirmation dialog allowing the user to add anyway
- [x] In the console UI, add a model whose test succeeds — should add directly as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when model connection tests fail, allowing users to proceed with adding the model despite the failed test.

* **Localization**
  * Added Chinese translation support for the failed model test confirmation message.

* **Bug Fixes**
  * Improved error handling for unknown providers in the CLI with clearer messaging and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->