### PR TITLE
fix(memory): avoid watcher shutdown from missing legacy memory.md

### DIFF
--- a/src/copaw/agents/memory/memory_manager.py
+++ b/src/copaw/agents/memory/memory_manager.py
@@ -119,25 +119,39 @@ class MemoryManager(ReMeCopaw):
         On case-sensitive filesystems, the lowercase path often does not
         exist and may terminate the watcher loop in some environments.
         """
-        memory_md_path = str((working_path / "MEMORY.md").absolute())
-        legacy_memory_md_path = str((working_path / "memory.md").absolute())
+        memory_md_path = str((working_path / "MEMORY.md").resolve())
+        legacy_memory_md_path = str((working_path / "memory.md").resolve())
 
         sanitized: list[str] = []
         seen: set[str] = set()
 
         for raw_path in watch_paths:
-            absolute_path = str(Path(raw_path).absolute())
-            if absolute_path == legacy_memory_md_path:
+            normalized_path = MemoryManager._normalize_watch_path(
+                raw_path=raw_path,
+                working_path=working_path,
+            )
+            if normalized_path == legacy_memory_md_path:
                 continue
-            if absolute_path in seen:
+            if normalized_path in seen:
                 continue
-            seen.add(absolute_path)
-            sanitized.append(absolute_path)
+            seen.add(normalized_path)
+            sanitized.append(normalized_path)
 
         if memory_md_path not in seen:
             sanitized.insert(0, memory_md_path)
 
         return sanitized
+
+    @staticmethod
+    def _normalize_watch_path(
+        raw_path: str,
+        working_path: Path,
+    ) -> str:
+        """Normalize watcher paths with working directory as relative base."""
+        path_obj = Path(raw_path)
+        if not path_obj.is_absolute():
+            path_obj = working_path / path_obj
+        return str(path_obj.resolve())
 
     def _patch_memory_watcher_paths(self) -> None:
         """Patch watcher config to avoid invalid legacy `memory.md` path."""

--- a/tests/agents/test_memory_manager_watch_paths.py
+++ b/tests/agents/test_memory_manager_watch_paths.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from types import SimpleNamespace
 
 from copaw.agents.memory.memory_manager import MemoryManager
 
 
-def test_sanitize_memory_watch_paths_removes_legacy_memory_md(tmp_path) -> None:
+def test_sanitize_memory_watch_paths_removes_legacy_memory_md(
+    tmp_path,
+) -> None:
     watch_paths = [
         str(tmp_path / "MEMORY.md"),
         str(tmp_path / "memory.md"),
@@ -21,7 +24,9 @@ def test_sanitize_memory_watch_paths_removes_legacy_memory_md(tmp_path) -> None:
     assert str(tmp_path / "memory") in sanitized
 
 
-def test_sanitize_memory_watch_paths_adds_memory_md_when_missing(tmp_path) -> None:
+def test_sanitize_memory_watch_paths_adds_memory_md_when_missing(
+    tmp_path,
+) -> None:
     watch_paths = [str(tmp_path / "memory")]
 
     sanitized = MemoryManager._sanitize_memory_watch_paths(
@@ -55,3 +60,27 @@ def test_patch_memory_watcher_paths_touches_memory_md(tmp_path) -> None:
     assert (tmp_path / "MEMORY.md").exists()
     assert str(tmp_path / "memory.md") not in watcher_config.watch_paths
     assert watcher_config.watch_paths[0] == str(tmp_path / "MEMORY.md")
+
+
+def test_sanitize_memory_watch_paths_resolves_relative_paths_with_working_path(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(outside)
+
+    watch_paths = [
+        "memory.md",
+        "memory",
+    ]
+    (tmp_path / "memory").mkdir(parents=True, exist_ok=True)
+
+    sanitized = MemoryManager._sanitize_memory_watch_paths(
+        watch_paths=watch_paths,
+        working_path=tmp_path,
+    )
+
+    assert str(tmp_path / "memory.md") not in sanitized
+    assert str(tmp_path / "MEMORY.md") in sanitized
+    assert str(tmp_path / "memory") in sanitized


### PR DESCRIPTION
## Problem

`memory_search` may stop reflecting new memory updates after app startup on case-sensitive filesystems.

Issue: https://github.com/agentscope-ai/CoPaw/issues/666

## Root Cause

`reme-ai==0.3.0.5` initializes CoPaw file watcher paths with both:
- `MEMORY.md`
- `memory.md` (legacy lowercase)
- `memory/`

In CoPaw, `memory.md` usually does not exist. On case-sensitive filesystems (e.g. Arch Linux in #666), this can trigger `FileNotFoundError` inside watcher loop startup path. Once that happens, watcher loop exits and memory incremental sync stops.

## Fix

In `MemoryManager` initialization, patch watcher paths after `ReMeCopaw` setup:

1. Remove legacy lowercase `memory.md` path.
2. Ensure uppercase `MEMORY.md` is present in watcher list.
3. De-duplicate and normalize watcher paths to absolute paths.
4. `touch` `MEMORY.md` to guarantee stable watch target.

This keeps watcher alive and preserves incremental indexing for `MEMORY.md` and `memory/` updates.

## Tests

Added regression tests:
- `tests/agents/test_memory_manager_watch_paths.py`
  - removes legacy `memory.md`
  - injects `MEMORY.md` if missing
  - ensures patching creates `MEMORY.md`

## Validation

- `pre-commit run --all-files` ✅
- `pytest -q tests/agents/test_memory_manager_watch_paths.py` ✅ (3 passed)
- `pytest` ⚠️ one existing unrelated failure remains in `tests/test_memory_compaction_hook.py::test_compaction_triggers_on_total_context_budget` (FakeMemoryManager test double signature mismatch). This PR does not touch that module.

Closes #666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-watch behavior by normalizing and de-duplicating watch paths, replacing legacy lowercase entries with the canonical MEMORY.md, and ensuring that MEMORY.md exists for consistent file monitoring.

* **Tests**
  * Added tests covering watch-path sanitization and the patching logic that updates watcher configurations to the canonical memory file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->