### PR TITLE
fix(docker): enable telegram and discord channels in Docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
           IS_BETA: ${{ steps.vars.outputs.is_beta }}
-          COPAW_ENABLED_CHANNELS: "discord,dingtalk,feishu,qq,console"
+          COPAW_ENABLED_CHANNELS: "discord,telegram,dingtalk,feishu,qq,console"
         run: |
           TAGS="-t ${ACR_REGISTRY}/${IMAGE}:${VERSION} -t ${ACR_REGISTRY}/${IMAGE}:pre"
           TAGS="${TAGS} -t docker.io/${IMAGE}:${VERSION} -t docker.io/${IMAGE}:pre"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,9 +16,9 @@ ENV NODE_ENV=production
 ENV WORKSPACE_DIR=/app
 ENV COPAW_WORKING_DIR=/app/working
 
-# Available channels for this image (imessage & discord excluded).
+# Available channels for this image.
 # Override at runtime with -e COPAW_ENABLED_CHANNELS=... if needed.
-ARG COPAW_ENABLED_CHANNELS="dingtalk,feishu,qq,console"
+ARG COPAW_ENABLED_CHANNELS="discord,telegram,dingtalk,feishu,qq,console"
 ENV COPAW_ENABLED_CHANNELS=${COPAW_ENABLED_CHANNELS}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -4,9 +4,9 @@
 # Example: bash scripts/docker_build.sh copaw:latest
 #          bash scripts/docker_build.sh myreg/copaw:v1 --no-cache
 #
-# By default the Docker image excludes imessage and discord channels.
+# By default the Docker image excludes imessage.
 # Override via:
-#   COPAW_ENABLED_CHANNELS=imessage,discord,dingtalk,feishu,qq,console \
+#   COPAW_ENABLED_CHANNELS=imessage,discord,telegram,dingtalk,feishu,qq,console \
 #       bash scripts/docker_build.sh
 set -e
 
@@ -17,8 +17,8 @@ DOCKERFILE="${DOCKERFILE:-$REPO_ROOT/deploy/Dockerfile}"
 TAG="${1:-copaw:latest}"
 shift || true
 
-# Channels to include in the image (default: exclude imessage & discord).
-ENABLED_CHANNELS="${COPAW_ENABLED_CHANNELS:-dingtalk,feishu,qq,console}"
+# Channels to include in the image (default: exclude imessage).
+ENABLED_CHANNELS="${COPAW_ENABLED_CHANNELS:-discord,telegram,dingtalk,feishu,qq,console}"
 
 echo "[docker_build] Building image: $TAG (Dockerfile: $DOCKERFILE)"
 docker build -f "$DOCKERFILE" \


### PR DESCRIPTION
## Description

Enable telegram and discord channels in Docker image

**Related Issue:** Fixes https://github.com/agentscope-ai/CoPaw/issues/831

**Security Considerations:** 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence


## Additional Notes

<img width="2388" height="902" alt="image" src="https://github.com/user-attachments/assets/7624fbb2-db9e-4527-8324-574fa7587f19" />
