### PR TITLE
chore:Refactor console build process to eliminate manual copy steps

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -82,7 +82,7 @@ ENV PATH="/app/venv/bin:$PATH"
 COPY pyproject.toml setup.py README.md ./
 COPY src ./src
 # Inject console dist from build stage (repo does not commit dist).
-COPY --from=console-builder /app/console/dist/ ./src/copaw/console/
+COPY --from=console-builder /app/src/copaw/console/ ./src/copaw/console/
 RUN pip install --no-cache-dir .
 
 # Init working dir with default config.json and HEARTBEAT.md (build time).

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -228,21 +228,10 @@ REM ──── Prepare console frontend ────────────�
 :prepare_console
 REM %~1 = RepoDir
 set "_REPO_DIR=%~1"
-set "_CONSOLE_SRC=%_REPO_DIR%\console\dist"
 set "_CONSOLE_DEST=%_REPO_DIR%\src\copaw\console"
 
 REM Already populated
 if exist "%_CONSOLE_DEST%\index.html" (
-    set "CONSOLE_AVAILABLE=1"
-    exit /b 0
-)
-
-REM Copy pre-built assets if available
-if exist "%_CONSOLE_SRC%\index.html" (
-    echo [copaw] Copying console frontend assets...
-    if not exist "%_CONSOLE_DEST%" mkdir "%_CONSOLE_DEST%"
-    xcopy /s /e /y /q "%_CONSOLE_SRC%\*" "%_CONSOLE_DEST%\" >nul
-    set "CONSOLE_COPIED=1"
     set "CONSOLE_AVAILABLE=1"
     exit /b 0
 )
@@ -277,10 +266,7 @@ if errorlevel 1 (
 )
 popd
 
