### PR TITLE
perf(console): handle unknown provider IDs and non-blocking model test (#568)

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -415,6 +415,7 @@
     "discoverModels": "Discover Models",
     "discoverModelsFailed": "Failed to discover models",
     "modelTestFailed": "Model validation failed, please check if the model ID is correct",
+    "modelTestFailedConfirm": "Model connection test failed: {{message}}. Do you still want to add this model?",
     "autoDiscoveredAndAdded": "Auto-discovered {{count}} models and added {{added}} new model(s)",
     "autoDiscoveredNoNew": "Auto-discovered {{count}} models; model list is already up to date",
     "autoDiscoverFailed": "Automatic model discovery failed; you can add models manually"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -415,6 +415,7 @@
     "discoverModels": "自动获取模型",
     "discoverModelsFailed": "自动获取模型失败",
     "modelTestFailed": "模型验证失败，请检查模型ID是否正确",
+    "modelTestFailedConfirm": "模型连接测试失败：{{message}}。是否仍要添加此模型？",
     "autoDiscoveredAndAdded": "已自动获取 {{count}} 个模型，并新增 {{added}} 个到可选列表",
     "autoDiscoveredNoNew": "已自动获取 {{count}} 个模型，当前列表已是最新",
     "autoDiscoverFailed": "自动获取模型失败，可在模型管理中手动添加"

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -51,6 +51,14 @@ export function RemoteModelManageModal({
       : (provider.extra_models || []).map((m) => m.id),
   );
 
+  const doAddModel = async (id: string, name: string) => {
+    await api.addModel(provider.id, { id, name });
+    message.success(t("models.modelAdded", { name }));
+    form.resetFields();
+    setAdding(false);
+    onSaved();
+  };
+
   const handleAddModel = async () => {
     try {
       const values = await form.validateFields();
@@ -64,16 +72,35 @@ export function RemoteModelManageModal({
       });
 
       if (!testResult.success) {
-        message.error(testResult.message || t("models.modelTestFailed"));
+        // Test failed – ask user whether to proceed anyway
+        setSaving(false);
+        Modal.confirm({
+          title: t("models.testConnectionFailed"),
+          content: t("models.modelTestFailedConfirm", {
+            message: testResult.message || t("models.modelTestFailed"),
+          }),
+          okText: t("models.addModel"),
+          cancelText: t("models.cancel"),
+          onOk: async () => {
+            setSaving(true);
+            try {
+              await doAddModel(id, name);
+            } catch (error) {
+              const errMsg =
+                error instanceof Error
+                  ? error.message
+                  : t("models.modelAddFailed");
+              message.error(errMsg);
+            } finally {
+              setSaving(false);
+            }
+          },
+        });
         return;
       }
 
       // Step 2: If test passed, add the model
-      await api.addModel(provider.id, { id, name });
-      message.success(t("models.modelAdded", { name }));
-      form.resetFields();
-      setAdding(false);
-      onSaved();
+      await doAddModel(id, name);
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) return;
       const errMsg =

--- a/src/copaw/cli/providers_cmd.py
+++ b/src/copaw/cli/providers_cmd.py
@@ -12,6 +12,7 @@ from ..providers import (
     add_model,
     create_custom_provider,
     delete_custom_provider,
+    get_provider,
     is_builtin,
     list_providers,
     load_providers_json,
@@ -62,7 +63,22 @@ def configure_provider_api_key_interactive(
             "Select provider to configure API key:",
         )
 
-    defn = PROVIDERS[provider_id]
+    defn = get_provider(provider_id)
+    if defn is None:
+        available = ", ".join(d.id for d in list_providers())
+        click.echo(
+            click.style(
+                f"Error: unknown provider '{provider_id}'. "
+                f"Available providers: {available}",
+                fg="red",
+            ),
+        )
+        click.echo(
+            "To add a custom provider, first run:\n"
+            f"  copaw models add-provider {provider_id} "
+            f'-n "My Provider"',
+        )
+        raise SystemExit(1)
 
     # Local providers (llamacpp, mlx) don't need API key configuration
     if defn.is_local:


### PR DESCRIPTION
## Description

- CLI: replace direct PROVIDERS[] lookup with get_provider() to avoid KeyError when user passes an unregistered provider ID to config-key
- Frontend: show confirmation dialog instead of hard-blocking model addition when test_model_connection fails, allowing users to add models for providers like DeepSeek/Doubao that may return non-standard test responses

**Related Issue:** Fixes #568

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When a model connection test fails, users can now choose to add the model anyway, providing greater flexibility during model configuration.

* **Bug Fixes**
  * Enhanced error messaging for unknown providers with helpful guidance on available options and how to add custom providers.

* **Localization**
  * Added English and Chinese translations for model connection test failure confirmation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->