### PR TITLE
fix(telegram): add typing loop timeout and fix stop() race condition

### DIFF
--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -462,7 +462,8 @@ class TelegramChannel(BaseChannel):
         except asyncio.CancelledError:
             pass
         finally:
-            self._typing_tasks.pop(chat_id, None)
+            if self._typing_tasks.get(chat_id) is asyncio.current_task():
+                self._typing_tasks.pop(chat_id, None)
 
     async def send(
         self,


### PR DESCRIPTION
## Description              
                                                                                                                                  
  Fix Telegram typing indicator: add 180s timeout to prevent indefinite typing loops, and fix race condition in `stop()` where new typing tasks could leak during shutdown.
                                                                                                                                                                                                                     
  **Background:** The typing loop (added in #640) runs every 4s but lacked a timeout — if the agent hangs or fails to respond, the loop runs forever. Additionally, `stop()` cleaned up typing tasks *before*
  cancelling the polling task, allowing new messages to start typing tasks in between.                                                                                                                               
                                                                                                                                                                                                                   
  **Changes:**
  - Add `_TYPING_TIMEOUT_S = 180` deadline to `_typing_loop`, with `finally` block to clean up the task dict entry on natural exit
  - Reorder `stop()`: cancel polling first (cut off message source), then clean up typing tasks

  **Related Issue:** Fix https://github.com/agentscope-ai/CoPaw/pull/640

  **Security Considerations:** Prevents resource exhaustion from unbounded typing loops; eliminates task leak on shutdown.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] Refactoring

  ## Component(s) Affected

  - [ ] Core / Backend (app, agents, config, providers, utils, local_models)
  - [ ] Console (frontend web UI)
  - [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
  - [ ] Skills
  - [ ] CLI
  - [ ] Documentation (website)
  - [ ] Tests
  - [ ] CI/CD
  - [ ] Scripts / Deploy

  ## Checklist

  - [ ] I ran `pre-commit run --all-files` locally and it passes
  - [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
  - [ ] I ran tests locally (`pytest` or as relevant) and they pass
  - [ ] Documentation updated (if needed)
  - [ ] Ready for review

  ## Testing

  1. Enable Telegram channel with `show_typing: true`
  2. Send a message — typing indicator should appear immediately and persist during agent processing
  3. When reply arrives, typing should stop
  4. Verify typing auto-stops after 180s if agent never replies (simulate by disconnecting agent)
  5. Restart CoPaw while typing is active — no errors or leaked tasks

  ## Local Verification Evidence

  ```bash
  pre-commit run --all-files
  # paste summary result

  pytest
  # paste summary result

  Additional Notes

  Only 1 file changed (channel.py), +8/-2 lines. No behavioral change for show_typing: false.
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents indefinite Telegram "typing" indicators by enforcing a typing timeout.
  * Ensures typing state is always cleaned up when operations finish, improving reliability.
  * Improves channel shutdown sequence to cancel main tasks before stopping typing indicators, yielding a more stable stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->