### PR TITLE
fix(imessage): surface channel errors to Console UI and CLI

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -3,6 +3,7 @@ export interface BaseChannelConfig {
   bot_prefix: string;
   filter_tool_messages?: boolean;
   filter_thinking?: boolean;
+  last_error?: string;
 }
 
 export interface IMessageChannelConfig extends BaseChannelConfig {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -262,7 +262,8 @@
     "voiceSetupLink": "Open Twilio Console",
     "filterAll": "All",
     "builtin": "Built-in",
-    "custom": "Custom"
+    "custom": "Custom",
+    "error": "Error"
   },
   "sessions": {
     "title": "Sessions",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -262,7 +262,8 @@
     "voiceSetupLink": "打开 Twilio 控制台",
     "filterAll": "全部",
     "builtin": "内置",
-    "custom": "自定义"
+    "custom": "自定义",
+    "error": "错误"
   },
   "sessions": {
     "title": "会话",

--- a/console/src/pages/Control/Channels/components/ChannelCard.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelCard.tsx
@@ -90,7 +90,9 @@ export function ChannelCard({
         )}
       </div>
 
-      {lastError && <div className={styles.cardError}>{lastError}</div>}
+      {enabled && lastError && (
+        <div className={styles.cardError}>{lastError}</div>
+      )}
 
       <div className={styles.cardHint}>{t("channels.clickCardToEdit")}</div>
     </Card>

--- a/console/src/pages/Control/Channels/components/ChannelCard.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelCard.tsx
@@ -23,7 +23,8 @@ export function ChannelCard({
   const { t } = useTranslation();
   const enabled = Boolean(config.enabled);
   const isBuiltin = Boolean(config.isBuiltin);
-  const lastError = typeof config.last_error === "string" ? config.last_error : "";
+  const lastError =
+    typeof config.last_error === "string" ? config.last_error : "";
   const label = getChannelLabel(channelKey);
   const getConfigString = (key: string) =>
     typeof config[key] === "string" ? config[key] : "";
@@ -89,9 +90,7 @@ export function ChannelCard({
         )}
       </div>
 
-      {lastError && (
-        <div className={styles.cardError}>{lastError}</div>
-      )}
+      {lastError && <div className={styles.cardError}>{lastError}</div>}
 
       <div className={styles.cardHint}>{t("channels.clickCardToEdit")}</div>
     </Card>

--- a/console/src/pages/Control/Channels/components/ChannelCard.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelCard.tsx
@@ -23,6 +23,7 @@ export function ChannelCard({
   const { t } = useTranslation();
   const enabled = Boolean(config.enabled);
   const isBuiltin = Boolean(config.isBuiltin);
+  const lastError = typeof config.last_error === "string" ? config.last_error : "";
   const label = getChannelLabel(channelKey);
   const getConfigString = (key: string) =>
     typeof config[key] === "string" ? config[key] : "";
@@ -59,10 +60,20 @@ export function ChannelCard({
         <div className={styles.statusContainer}>
           <div
             className={`${styles.statusDot} ${
-              enabled ? styles.enabled : styles.disabled
+              enabled
+                ? lastError
+                  ? styles.error
+                  : styles.enabled
+                : styles.disabled
             }`}
           />
-          <div>{enabled ? t("common.enabled") : t("common.disabled")}</div>
+          <div>
+            {enabled
+              ? lastError
+                ? t("channels.error")
+                : t("common.enabled")
+              : t("common.disabled")}
+          </div>
         </div>
       </div>
 
@@ -77,6 +88,10 @@ export function ChannelCard({
           </>
         )}
       </div>
+
+      {lastError && (
+        <div className={styles.cardError}>{lastError}</div>
+      )}
 
       <div className={styles.cardHint}>{t("channels.clickCardToEdit")}</div>
     </Card>

--- a/console/src/pages/Control/Channels/index.module.less
+++ b/console/src/pages/Control/Channels/index.module.less
@@ -157,6 +157,11 @@
     background-color: #d9d9d9;
     box-shadow: none;
   }
+
+  &.error {
+    background-color: #ff4d4f;
+    box-shadow: 0 0 0 2px rgba(255, 77, 79, 0.2);
+  }
 }
 
 .channelTag {
@@ -182,6 +187,17 @@
   font-size: 12px;
   color: #999;
   margin-bottom: 12px;
+}
+
+.cardError {
+  font-size: 12px;
+  color: #ff4d4f;
+  background: rgba(255, 77, 79, 0.06);
+  border-radius: 6px;
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .cardHint {

--- a/console/src/pages/Control/Channels/index.module.less
+++ b/console/src/pages/Control/Channels/index.module.less
@@ -197,7 +197,7 @@
   padding: 6px 10px;
   margin-bottom: 8px;
   line-height: 1.4;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .cardHint {

--- a/src/copaw/app/channels/base.py
+++ b/src/copaw/app/channels/base.py
@@ -89,6 +89,7 @@ class BaseChannel(ABC):
         self._filter_tool_messages = filter_tool_messages
         self._filter_thinking = filter_thinking
         self._enqueue: EnqueueCallback = None
+        self.last_error: Optional[str] = None
         self._render_style = RenderStyle(
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -14,6 +14,7 @@ import base64
 import hashlib
 from pathlib import Path
 from typing import Any, Dict, Optional, List
+from urllib.parse import quote as urlquote
 
 from agentscope_runtime.engine.schemas.agent_schemas import (
     TextContent,
@@ -199,7 +200,10 @@ class IMessageChannel(BaseChannel):
             return
 
         try:
-            conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+            conn = sqlite3.connect(
+                f"file:{urlquote(self.db_path, safe='/')}?mode=ro",
+                uri=True,
+            )
             conn.row_factory = sqlite3.Row
             last_rowid = conn.execute(
                 "SELECT IFNULL(MAX(ROWID),0) FROM message",

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -185,7 +185,10 @@ class IMessageChannel(BaseChannel):
                 "Grant Full Disk Access to your terminal app in "
                 "System Settings > Privacy & Security > Full Disk Access."
             )
-            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            logger.error(
+                "iMessage watcher failed to start: %s",
+                self.last_error,
+            )
             return
         except OSError:
             if not db.exists():
@@ -196,7 +199,10 @@ class IMessageChannel(BaseChannel):
                 self.last_error = (
                     f"Cannot access iMessage database ({self.db_path})."
                 )
-            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            logger.error(
+                "iMessage watcher failed to start: %s",
+                self.last_error,
+            )
             return
 
         try:
@@ -212,7 +218,10 @@ class IMessageChannel(BaseChannel):
             self.last_error = (
                 f"Cannot open iMessage database ({self.db_path}): {exc}"
             )
-            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            logger.error(
+                "iMessage watcher failed to start: %s",
+                self.last_error,
+            )
             return
 
         self.last_error = None

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -175,6 +175,29 @@ class IMessageChannel(BaseChannel):
             self.db_path,
         )
 
+        db = Path(self.db_path)
+        try:
+            db.stat()
+        except PermissionError:
+            self.last_error = (
+                f"Cannot read iMessage database ({self.db_path}). "
+                "Grant Full Disk Access to your terminal app in "
+                "System Settings > Privacy & Security > Full Disk Access."
+            )
+            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            return
+        except OSError:
+            if not db.exists():
+                self.last_error = (
+                    f"iMessage database not found: {self.db_path}"
+                )
+            else:
+                self.last_error = (
+                    f"Cannot access iMessage database ({self.db_path})."
+                )
+            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            return
+
         try:
             conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
             conn.row_factory = sqlite3.Row
@@ -183,13 +206,9 @@ class IMessageChannel(BaseChannel):
             ).fetchone()[0]
         except sqlite3.OperationalError as exc:
             self.last_error = (
-                f"Cannot open iMessage database ({self.db_path}): {exc}. "
-                "Grant Full Disk Access to your terminal app in "
-                "System Settings > Privacy & Security > Full Disk Access."
+                f"Cannot open iMessage database ({self.db_path}): {exc}"
             )
-            logger.error(
-                "iMessage watcher failed to start: %s", self.last_error
-            )
+            logger.error("iMessage watcher failed to start: %s", self.last_error)
             return
 
         self.last_error = None

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -175,11 +175,22 @@ class IMessageChannel(BaseChannel):
             self.db_path,
         )
 
-        conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
-        conn.row_factory = sqlite3.Row
-        last_rowid = conn.execute(
-            "SELECT IFNULL(MAX(ROWID),0) FROM message",
-        ).fetchone()[0]
+        try:
+            conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+            last_rowid = conn.execute(
+                "SELECT IFNULL(MAX(ROWID),0) FROM message",
+            ).fetchone()[0]
+        except sqlite3.OperationalError as exc:
+            self.last_error = (
+                f"Cannot open iMessage database ({self.db_path}): {exc}. "
+                "Grant Full Disk Access to your terminal app in "
+                "System Settings > Privacy & Security > Full Disk Access."
+            )
+            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            return
+
+        self.last_error = None
 
         try:
             while not self._stop_event.is_set():
@@ -273,8 +284,15 @@ ORDER BY m.ROWID ASC
             logger.debug("disabled by env IMESSAGE_ENABLED=0")
             return
 
-        self._imsg_path = self._ensure_imsg()
+        try:
+            self._imsg_path = self._ensure_imsg()
+        except RuntimeError as exc:
+            self.last_error = str(exc)
+            logger.error("iMessage channel start failed: %s", self.last_error)
+            return
+
         logger.info(f"IMessage channel started with binary: {self._imsg_path}")
+        self.last_error = None
 
         self._stop_event.clear()
         self._thread = threading.Thread(target=self._watcher_loop, daemon=True)

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -187,7 +187,9 @@ class IMessageChannel(BaseChannel):
                 "Grant Full Disk Access to your terminal app in "
                 "System Settings > Privacy & Security > Full Disk Access."
             )
-            logger.error("iMessage watcher failed to start: %s", self.last_error)
+            logger.error(
+                "iMessage watcher failed to start: %s", self.last_error
+            )
             return
 
         self.last_error = None

--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -328,6 +328,7 @@ class ChannelManager:
         )
         for g in snapshot:
             try:
+                g.last_error = None
                 await g.start()
             except Exception as exc:
                 logger.exception(f"failed to start channels={g.channel}")

--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -339,7 +339,11 @@ class ChannelManager:
             (c for c in snapshot if c.channel == "console"),
             None,
         )
-        if console_ch is not None and hasattr(console_ch, "_print_error"):
+        if (
+            console_ch is not None
+            and getattr(console_ch, "enabled", False)
+            and hasattr(console_ch, "_print_error")
+        ):
             for ch in snapshot:
                 err = getattr(ch, "last_error", None)
                 if err and ch.channel != "console":

--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -343,7 +343,7 @@ class ChannelManager:
                 err = getattr(ch, "last_error", None)
                 if err and ch.channel != "console":
                     console_ch._print_error(
-                        f"Channel '{ch.channel}' failed to start: {err}"
+                        f"Channel '{ch.channel}' failed to start: {err}",
                     )
 
     async def stop_all(self) -> None:

--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -329,8 +329,22 @@ class ChannelManager:
         for g in snapshot:
             try:
                 await g.start()
-            except Exception:
+            except Exception as exc:
                 logger.exception(f"failed to start channels={g.channel}")
+                g.last_error = str(exc)
+
+        # Surface startup errors via console channel
+        console_ch = next(
+            (c for c in snapshot if c.channel == "console"),
+            None,
+        )
+        if console_ch is not None and hasattr(console_ch, "_print_error"):
+            for ch in snapshot:
+                err = getattr(ch, "last_error", None)
+                if err and ch.channel != "console":
+                    console_ch._print_error(
+                        f"Channel '{ch.channel}' failed to start: {err}"
+                    )
 
     async def stop_all(self) -> None:
         self._in_progress.clear()
@@ -404,10 +418,11 @@ class ChannelManager:
         logger.info(f"Pre-starting new channel: {new_channel_name}")
         try:
             await new_channel.start()
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 f"Failed to start new channel: {new_channel_name}",
             )
+            new_channel.last_error = str(exc)
             try:
                 await new_channel.stop()
             except Exception:

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -56,7 +56,11 @@ async def list_channels(request: Request) -> dict:
     if channel_manager is not None:
         for ch in channel_manager.channels:
             ch_key = getattr(ch, "channel", None)
-            if ch_key and ch_key in result and isinstance(result[ch_key], dict):
+            if (
+                ch_key
+                and ch_key in result
+                and isinstance(result[ch_key], dict)
+            ):
                 err = getattr(ch, "last_error", None)
                 if err:
                     result[ch_key]["last_error"] = err

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/config", tags=["config"])
     summary="List all channels",
     description="Retrieve configuration for all available channels",
 )
-async def list_channels() -> dict:
+async def list_channels(request: Request) -> dict:
     """List all channel configs (filtered by available channels)."""
     config = load_config()
     available = get_available_channels()
@@ -50,6 +50,16 @@ async def list_channels() -> dict:
         if isinstance(channel_data, dict):
             channel_data["isBuiltin"] = key in BUILTIN_CHANNEL_KEYS
         result[key] = channel_data
+
+    # Merge runtime error state from running channel instances
+    channel_manager = getattr(request.app.state, "channel_manager", None)
+    if channel_manager is not None:
+        for ch in channel_manager.channels:
+            ch_key = getattr(ch, "channel", None)
+            if ch_key and ch_key in result and isinstance(result[ch_key], dict):
+                err = getattr(ch, "last_error", None)
+                if err:
+                    result[ch_key]["last_error"] = err
 
     return result
 

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -819,7 +819,8 @@ def _strip_ansi(s: str) -> str:
         \x1B                      # ESC
         (?:
             \[ [0-?]* [ -/]* [@-~]     # CSI sequence
-          | \] [^\x1b\x07]* (?:\x07|\x1b\\)  # OSC sequence terminated by BEL or ST
+          # OSC sequence terminated by BEL or ST
+          | \] [^\x1b\x07]* (?:\x07|\x1b\\)
           | [@-Z\\-_]                  # 7-bit C1 escape (single-char)
         )
         """,

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -828,14 +828,26 @@ def _validate_channel(key: str, ch) -> list:
             db_path = ch.get("db_path")
         if db_path:
             expanded = os.path.expanduser(db_path)
-            if not os.path.exists(expanded):
-                warnings.append(f"iMessage database not found: {expanded}")
-            elif not os.access(expanded, os.R_OK):
+            try:
+                os.stat(expanded)
+            except PermissionError:
                 warnings.append(
                     f"Cannot read iMessage database: {expanded}. "
                     "Grant Full Disk Access to your terminal in "
                     "System Settings > Privacy & Security > Full Disk Access.",
                 )
+            except FileNotFoundError:
+                warnings.append(
+                    f"iMessage database not found: {expanded}",
+                )
+            else:
+                if not os.access(expanded, os.R_OK):
+                    warnings.append(
+                        f"Cannot read iMessage database: {expanded}. "
+                        "Grant Full Disk Access to your terminal in "
+                        "System Settings > Privacy & Security > "
+                        "Full Disk Access.",
+                    )
 
     return warnings
 

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -814,7 +814,18 @@ def _strip_ansi(s: str) -> str:
     """Strip ANSI escape sequences from a string."""
     import re
 
-    return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", s)
+    ansi_escape = re.compile(
+        r"""
+        \x1B                      # ESC
+        (?:
+            \[ [0-?]* [ -/]* [@-~]     # CSI sequence
+          | \] [^\x1b\x07]* (?:\x07|\x1b\\)  # OSC sequence terminated by BEL or ST
+          | [@-Z\\-_]                  # 7-bit C1 escape (single-char)
+        )
+        """,
+        re.VERBOSE,
+    )
+    return ansi_escape.sub("", s)
 
 
 def _validate_channel(key: str, ch: Any) -> list[str]:

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import click
 
@@ -816,9 +817,9 @@ def _strip_ansi(s: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", s)
 
 
-def _validate_channel(key: str, ch) -> list:
+def _validate_channel(key: str, ch: Any) -> list[str]:
     """Run static validation checks for a channel config. Returns warnings."""
-    warnings: list = []
+    warnings: list[str] = []
 
     if key == "imessage":
         import shutil
@@ -831,7 +832,8 @@ def _validate_channel(key: str, ch) -> list:
             )
 
         db_path = (
-            ch.get("db_path") if isinstance(ch, dict)
+            ch.get("db_path")
+            if isinstance(ch, dict)
             else getattr(ch, "db_path", None)
         )
         if db_path:

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -809,6 +809,13 @@ def _channel_enabled(ch) -> bool:
     return False
 
 
+def _strip_ansi(s: str) -> str:
+    """Strip ANSI escape sequences from a string."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", s)
+
+
 def _validate_channel(key: str, ch) -> list:
     """Run static validation checks for a channel config. Returns warnings."""
     warnings: list = []
