### PR TITLE
fix(formatter): add reasoning_content in messages

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -140,9 +140,7 @@ def _create_file_block_support_formatter(
             messages = await super()._format(msgs)
 
             if reasoning_contents:
-                in_assistant = [
-                    m for m in msgs if m.role == "assistant"
-                ]
+                in_assistant = [m for m in msgs if m.role == "assistant"]
                 out_assistant = [
                     m for m in messages if m.get("role") == "assistant"
                 ]


### PR DESCRIPTION
## Description

As the title says

**Related Issue:** Fixes #507 and #388 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves assistant reasoning content gathered during message processing and injects it into the corresponding assistant responses when message mapping is consistent.
  * Adds safeguards to skip injection and emit a warning if message counts mismatch to avoid incorrect or partial reasoning being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->