### PR TITLE
fix: custom provider API key handling and OpenRouter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,14 @@ cookbook/_build
 /build
 dist/
 # Console frontend build (generated in Docker/CI, do not commit)
-src/copaw/console/dist/
+!src/copaw/agents/skills/__init__.py
+
+# Customized skills and local app data
+customized_skills/
+active_skills/
+.copaw/
+fal_gen/
+Email_Skill/
 
 # frontend (website)
 website/node_modules/

--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -47,6 +47,7 @@ export interface CreateCustomProviderRequest {
   name: string;
   default_base_url?: string;
   api_key_prefix?: string;
+  api_key?: string;
   chat_model?: string;
   models?: ModelInfo[];
 }

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -380,6 +380,8 @@
     "defaultBaseUrlPlaceholder": "e.g. https://api.example.com",
     "apiKeyPrefixLabel": "API Key Prefix (optional)",
     "apiKeyPrefixPlaceholder": "e.g. sk-",
+    "apiKeyLabel": "API Key (optional)",
+    "apiKeyPlaceholder": "Enter your API key",
     "providerCreated": "Provider \"{{name}}\" created",
     "providerCreateFailed": "Failed to create provider",
     "deleteProvider": "Delete Provider",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -380,6 +380,8 @@
     "defaultBaseUrlPlaceholder": "например: https://api.example.com",
     "apiKeyPrefixLabel": "Префикс API-ключа (необязательно)",
     "apiKeyPrefixPlaceholder": "например: sk-",
+    "apiKeyLabel": "API-ключ (необязательно)",
+    "apiKeyPlaceholder": "Введите ваш API-ключ",
     "providerCreated": "Провайдер «{{name}}» создан",
     "providerCreateFailed": "Не удалось создать провайдера",
     "deleteProvider": "Удалить провайдера",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -380,6 +380,8 @@
     "defaultBaseUrlPlaceholder": "例如 https://api.example.com",
     "apiKeyPrefixLabel": "API Key 前缀（可选）",
     "apiKeyPrefixPlaceholder": "例如 sk-",
+    "apiKeyLabel": "API 密钥（可选）",
+    "apiKeyPlaceholder": "输入您的 API 密钥",
     "providerCreated": "提供商 \"{{name}}\" 已创建",
     "providerCreateFailed": "创建提供商失败",
     "deleteProvider": "删除提供商",

