### PR TITLE
fix(shell): enforce timeout around communicate to avoid hangs

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -67,7 +67,7 @@ def _execute_subprocess_sync(
         return -1, "", str(e)
 
 
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches, too-many-statements
 async def execute_shell_command(
     command: str,
     timeout: int = 60,


### PR DESCRIPTION
## Summary
- apply timeout directly to `proc.communicate()` instead of `wait()` + `communicate()`
- avoid secondary hangs in timeout cleanup by bounding the post-terminate pipe drain

## Why
`wait()` can return while `communicate()` still blocks if descendants keep stdout/stderr pipes open. In that case, `timeout` is effectively bypassed and tool calls can stay silent for minutes.

## Validation
- `python3 -m py_compile src/copaw/agents/tools/shell.py`
- reproduced behavior with long-lived background child and verified timeout now returns promptly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout enforcement for shell commands to prevent hangs when child processes keep output pipes open.
  * Enhanced cleanup during timeouts to ensure processes are terminated gracefully and resources released.
  * Ensured output retrieval cannot block indefinitely and, when necessary, appends a timeout note to stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->