### PR TITLE
fix(chats): use UTC-Time

### DIFF
--- a/console/src/pages/Control/Sessions/components/columns.tsx
+++ b/console/src/pages/Control/Sessions/components/columns.tsx
@@ -10,6 +10,14 @@ interface ColumnHandlers {
   t: TFunction;
 }
 
+/** Normalize ISO string to UTC for consistent sorting across mixed timezone formats. */
+const toUTCTime = (ts: string | null | undefined): number => {
+  if (!ts) return 0;
+  const normalized =
+    /[Z+\-]\d{2}:?\d{2}$/.test(ts) || ts.endsWith("Z") ? ts : ts + "Z";
+  return new Date(normalized).getTime();
+};
+
 export const createColumns = (
   handlers: ColumnHandlers,
 ): ColumnsType<Session> => {
@@ -56,12 +64,8 @@ export const createColumns = (
       key: "created_at",
       width: 180,
       render: (timestamp: string | number | null) => formatTime(timestamp),
-      sorter: (a: Session, b: Session) => {
-        const timeA = a.created_at ? new Date(a.created_at).getTime() : 0;
-        const timeB = b.created_at ? new Date(b.created_at).getTime() : 0;
-        return timeA - timeB;
-      },
-      defaultSortOrder: "descend",
+      sorter: (a: Session, b: Session) =>
+        toUTCTime(a.created_at) - toUTCTime(b.created_at),
     },
     {
       title: "UpdatedAt",
@@ -69,11 +73,9 @@ export const createColumns = (
       key: "updated_at",
       width: 180,
       render: (timestamp: string | number | null) => formatTime(timestamp),
-      sorter: (a: Session, b: Session) => {
-        const timeA = a.updated_at ? new Date(a.updated_at).getTime() : 0;
-        const timeB = b.updated_at ? new Date(b.updated_at).getTime() : 0;
-        return timeA - timeB;
-      },
+      sorter: (a: Session, b: Session) =>
+        toUTCTime(a.updated_at) - toUTCTime(b.updated_at),
+      defaultSortOrder: "descend",
     },
     {
       title: "Action",

--- a/console/src/pages/Control/Sessions/components/constants.ts
+++ b/console/src/pages/Control/Sessions/components/constants.ts
@@ -14,10 +14,24 @@ export const CHANNEL_COLORS: Record<string, string> = {
   console: "green",
 } as const;
 
+/**
+ * Normalize ISO timestamp to ensure UTC timezone is always recognized.
+ * Timestamps without timezone suffix (e.g. from datetime.utcnow()) are
+ * treated as local time by browsers, causing incorrect display. Appending
+ * 'Z' forces UTC interpretation, consistent with timezone-aware timestamps.
+ */
+const normalizeTimestamp = (timestamp: string): string => {
+  if (/[Z+\-]\d{2}:?\d{2}$/.test(timestamp) || timestamp.endsWith("Z")) {
+    return timestamp;
+  }
+  return timestamp + "Z";
+};
+
 export const formatTime = (timestamp: string | number | null): string => {
   if (timestamp === null || timestamp === undefined) return "N/A";
-  const date =
-    typeof timestamp === "string" ? new Date(timestamp) : new Date(timestamp);
+  const normalized =
+    typeof timestamp === "string" ? normalizeTimestamp(timestamp) : timestamp;
+  const date = new Date(normalized);
   return date.toLocaleString("zh-CN", {
     year: "numeric",
     month: "2-digit",

--- a/src/copaw/app/runner/manager.py
+++ b/src/copaw/app/runner/manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from .models import ChatSpec
@@ -137,7 +137,7 @@ class ChatManager:
             Updated chat spec
         """
         async with self._lock:
-            spec.updated_at = datetime.utcnow()
+            spec.updated_at = datetime.now(timezone.utc)
             await self._repo.upsert_chat(spec)
             return spec
 


### PR DESCRIPTION
## Description

When a browser's new Date() function encounters a string without a timezone, it will parse it according to the local time (e.g., users with UTC+8 will think it is Beijing time). This causes the actual UTC time corresponding to updated_at to be earlier than created_at, resulting in the error message "creation time is later than update time".

![时间没问题](https://github.com/user-attachments/assets/f46ca453-548e-483a-9fa5-77858c4089f7)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

Fixes #769

<!-- end of auto-generated comment: release notes by coderabbit.ai -->