-if exist "%_CONSOLE_SRC%\index.html" (
-    if not exist "%_CONSOLE_DEST%" mkdir "%_CONSOLE_DEST%"
-    xcopy /s /e /y /q "%_CONSOLE_SRC%\*" "%_CONSOLE_DEST%\" >nul
-    set "CONSOLE_COPIED=1"
+if exist "%_CONSOLE_DEST%\index.html" (
     set "CONSOLE_AVAILABLE=1"
     echo [copaw] Console frontend built successfully
     exit /b 0
@@ -292,10 +278,7 @@ exit /b 0
 REM ──── Cleanup console frontend ────────────────────────────────────────────────────────────────────────────────────────────────────
 :cleanup_console
 REM %~1 = RepoDir
-if "%CONSOLE_COPIED%"=="1" (
-    set "_CLEANUP_DEST=%~1\src\copaw\console"
-    if exist "!_CLEANUP_DEST!" rd /s /q "!_CLEANUP_DEST!" 2>nul
-)
+REM No cleanup needed as console build is integrated into source tree
 exit /b 0
 
 REM ══════════════════════════════ MAIN ═════════════════════════════════════════

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -212,27 +212,15 @@ Write-Info "Python environment ready ($pyVersion)"
 $ExtrasSuffix = ""
 if ($Extras) { $ExtrasSuffix = "[$Extras]" }
 
-$script:ConsoleCopied   = $false
 $script:ConsoleAvailable = $false
 
 function Prepare-Console {
     param([string]$RepoDir)
 
-    $consoleSrc  = Join-Path $RepoDir "console\dist"
     $consoleDest = Join-Path $RepoDir "src\copaw\console"
 
     # Already populated
     if (Test-Path (Join-Path $consoleDest "index.html")) { $script:ConsoleAvailable = $true; return }
-
-    # Copy pre-built assets if available
-    if ((Test-Path $consoleSrc) -and (Test-Path (Join-Path $consoleSrc "index.html"))) {
-        Write-Info "Copying console frontend assets..."
-        New-Item -ItemType Directory -Path $consoleDest -Force | Out-Null
-        Copy-Item -Path "$consoleSrc\*" -Destination $consoleDest -Recurse -Force
-        $script:ConsoleCopied   = $true
-        $script:ConsoleAvailable = $true
-        return
-    }
 
     # Try to build if npm is available
     $packageJson = Join-Path $RepoDir "console\package.json"
@@ -258,10 +246,7 @@ function Prepare-Console {
     } finally {
         Pop-Location
     }
-    if (Test-Path (Join-Path $consoleSrc "index.html")) {
-        New-Item -ItemType Directory -Path $consoleDest -Force | Out-Null
-        Copy-Item -Path "$consoleSrc\*" -Destination $consoleDest -Recurse -Force
-        $script:ConsoleCopied   = $true
+    if (Test-Path (Join-Path $consoleDest "index.html")) {
         $script:ConsoleAvailable = $true
         Write-Info "Console frontend built successfully"
         return
@@ -272,12 +257,7 @@ function Prepare-Console {
 
 function Cleanup-Console {
     param([string]$RepoDir)
-    if ($script:ConsoleCopied) {
-        $consoleDest = Join-Path $RepoDir "src\copaw\console"
-        if (Test-Path $consoleDest) {
-            Remove-Item -Path "$consoleDest\*" -Recurse -Force -ErrorAction SilentlyContinue
-        }
-    }
+    # No cleanup needed as console build is integrated into source tree
 }
 
 $VenvCopaw = Join-Path $CopawVenv "Scripts\copaw.exe"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,26 +135,13 @@ if [ -n "$EXTRAS" ]; then
 fi
 
 ## Ensure console frontend assets are in src/copaw/console/ for source installs.
-## Sets _CONSOLE_COPIED=1 if we populated the directory (so we can clean up).
-_CONSOLE_COPIED=0
 _CONSOLE_AVAILABLE=0
 prepare_console() {
     local repo_dir="$1"
-    local console_src="$repo_dir/console/dist"
     local console_dest="$repo_dir/src/copaw/console"
 
     # Already populated
     if [ -f "$console_dest/index.html" ]; then
-        _CONSOLE_AVAILABLE=1
-        return
-    fi
-
-    # Copy pre-built assets if available (e.g. developer already ran npm build)
-    if [ -d "$console_src" ] && [ -f "$console_src/index.html" ]; then
-        info "Copying console frontend assets..."
-        mkdir -p "$console_dest"
-        cp -R "$console_src/"* "$console_dest/"
-        _CONSOLE_COPIED=1
         _CONSOLE_AVAILABLE=1
         return
     fi
@@ -174,10 +161,7 @@ prepare_console() {
 
     info "Building console frontend (npm ci && npm run build)..."
     (cd "$repo_dir/console" && npm ci && npm run build)
-    if [ -f "$console_src/index.html" ]; then
-        mkdir -p "$console_dest"
-        cp -R "$console_src/"* "$console_dest/"
-        _CONSOLE_COPIED=1
+    if [ -f "$console_dest/index.html" ]; then
         _CONSOLE_AVAILABLE=1
         info "Console frontend built successfully"
         return
@@ -186,12 +170,9 @@ prepare_console() {
     warn "Console build completed but index.html not found — the web UI won't be available."
 }
 
-## Remove console assets we copied into the source tree.
+## No cleanup needed as console build is integrated into source tree.
 cleanup_console() {
-    local repo_dir="$1"
-    if [ "$_CONSOLE_COPIED" = 1 ]; then
-        rm -rf "$repo_dir/src/copaw/console/"*
-    fi
+    : # no-op
 }
 
 if [ "$FROM_SOURCE" = true ]; then

--- a/scripts/wheel_build.sh
+++ b/scripts/wheel_build.sh
@@ -13,15 +13,14 @@ echo "[wheel_build] Building console frontend..."
 (cd "$CONSOLE_DIR" && npm ci)
 (cd "$CONSOLE_DIR" && npm run build)
 
-echo "[wheel_build] Copying console/dist/* -> src/copaw/console/..."
-rm -rf "$CONSOLE_DEST"/*
-
-mkdir -p "$CONSOLE_DEST"
-cp -R "$CONSOLE_DIR/dist/"* "$CONSOLE_DEST/"
-
 echo "[wheel_build] Building wheel + sdist..."
-python3 -m pip install --quiet build
 rm -rf dist/*
-python3 -m build --outdir dist .
+if command -v uv &>/dev/null; then
+    uv pip install --quiet build
+    uv build --out-dir dist .
+else
+    python3 -m pip install --quiet build
+    python3 -m build --outdir dist .
+fi
 
 echo "[wheel_build] Done. Wheel(s) in: $REPO_ROOT/dist/"


### PR DESCRIPTION
## Description

Simplify the Console frontend build process by removing manual copy steps.

**Related Issue:** None (internal build process optimization)

**Security Considerations:** None (only involves build script path adjustments, no runtime security impact)

## Type of Change

- [x] Refactoring

## Component(s) Affected

- [x] Scripts / Deploy
- [x] Console (frontend web UI)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] Ready for review

## Testing

Run the build script to verify:

```bash
bash scripts/wheel_build.sh
```

**Verification Items:**
- Console frontend builds output to `dist/` directory
- No manual copy to `src/copaw/console/` needed
- Wheel package correctly includes frontend assets from `src/copaw/console/`
- Dockerfile copies build artifacts from the correct path

## Local Verification Evidence

```bash
# Pre-commit checks
.venv/bin/pre-commit run --files deploy/Dockerfile scripts/install.sh scripts/install.bat scripts/install.ps1 scripts/wheel_build.sh
# ✅ All checks passed

# Build script test
bash scripts/wheel_build.sh
# ✅ [wheel_build] Building console frontend... (14.94s)
# ✅ [wheel_build] Building wheel + sdist...
# ✅ Wheel package includes 46 console files

# Shell syntax check
bash -n scripts/install.sh && bash -n scripts/wheel_build.sh
# ✅ Shell syntax OK
```

**Build Artifact Verification:**
```bash
ls -lh dist/*.whl dist/*.tar.gz
# -rw-r--r--  6.6M copaw-0.0.5.post1-py3-none-any.whl
# -rw-r--r--  6.4M copaw-0.0.5.post1.tar.gz

.venv/bin/python -m zipfile -l dist/copaw-*.whl | grep "copaw/console" | wc -l
# 46 (console files included)
```

## Additional Notes

**Background:**
- Commit f39e74f enabled `outDir: ../src/copaw/console` in `vite.config.ts`
- Vite build outputs directly to the Python package source tree, eliminating manual copy steps
- PR #647 temporarily disabled this configuration; now re-enabled with proper script support

**Code Impact:**
- Net reduction of 56 lines (+17/-73)
- Removed `console/dist/` copy logic
- Dockerfile copies build artifacts from `/app/src/copaw/console/`

**Branch Information:**
- Based on `upstream/main` (dfa270e)
- Clean branch with only necessary install script modifications

## Changes Summary

| File | Changes |
|------|---------|
| `wheel_build.sh` | Remove manual `dist/*` copy step, add `uv build` support |
| `Dockerfile` | Fix COPY path: `/app/console/dist/` → `/app/src/copaw/console/` |
| `install.sh` | Simplify console prepare logic, remove copy and cleanup code |
| `install.bat` | Simplify console prepare logic, remove copy and cleanup code |
| `install.ps1` | Simplify console prepare logic, remove copy and cleanup code |

**Stats:** 5 files changed, 17 insertions(+), 73 deletions(-)