@@ -823,27 +830,29 @@ def _validate_channel(key: str, ch) -> list:
                 "Install with: brew install steipete/tap/imsg",
             )
 
-        db_path = getattr(ch, "db_path", None)
-        if isinstance(ch, dict):
-            db_path = ch.get("db_path")
+        db_path = (
+            ch.get("db_path") if isinstance(ch, dict)
+            else getattr(ch, "db_path", None)
+        )
         if db_path:
             expanded = os.path.expanduser(db_path)
+            safe_expanded = _strip_ansi(expanded)
             try:
                 os.stat(expanded)
             except PermissionError:
                 warnings.append(
-                    f"Cannot read iMessage database: {expanded}. "
+                    f"Cannot read iMessage database: {safe_expanded}. "
                     "Grant Full Disk Access to your terminal in "
                     "System Settings > Privacy & Security > Full Disk Access.",
                 )
             except FileNotFoundError:
                 warnings.append(
-                    f"iMessage database not found: {expanded}",
+                    f"iMessage database not found: {safe_expanded}",
                 )
             else:
                 if not os.access(expanded, os.R_OK):
                     warnings.append(
-                        f"Cannot read iMessage database: {expanded}. "
+                        f"Cannot read iMessage database: {safe_expanded}. "
                         "Grant Full Disk Access to your terminal in "
                         "System Settings > Privacy & Security > "
                         "Full Disk Access.",

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -809,6 +809,37 @@ def _channel_enabled(ch) -> bool:
     return False
 
 
+def _validate_channel(key: str, ch) -> list:
+    """Run static validation checks for a channel config. Returns warnings."""
+    warnings: list = []
+
+    if key == "imessage":
+        import shutil
+        import os
+
+        if not shutil.which("imsg"):
+            warnings.append(
+                "imsg binary not found. "
+                "Install with: brew install steipete/tap/imsg",
+            )
+
+        db_path = getattr(ch, "db_path", None)
+        if isinstance(ch, dict):
+            db_path = ch.get("db_path")
+        if db_path:
+            expanded = os.path.expanduser(db_path)
+            if not os.path.exists(expanded):
+                warnings.append(f"iMessage database not found: {expanded}")
+            elif not os.access(expanded, os.R_OK):
+                warnings.append(
+                    f"Cannot read iMessage database: {expanded}. "
+                    "Grant Full Disk Access to your terminal in "
+                    "System Settings > Privacy & Security > Full Disk Access.",
+                )
+
+    return warnings
+
+
 @channels_group.command("list")
 def list_cmd() -> None:
     """Show current channel configuration."""
@@ -843,6 +874,10 @@ def list_cmd() -> None:
                 _mask(str(value)) if field_name in _SECRET_FIELDS else value
             )
             click.echo(f"  {field_name:20s}: {display}")
