### PR TITLE
feat(channels): unify allowlist access control, and allow list for feishu and discord

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -3,6 +3,9 @@ export interface BaseChannelConfig {
   bot_prefix: string;
   filter_tool_messages?: boolean;
   filter_thinking?: boolean;
+  dm_policy?: "open" | "allowlist";
+  group_policy?: "open" | "allowlist";
+  allow_from?: string[];
 }
 
 export interface IMessageChannelConfig extends BaseChannelConfig {
@@ -19,9 +22,6 @@ export interface DiscordConfig extends BaseChannelConfig {
 export interface DingTalkConfig extends BaseChannelConfig {
   client_id: string;
   client_secret: string;
-  dm_policy: "open" | "allowlist";
-  group_policy: "open" | "allowlist";
-  allow_from: string[];
 }
 
 export interface FeishuConfig extends BaseChannelConfig {
@@ -42,10 +42,6 @@ export interface TelegramConfig extends BaseChannelConfig {
   http_proxy: string;
   http_proxy_auth: string;
   show_typing?: boolean;
-  dm_policy?: "open" | "allowlist";
-  group_policy?: "open" | "allowlist";
-  allow_from?: string[];
-  deny_message?: string;
 }
 
 export type ConsoleConfig = BaseChannelConfig;

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -14,6 +14,13 @@ import type { FormInstance } from "antd";
 import { getChannelLabel, type ChannelKey } from "./constants";
 import styles from "../index.module.less";
 
+const CHANNELS_WITH_ACCESS_CONTROL: ChannelKey[] = [
+  "telegram",
+  "dingtalk",
+  "discord",
+  "feishu",
+];
+
 interface ChannelDrawerProps {
   open: boolean;
   activeKey: ChannelKey | null;
@@ -52,6 +59,49 @@ export function ChannelDrawer({
 }: ChannelDrawerProps) {
   const { t } = useTranslation();
   const label = activeKey ? getChannelLabel(activeKey) : activeLabel;
+
+  const renderAccessControlFields = () => (
+    <>
+      <Form.Item
+        name="dm_policy"
+        label={t("channels.dmPolicy")}
+        tooltip={t("channels.dmPolicyTooltip")}
+        initialValue="open"
+      >
+        <Select
+          options={[
+            { value: "open", label: t("channels.policyOpen") },
+            { value: "allowlist", label: t("channels.policyAllowlist") },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item
+        name="group_policy"
+        label={t("channels.groupPolicy")}
+        tooltip={t("channels.groupPolicyTooltip")}
+        initialValue="open"
+      >
+        <Select
+          options={[
+            { value: "open", label: t("channels.policyOpen") },
+            { value: "allowlist", label: t("channels.policyAllowlist") },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item
+        name="allow_from"
+        label={t("channels.allowFrom")}
+        tooltip={t("channels.allowFromTooltip")}
+        initialValue={[]}
+      >
+        <Select
+          mode="tags"
+          placeholder={t("channels.allowFromPlaceholder")}
+          tokenSeparators={[","]}
+        />
+      </Form.Item>
+    </>
+  );
 
   // Renders builtin channel-specific fields
   const renderBuiltinExtraFields = (key: ChannelKey) => {
@@ -99,44 +149,6 @@ export function ChannelDrawer({
             </Form.Item>
             <Form.Item name="client_secret" label="Client Secret">
               <Input.Password />
-            </Form.Item>
-            <Form.Item
-              name="dm_policy"
-              label={t("channels.dmPolicy")}
-              tooltip={t("channels.dmPolicyTooltip")}
-              initialValue="open"
-            >
-              <Select
-                options={[
-                  { value: "open", label: t("channels.policyOpen") },
-                  { value: "allowlist", label: t("channels.policyAllowlist") },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item
-              name="group_policy"
-              label={t("channels.groupPolicy")}
-              tooltip={t("channels.groupPolicyTooltip")}
-              initialValue="open"
-            >
-              <Select
-                options={[
-                  { value: "open", label: t("channels.policyOpen") },
-                  { value: "allowlist", label: t("channels.policyAllowlist") },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item
-              name="allow_from"
-              label={t("channels.allowFrom")}
-              tooltip={t("channels.allowFromTooltip")}
-              initialValue={[]}
-            >
-              <Select
-                mode="tags"
-                placeholder={t("channels.allowFromPlaceholder")}
-                tokenSeparators={[","]}
-              />
             </Form.Item>
           </>
         );
@@ -197,51 +209,6 @@ export function ChannelDrawer({
               valuePropName="checked"
             >
               <Switch />
-            </Form.Item>
-            <Form.Item
-              name="dm_policy"
-              label={t("channels.dmPolicy")}
-              tooltip={t("channels.dmPolicyTooltip")}
-              initialValue="open"
-            >
-              <Select
-                options={[
-                  { value: "open", label: t("channels.policyOpen") },
-                  { value: "allowlist", label: t("channels.policyAllowlist") },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item
-              name="group_policy"
-              label={t("channels.groupPolicy")}
-              tooltip={t("channels.groupPolicyTooltip")}
-              initialValue="open"
-            >
-              <Select
-                options={[
-                  { value: "open", label: t("channels.policyOpen") },
-                  { value: "allowlist", label: t("channels.policyAllowlist") },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item
-              name="allow_from"
-              label={t("channels.allowFrom")}
-              tooltip={t("channels.allowFromTooltip")}
-              initialValue={[]}
-            >
-              <Select
-                mode="tags"
-                placeholder={t("channels.allowFromPlaceholder")}
-                tokenSeparators={[","]}
-              />
-            </Form.Item>
-            <Form.Item
-              name="deny_message"
-              label={t("channels.denyMessage")}
-              tooltip={t("channels.denyMessageTooltip")}
-            >
-              <Input.TextArea rows={3} />
             </Form.Item>
           </>
         );
@@ -427,6 +394,9 @@ export function ChannelDrawer({
           {isBuiltin
             ? renderBuiltinExtraFields(activeKey)
             : renderCustomExtraFields(initialValues)}
+
+          {CHANNELS_WITH_ACCESS_CONTROL.includes(activeKey) &&
+            renderAccessControlFields()}
 
           <Form.Item>
             <div className={styles.formActions}>

--- a/src/copaw/app/channels/base.py
+++ b/src/copaw/app/channels/base.py
@@ -82,12 +82,20 @@ class BaseChannel(ABC):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        dm_policy: str = "open",
+        group_policy: str = "open",
+        allow_from: Optional[list] = None,
+        deny_message: str = "",
     ):
         self._process = process
         self._on_reply_sent = on_reply_sent
         self._show_tool_details = show_tool_details
         self._filter_tool_messages = filter_tool_messages
         self._filter_thinking = filter_thinking
+        self.dm_policy = dm_policy or "open"
+        self.group_policy = group_policy or "open"
+        self.allow_from = set(allow_from or [])
+        self.deny_message = deny_message or ""
         self._enqueue: EnqueueCallback = None
         self._render_style = RenderStyle(
             show_tool_details=show_tool_details,
@@ -240,6 +248,30 @@ class BaseChannel(ABC):
         pending = self._pending_content_by_session.pop(session_id, [])
         merged = pending + list(content_parts)
         return (True, merged)
+
+    def _check_allowlist(
+        self,
+        sender_id: str,
+        is_group: bool,
+    ) -> tuple[bool, Optional[str]]:
+        """Check sender against allowlist policy."""
+        policy = self.group_policy if is_group else self.dm_policy
+        if policy == "open":
+            return True, None
+        if sender_id in self.allow_from:
+            return True, None
+        if self.deny_message:
+            return False, self.deny_message
+        if is_group:
+            return (
+                False,
+                "Sorry, this bot is only available to authorized users.",
+            )
+        return False, (
+            "Sorry, you are not authorized to use this bot. "
+            "Please contact the administrator to add your ID "
+            f"to the allowlist. Your ID: {sender_id}"
+        )
 
     def set_enqueue(self, cb: EnqueueCallback) -> None:
         """Set enqueue callback (called by ChannelManager)."""

--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -92,6 +92,7 @@ class DingTalkChannel(BaseChannel):
         dm_policy: str = "open",
         group_policy: str = "open",
         allow_from: Optional[List[str]] = None,
+        deny_message: str = "",
         filter_thinking: bool = False,
     ):
         super().__init__(
@@ -100,15 +101,16 @@ class DingTalkChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=dm_policy,
+            group_policy=group_policy,
+            allow_from=allow_from,
+            deny_message=deny_message,
         )
         self.enabled = enabled
         self.client_id = client_id
         self.client_secret = client_secret
         self.bot_prefix = bot_prefix
         self._media_dir = Path(media_dir).expanduser()
-        self.dm_policy = dm_policy or "open"
-        self.group_policy = group_policy or "open"
-        self.allow_from = set(allow_from or [])
 
         self._client: Optional[dingtalk_stream.DingTalkStreamClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -157,6 +159,7 @@ class DingTalkChannel(BaseChannel):
             dm_policy=os.getenv("DINGTALK_DM_POLICY", "open"),
             group_policy=os.getenv("DINGTALK_GROUP_POLICY", "open"),
             allow_from=allow_from,
+            deny_message=os.getenv("DINGTALK_DENY_MESSAGE", ""),
         )
 
     @classmethod
@@ -182,6 +185,7 @@ class DingTalkChannel(BaseChannel):
             dm_policy=config.dm_policy or "open",
             group_policy=config.group_policy or "open",
             allow_from=config.allow_from or [],
+            deny_message=config.deny_message or "",
             filter_thinking=filter_thinking,
         )
 
@@ -1211,53 +1215,6 @@ class DingTalkChannel(BaseChannel):
         ):
             self._reply_sync(pm, SENT_VIA_WEBHOOK)
 
-    def _check_allowlist(
-        self,
-        sender_id: str,
-        conversation_type: str,
-    ) -> tuple[bool, Optional[str]]:
-        """Check if sender is allowed based on dm_policy/group_policy.
-
-        Args:
-            sender_id: The sender's ID (format: nickname#last4)
-            conversation_type: "dm" for direct message, "group" for group chat
-
-        Returns:
-            (allowed, error_message): allowed=True if message should be
-            processed, error_message contains the rejection message if not
-            allowed
-        """
-        # Determine which policy to apply
-        is_group = conversation_type == "group"
-        policy = self.group_policy if is_group else self.dm_policy
-
-        # If policy is "open", allow all
-        if policy == "open":
-            return True, None
-
-        # If policy is "allowlist", check if sender is in allow_from
-        if sender_id in self.allow_from:
-            return True, None
-
-        # Not allowed - return rejection message
-        if is_group:
-            msg = (
-                "抱歉，此机器人仅对授权用户开放。请联系管理员配置访问权限。\n"
-                f"您的 ID：{sender_id}\n"
-                "Sorry, this bot is only available to authorized users. "
-                "Please contact the administrator. Your ID: "
-                f"{sender_id}"
-            )
-        else:
-            msg = (
-                "抱歉，您没有权限使用此机器人。请联系管理员添加您的 ID 到白名单。\n"
-                f"您的 ID：{sender_id}\n"
-                "Sorry, you are not authorized to use this bot. "
-                "Please contact the administrator to add your ID to "
-                f"the allowlist. Your ID: {sender_id}"
-            )
-        return False, msg
-
     async def _run_process_loop(
         self,
         request: Any,
@@ -1267,33 +1224,29 @@ class DingTalkChannel(BaseChannel):
         """Use webhook multi-message send instead of default loop."""
         del to_handle
 
-        # Check allowlist before processing
         sender_id = getattr(request, "user_id", "") or ""
-        conversation_type = (send_meta or {}).get("conversation_type", "dm")
+        is_group = bool((send_meta or {}).get("is_group", False))
         allowed, error_msg = self._check_allowlist(
             sender_id,
-            conversation_type,
+            is_group,
         )
         if not allowed:
             logger.info(
-                "dingtalk allowlist blocked: sender=%s conversation_type=%s",
+                "dingtalk allowlist blocked: sender=%s is_group=%s",
                 sender_id,
-                conversation_type,
+                is_group,
             )
-            # Send rejection message
             session_webhook = self._get_session_webhook(send_meta)
-            # error_msg is always str when allowed is False
-            rejection_msg = error_msg or ""
             if session_webhook:
                 await self._send_via_session_webhook(
                     session_webhook,
-                    self.bot_prefix + rejection_msg,
+                    self.bot_prefix + (error_msg or ""),
                     bot_prefix="",
                 )
             else:
                 self._reply_sync_batch(
                     send_meta,
-                    self.bot_prefix + rejection_msg,
+                    self.bot_prefix + (error_msg or ""),
                 )
             return
 

--- a/src/copaw/app/channels/dingtalk/handler.py
+++ b/src/copaw/app/channels/dingtalk/handler.py
@@ -239,6 +239,7 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
                 "reply_future": reply_future,
                 "reply_loop": loop,
                 "conversation_type": conversation_type,
+                "is_group": conversation_type == "group",
             }
             if conversation_id:
                 meta["conversation_id"] = conversation_id

--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -40,6 +40,10 @@ class DiscordChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        dm_policy: str = "open",
+        group_policy: str = "open",
+        allow_from: Optional[list] = None,
+        deny_message: str = "",
     ):
         super().__init__(
             process,
@@ -47,6 +51,10 @@ class DiscordChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=dm_policy,
+            group_policy=group_policy,
+            allow_from=allow_from,
+            deny_message=deny_message,
         )
         self.enabled = enabled
         self.token = token
@@ -148,6 +156,7 @@ class DiscordChannel(BaseChannel):
                                 ),
                             )
 
+                is_group = message.guild is not None
                 meta = {
                     "user_id": str(message.author.id),
                     "channel_id": str(message.channel.id),
@@ -155,8 +164,23 @@ class DiscordChannel(BaseChannel):
                     if message.guild
                     else None,
                     "message_id": str(message.id),
-                    "is_dm": message.guild is None,
+                    "is_dm": not is_group,
+                    "is_group": is_group,
                 }
+
+                allowed, error_msg = self._check_allowlist(
+                    str(message.author.id),
+                    is_group,
+                )
+                if not allowed:
+                    logger.info(
+                        "discord allowlist blocked: sender=%s is_group=%s",
+                        message.author.id,
+                        is_group,
+                    )
+                    await message.channel.send(error_msg or "")
+                    return
+
                 native = {
                     "channel_id": self.channel,
                     "sender_id": str(message.author),
@@ -176,6 +200,12 @@ class DiscordChannel(BaseChannel):
         process: ProcessHandler,
         on_reply_sent: OnReplySent = None,
     ) -> "DiscordChannel":
+        allow_from_env = os.getenv("DISCORD_ALLOW_FROM", "")
+        allow_from = (
+            [s.strip() for s in allow_from_env.split(",") if s.strip()]
+            if allow_from_env
+            else []
+        )
         return cls(
             process=process,
             enabled=os.getenv("DISCORD_CHANNEL_ENABLED", "1") == "1",
@@ -187,6 +217,10 @@ class DiscordChannel(BaseChannel):
             http_proxy_auth=os.getenv("DISCORD_HTTP_PROXY_AUTH", ""),
             bot_prefix=os.getenv("DISCORD_BOT_PREFIX", "[BOT] "),
             on_reply_sent=on_reply_sent,
+            dm_policy=os.getenv("DISCORD_DM_POLICY", "open"),
+            group_policy=os.getenv("DISCORD_GROUP_POLICY", "open"),
+            allow_from=allow_from,
+            deny_message=os.getenv("DISCORD_DENY_MESSAGE", ""),
         )
 
     @classmethod
@@ -210,6 +244,10 @@ class DiscordChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=config.dm_policy or "open",
+            group_policy=config.group_policy or "open",
+            allow_from=config.allow_from or [],
+            deny_message=config.deny_message or "",
         )
 
     async def send(

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -160,6 +160,10 @@ class FeishuChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        dm_policy: str = "open",
+        group_policy: str = "open",
+        allow_from: Optional[List[str]] = None,
+        deny_message: str = "",
     ):
         super().__init__(
             process,
@@ -167,6 +171,10 @@ class FeishuChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=dm_policy,
+            group_policy=group_policy,
+            allow_from=allow_from,
+            deny_message=deny_message,
         )
         self.enabled = enabled
         self.app_id = app_id
@@ -204,6 +212,12 @@ class FeishuChannel(BaseChannel):
     ) -> "FeishuChannel":
         import os
 
+        allow_from_env = os.getenv("FEISHU_ALLOW_FROM", "")
+        allow_from = (
+            [s.strip() for s in allow_from_env.split(",") if s.strip()]
+            if allow_from_env
+            else []
+        )
         return cls(
             process=process,
             enabled=os.getenv("FEISHU_CHANNEL_ENABLED", "0") == "1",
@@ -214,6 +228,10 @@ class FeishuChannel(BaseChannel):
             verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", ""),
             media_dir=os.getenv("FEISHU_MEDIA_DIR", "~/.copaw/media"),
             on_reply_sent=on_reply_sent,
+            dm_policy=os.getenv("FEISHU_DM_POLICY", "open"),
+            group_policy=os.getenv("FEISHU_GROUP_POLICY", "open"),
+            allow_from=allow_from,
+            deny_message=os.getenv("FEISHU_DENY_MESSAGE", ""),
         )
 
     @classmethod
@@ -239,6 +257,10 @@ class FeishuChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=config.dm_policy or "open",
+            group_policy=config.group_policy or "open",
+            allow_from=config.allow_from or [],
+            deny_message=config.deny_message or "",
         )
 
     def resolve_session_id(
@@ -674,16 +696,35 @@ class FeishuChannel(BaseChannel):
             if not content_parts:
                 return
 
+            is_group = chat_type == "group"
             meta: Dict[str, Any] = {
                 "feishu_message_id": message_id,
                 "feishu_chat_id": chat_id,
                 "feishu_chat_type": chat_type,
                 "feishu_sender_id": sender_id,
+                "is_group": is_group,
             }
-            receive_id = chat_id if chat_type == "group" else sender_id
-            receive_id_type = "chat_id" if chat_type == "group" else "open_id"
+            receive_id = chat_id if is_group else sender_id
+            receive_id_type = "chat_id" if is_group else "open_id"
             meta["feishu_receive_id"] = receive_id
             meta["feishu_receive_id_type"] = receive_id_type
+
+            allowed, error_msg = self._check_allowlist(
+                sender_id,
+                is_group,
+            )
+            if not allowed:
+                logger.info(
+                    "feishu allowlist blocked: sender=%s is_group=%s",
+                    sender_id,
+                    is_group,
+                )
+                await self._send_text(
+                    receive_id_type,
+                    receive_id,
+                    error_msg or "",
+                )
+                return
 
             session_id = self.resolve_session_id(sender_id, meta)
             native = {

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -206,58 +206,6 @@ def _message_meta(update: Any) -> dict:
     }
 
 
-def _check_telegram_allowlist(
-    sender_id: str,
-    is_group: bool,
-    dm_policy: str,
-    group_policy: str,
-    allow_from: set,
-    deny_message: str = "",
-) -> tuple[bool, Optional[str]]:
-    """Check if sender is allowed based on dm_policy/group_policy.
-
-    Args:
-        sender_id: The sender's user ID
-        is_group: Whether the message is from a group chat
-        dm_policy: "open" or "allowlist" for direct messages
-        group_policy: "open" or "allowlist" for group messages
-        allow_from: Set of allowed sender IDs
-        deny_message: Custom message for denied users
-
-    Returns:
-        (allowed, error_message): allowed=True if message should be
-        processed, error_message contains the rejection message if not
-        allowed
-    """
-    # Determine which policy to apply
-    policy = group_policy if is_group else dm_policy
-
-    # If policy is "open", allow all
-    if policy == "open":
-        return True, None
-
-    # If policy is "allowlist", check if sender is in allow_from
-    if sender_id in allow_from:
-        return True, None
-
-    # Use custom message if provided, otherwise use default
-    if deny_message:
-        msg = deny_message
-    elif is_group:
-        msg = (
-            "Sorry, this bot is only available to authorized users. "
-            "Please contact the administrator. Your ID: "
-            f"{sender_id}"
-        )
-    else:
-        msg = (
-            "Sorry, you are not authorized to use this bot. "
-            "Please contact the administrator to add your ID to "
-            f"the allowlist. Your ID: {sender_id}"
-        )
-    return False, msg
-
-
 class TelegramChannel(BaseChannel):
     """Telegram channel: Bot API polling; session_id = telegram:{chat_id}."""
 
@@ -289,6 +237,10 @@ class TelegramChannel(BaseChannel):
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
+            dm_policy=dm_policy,
+            group_policy=group_policy,
+            allow_from=allow_from,
+            deny_message=deny_message,
         )
         self.enabled = enabled
         self._bot_token = bot_token
@@ -299,10 +251,6 @@ class TelegramChannel(BaseChannel):
             Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
         )
         self._show_typing = show_typing
-        self.dm_policy = dm_policy or "open"
-        self.group_policy = group_policy or "open"
-        self.allow_from = set(allow_from or [])
-        self.deny_message = deny_message or ""
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._task: Optional[asyncio.Task] = None
         self._application = None
@@ -379,26 +327,20 @@ class TelegramChannel(BaseChannel):
             sender_id = str(getattr(user, "id", "")) if user else chat_id
             is_group = meta.get("is_group", False)
 
-            # Check allowlist before processing
-            allowed, error_msg = _check_telegram_allowlist(
-                sender_id=sender_id,
-                is_group=is_group,
-                dm_policy=self.dm_policy,
-                group_policy=self.group_policy,
-                allow_from=self.allow_from,
-                deny_message=self.deny_message,
+            allowed, error_msg = self._check_allowlist(
+                sender_id,
+                is_group,
             )
             if not allowed:
                 logger.info(
-                    "telegram allowlist blocked: sender_id=%s is_group=%s",
+                    "telegram allowlist blocked: sender=%s is_group=%s",
                     sender_id,
                     is_group,
                 )
-                # Send rejection message
                 try:
                     await context.bot.send_message(
                         chat_id=chat_id,
-                        text=error_msg or "Unauthorized access.",
+                        text=error_msg,
                     )
                 except Exception:
                     logger.debug(

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -16,6 +16,10 @@ class BaseChannelConfig(BaseModel):
     bot_prefix: str = ""
     filter_tool_messages: bool = False
     filter_thinking: bool = False
+    dm_policy: Literal["open", "allowlist"] = "open"
+    group_policy: Literal["open", "allowlist"] = "open"
+    allow_from: List[str] = Field(default_factory=list)
+    deny_message: str = ""
 
 
 class IMessageChannelConfig(BaseChannelConfig):
@@ -34,20 +38,9 @@ class DiscordConfig(BaseChannelConfig):
 
 
 class DingTalkConfig(BaseChannelConfig):
-    """DingTalk: client_id, client_secret; media_dir for received media.
-
-    Security / allowlist:
-        dm_policy    - "open" (default) or "allowlist" for direct messages
-        group_policy - "open" (default) or "allowlist" for group messages
-        allow_from   - list of sender IDs allowed when policy is "allowlist"
-    """
-
     client_id: str = ""
     client_secret: str = ""
     media_dir: str = "~/.copaw/media"
-    dm_policy: Literal["open", "allowlist"] = "open"
-    group_policy: Literal["open", "allowlist"] = "open"
-    allow_from: List[str] = Field(default_factory=list)
 
 
 class FeishuConfig(BaseChannelConfig):
@@ -69,23 +62,10 @@ class QQConfig(BaseChannelConfig):
 
 
 class TelegramConfig(BaseChannelConfig):
-    """Telegram channel: bot_token from BotFather; optional proxy.
-
-    Security / allowlist:
-        dm_policy    - "open" (default) or "allowlist" for direct messages
-        group_policy - "open" (default) or "allowlist" for group messages
-        allow_from   - list of sender IDs allowed when policy is "allowlist"
-        deny_message - custom message shown to unauthorized users
-    """
-
     bot_token: str = ""
     http_proxy: str = ""
     http_proxy_auth: str = ""
     show_typing: Optional[bool] = None
-    dm_policy: Literal["open", "allowlist"] = "open"
-    group_policy: Literal["open", "allowlist"] = "open"
-    allow_from: List[str] = Field(default_factory=list)
-    deny_message: str = ""
 
 
 class ConsoleConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

Unify allowlist access control into BaseChannel. Previously, only Telegram and DingTalk had duplicated, inconsistent allowlist implementations. This PR:
                                                                                                                                                                                                                                                                
- Lifts `dm_policy`, `group_policy`, `allow_from`, `deny_message` into `BaseChannelConfig` and `BaseChannel._check_allowlist()`
- Adds allowlist support to Discord and Feishu                                                                                                                                                                                      
- Extracts shared `renderAccessControlFields()` in the frontend for the four channels                                                                                                                                                          
- Changes group chat denial behavior: instead of silent ignore, sends a unified reply without exposing user_id ("Sorry, this bot is only available to authorized users.")
- DM denial includes user_id in the message (private, only the user sees it)

### Allowlist Behavior
                                                                                                                                                                                                                                                                
  | Scenario | `policy: "open"` (default) | `policy: "allowlist"`, sender **in** list | `policy: "allowlist"`, sender **not in** list |                                                                                                                         
  |----------|---------------------------|------------------------------------------|----------------------------------------------|                                                                                                                            
  | **DM** | Allowed | Allowed | Denied — reply includes sender's user ID (private, only they see it) |                                                                                                                                                         
  | **Group / @mention** | Allowed | Allowed | Denied — reply with generic message, no user ID exposed |                                                                                                                                                        
                                                                                                                                                                                                                                                                
  - `dm_policy` and `group_policy` are independent — e.g. you can leave DM open but restrict group access
  - Denied messages are sent directly by the channel (not routed through the agent), so no LLM tokens are consumed
  - **Discord note:** Discord bots receive all messages in channels they have access to (not just @mentions). When `group_policy: "allowlist"` is set, the allowlist check applies to every message, not only @mentions.

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

See if user outside allowlist can reply to messages.

## Local Verification Evidence

check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

## Additional Notes