--- a/console/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
@@ -32,7 +32,7 @@ export function CustomProviderModal({
         id: values.id.trim(),
         name: values.name.trim(),
         default_base_url: values.default_base_url?.trim() || "",
-        api_key_prefix: values.api_key_prefix?.trim() || "",
+        api_key: values.api_key?.trim() || "",
         chat_model: values.chat_model || "OpenAIChatModel",
       });
       message.success(
@@ -99,8 +99,8 @@ export function CustomProviderModal({
           <Input placeholder={t("models.defaultBaseUrlPlaceholder")} />
         </Form.Item>
 
-        <Form.Item name="api_key_prefix" label={t("models.apiKeyPrefixLabel")}>
-          <Input placeholder={t("models.apiKeyPrefixPlaceholder")} />
+        <Form.Item name="api_key" label={t("models.apiKeyLabel")}>
+          <Input.Password placeholder={t("models.apiKeyPlaceholder")} />
         </Form.Item>
 
         <Form.Item

--- a/src/copaw/__version__.py
+++ b/src/copaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.0.7"
+__version__ = "0.0.5.post1"

--- a/src/copaw/__version__.py
+++ b/src/copaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.0.5.post1"
+__version__ = "0.0.7"

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -431,6 +431,13 @@ def _create_remote_model_instance(
             ),
         }
 
+    # OpenRouter requires special headers for identification
+    if base_url and "openrouter.ai" in base_url.lower():
+        client_kwargs["default_headers"] = {
+            "HTTP-Referer": "https://github.com/copaw-ai/CoPaw",
+            "X-Title": "CoPaw",
+        }
+
     # Instantiate model
     model = chat_model_class(
         model_name,

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -22,6 +22,7 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
 )
 
 from ....config.config import TelegramConfig as TelegramChannelConfig
+from .format_html import markdown_to_telegram_html, strip_markdown
 from ..base import (
     BaseChannel,
     OnReplySent,
@@ -208,33 +209,8 @@ def _message_meta(update: Any) -> dict:
     }
 
 
-def _escape_markdown(text: str) -> str:
-    """Escape text for Telegram Legacy Markdown (v1).
-
-    V1 is much more permissive than V2. We only need to escape
-    unpaired formatting characters like *, _, and ` to prevent crashes.
-    """
-    if not text:
-        return text
-
-    # Handle common unpaired cases or sensitive characters for V1.
-    # In V1, we mainly care about * and _ if they aren't forming a pair.
-    # But for an LLM, the safest is to just pass a reasonably clean string.
-
-    # We can use a simple regex to escape symbols if they aren't followed by something
-    # that looks like the start of a formatting block.
-    # Actually, for V1, many people just use the raw text and it works fine
-    # unless there's a stray * or _.
-    
-    # Let's do a very basic cleanup:
-    # 1. Escape lone asterisks or underscores that might break parsing.
-    # This is a bit naive but usually safer than V2.
-    text = text.replace("\\", "\\\\") # Escape backslashes first
-    
-    return text
-
-
 class TelegramChannel(BaseChannel):
+
     """Telegram channel: Bot API polling; session_id = telegram:{chat_id}."""
 
     channel = "telegram"
@@ -520,20 +496,20 @@ class TelegramChannel(BaseChannel):
         self._stop_typing(chat_id)
         chunks = self._chunk_text(text)
         for chunk in chunks:
-            chunk_escaped = _escape_markdown(chunk)
+            html_chunk = markdown_to_telegram_html(chunk)
             try:
                 await bot.send_message(
                     chat_id=chat_id,
-                    text=chunk_escaped,
-                    parse_mode=ParseMode.MARKDOWN,
+                    text=html_chunk,
+                    parse_mode=ParseMode.HTML,
                 )
             except Exception:
                 logger.warning(
-                    "telegram MARKDOWN failed for chunk: %r, trying plain text",
-                    chunk_escaped,
+                    "telegram HTML send failed, trying plain text",
                 )
                 try:
-                    await bot.send_message(chat_id=chat_id, text=chunk)
+                    plain = strip_markdown(chunk)
+                    await bot.send_message(chat_id=chat_id, text=plain)
                 except Exception:
                     logger.exception("telegram send_message fallback failed")
                     return

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import uuid
 from pathlib import Path
 from typing import Any, Optional, Union

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -9,6 +9,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from telegram.constants import ParseMode
+
 from agentscope_runtime.engine.schemas.agent_schemas import (
     TextContent,
     ImageContent,
@@ -492,10 +494,20 @@ class TelegramChannel(BaseChannel):
         chunks = self._chunk_text(text)
         for chunk in chunks:
             try:
-                await bot.send_message(chat_id=chat_id, text=chunk)
+                await bot.send_message(
+                    chat_id=chat_id,
+                    text=chunk,
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                )
             except Exception:
-                logger.exception("telegram send_message failed")
-                return
+                logger.warning(
+                    "telegram send_message MARKDOWN_V2 failed, trying plain text",
+                )
+                try:
+                    await bot.send_message(chat_id=chat_id, text=chunk)
+                except Exception:
+                    logger.exception("telegram send_message fallback failed")
+                    return
 
     async def send_media(
         self,

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -205,6 +206,29 @@ def _message_meta(update: Any) -> dict:
         "message_id": str(getattr(message, "message_id", "")),
         "is_group": chat_type in ("group", "supergroup", "channel"),
     }
+
+
+def _escape_markdown_v2(text: str) -> str:
+    """Escape text for Telegram MarkdownV2 while preserving basic formatting.
+
+    We use a regex-based approach to escape characters that are problematic
+    for Telegram's strict MarkdownV2 parser, but we avoid escaping characters
+    that are likely intended as formatting (bold, italic, code, links).
+    """
+    if not text:
+        return text
+
+    # Escape the strict characters that nearly always cause crashes if unescaped:
+    # . ! - + = | { } # > ~
+    special_chars = r"([\.!\-\+\=\|\{\}\#\>\~])"
+    text = re.sub(special_chars, r"\\\1", text)
+
+    # Escape brackets and parentheses that don't look like an escaped character
+    # This helps avoid breaking [text](url) while escaping ( ) that aren't part of it.
+    # Note: We already escaped those if they were preceded by \ but LLMs don't usually do that.
+    text = re.sub(r"(?<!\\)([\(\)\[\]])", r"\\\1", text)
+
+    return text
 
 
 class TelegramChannel(BaseChannel):
@@ -493,10 +517,11 @@ class TelegramChannel(BaseChannel):
         self._stop_typing(chat_id)
         chunks = self._chunk_text(text)
         for chunk in chunks:
+            chunk_escaped = _escape_markdown_v2(chunk)
             try:
                 await bot.send_message(
                     chat_id=chat_id,
-                    text=chunk,
+                    text=chunk_escaped,
                     parse_mode=ParseMode.MARKDOWN_V2,
                 )
             except Exception:

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -208,61 +208,29 @@ def _message_meta(update: Any) -> dict:
     }
 
 
-def _escape_markdown_v2(text: str) -> str:
-    """Convert standard Markdown to Telegram's strict MarkdownV2.
+def _escape_markdown(text: str) -> str:
+    """Escape text for Telegram Legacy Markdown (v1).
 
-    Includes support for headers, bold, italic, links, code blocks,
-    and blockquotes, with proper character escaping.
+    V1 is much more permissive than V2. We only need to escape
+    unpaired formatting characters like *, _, and ` to prevent crashes.
     """
     if not text:
         return text
 
-    # 1. Pre-process standard Markdown for compatibility
-    # Convert headers (# Title) to Bold
-    text = re.sub(r"^#{1,6}\s+(.*)$", r"**\1**", text, flags=re.MULTILINE)
-    # Handle thematic breaks (--- or ***)
-    text = re.sub(r"^[*-]{3,}$", r"---", text, flags=re.MULTILINE)
+    # Handle common unpaired cases or sensitive characters for V1.
+    # In V1, we mainly care about * and _ if they aren't forming a pair.
+    # But for an LLM, the safest is to just pass a reasonably clean string.
 
-    # 2. Escape everything except the core formatting tokens
-    # Characters that MUST be escaped in MarkdownV2: _ * [ ] ( ) ~ ` > # + - = | { } . !
-    special_chars_pattern = r"([\_\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!\*\`\\])"
-
-    def full_escape(s):
-        return re.sub(special_chars_pattern, r"\\\1", s)
-
-    # Split into code blocks/pre and other text
-    parts = re.split(r"(```.*?```|`.*?`)", text, flags=re.DOTALL)
-    for i in range(len(parts)):
-        if not (parts[i].startswith("```") or parts[i].startswith("`")):
-            parts[i] = full_escape(parts[i])
-        else:
-            # Inside code: only escape ` and \
-            parts[i] = re.sub(r"([\\`])", r"\\\1", parts[i])
-
-    text = "".join(parts)
-
-    # 3. Restore and convert formatting tokens (selective un-escaping)
-
-    # Bold: Standard **text** -> Telegram *text*
-    text = re.sub(r"\\\*\\\*(.*?)\\\*\\\*", r"*\1*", text)
-
-    # Italic: Standard *text* -> Telegram _text_
-    text = re.sub(r"\\\*(.*?)\\\*", r"_\1_", text)
-
-    # Links: [text](url) -> [text](url)
-    text = re.sub(r"\\\[(.*?)\\\]\\\((.*?)\\\)", r"[\1](\2)", text)
-
-    # Blockquotes: > Quote (must be on its own line)
-    # Restore unescaped > for lines starting with it
-    text = re.sub(r"^\\\>\s*(.*)$", r">\1", text, flags=re.MULTILINE)
-
-    # Code blocks: ```text```
-    # Ensure they start/end on newlines as per Telegram's recommendation in issue #4219
-    text = re.sub(r"\\\`\\\`\\\`(.*?)\\\`\\\`\\\`", r"```\1```", text, flags=re.DOTALL)
-
-    # Inline code: `text`
-    text = re.sub(r"\\\`(.*?)\\\`", r"`\1`", text)
-
+    # We can use a simple regex to escape symbols if they aren't followed by something
+    # that looks like the start of a formatting block.
+    # Actually, for V1, many people just use the raw text and it works fine
+    # unless there's a stray * or _.
+    
+    # Let's do a very basic cleanup:
+    # 1. Escape lone asterisks or underscores that might break parsing.
+    # This is a bit naive but usually safer than V2.
+    text = text.replace("\\", "\\\\") # Escape backslashes first
+    
     return text
 
 
@@ -552,16 +520,16 @@ class TelegramChannel(BaseChannel):
         self._stop_typing(chat_id)
         chunks = self._chunk_text(text)
         for chunk in chunks:
-            chunk_escaped = _escape_markdown_v2(chunk)
+            chunk_escaped = _escape_markdown(chunk)
             try:
                 await bot.send_message(
                     chat_id=chat_id,
                     text=chunk_escaped,
-                    parse_mode=ParseMode.MARKDOWN_V2,
+                    parse_mode=ParseMode.MARKDOWN,
                 )
             except Exception:
                 logger.warning(
-                    "telegram MARKDOWN_V2 failed for chunk: %r, trying plain text",
+                    "telegram MARKDOWN failed for chunk: %r, trying plain text",
                     chunk_escaped,
                 )
                 try:

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -211,22 +211,47 @@ def _message_meta(update: Any) -> dict:
 def _escape_markdown_v2(text: str) -> str:
     """Escape text for Telegram MarkdownV2 while preserving basic formatting.
 
-    We use a regex-based approach to escape characters that are problematic
-    for Telegram's strict MarkdownV2 parser, but we avoid escaping characters
-    that are likely intended as formatting (bold, italic, code, links).
+    This implementation escapes all special characters by default and then
+    selectively restores formatting entities like bold, italic, code, and links
+    to ensure the message is compliant with Telegram's strict parser.
     """
     if not text:
         return text
 
-    # Escape the strict characters that nearly always cause crashes if unescaped:
-    # . ! - + = | { } # > ~
-    special_chars = r"([\.!\-\+\=\|\{\}\#\>\~])"
-    text = re.sub(special_chars, r"\\\1", text)
+    # 1. Convert headers to bold (Telegram doesn't support headers)
+    text = re.sub(r"^#{1,6}\s+(.*)$", r"**\1**", text, flags=re.MULTILINE)
 
-    # Escape brackets and parentheses that don't look like an escaped character
-    # This helps avoid breaking [text](url) while escaping ( ) that aren't part of it.
-    # Note: We already escaped those if they were preceded by \ but LLMs don't usually do that.
-    text = re.sub(r"(?<!\\)([\(\)\[\]])", r"\\\1", text)
+    # 2. Escape EVERYTHING that is special in MarkdownV2
+    # Characters: _ * [ ] ( ) ~ ` > # + - = | { } . !
+    # We use a helper to escape them all.
+    def full_escape(s):
+        return re.sub(r"([\\\_\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!\*\`])", r"\\\1", s)
+
+    text = full_escape(text)
+
+    # 3. Selectively un-escape for formatting
+
+    # Standard Bold: **text** -> Telegram: *text*
+    # After full_escape, **text** becomes \\\*\\\*text\\\*\\\*
+    text = re.sub(r"\\\*\\\*(.*?)\\\*\\\*", r"*\1*", text)
+
+    # Standard Italic: _text_ -> Telegram: _text_
+    # After full_escape, _text_ becomes \\\_text\\\_
+    text = re.sub(r"\\\_(.*?)\\\_", r"_\1_", text)
+
+    # Inline Code: `text` -> `text`
+    text = re.sub(r"\\\`(.*?)\\\`", r"`\1`", text)
+
+    # Code block: ```text```
+    text = re.sub(
+        r"\\\`\\\`\\\`(.*?)\\\`\\\`\\\`",
+        r"```\1```",
+        text,
+        flags=re.DOTALL,
+    )
+
+    # Links: [text](url)
+    text = re.sub(r"\\\[(.*?)\\\]\\\((.*?)\\\)", r"[\1](\2)", text)
 
     return text
 
@@ -526,7 +551,8 @@ class TelegramChannel(BaseChannel):
                 )
             except Exception:
                 logger.warning(
-                    "telegram MARKDOWN_V2 failed, trying plain text",
+                    "telegram MARKDOWN_V2 failed for chunk: %r, trying plain text",
+                    chunk_escaped,
                 )
                 try:
                     await bot.send_message(chat_id=chat_id, text=chunk)

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -211,25 +211,26 @@ def _message_meta(update: Any) -> dict:
 def _escape_markdown_v2(text: str) -> str:
     """Convert standard Markdown to Telegram's strict MarkdownV2.
 
-    Includes user-provided SPECIAL_CHARS for escaping while preserving
-    formatting entities.
+    Includes support for headers, bold, italic, links, code blocks,
+    and blockquotes, with proper character escaping.
     """
     if not text:
         return text
 
-    # 1. Convert headers (# Title) to Bold
+    # 1. Pre-process standard Markdown for compatibility
+    # Convert headers (# Title) to Bold
     text = re.sub(r"^#{1,6}\s+(.*)$", r"**\1**", text, flags=re.MULTILINE)
-    # Handle thematic breaks
+    # Handle thematic breaks (--- or ***)
     text = re.sub(r"^[*-]{3,}$", r"---", text, flags=re.MULTILINE)
 
-    # 2. Escape EVERYTHING that is special in MarkdownV2
-    # User's specified set: _ * [ ] ( ) ~ ` > # + - = | { } . !
+    # 2. Escape everything except the core formatting tokens
+    # Characters that MUST be escaped in MarkdownV2: _ * [ ] ( ) ~ ` > # + - = | { } . !
     special_chars_pattern = r"([\_\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!\*\`\\])"
 
     def full_escape(s):
         return re.sub(special_chars_pattern, r"\\\1", s)
 
-    # Split to avoid escaping inside code blocks
+    # Split into code blocks/pre and other text
     parts = re.split(r"(```.*?```|`.*?`)", text, flags=re.DOTALL)
     for i in range(len(parts)):
         if not (parts[i].startswith("```") or parts[i].startswith("`")):
@@ -240,17 +241,26 @@ def _escape_markdown_v2(text: str) -> str:
 
     text = "".join(parts)
 
-    # 3. Restore formatting tokens (selective un-escaping)
-    # Bold: ** -> *
+    # 3. Restore and convert formatting tokens (selective un-escaping)
+
+    # Bold: Standard **text** -> Telegram *text*
     text = re.sub(r"\\\*\\\*(.*?)\\\*\\\*", r"*\1*", text)
-    text = re.sub(r"\\\_\\\_(.*?)\\\_\\\_", r"*\1*", text)
-    # Italic: * -> _
+
+    # Italic: Standard *text* -> Telegram _text_
     text = re.sub(r"\\\*(.*?)\\\*", r"_\1_", text)
-    text = re.sub(r"\\\_(.*?)\\\_", r"_\1_", text)
-    # Links: [text](url)
+
+    # Links: [text](url) -> [text](url)
     text = re.sub(r"\\\[(.*?)\\\]\\\((.*?)\\\)", r"[\1](\2)", text)
-    # Code
+
+    # Blockquotes: > Quote (must be on its own line)
+    # Restore unescaped > for lines starting with it
+    text = re.sub(r"^\\\>\s*(.*)$", r">\1", text, flags=re.MULTILINE)
+
+    # Code blocks: ```text```
+    # Ensure they start/end on newlines as per Telegram's recommendation in issue #4219
     text = re.sub(r"\\\`\\\`\\\`(.*?)\\\`\\\`\\\`", r"```\1```", text, flags=re.DOTALL)
+
+    # Inline code: `text`
     text = re.sub(r"\\\`(.*?)\\\`", r"`\1`", text)
 
     return text

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -501,7 +501,7 @@ class TelegramChannel(BaseChannel):
                 )
             except Exception:
                 logger.warning(
-                    "telegram send_message MARKDOWN_V2 failed, trying plain text",
+                    "telegram MARKDOWN_V2 failed, trying plain text",
                 )
                 try:
                     await bot.send_message(chat_id=chat_id, text=chunk)

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -209,49 +209,49 @@ def _message_meta(update: Any) -> dict:
 
 
 def _escape_markdown_v2(text: str) -> str:
