### PR TITLE
fix(channels): add discord send_media

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -340,7 +340,7 @@ class DiscordChannel(BaseChannel):
                 async with session.get(url) as resp:
                     if resp.status != 200:
                         logger.warning(
-                            "discord send_media: download " "failed status=%d",
+                            "discord send_media: download failed status=%d",
                             resp.status,
                         )
                         return
@@ -348,12 +348,11 @@ class DiscordChannel(BaseChannel):
             parsed_path = urlparse(url).path
             suffix = Path(parsed_path).suffix
             fname = Path(parsed_path).name or f"file{suffix}"
-            tmp = tempfile.NamedTemporaryFile(
+            with tempfile.NamedTemporaryFile(
                 delete=False,
                 suffix=suffix,
-            )
-            tmp.write(data)
-            tmp.close()
+            ) as tmp:
+                tmp.write(data)
             temp_path = tmp.name
             file = discord.File(
                 temp_path,


### PR DESCRIPTION
## Description

Add send_media to discord channel.

**Related Issue:** Fixes https://github.com/agentscope-ai/CoPaw/issues/839 and https://github.com/agentscope-ai/CoPaw/issues/286

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Open discord channel, ask the bot to send image / pdfs to user.

## Local Verification Evidence

User successfully sends and receives image.

## Additional Notes

N/A
