### PR TITLE
feat(installer): add auto PyPI mirror selection for China users

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,10 +19,10 @@ choose_pypi_mirror() {
     # Test the connectivity of the official PyPI source (timeout 3 seconds, no output)
     if curl -s --connect-timeout 3 https://pypi.org/simple/ > /dev/null 2>&1; then
         echo "https://pypi.org/simple/"
-        info "Using official PyPI source (network is good)"
+        info "Using official PyPI source (network is good)" >&2
     else
         echo "https://mirrors.aliyun.com/pypi/simple/"
-        info "Using Aliyun PyPI mirror (official source is unreachable)"
+        info "Using Aliyun PyPI mirror (official source is unreachable)" >&2
     fi
 }
 PYPI_MIRROR=$(choose_pypi_mirror)
@@ -237,7 +237,7 @@ else
     fi
 
     info "Installing ${PACKAGE}${EXTRAS_SUFFIX} from PyPI..."
-    uv pip install "${PACKAGE}${EXTRAS_SUFFIX}" --python "$COPAW_VENV/bin/python" --prerelease=allow --quiet --index-url "$PYPI_MIRROR"
+    uv pip install "${PACKAGE}${EXTRAS_SUFFIX}" --python "$COPAW_VENV/bin/python" --prerelease=allow --index-url "$PYPI_MIRROR"
 fi
 
 # Verify the CLI entry point exists


### PR DESCRIPTION
## Description

This PR optimizes the installation experience for users in mainland China by adding automatic PyPI mirror selection logic to the install.sh script, solving the problem of slow/frozen installation caused by poor access to the official PyPI source.
Key improvements:

1.  Added a choose_pypi_mirror() function that tests connectivity to the official PyPI source (3s timeout) — uses Aliyun PyPI mirror (https://mirrors.aliyun.com/pypi/simple/) if the official source is unreachable, otherwise uses the official source (compatible with overseas users).

2.   Set UV_VENV_CLEAR=1 to auto-clear old virtual environments and skip interactive prompts, improving the automated installation experience.

3. Removed the --quiet flag from uv pip install to show installation progress, avoiding user confusion about "frozen" installs.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** No security implications — this change only modifies the PyPI source selection logic and installation prompt behavior, without touching authentication, environment/config handling, or core business logic.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

1. How to test these changes

1. Test in mainland China network environment:

- Run the modified install.sh script: bash scripts/install.sh
- Verify that the script automatically switches to Aliyun PyPI mirror (log shows "Using Aliyun PyPI mirror")
- Verify installation completes without freezing, and copaw --version outputs correctly
- Verify no interactive prompt for virtual environment replacement

2. Test in overseas network environment:

- Run the modified install.sh script: bash scripts/install.sh
- Verify that the script uses the official PyPI source (log shows "Using official PyPI source")
- Verify installation completes normally
## Local Verification Evidence



## Additional Notes

Additional Notes
- This change is fully backward-compatible — no impact on existing users in any region.
- The mirror selection logic uses a 3-second timeout, which balances speed and accuracy for mainland China networks.
- Tested only in mainland China VPS (Linux), but the logic ensures overseas users will use the official PyPI source by default.
