### PR TITLE
fix: prevent app startup failure when MCP client init fails (fixes #668)

### DIFF
--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -70,10 +70,12 @@ async def lifespan(
     if hasattr(config, "mcp"):
         try:
             await mcp_manager.init_from_config(config.mcp)
-            runner.set_mcp_manager(mcp_manager)
             logger.debug("MCP client manager initialized")
-        except Exception:
+        except BaseException as e:
+            if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                raise
             logger.exception("Failed to initialize MCP manager")
+    runner.set_mcp_manager(mcp_manager)
 
     # --- channel connector init/start (from config.json) ---
     channel_manager = ChannelManager.from_config(
@@ -119,7 +121,9 @@ async def lifespan(
             )
             await mcp_watcher.start()
             logger.debug("MCP config watcher started")
-        except Exception:
+        except BaseException as e:
+            if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                raise
             logger.exception("Failed to start MCP watcher")
 
     # expose to endpoints

--- a/src/copaw/app/mcp/manager.py
+++ b/src/copaw/app/mcp/manager.py
@@ -50,7 +50,9 @@ class MCPClientManager:
             try:
                 await self._add_client(key, client_config)
                 logger.debug(f"MCP client '{key}' initialized successfully")
-            except Exception as e:
+            except BaseException as e:
+                if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                    raise
                 logger.warning(
                     f"Failed to initialize MCP client '{key}': {e}",
                     exc_info=True,


### PR DESCRIPTION
## Description

When an MCP client failed to connect (e.g. server returns 405, timeout, or connection errors), the app exited with "Application startup failed. Exiting." because the raised exceptions were not subclasses of `Exception` (`asyncio.CancelledError`, `BaseExceptionGroup`/`ExceptionGroup`), so the existing `except Exception` handlers did not catch them.

**Related Issue:** Fixes #(issue_number) or Relates to #668  #718

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling during initialization to ensure proper resource cleanup in edge cases.
  * Enhanced interrupt handling for more graceful application shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->