### PR TITLE
fix(providers): use max_completion_tokens for OpenAI connection test

### DIFF
--- a/src/copaw/providers/store.py
+++ b/src/copaw/providers/store.py
@@ -1315,7 +1315,7 @@ async def test_model_connection(
         test_payload = {
             "model": model_id,
             "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 1,
+            "max_completion_tokens": 1,
         }
 
     try:

--- a/src/copaw/providers/store.py
+++ b/src/copaw/providers/store.py
@@ -1315,7 +1315,7 @@ async def test_model_connection(
         test_payload = {
             "model": model_id,
             "messages": [{"role": "user", "content": "hi"}],
-            "max_completion_tokens": 1,
+            "max_completion_tokens": 100,
         }
 
     try:


### PR DESCRIPTION
## Summary
- Fix Azure OpenAI connection test failing for GPT-5 and o-series models by using `max_completion_tokens` instead of the deprecated `max_tokens` parameter in the OpenAI-compatible test payload.

Closes #733

## Test plan
- [ ] Configure an Azure OpenAI provider with a GPT-5 series model and verify the connection test succeeds
- [ ] Verify connection tests still work for other OpenAI-compatible providers (OpenAI, DashScope, ModelScope, etc.)
- [ ] Verify Anthropic provider connection test is unaffected (it correctly uses `max_tokens` per the Anthropic API)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated model-connection test payload to align with a renamed token-limit parameter so tests reflect the current request format.
  * Confirmed no changes to public interfaces or control flow; test adjustment only ensures continued accuracy of model connection checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->