### PR TITLE
fix(tool): fix execute_shell_command encoding issue on Windows

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -125,13 +125,8 @@ async def execute_shell_command(
                     proc.communicate(),
                     timeout=timeout,
                 )
-                encoding = locale.getpreferredencoding(False) or "utf-8"
-                stdout_str = stdout.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
-                stderr_str = stderr.decode(encoding, errors="replace").strip(
-                    "\n",
-                )
+                stdout_str = smart_decode(stdout)
+                stderr_str = smart_decode(stderr)
                 returncode = proc.returncode
 
             except asyncio.TimeoutError:
@@ -161,19 +156,8 @@ async def execute_shell_command(
                         )
                     except asyncio.TimeoutError:
                         stdout, stderr = b"", b""
-                    encoding = locale.getpreferredencoding(False) or "utf-8"
-                    stdout_str = stdout.decode(
-                        encoding,
-                        errors="replace",
-                    ).strip(
-                        "\n",
-                    )
-                    stderr_str = stderr.decode(
-                        encoding,
-                        errors="replace",
-                    ).strip(
-                        "\n",
-                    )
+                    stdout_str = smart_decode(stdout)
+                    stderr_str = smart_decode(stderr)
                     if stderr_str:
                         stderr_str += f"\n{stderr_suffix}"
                     else:
@@ -220,3 +204,13 @@ async def execute_shell_command(
                 ),
             ],
         )
+
+
+def smart_decode(data: bytes) -> str:
+    try:
+        decoded_str = data.decode("utf-8")
+    except UnicodeDecodeError:
+        encoding = locale.getpreferredencoding(False) or "utf-8"
+        decoded_str = data.decode(encoding, errors="replace")
+
+    return decoded_str.strip("\n")


### PR DESCRIPTION
## Description

Windows 环境下使用 Windows Terminal 等终端启动 copaw, execute_shell_command 工具会出现输出乱码问题。原因是使用 locale.getpreferredencoding() 返回的系统编码（cp936/GBK）去解码 UTF-8 输出的内容。新增 smart_decode 函数，优先尝试 UTF-8，解码失败时回退到系统编码，兼容传统 CMD 终端。

## Type of Change

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ x ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ x ] Ready for review

## Testing

在 Windows 中文环境使用 Windows Terminal 启动 copaw, 让 agent 使用 execute_shell_command 执行 dir ,观察目录两个字会不会变成乱码

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
