### PR TITLE
docs（频道配置）: 完善 iMessage 安装说明，区分 Intel 和 Apple Silicon Mac

### DIFF
--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -269,6 +269,7 @@ The app polls the local iMessage database for new messages and sends replies on 
     git clone https://github.com/steipete/imsg.git
     cd imsg
     make build
+    cp ./bin/imsg /usr/local/bin/
     ```
 - The default iMessage database path is `~/Library/Messages/chat.db`. Use this unless you've moved the database.
 - The app needs **Full Disk Access** (System Settings → Privacy & Security → Full Disk

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -264,6 +264,7 @@
     git clone https://github.com/steipete/imsg.git
     cd imsg
     make build
+    cp ./bin/imsg /usr/local/bin/
     ```
 - 系统 iMessage 数据库默认路径为 `~/Library/Messages/chat.db`，若你改过系统路径，请填实际路径。
 - 应用需要 **完全磁盘访问权限**（系统设置 → 隐私与安全性 → 完全磁盘访问权限），否则无法读取 `chat.db`。


### PR DESCRIPTION
完善 iMessage 安装说明，区分 Intel 和 Apple Silicon Mac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated iMessage installation instructions with architecture-specific guidance: Apple Silicon users keep the direct install; Intel-based Macs are given clone-and-build-from-source steps.
  * Clarified that iMessage data (chat.db) remains on the local machine and that default path and permission requirements are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->