### PR TITLE
feat(config): enable ConfigWatcher to detect MCP changes

### DIFF
--- a/src/copaw/config/watcher.py
+++ b/src/copaw/config/watcher.py
@@ -47,7 +47,12 @@ def _raw_mcp_hash(config_path: Path) -> int:
         if mcp is None:
             return hash("None")
         # Canonical JSON for stable hashing (sorted keys, compact separators)
-        canonical = json.dumps(mcp, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+        canonical = json.dumps(
+            mcp,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
         return hash(canonical)
     except (FileNotFoundError, json.JSONDecodeError, PermissionError, OSError):
         return hash("None")
@@ -103,7 +108,7 @@ class ConfigWatcher:
     # ------------------------------------------------------------------
 
     def _snapshot(self) -> None:
-        """Load current config; record mtime, channels hash, heartbeat hash, mcp hash."""
+        """Load config; record mtime, channels, heartbeat, and mcp hashes."""
         try:
             self._last_mtime = self._config_path.stat().st_mtime
         except FileNotFoundError:
@@ -223,7 +228,7 @@ class ConfigWatcher:
             self._last_heartbeat_hash = new_hb_hash
 
     async def _apply_mcp_change(self) -> None:
-        """Check if MCP section changed in config file; warn if changed (requires restart).
+        """Check if MCP section changed; warn if changed (requires restart).
 
         Only warns on actual changes (not first-load), since MCP config
         requires server restart to apply.
@@ -235,9 +240,10 @@ class ConfigWatcher:
             return
         if new_mcp_hash != self._last_mcp_hash:
             self._last_mcp_hash = new_mcp_hash
-            logger.warning(
-                "ConfigWatcher: MCP config changed - restart required to apply changes",
+            msg = (
+                "MCP config changed - restart needed unless MCP hot-reload on"
             )
+            logger.warning("ConfigWatcher: %s", msg)
 
     async def _poll_loop(self) -> None:
         while True:


### PR DESCRIPTION
## Summary

Add MCP config hash tracking to ConfigWatcher for hot-reload detection.

Related #430 (partial - addresses MCP hot-reload roadmap item)

## Problem

When MCP server configuration changes in config.json, ConfigWatcher does not detect the change, so CoPaw continues using old MCP settings without warning the user that a restart is needed.

## Solution

Add MCP section hash tracking:
- `_mcp_hash()` - Hash MCP config for change detection
- `_last_mcp_hash` - Track last seen hash
- `_apply_mcp_change()` - Detect changes and log warning

## Changes

| File | Changes |
|------|---------|
| `src/copaw/config/watcher.py` | +27 lines - adds MCP hash tracking |

## Testing

1. Start CoPaw with MCP config
2. Modify MCP servers in config.json
3. Observe log: "ConfigWatcher: MCP config changed - restart required to apply changes"

## References

- Roadmap #430: "Skills and MCP runtime install, hot-reload improvements" (Planned)
- Complements PR #673 (channel hot-reload) to complete config hot-reload coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration watcher now monitors Model Configuration Provider (MCP) by hashing on-disk MCP data to detect changes.
  * Records an MCP snapshot at startup to establish a baseline and avoid spurious warnings on first load.
  * Detects subsequent MCP changes during regular checks and issues a clear notification advising a restart to apply updates.
  * Gracefully handles missing or unreadable MCP data without triggering false alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->