### PR TITLE
fix(cli): correct request payload format for agent-type cron jobs

### DIFF
--- a/src/copaw/cli/cron_cmd.py
+++ b/src/copaw/cli/cron_cmd.py
@@ -149,15 +149,9 @@ def _build_spec_from_cli(
             "schedule": schedule,
             "task_type": "agent",
             "request": {
-                "input": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": [{"type": "text", "text": text.strip()}],
-                    },
-                ],
+                "input": text.strip(),
                 "session_id": target_session,
-                "user_id": "cron",
+                "user_id": target_user,
             },
             "dispatch": dispatch,
             "runtime": runtime,


### PR DESCRIPTION
## Description

`copaw cron create` CLI command returns **502 Bad Gateway** when creating an `agent` type cron job. The root cause is a data format mismatch between the CLI payload and the API's expected schema.

### What happened:
When running `copaw cron create --type agent ...`, the CLI sends a request with `request.input` as an **array of message objects**, but the API expects `input` to be a **string** (or simple object). Additionally, `user_id` is hardcoded to `"cron"` instead of using the provided `--target-user` value.

### What was expected:
The CLI should construct the payload correctly to match the API's `CronJobRequest` model, allowing agent-type cron jobs to be created successfully.

## Component(s) Affected

- [x] CLI

## Environment

- **CoPaw version:** 0.0.4
- **OS:** macOS (Darwin)
- **Install method:** pip (virtual environment)
- **Python version:** 3.12

## Root Cause Analysis

In `src/copaw/cli/cron_cmd.py`, the `_build_spec_from_cli()` function constructs an incorrect payload for `agent` type tasks:

```python
# Before (incorrect):
"request": {
    "input": [  # ❌ Should be string, not array
        {
            "role": "user",
            "type": "message",
            "content": [{"type": "text", "text": text.strip()}],
        },
    ],
    "session_id": target_session,
    "user_id": "cron",  # ❌ Should be target_user
}

# After (correct):
"request": {
    "input": text.strip(),  # ✅ String format
    "session_id": target_session,
    "user_id": target_user,  # ✅ Use provided target_user
}
```

## Testing

Verified with direct API call using correct format:
```bash
curl -X POST http://127.0.0.1:8088/api/cron/jobs \
  -H "Content-Type: application/json" \
  -d '{
    "id": "test",
    "schedule": {"type": "cron", "cron": "0 21 * * *"},
    "dispatch": {
      "channel": "console",
      "target": {"user_id": "default", "session_id": "test"}
    },
    "task_type": "agent",
    "name": "Test",
    "request": {
      "input": "test prompt",
      "session_id": "test",
      "user_id": "default"
    }
  }'
# Returns 200 OK with created job
```

## Additional Notes

**Workaround before fix:** Use direct HTTP API calls with `curl` or create jobs via JSON file (`-f` flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Agent tasks now route to the correct user instead of using a default user identifier
  * Simplified agent task input handling for improved processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->