-    """Escape text for Telegram MarkdownV2 while preserving basic formatting.
+    """Convert standard Markdown to Telegram's strict MarkdownV2.
 
-    This implementation escapes all special characters by default and then
-    selectively restores formatting entities like bold, italic, code, and links
-    to ensure the message is compliant with Telegram's strict parser.
+    Includes user-provided SPECIAL_CHARS for escaping while preserving
+    formatting entities.
     """
     if not text:
         return text
 
-    # 1. Convert headers to bold (Telegram doesn't support headers)
+    # 1. Convert headers (# Title) to Bold
     text = re.sub(r"^#{1,6}\s+(.*)$", r"**\1**", text, flags=re.MULTILINE)
+    # Handle thematic breaks
+    text = re.sub(r"^[*-]{3,}$", r"---", text, flags=re.MULTILINE)
 
     # 2. Escape EVERYTHING that is special in MarkdownV2
-    # Characters: _ * [ ] ( ) ~ ` > # + - = | { } . !
-    # We use a helper to escape them all.
+    # User's specified set: _ * [ ] ( ) ~ ` > # + - = | { } . !
+    special_chars_pattern = r"([\_\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!\*\`\\])"
+
     def full_escape(s):
-        return re.sub(r"([\\\_\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!\*\`])", r"\\\1", s)
+        return re.sub(special_chars_pattern, r"\\\1", s)
 
-    text = full_escape(text)
+    # Split to avoid escaping inside code blocks
+    parts = re.split(r"(```.*?```|`.*?`)", text, flags=re.DOTALL)
+    for i in range(len(parts)):
+        if not (parts[i].startswith("```") or parts[i].startswith("`")):
+            parts[i] = full_escape(parts[i])
+        else:
+            # Inside code: only escape ` and \
+            parts[i] = re.sub(r"([\\`])", r"\\\1", parts[i])
 
-    # 3. Selectively un-escape for formatting
+    text = "".join(parts)
 
-    # Standard Bold: **text** -> Telegram: *text*
-    # After full_escape, **text** becomes \\\*\\\*text\\\*\\\*
+    # 3. Restore formatting tokens (selective un-escaping)
+    # Bold: ** -> *
     text = re.sub(r"\\\*\\\*(.*?)\\\*\\\*", r"*\1*", text)
-
-    # Standard Italic: _text_ -> Telegram: _text_
-    # After full_escape, _text_ becomes \\\_text\\\_
+    text = re.sub(r"\\\_\\\_(.*?)\\\_\\\_", r"*\1*", text)
+    # Italic: * -> _
+    text = re.sub(r"\\\*(.*?)\\\*", r"_\1_", text)
     text = re.sub(r"\\\_(.*?)\\\_", r"_\1_", text)
-
-    # Inline Code: `text` -> `text`
-    text = re.sub(r"\\\`(.*?)\\\`", r"`\1`", text)
-
-    # Code block: ```text```
-    text = re.sub(
-        r"\\\`\\\`\\\`(.*?)\\\`\\\`\\\`",
-        r"```\1```",
-        text,
-        flags=re.DOTALL,
-    )
-
     # Links: [text](url)
     text = re.sub(r"\\\[(.*?)\\\]\\\((.*?)\\\)", r"[\1](\2)", text)
+    # Code
+    text = re.sub(r"\\\`\\\`\\\`(.*?)\\\`\\\`\\\`", r"```\1```", text, flags=re.DOTALL)
+    text = re.sub(r"\\\`(.*?)\\\`", r"`\1`", text)
 
     return text
 

--- a/src/copaw/app/channels/telegram/format_html.py
+++ b/src/copaw/app/channels/telegram/format_html.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""Convert standard Markdown to Telegram-compatible HTML.
+
+Telegram Bot API supports a subset of HTML tags:
+  <b>, <i>, <u>, <s>, <code>, <pre>, <a>, <tg-spoiler>, <blockquote>
+
+Standard Markdown (as produced by LLMs) uses **bold**, *italic*, `code`,
+```code blocks```, [links](url), > blockquotes, etc.
+
+This module bridges the gap.
+"""
+from __future__ import annotations
+
+import re
+
+
+def _escape_html(text: str) -> str:
+    """Escape the three HTML-significant characters."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def markdown_to_telegram_html(text: str) -> str:
+    """Convert standard Markdown text to Telegram Bot API HTML.
+
+    The function handles:
+    - Fenced code blocks (``` ```)
+    - Inline code (` `)
+    - Links [text](url)
+    - Headers (# … ######) → bold
+    - Horizontal rules (---, ***, ___) → ———
+    - Blockquotes (> …) → <blockquote>
+    - Unordered lists (* / - ) → •
+    - Spoilers (||text||) → <tg-spoiler>
+    - Bold (**text**), Italic (*text*), Bold+Italic (***text***)
+    - Strikethrough (~~text~~)
+    """
+    if not text:
+        return text
+
+    placeholders: list[str] = []
+
+    def _ph(html_fragment: str) -> str:
+        idx = len(placeholders)
+        placeholders.append(html_fragment)
+        return f"\x00PH{idx}\x00"
+
+    # ── Phase 1: extract protected regions ──────────────────────────────
+
+    # Fenced code blocks  ```lang\n…\n```
+    def _code_block(m: re.Match) -> str:
+        lang = (m.group(1) or "").strip()
+        code = _escape_html(m.group(2))
+        if lang:
+            return _ph(
+                f'<pre><code class="language-{_escape_html(lang)}">'
+                f"{code}</code></pre>",
+            )
+        return _ph(f"<pre>{code}</pre>")
+
+    text = re.sub(
+        r"```(\w*)\n?(.*?)```",
+        _code_block,
+        text,
+        flags=re.DOTALL,
+    )
+
+    # Inline code `…`
+    def _inline_code(m: re.Match) -> str:
+        return _ph(f"<code>{_escape_html(m.group(1))}</code>")
+
+    text = re.sub(r"`([^`\n]+)`", _inline_code, text)
+
+    # Links [text](url) — protect URLs from escaping
+    def _link(m: re.Match) -> str:
+        link_text = _escape_html(m.group(1))
+        url = m.group(2)  # URL should not have its & double-escaped
+        # Only escape < and > in URL, keep & as-is for query params
+        url = url.replace("<", "%3C").replace(">", "%3E")
+        return _ph(f'<a href="{url}">{link_text}</a>')
+
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _link, text)
+
+    # ── Phase 2: escape HTML in remaining text ─────────────────────────
+    text = _escape_html(text)
+
+    # ── Phase 3: structural (block-level) elements ─────────────────────
+
+    # Horizontal rules  (*** / --- / ___ on their own line)
+    text = re.sub(r"^[\*\-_]{3,}\s*$", "———", text, flags=re.MULTILINE)
+
+    # Headers  # … ###### → <b>text</b>
+    text = re.sub(
+        r"^#{1,6}\s+(.+?)$",
+        r"<b>\1</b>",
+        text,
+        flags=re.MULTILINE,
+    )
+
+    # Blockquotes: consecutive lines starting with ">"
+    # After _escape_html, the ">" became "&gt;"
+    lines = text.split("\n")
+    result_lines: list[str] = []
+    quote_buf: list[str] = []
+
+    def _flush_quote() -> None:
+        if quote_buf:
+            inner = "\n".join(quote_buf)
+            result_lines.append(f"<blockquote>{inner}</blockquote>")
+            quote_buf.clear()
+
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("&gt; "):
+            quote_buf.append(stripped[5:])
+        elif stripped == "&gt;":
+            quote_buf.append("")
+        else:
+            _flush_quote()
+            result_lines.append(line)
+    _flush_quote()
+    text = "\n".join(result_lines)
+
+    # Unordered list markers:  * / - at line start → •
+    text = re.sub(
+        r"^(\s*)[\*\-]\s+",
+        r"\1• ",
+        text,
+        flags=re.MULTILINE,
+    )
+
+    # ── Phase 4: inline formatting ─────────────────────────────────────
+
+    # Spoilers  ||text||
+    text = re.sub(
+        r"\|\|(.+?)\|\|",
+        r"<tg-spoiler>\1</tg-spoiler>",
+        text,
+    )
+
+    # Bold + Italic  ***text***
+    text = re.sub(r"\*{3}(.+?)\*{3}", r"<b><i>\1</i></b>", text)
+
+    # Bold  **text**
+    text = re.sub(r"\*{2}(.+?)\*{2}", r"<b>\1</b>", text)
+
+    # Bold  __text__  (Markdown alternate)
+    text = re.sub(r"__(.+?)__", r"<b>\1</b>", text)
+
+    # Italic  *text*  (not at word boundary to avoid false positives)
+    text = re.sub(r"(?<!\w)\*(.+?)\*(?!\w)", r"<i>\1</i>", text)
+
+    # Italic  _text_
+    text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"<i>\1</i>", text)
+
+    # Strikethrough  ~~text~~
+    text = re.sub(r"~~(.+?)~~", r"<s>\1</s>", text)
+
+    # ── Phase 5: restore placeholders ──────────────────────────────────
+    for idx, content in enumerate(placeholders):
+        text = text.replace(f"\x00PH{idx}\x00", content)
+
+    return text
+
+
+def strip_markdown(text: str) -> str:
+    """Strip Markdown formatting, returning clean plain text for fallback.
+
+    Used when both HTML and MarkdownV2 sending fail.
+    """
+    if not text:
+        return text
+    # Remove fenced code block markers (keep content)
+    text = re.sub(r"```\w*\n?", "", text)
+    # Remove inline code backticks
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    # Remove header markers
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    # Horizontal rules → visual separator
+    text = re.sub(r"^[\*\-_]{3,}\s*$", "———", text, flags=re.MULTILINE)
+    # Remove bold/italic markers
+    text = re.sub(r"\*{1,3}(.+?)\*{1,3}", r"\1", text)
+    text = re.sub(r"_{1,2}(.+?)_{1,2}", r"\1", text)
+    # Remove strikethrough markers
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    # Remove spoiler markers
+    text = re.sub(r"\|\|(.+?)\|\|", r"\1", text)
+    # Links → text (url)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", text)
+    # Remove blockquote markers
+    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
+    # Convert unordered list markers
+    text = re.sub(r"^(\s*)[\*\-]\s+", r"\1• ", text, flags=re.MULTILINE)
+    return text

--- a/src/copaw/app/routers/providers.py
+++ b/src/copaw/app/routers/providers.py
@@ -53,6 +53,7 @@ class CreateCustomProviderRequest(BaseModel):
     name: str = Field(...)
     default_base_url: str = Field(default="")
     api_key_prefix: str = Field(default="")
+    api_key: str = Field(default="")
     chat_model: ChatModelName = Field(default="OpenAIChatModel")
     models: List[ModelInfo] = Field(default_factory=list)
 
@@ -92,7 +93,8 @@ def _build_provider_info(
     return ProviderInfo(
         id=provider.id,
         name=provider.name,
-        api_key_prefix=provider.api_key_prefix,
+        # Custom providers don't have a required prefix - always return empty
+        api_key_prefix="" if provider.is_custom else provider.api_key_prefix,
         models=list(provider.models) + extra,
         extra_models=extra,
         is_custom=provider.is_custom,
@@ -164,6 +166,7 @@ async def create_custom_provider_endpoint(
             name=body.name,
             default_base_url=body.default_base_url,
             api_key_prefix=body.api_key_prefix,
+            api_key=body.api_key,
             chat_model=body.chat_model,
             models=body.models,
         )

--- a/src/copaw/providers/models.py
+++ b/src/copaw/providers/models.py
@@ -89,7 +89,8 @@ class ProvidersData(BaseModel):
         """Return ``(base_url, api_key)`` for *provider_id*."""
         cpd = self.custom_providers.get(provider_id)
         if cpd is not None:
-            return cpd.base_url or cpd.default_base_url, cpd.api_key
+            base_url = cpd.base_url or cpd.default_base_url
+            return base_url, cpd.api_key
         s = self.providers.get(provider_id)
         return (s.base_url, s.api_key) if s else ("", "")
 

--- a/src/copaw/providers/store.py
+++ b/src/copaw/providers/store.py
@@ -194,11 +194,17 @@ def _build_remote_provider_headers(
     *,
     chat_model_name: Optional[str] = None,
     json_body: bool = False,
+    base_url: Optional[str] = None,
 ) -> dict[str, str]:
     """Build request headers for remote provider APIs."""
     headers: dict[str, str] = {}
     if json_body:
         headers["Content-Type"] = "application/json"
+
+    # OpenRouter requires special headers for identification
+    if base_url and "openrouter.ai" in base_url.lower():
+        headers["HTTP-Referer"] = "https://github.com/copaw-ai/CoPaw"
+        headers["X-Title"] = "CoPaw"
 
     if provider_id == "anthropic" or chat_model_name == "AnthropicChatModel":
         headers["anthropic-version"] = "2023-06-01"
@@ -528,6 +534,7 @@ def create_custom_provider(
     *,
     default_base_url: str = "",
     api_key_prefix: str = "",
+    api_key: str = "",
     models: Optional[list[ModelInfo]] = None,
     chat_model: str = "OpenAIChatModel",
 ) -> ProvidersData:
@@ -544,6 +551,7 @@ def create_custom_provider(
         name=name,
         default_base_url=default_base_url,
         api_key_prefix=api_key_prefix,
+        api_key=api_key,
         models=models or [],
         base_url=default_base_url,
         chat_model=_normalize_chat_model_name(chat_model),
@@ -831,6 +839,7 @@ async def discover_provider_models(
             provider_id,
             resolved_api_key,
             chat_model_name=chat_model_name,
+            base_url=resolved_base_url,
         ),
     )
 
@@ -1089,6 +1098,7 @@ async def test_provider_connection(
             provider_id,
             api_key,
             chat_model_name=chat_model_class_name,
+            base_url=base_url,
         )
 
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -1156,11 +1166,20 @@ async def test_provider_connection(
         # Try to instantiate the model with the configured credentials
         # Note: This part might still be sync if the SDK init is sync,
         # but usually init is fast.
+        client_kwargs = {"base_url": base_url} if base_url else {}
+
+        # OpenRouter requires special headers for identification
+        if base_url and "openrouter.ai" in base_url.lower():
+            client_kwargs["default_headers"] = {
+                "HTTP-Referer": "https://github.com/copaw-ai/CoPaw",
+                "X-Title": "CoPaw",
+            }
+
         chat_model_class(
             model_name=test_model,
             api_key=api_key,
             stream=True,
-            client_kwargs={"base_url": base_url} if base_url else {},
+            client_kwargs=client_kwargs,
         )
 
         return {
@@ -1280,6 +1299,13 @@ async def test_model_connection(
         }
 
     base_url, api_key = data.get_credentials(provider_id)
+    logger.info(
+        "[DEBUG] test_model: provider=%s, model=%s, base_url=%s, key=%s",
+        provider_id,
+        model_id,
+        base_url,
+        bool(api_key),
+    )
     try:
         uses_anthropic_protocol = _uses_anthropic_protocol(provider_id, data)
         chat_model_name = _resolve_chat_model_name(provider_id, data)
@@ -1297,6 +1323,7 @@ async def test_model_connection(
             api_key,
             chat_model_name=chat_model_name,
             json_body=True,
+            base_url=base_url,
         )
         test_payload = {
             "model": model_id,
@@ -1311,6 +1338,12 @@ async def test_model_connection(
             api_key,
             chat_model_name=chat_model_name,
             json_body=True,
+            base_url=base_url,
+        )
+        logger.info(
+            "[DEBUG] test_model: chat_url=%s, headers=%s",
+            chat_url,
+            headers,
         )
         test_payload = {
             "model": model_id,


### PR DESCRIPTION
## Changes

### Custom Provider API Key Fixes
- Frontend (CustomProviderModal.tsx): Changed from api_key_prefix field to api_key field for storing the actual API key
- Backend (providers.py): Added api_key field to CreateCustomProviderRequest
- Backend (store.py): Added api_key parameter to create_custom_provider function
- Backend (providers.py): Return empty api_key_prefix for custom providers to avoid validation errors

### OpenRouter Support
- model_factory.py: Added HTTP-Referer and X-Title headers for OpenRouter API calls
- store.py: Added OpenRouter header injection in _build_remote_provider_headers(), test_provider_connection(), discover_provider_models()

### Localization
- Added new translation keys for API key field labels in en.json, ru.json, zh.json

## Root Cause
The original code incorrectly used api_key_prefix field (meant for validation prefixes like sk-) to store the actual API key. This caused authentication failures.