### PR TITLE
feat: add interactive_choice tool for chat card interaction

### DIFF
--- a/console/src/pages/Chat/InteractiveChoice/index.tsx
+++ b/console/src/pages/Chat/InteractiveChoice/index.tsx
@@ -1,0 +1,294 @@
+import { Card, Radio, Input, Button, Space, Typography } from "antd";
+import XMarkdown from "@ant-design/x-markdown";
+import { createStyles } from "antd-style";
+import { useMemo, useState, useCallback } from "react";
+import { CheckCircleFilled } from "@ant-design/icons";
+import { getApiUrl, getApiToken } from "../../../api/config";
+
+interface OptionItem {
+  type: "fixed" | "editable";
+  label: string;
+}
+
+interface CardData {
+  text: string;
+  options: OptionItem[];
+}
+
+interface CustomWindow extends Window {
+  currentSessionId?: string;
+}
+
+declare const window: CustomWindow;
+
+const useStyles = createStyles(({ css, token }) => ({
+  container: css`
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid ${token.colorBorderSecondary};
+    overflow: hidden;
+
+    .ant-card-body {
+      padding: 20px 24px;
+    }
+  `,
+  markdownSection: css`
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid ${token.colorBorderSecondary};
+
+    & > *:last-child {
+      margin-bottom: 0;
+    }
+  `,
+  optionsSection: css`
+    margin-bottom: 20px;
+  `,
+  optionsLabel: css`
+    display: block;
+    margin-bottom: 10px;
+    font-weight: 500;
+    color: ${token.colorTextSecondary};
+  `,
+  editableInput: css`
+    margin-top: 12px;
+  `,
+  confirmBtn: css`
+    margin-top: 4px;
+  `,
+  confirmedBanner: css`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: ${token.colorSuccessBg};
+    border-radius: 8px;
+    margin-top: 4px;
+  `,
+  confirmedPrefix: css`
+    color: ${token.colorTextSecondary};
+    margin-right: 6px;
+  `,
+  confirmedValue: css`
+    font-weight: 600;
+    color: ${token.colorText};
+  `,
+}));
+
+function parseCardArgs(content: any[]): CardData | null {
+  try {
+    const argsRaw = content[0]?.data?.arguments;
+    if (!argsRaw) return null;
+    const args = typeof argsRaw === "string" ? JSON.parse(argsRaw) : argsRaw;
+    const opts =
+      typeof args.options === "string"
+        ? JSON.parse(args.options)
+        : args.options;
+    if (args.text && Array.isArray(opts)) {
+      return { text: args.text, options: opts };
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+interface CompletedDisplay {
+  prefix: string;
+  value: string;
+}
+
+function formatCompletedDisplay(raw: string): CompletedDisplay {
+  const fixedMatch = raw.match(/^用户选择的是(.+)$/);
+  if (fixedMatch && !raw.includes("补充内容为")) {
+    return { prefix: "你的选择是", value: fixedMatch[1] };
+  }
+  const editableMatch = raw.match(/补充内容为(.+)$/);
+  if (editableMatch) {
+    return { prefix: "你的输入是", value: editableMatch[1] };
+  }
+  return { prefix: "", value: raw };
+}
+
+function extractPlainText(raw: any): string | null {
+  if (!raw) return null;
+  let val = raw;
+  if (typeof val === "string") {
+    try {
+      val = JSON.parse(val);
+    } catch {
+      return val;
+    }
+  }
+  if (typeof val === "string") return val;
+  if (Array.isArray(val)) {
+    const textItem = val.find(
+      (item: any) => item?.type === "text" && typeof item?.text === "string",
+    );
+    if (textItem) return textItem.text;
+  }
+  if (typeof val === "object" && val?.type === "text" && val?.text) {
+    return val.text;
+  }
+  return typeof raw === "string" ? raw : JSON.stringify(raw);
+}
+
+function parseCompletedResult(content: any[]): CompletedDisplay | null {
+  if (!content || content.length < 2) return null;
+  const output = content[1]?.data?.output;
+  if (!output) return null;
+  const text = extractPlainText(output);
+  if (!text) return null;
+  if (text.startsWith("Error:") || text.includes("交互超时")) {
+    return { prefix: "", value: text };
+  }
+  return formatCompletedDisplay(text);
+}
+
+export default function InteractiveChoice(props: {
+  data: { content: any[]; status?: string };
+}) {
+  const { styles } = useStyles();
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [editableText, setEditableText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const content = props.data?.content;
+  const cardData = useMemo(() => parseCardArgs(content), [content]);
+  const completedResult = useMemo(
+    () => parseCompletedResult(content),
+    [content],
+  );
+  const isCompleted = completedResult !== null;
+
+  const handleConfirm = useCallback(async () => {
+    if (selectedIndex === null || !cardData) return;
+
+    const option = cardData.options[selectedIndex];
+    let resultText: string;
+    if (option.type === "fixed") {
+      resultText = `用户选择的是${option.label}`;
+    } else {
+      resultText = `用户选择的是其他，补充内容为${editableText}`;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const sessionId = window.currentSessionId || "";
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      const token = getApiToken();
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const res = await fetch(getApiUrl("/interaction"), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          session_id: sessionId,
+          result: resultText,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.detail || `HTTP ${res.status}`);
+      }
+    } catch (e: any) {
+      setSubmitError(e.message || "提交失败");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selectedIndex, editableText, cardData]);
+
+  if (!cardData) return null;
+
+  const selectedOption =
+    selectedIndex !== null ? cardData.options[selectedIndex] : null;
+  const isEditable = selectedOption?.type === "editable";
+  const canConfirm =
+    selectedIndex !== null &&
+    (!isEditable || editableText.trim().length > 0) &&
+    !submitting;
+
+  return (
+    <Card className={styles.container} bordered={false}>
+      <div className={styles.markdownSection}>
+        <XMarkdown>{cardData.text}</XMarkdown>
+      </div>
+
+      {isCompleted ? (
+        <div className={styles.confirmedBanner}>
+          <CheckCircleFilled style={{ color: "#52c41a", fontSize: 16 }} />
+          {completedResult!.prefix ? (
+            <Typography.Text>
+              <span className={styles.confirmedPrefix}>
+                {completedResult!.prefix}
+              </span>
+              <span className={styles.confirmedValue}>
+                {completedResult!.value}
+              </span>
+            </Typography.Text>
+          ) : (
+            <Typography.Text>{completedResult!.value}</Typography.Text>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className={styles.optionsSection}>
+            <Typography.Text className={styles.optionsLabel}>
+              请选择：
+            </Typography.Text>
+            <Radio.Group
+              value={selectedIndex}
+              onChange={(e) => {
+                setSelectedIndex(e.target.value);
+                setEditableText("");
+              }}
+              disabled={submitting}
+            >
+              <Space wrap size="middle">
+                {cardData.options.map((opt, idx) => (
+                  <Radio.Button key={idx} value={idx}>
+                    {opt.label}
+                  </Radio.Button>
+                ))}
+              </Space>
+            </Radio.Group>
+
+            {isEditable && (
+              <Input.TextArea
+                className={styles.editableInput}
+                placeholder={selectedOption!.label}
+                value={editableText}
+                onChange={(e) => setEditableText(e.target.value)}
+                autoSize={{ minRows: 2, maxRows: 6 }}
+                disabled={submitting}
+              />
+            )}
+          </div>
+
+          <Button
+            className={styles.confirmBtn}
+            type="primary"
+            block
+            loading={submitting}
+            disabled={!canConfirm}
+            onClick={handleConfirm}
+          >
+            确认
+          </Button>
+
+          {submitError && (
+            <Typography.Text type="danger" style={{ marginTop: 8 }}>
+              {submitError}
+            </Typography.Text>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -11,6 +11,7 @@ import sessionApi from "./sessionApi";
 import { useLocalStorageState } from "ahooks";
 import defaultConfig, { DefaultConfig } from "./OptionsPanel/defaultConfig";
 import Weather from "./Weather";
+import InteractiveChoice from "./InteractiveChoice";
 import { getApiUrl, getApiToken } from "../../api/config";
 import { providerApi } from "../../api/modules/provider";
 import "./index.module.less";
@@ -134,6 +135,7 @@ export default function ChatPage() {
       },
       customToolRenderConfig: {
         "weather search mock": Weather,
+        interactive_choice: InteractiveChoice,
       },
     } as unknown as IAgentScopeRuntimeWebUIOptions;
   }, [optionsConfig]);

--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -32,6 +32,7 @@ from .tools import (
     edit_file,
     execute_shell_command,
     get_current_time,
+    interactive_choice,
     read_file,
     send_file_to_user,
     write_file,
@@ -198,6 +199,10 @@ class CoPawAgent(ReActAgent):
         )
         toolkit.register_tool_function(
             get_current_time,
+            namesake_strategy=namesake_strategy,
+        )
+        toolkit.register_tool_function(
+            interactive_choice,
             namesake_strategy=namesake_strategy,
         )
 

--- a/src/copaw/agents/tools/__init__.py
+++ b/src/copaw/agents/tools/__init__.py
@@ -21,6 +21,7 @@ from .browser_control import browser_use
 from .desktop_screenshot import desktop_screenshot
 from .memory_search import create_memory_search_tool
 from .get_current_time import get_current_time
+from .interactive_choice import interactive_choice
 
 __all__ = [
     "execute_python_code",
@@ -38,4 +39,5 @@ __all__ = [
     "browser_use",
     "create_memory_search_tool",
     "get_current_time",
+    "interactive_choice",
 ]

--- a/src/copaw/agents/tools/interactive_choice.py
+++ b/src/copaw/agents/tools/interactive_choice.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""Interactive choice card tool for chat interface.
+
+Presents an interactive selection card to the user in the chat UI,
+supporting fixed buttons and editable text input options.
+The tool blocks until the user confirms their selection.
+"""
+
+import asyncio
+import json
+import logging
+from typing import List
+
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+
+from copaw.app.interaction import (
+    InteractionManager,
+    current_session_id,
+)
+
+logger = logging.getLogger(__name__)
+
+_INTERACTION_TIMEOUT = 600  # 10 minutes
+
+
+def _make_error(msg: str) -> ToolResponse:
+    return ToolResponse(content=[TextBlock(type="text", text=msg)])
+
+
+def _validate_options(
+    raw: str,
+) -> tuple[List[dict] | None, ToolResponse | None]:
+    """Parse and validate the options JSON string.
+
+    Returns (parsed_options, None) on success, or (None, error_response)
+    on failure.
+    """
+    try:
+        parsed: List[dict] = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None, _make_error(
+            "Error: 'options' parameter must be a valid "
+            "JSON string representing a list of option objects.",
+        )
+
+    for i, opt in enumerate(parsed):
+        if not isinstance(opt, dict):
+            return None, _make_error(
+                f"Error: Option at index {i} is not a dict.",
+            )
+        if opt.get("type") not in ("fixed", "editable"):
+            return None, _make_error(
+                f"Error: Option at index {i} must have "
+                f'"type" set to "fixed" or "editable".',
+            )
+        if not opt.get("label"):
+            return None, _make_error(
+                f"Error: Option at index {i} must have "
+                f'a non-empty "label".',
+            )
+
+    return parsed, None
+
+
+async def interactive_choice(
+    text: str,
+    options: str,
+) -> ToolResponse:
+    """Display an interactive selection card to the user in the chat
+    interface and wait for their response. The card contains descriptive
+    text (supports Markdown) and a list of selectable options.
+
+    This tool will block until the user makes a selection and confirms.
+
+    Args:
+        text (`str`):
+            Descriptive text displayed at the top of the card.
+            Supports full Markdown syntax including headings, lists,
+            bold, code blocks, tables, etc.
+        options (`str`):
+            A JSON-encoded list of option objects. Each object must have:
+            - "type" (str): Either "fixed" (a preset button) or
+              "editable" (a button that reveals a text input field).
+            - "label" (str): For "fixed" type, the button display text.
+              For "editable" type, the placeholder hint text
+              (e.g. "其他，请手动输入").
+
+            Example:
+            [
+              {"type": "fixed", "label": "方案一"},
+              {"type": "fixed", "label": "方案二"},
+              {"type": "editable", "label": "其他，请手动输入"}
+            ]
+
+    Returns:
+        `ToolResponse`:
+            The user's selection result. For fixed buttons: "用户选择的
+            是{label}". For editable buttons: "用户选择的是其他，补充内
+            容为{user_input}".
+    """
+    parsed_options, err = _validate_options(options)
+    if err is not None:
+        return err
+
+    session_id = current_session_id.get()
+    if session_id is None:
+        logger.warning(
+            "interactive_choice called without session context; "
+            "returning card data without waiting for user input",
+        )
+        payload = json.dumps(
+            {"text": text, "options": parsed_options},
+            ensure_ascii=False,
+        )
+        return ToolResponse(
+            content=[TextBlock(type="text", text=payload)],
+        )
+
+    interaction = InteractionManager.create(session_id)
+    try:
+        await asyncio.wait_for(
+            interaction.event.wait(),
+            timeout=_INTERACTION_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text="用户未在规定时间内做出选择，交互超时。",
+                ),
+            ],
+        )
+    finally:
+        InteractionManager.cleanup(session_id)
+
+    result = interaction.result or "用户未做出选择"
+    return ToolResponse(
+        content=[TextBlock(type="text", text=result)],
+    )

--- a/src/copaw/app/interaction.py
+++ b/src/copaw/app/interaction.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Interaction manager for interactive tool calls.
+
+Coordinates async tool functions that need user input from the frontend.
+Uses asyncio.Event for signaling between the tool coroutine and the
+HTTP handler that receives the user's response.
+"""
+
+import asyncio
+import contextvars
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+current_session_id: contextvars.ContextVar[
+    Optional[str]
+] = contextvars.ContextVar("copaw_interaction_session_id", default=None)
+
+
+class _PendingInteraction:
+    __slots__ = ("event", "result")
+
+    def __init__(self) -> None:
+        self.event = asyncio.Event()
+        self.result: Optional[str] = None
+
+
+class InteractionManager:
+    """Manages pending interactive tool calls awaiting user responses."""
+
+    _pending: dict[str, _PendingInteraction] = {}
+
+    @classmethod
+    def create(cls, session_id: str) -> _PendingInteraction:
+        old = cls._pending.pop(session_id, None)
+        if old is not None:
+            old.event.set()
+        interaction = _PendingInteraction()
+        cls._pending[session_id] = interaction
+        return interaction
+
+    @classmethod
+    def resolve(cls, session_id: str, result: str) -> bool:
+        interaction = cls._pending.get(session_id)
+        if interaction is None:
+            return False
+        interaction.result = result
+        interaction.event.set()
+        return True
+
+    @classmethod
+    def cleanup(cls, session_id: str) -> None:
+        cls._pending.pop(session_id, None)

--- a/src/copaw/app/routers/__init__.py
+++ b/src/copaw/app/routers/__init__.py
@@ -13,6 +13,7 @@ from .mcp import router as mcp_router
 from ..crons.api import router as cron_router
 from ..runner.api import router as runner_router
 from .console import router as console_router
+from .interaction import router as interaction_router
 
 
 router = APIRouter()
@@ -20,6 +21,7 @@ router = APIRouter()
 router.include_router(agent_router)
 router.include_router(config_router)
 router.include_router(console_router)
+router.include_router(interaction_router)
 router.include_router(cron_router)
 router.include_router(local_models_router)
 router.include_router(mcp_router)

--- a/src/copaw/app/routers/interaction.py
+++ b/src/copaw/app/routers/interaction.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""API endpoint for resolving interactive tool calls."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..interaction import InteractionManager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/interaction", tags=["interaction"])
+
+
+class InteractionRequest(BaseModel):
+    session_id: str
+    result: str
+
+
+@router.post("")
+async def resolve_interaction(body: InteractionRequest) -> dict:
+    """Receive the user's interactive choice and unblock the tool."""
+    success = InteractionManager.resolve(body.session_id, body.result)
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail="No pending interaction for this session",
+        )
+    return {"status": "ok"}

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -20,6 +20,7 @@ from .query_error_dump import write_query_error_dump
 from .session import SafeJSONSession
 from .utils import build_env_context
 from ..channels.schema import DEFAULT_CHANNEL
+from ..interaction import current_session_id
 from ...agents.memory import MemoryManager
 from ...agents.model_factory import create_model_and_formatter
 from ...agents.react_agent import CoPawAgent
@@ -97,6 +98,8 @@ class AgentRunner(Runner):
                     indent=2,
                 ),
             )
+
+            current_session_id.set(session_id)
 
             env_context = build_env_context(
                 session_id=session_id,


### PR DESCRIPTION
## Description

Add a built-in tool that presents an interactive selection card in the chat UI. The tool blocks until the user confirms their choice, then returns the result as a proper tool response.

Backend:
- interactive_choice tool with async wait via InteractionManager
- POST /api/interaction endpoint to receive user selections
- Session context var for routing interactions

Frontend:
- InteractiveChoice component (antd Card/Radio/Input/Markdown)
- Calls backend API on confirm, renders completed state from tool result

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

front test

## Local Verification Evidence

```bash
pre-commit run --all-files

CoPaw git:(feature/interactive_choice) ✗ pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

pytest（test_compaction_triggers_on_total_context_budget error is unrelated to this PR）
(copaw) (base) ➜  CoPaw git:(feature/interactive_choice) ✗ pytest
======================================== test session starts ========================================
platform darwin -- Python 3.10.18, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/linxuanrui/Documents/projects/CoPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 60 items                                                                                  

tests/channels/test_qq_url_sanitize.py ..                                                     [  3%]
tests/test_command_dispatch.py ..........                                                     [ 20%]
tests/test_conversation_relay.py ........                                                     [ 33%]
tests/test_mcp_resilience.py ........                                                         [ 46%]
tests/test_memory_compaction_hook.py F.                                                       [ 50%]
tests/test_ollama_manager_timeout.py .                                                        [ 51%]
tests/test_openai_stream_toolcall_compat.py ...                                               [ 56%]
tests/test_react_agent_tool_choice.py ....                                                    [ 63%]
tests/test_session.py .....                                                                   [ 71%]
tests/test_tunnel.py .....                                                                    [ 80%]
tests/test_twiml.py ........                                                                  [ 93%]
tests/test_voice_config.py ....                                                               [100%]

============================================= FAILURES ==============================================
_________________________ test_compaction_triggers_on_total_context_budget __________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1160895d0>

    async def test_compaction_triggers_on_total_context_budget(
        monkeypatch,
    ) -> None:
        monkeypatch.setattr(
            "copaw.agents.hooks.memory_compaction.safe_count_message_tokens",
            _fake_safe_count_message_tokens,
        )
        monkeypatch.setattr(
            "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
            _fake_safe_count_str_tokens,
        )
    
        memory_manager = FakeMemoryManager()
        hook = MemoryCompactionHook(
            memory_manager=memory_manager,
            memory_compact_threshold=950,
            keep_recent=1,
        )
    
        # message_tokens = 950 (at threshold),
        # so no compaction by message-only count
        # summary_tokens > 0 for non-empty wrapped summary
        # total = message_tokens + summary_tokens > threshold => should compact.
        messages = [
            FakeMsg(id="sys", role="system", token_count=250),
            FakeMsg(id="old-1", role="user", token_count=250),
            FakeMsg(id="old-2", role="assistant", token_count=250),
            FakeMsg(id="recent", role="user", token_count=200),
        ]
        agent = _make_agent(messages=messages, summary="existing-summary")
    
        await hook(agent=agent, kwargs={})
    
>       assert memory_manager.compact_calls
E       assert []
E        +  where [] = <tests.test_memory_compaction_hook.FakeMemoryManager object at 0x1160890c0>.compact_calls

tests/test_memory_compaction_hook.py:149: AssertionError
--------------------------------------- Captured stderr call ----------------------------------------
INFO src/copaw/agents/hooks/memory_compaction.py:148 | 2026-03-05 15:29:32 | Memory compaction triggered: estimated total 954 tokens (messages: 950, summary: 4, threshold: 950), system_prompt_msgs: 1, compactable_msgs: 2, keep_recent_msgs: 1
ERROR src/copaw/agents/hooks/memory_compaction.py:188 | 2026-03-05 15:29:32 | Failed to compact memory in pre_reasoning hook: FakeMemoryManager.compact_memory() got an unexpected keyword argument 'messages'
Traceback (most recent call last):
  File "/Users/linxuanrui/Documents/projects/CoPaw/src/copaw/agents/hooks/memory_compaction.py", line 166, in __call__
    compact_content = await self.memory_manager.compact_memory(
TypeError: FakeMemoryManager.compact_memory() got an unexpected keyword argument 'messages'
====================================== short test summary info ======================================
FAILED tests/test_memory_compaction_hook.py::test_compaction_triggers_on_total_context_budget - assert []
=================================== 1 failed, 59 passed in 2.89s ====================================
```

## Additional Example

![钉钉录屏_2026-03-05 151851](https://github.com/user-attachments/assets/49d03611-fb41-4712-99e3-8f457522ba22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive multiple-choice cards to the chat interface with support for fixed and editable options.
  * Implemented user input handling for interactive selections with timeout and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->