### PR TITLE
fix(console): resolve table checkbox overlapping issue in sessions page

### DIFF
--- a/console/src/pages/Control/Sessions/components/columns.tsx
+++ b/console/src/pages/Control/Sessions/components/columns.tsx
@@ -29,7 +29,6 @@ export const createColumns = (
       dataIndex: "id",
       key: "id",
       width: 250,
-      fixed: "left",
     },
     {
       title: "Name",

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -138,6 +138,8 @@ function SessionsPage() {
   });
 
   const rowSelection = {
+    fixed: true,
+    columnWidth: 50,
     selectedRowKeys,
     onChange: (newSelectedRowKeys: React.Key[]) => {
       setSelectedRowKeys(newSelectedRowKeys);


### PR DESCRIPTION
## Description

This PR fixes a critical UI bug on the Sessions control page where the `rowSelection` checkbox column visually overlapped or was partially hidden by the "ID" column during horizontal scrolling. 

### Cause
The layout conflict occurred because both columns attempted to secure sticky positioning within Ant Design's `Table` component. The lack of an explicit width boundary for the checkbox selector effectively caused the `ID` column (`left: 32px`) to overlap the actual rendered size of the checkboxes.

### Changes Made
- **console/src/pages/Control/Sessions/components/columns.tsx**: Removed the `fixed: "left"` property from the "ID" column. Fixing it without width bounds was enforcing an overlap over the selection boxes.
- **console/src/pages/Control/Sessions/index.tsx**: Added an explicit `columnWidth: 50` parameter alongside `fixed: true` to the `rowSelection` configuration. This forces Ant Design's grid calculator to reserve stable space for the checkboxes to stay sticky horizontally.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
Before
<img width="1674" height="442" alt="image" src="https://github.com/user-attachments/assets/6502e683-0864-4d69-b66a-65353bebfe78" />
After
<img width="1617" height="363" alt="image" src="https://github.com/user-attachments/assets/6b77ed00-8be9-442e-9068-2509e2c7bff9" />

