### PR TITLE
fix(channels): resolve console build TS2352 in ChannelCard

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelCard.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelCard.tsx
@@ -1,9 +1,5 @@
 import { Card, Tooltip } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
-import type {
-  SingleChannelConfig,
-  VoiceChannelConfig,
-} from "../../../../api/types";
 import { getChannelLabel, type ChannelKey } from "./constants";
 import styles from "../index.module.less";
 
@@ -28,6 +24,10 @@ export function ChannelCard({
   const enabled = Boolean(config.enabled);
   const isBuiltin = Boolean(config.isBuiltin);
   const label = getChannelLabel(channelKey);
+  const getConfigString = (key: string) =>
+    typeof config[key] === "string" ? config[key] : "";
+  const phoneNumber = getConfigString("phone_number");
+  const botPrefix = getConfigString("bot_prefix");
 
   const getCardClassNames = () => {
     if (isHover) return `${styles.channelCard} ${styles.hover}`;
@@ -69,14 +69,11 @@ export function ChannelCard({
       <div className={styles.cardDescription}>
         {channelKey === "voice" ? (
           <>
-            {t("channels.phoneNumber")}:{" "}
-            {(config as VoiceChannelConfig).phone_number ||
-              t("channels.notSet")}
+            {t("channels.phoneNumber")}: {phoneNumber || t("channels.notSet")}
           </>
         ) : (
           <>
-            {t("channels.botPrefix")}:{" "}
-            {(config as SingleChannelConfig).bot_prefix || t("channels.notSet")}
+            {t("channels.botPrefix")}: {botPrefix || t("channels.notSet")}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary

Fixes a TypeScript build failure in the Console channels card view.

Closes #685.

## Problem

`console/src/pages/Control/Channels/components/ChannelCard.tsx` typed `config` as `Record<string, unknown>` but used direct assertions to `VoiceChannelConfig` and `SingleChannelConfig`.

With current TypeScript settings, this triggers `TS2352` during `npm run build`:

- Conversion of `Record<string, unknown>` to `VoiceChannelConfig`
- Conversion of `Record<string, unknown>` to `SingleChannelConfig`

## Root Cause

`config` is intentionally dynamic (`Record<string, unknown>`) because channel keys/configs are not strictly static in this page. Casting it to strict interfaces creates an unsafe and rejected narrowing path.

## Solution

- Removed the strict interface assertions in `ChannelCard`.
- Added a safe string extractor for dynamic config values.
- Read `phone_number` and `bot_prefix` through runtime type checks (`typeof value === "string"`).
- Kept existing UI behavior (`notSet` fallback) unchanged.

## Validation

### Passed

- `console`: `npm run build`
- repository: `pre-commit run --all-files`

### Known baseline failures (unrelated to this change)

- `pytest` currently fails at collection due to missing dependency/module:
  - `ModuleNotFoundError: No module named 'reme.memory.file_based_copaw'`
- `console` lint currently has pre-existing errors in multiple files unrelated to this patch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing phone numbers and bot prefixes in channel cards by displaying a "not set" indicator when values are empty.
  * Enhanced reliability of configuration value retrieval in the channel card component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->