### PR TITLE
feat(feishu): add post message type support for receiving

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -52,6 +52,8 @@ from .constants import (
 )
 from .utils import (
     extract_json_key,
+    extract_post_image_keys,
+    extract_post_text,
     normalize_feishu_md,
     sender_display_string,
     short_session_id_from_full_id,
@@ -614,6 +616,25 @@ class FeishuChannel(BaseChannel):
                 text = extract_json_key(content_raw, "text")
                 if text:
                     text_parts.append(text)
+            elif msg_type == "post":
+                text = extract_post_text(content_raw)
+                if text:
+                    text_parts.append(text)
+                # Download images in post message
+                for img_key in extract_post_image_keys(content_raw):
+                    url_or_path = await self._download_image_resource(
+                        message_id,
+                        img_key,
+                    )
+                    if url_or_path:
+                        content_parts.append(
+                            ImageContent(
+                                type=ContentType.IMAGE,
+                                image_url=url_or_path,
+                            ),
+                        )
+                    else:
+                        text_parts.append("[image: download failed]")
             elif msg_type == "image":
                 image_key = extract_json_key(
                     content_raw,

--- a/src/copaw/app/channels/feishu/utils.py
+++ b/src/copaw/app/channels/feishu/utils.py
@@ -40,6 +40,87 @@ def extract_json_key(content: Optional[str], *keys: str) -> Optional[str]:
     return None
 
 
+def extract_post_text(content: Optional[str]) -> Optional[str]:
+    # pylint: disable=too-many-branches
+    """Extract plain text from Feishu post message content."""
+    if not content:
+        return None
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    parts: list[str] = []
+
+    # Extract title if present
+    title = data.get("title")
+    if title and isinstance(title, str) and title.strip():
+        parts.append(title.strip())
+
+    # Extract text from content blocks
+    content_blocks = data.get("content") or []
+    if isinstance(content_blocks, list):
+        for block in content_blocks:
+            if not isinstance(block, list):
+                continue
+            for item in block:
+                if not isinstance(item, dict):
+                    continue
+                tag = item.get("tag")
+                # text, code_block, md tags have text field
+                if tag in {"text", "code_block", "md"}:
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        parts.append(text.strip())
+                # a tag: text + href as markdown link
+                elif tag == "a":
+                    text = item.get("text", "")
+                    href = item.get("href", "")
+                    if href:
+                        parts.append(f"[{text}]({href})" if text else href)
+                    elif text:
+                        parts.append(text.strip())
+                # at tag uses user_name
+                elif tag == "at":
+                    user_name = item.get("user_name") or item.get("user_id")
+                    if isinstance(user_name, str) and user_name.strip():
+                        parts.append(f"@{user_name.strip()}")
+
+    return " ".join(parts) if parts else None
+
+
+def extract_post_image_keys(content: Optional[str]) -> list[str]:
+    """Extract image_key list from Feishu post message content."""
+    if not content:
+        return []
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    keys: list[str] = []
+    content_blocks = data.get("content") or []
+    if isinstance(content_blocks, list):
+        for block in content_blocks:
+            if not isinstance(block, list):
+                continue
+            for item in block:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("tag") == "img":
+                    key = item.get("image_key")
+                    if isinstance(key, str) and key.strip():
+                        keys.append(key.strip())
+
+    return keys
+
+
 def normalize_feishu_md(text: str) -> str:
     """
     Light markdown normalization for Feishu post (avoid broken rendering).


### PR DESCRIPTION
## Description

  - Add extract_post_text() to parse text from post message content
  - Add extract_post_image_keys() to extract image keys from post message
  - Handle post message type in _on_message() to receive rich text messages
  - Support text, link, at, image, code_block, md tags in post messages

**Related Issue:** https://github.com/agentscope-ai/CoPaw/issues/619


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```
