### PR TITLE
feat: add interrupted msg in memory

### DIFF
--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -555,3 +555,19 @@ class CoPawAgent(ReActAgent):
 
         # Normal message processing
         return await super().reply(msg=msg, structured_model=structured_model)
+
+    async def interrupt(self, msg: Msg | list[Msg] | None = None) -> None:
+        """Interrupt the current reply process and wait for cleanup."""
+        if self._reply_task and not self._reply_task.done():
+            task = self._reply_task
+            task.cancel(msg)
+            try:
+                await task
+            except asyncio.CancelledError:
+                if not task.cancelled():
+                    raise
+            except Exception:
+                logger.warning(
+                    "Exception occurred during interrupt cleanup",
+                    exc_info=True,
+                )


### PR DESCRIPTION
## Description

As the title says.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)
#230 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent interruption support now available. Users can cancel running operations at any time with optional messaging capabilities. The feature includes comprehensive error handling and proper resource cleanup for safe, graceful termination of long-running tasks, giving users greater control over agent execution and system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->