### PR TITLE
feat(cron): add pause/resume state persistence

### DIFF
--- a/console/src/api/types/cronjob.ts
+++ b/console/src/api/types/cronjob.ts
@@ -34,6 +34,7 @@ export interface CronJobSpecInput {
   id: string;
   name: string;
   enabled?: boolean;
+  paused?: boolean;
   schedule: CronJobSchedule;
   task_type?: "text" | "agent";
   text?: string;

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -212,7 +212,11 @@
     "misfireGraceSecondsTooltip": "Grace period for missed executions. If a job misses its scheduled time by more than this, it won't run.",
     "executeNowTitle": "Execute Task Now",
     "executeNowContent": "Are you sure you want to execute \"{{name}}\" now?",
-    "executeNowConfirm": "Execute Now"
+    "executeNowConfirm": "Execute Now",
+    "running": "Running",
+    "paused": "Paused",
+    "pause": "Pause",
+    "resume": "Resume"
   },
   "channels": {
     "title": "Channels",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -212,7 +212,11 @@
     "misfireGraceSecondsTooltip": "错过执行的宽限期。如果任务错过计划时间超过此时长，将不会执行。",
     "executeNowTitle": "立即执行任务",
     "executeNowContent": "确定要立即执行任务 \"{{name}}\" 吗？",
-    "executeNowConfirm": "立即执行"
+    "executeNowConfirm": "立即执行",
+    "running": "运行中",
+    "paused": "已暂停",
+    "pause": "暂停",
+    "resume": "恢复"
   },
   "channels": {
     "title": "频道",

--- a/console/src/pages/Control/CronJobs/components/columns.tsx
+++ b/console/src/pages/Control/CronJobs/components/columns.tsx
@@ -11,6 +11,7 @@ type CronJob = CronJobSpecOutput;
 
 interface ColumnHandlers {
   onToggleEnabled: (job: CronJob) => void;
+  onTogglePaused: (job: CronJob) => void;
   onExecuteNow: (job: CronJob) => void;
   onEdit: (job: CronJob) => void;
   onDelete: (jobId: string) => void;
@@ -65,28 +66,43 @@ export const createColumns = (
       dataIndex: "enabled",
       key: "enabled",
       width: 100,
-      render: (enabled: boolean) => (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            fontSize: 12,
-          }}
-        >
+      render: (enabled: boolean, record: CronJob) => {
+        const paused = record.paused ?? false;
+        let statusText: string;
+        let statusColor: string;
+
+        if (!enabled) {
+          statusText = handlers.t("common.disabled");
+          statusColor = "#d9d9d9";
+        } else if (paused) {
+          statusText = handlers.t("cronJobs.paused");
+          statusColor = "#faad14";
+        } else {
+          statusText = handlers.t("cronJobs.running");
+          statusColor = "#52c41a";
+        }
+
+        return (
           <span
             style={{
-              width: 6,
-              height: 6,
-              borderRadius: "50%",
-              backgroundColor: enabled ? "#52c41a" : "#d9d9d9",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
             }}
-          />
-          {enabled
-            ? handlers.t("common.enabled")
-            : handlers.t("common.disabled")}
-        </span>
-      ),
+          >
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                backgroundColor: statusColor,
+              }}
+            />
+            {statusText}
+          </span>
+        );
+      },
     },
     {
       title: handlers.t("cronJobs.scheduleType"),
@@ -359,6 +375,17 @@ export const createColumns = (
                 ? handlers.t("cronJobs.disable")
                 : handlers.t("common.enable")}
             </Button>
+            {record.enabled && (
+              <Button
+                type="link"
+                size="small"
+                onClick={() => handlers.onTogglePaused(record)}
+              >
+                {record.paused
+                  ? handlers.t("cronJobs.resume")
+                  : handlers.t("cronJobs.pause")}
+              </Button>
+            )}
             <Button
               type="link"
               size="small"

--- a/console/src/pages/Control/CronJobs/index.tsx
+++ b/console/src/pages/Control/CronJobs/index.tsx
@@ -23,6 +23,7 @@ function CronJobsPage() {
     updateJob,
     deleteJob,
     toggleEnabled,
+    togglePaused,
     executeNow,
   } = useCronJobs();
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -89,6 +90,10 @@ function CronJobsPage() {
 
   const handleToggleEnabled = async (job: CronJob) => {
     await toggleEnabled(job);
+  };
+
+  const handleTogglePaused = async (job: CronJob) => {
+    await togglePaused(job);
   };
 
   const handleExecuteNow = async (job: CronJob) => {
@@ -168,6 +173,7 @@ function CronJobsPage() {
 
   const columns = createColumns({
     onToggleEnabled: handleToggleEnabled,
+    onTogglePaused: handleTogglePaused,
     onExecuteNow: handleExecuteNow,
     onEdit: handleEdit,
     onDelete: handleDelete,

--- a/console/src/pages/Control/CronJobs/useCronJobs.ts
+++ b/console/src/pages/Control/CronJobs/useCronJobs.ts
@@ -112,6 +112,29 @@ export function useCronJobs() {
     }
   };
 
+  const togglePaused = async (job: CronJob) => {
+    const paused = job.paused ?? false;
+    const updated = { ...job, paused: !paused };
+    setJobs((prev) => prev.map((j) => (j.id === job.id ? updated : j)));
+
+    try {
+      if (!paused) {
+        await api.pauseCronJob(job.id);
+      } else {
+        await api.resumeCronJob(job.id);
+      }
+      // Refetch to get the latest state from server
+      await fetchJobs();
+      message.success(`${paused ? "Resumed" : "Paused"}`);
+      return true;
+    } catch (error) {
+      console.error("Failed to toggle pause state", error);
+      setJobs((prev) => prev.map((j) => (j.id === job.id ? job : j)));
+      message.error("Operation failed");
+      return false;
+    }
+  };
+
   const executeNow = async (jobId: string) => {
     try {
       await api.triggerCronJob(jobId);
@@ -131,6 +154,7 @@ export function useCronJobs() {
     updateJob,
     deleteJob,
     toggleEnabled,
+    togglePaused,
     executeNow,
   };
 }

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -112,10 +112,18 @@ class CronManager:
     async def pause_job(self, job_id: str) -> None:
         async with self._lock:
             self._scheduler.pause_job(job_id)
+            job = await self._repo.get_job(job_id)
+            if job:
+                job.paused = True
+                await self._repo.upsert_job(job)
 
     async def resume_job(self, job_id: str) -> None:
         async with self._lock:
             self._scheduler.resume_job(job_id)
+            job = await self._repo.get_job(job_id)
+            if job:
+                job.paused = False
+                await self._repo.upsert_job(job)
 
     async def reschedule_heartbeat(self) -> None:
         """Reload heartbeat config and update or remove the heartbeat job."""
@@ -214,7 +222,7 @@ class CronManager:
             replace_existing=True,
         )
 
-        if not spec.enabled:
+        if not spec.enabled or spec.paused:
             self._scheduler.pause_job(spec.id)
 
         # update next_run

--- a/src/copaw/app/crons/models.py
+++ b/src/copaw/app/crons/models.py
@@ -83,6 +83,7 @@ class CronJobSpec(BaseModel):
     id: str
     name: str
     enabled: bool = True
+    paused: bool = False
 
     schedule: ScheduleSpec
     task_type: TaskType = "agent"


### PR DESCRIPTION
- Add  field to CronJobSpec for persistent pause state
- Update manager to persist pause state on pause/resume operations
- Display pause status in frontend (Running/Paused/Disabled)
- Add pause/resume toggle button in job list actions

## Description

实现定时任务 pause/resume 状态持久化与前端显示。

用户通过对话方式操作定时任务时（如"帮我暂停这个定时任务"），pause 状态仅存在于 APScheduler
 内存中，服务重启后丢失，导致被暂停的任务意外被调度执行


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