+
+        if _channel_enabled(ch):
+            for warning in _validate_channel(key, ch):
+                click.echo(click.style(f"  ⚠ {warning}", fg="yellow"))
 
     click.echo()
 


### PR DESCRIPTION
## Summary
- Fix silent crash in iMessage channel when `chat.db` is inaccessible (e.g. missing Full Disk Access on macOS)
- Add `last_error` attribute to `BaseChannel` so any channel can report runtime errors
- Surface channel errors in three places: Console UI (red error dot + banner on channel card), CLI (`copaw channels list` static validation), and terminal output (console channel prints startup errors)

## Test plan
- [x] Start CoPaw without Full Disk Access granted to the terminal — verify iMessage shows red error dot in Console UI with actionable message
- [x] Run `copaw channels list` with iMessage enabled but no Full Disk Access — verify yellow warning appears
- [x] Verify the terminal prints a red error message on startup when iMessage fails
- [x] Start CoPaw with Full Disk Access granted — verify iMessage shows green dot with no errors
- [x] Remove `imsg` binary from PATH and start — verify "imsg binary not found" error surfaces in all three places

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channels now display runtime error messages with a distinct visual error state in the management UI.
  * Channel runtime errors are surfaced through the API and diagnostics.
  * Channel listings include setup/validation warnings (e.g., iMessage accessibility) in CLI output.

* **Bug Fixes**
  * Improved robustness and error handling for channel startup and database access, with descriptive error exposure.

* **Documentation**
  * Added localized "Error" label for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->