### PR TITLE
fix(discord): split messages exceeding Discord's 2000 character limit

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import logging
 import asyncio
+import re
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
@@ -31,10 +32,14 @@ from ..base import (
 
 logger = logging.getLogger(__name__)
 
+# Regex that matches a code-fence opening/closing line (``` or ~~~).
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
 
 class DiscordChannel(BaseChannel):
     channel = "discord"
     uses_manager_queue = True
+    _DISCORD_MAX_LEN: int = 2000
 
     def __init__(
         self,
@@ -281,6 +286,70 @@ class DiscordChannel(BaseChannel):
             return user.dm_channel or await user.create_dm()
         return None
 
+    @staticmethod
+    def _chunk_text(text: str, max_len: int = 2000) -> list[str]:
+        """Split *text* into chunks that fit Discord's message limit.
+
+        Splits at newline boundaries to preserve formatting.  If a single
+        line exceeds *max_len* it is hard-split at *max_len*.
+
+        Markdown code fences are tracked so that a chunk ending inside an
+        open fence gets a closing fence appended and the next chunk gets
+        a matching opening fence prepended.  This keeps code blocks
+        rendered correctly across split messages.
+        """
+        if len(text) <= max_len:
+            return [text]
+
+        chunks: list[str] = []
+        current: list[str] = []
+        current_len = 0
+        fence_open: str = ""  # e.g. "```python"
+
+        def _flush() -> None:
+            nonlocal fence_open
+            body = "".join(current).rstrip("\n")
+            if fence_open:
+                body += "\n```"  # close dangling fence
+            chunks.append(body)
+            current.clear()
+
+        for line in text.split("\n"):
+            line_with_nl = line + "\n"
+            stripped = line.strip()
+
+            # Detect fence toggle.
+            if _FENCE_RE.match(stripped):
+                if fence_open:
+                    fence_open = ""
+                else:
+                    fence_open = stripped
+
+            # Flush if adding this line would exceed the limit.
+            if current and current_len + len(line_with_nl) > max_len:
+                saved_fence = fence_open
+                _flush()
+                current_len = 0
+                # Re-open the fence in the next chunk.
+                if saved_fence:
+                    fence_open = saved_fence
+                    reopener = saved_fence + "\n"
+                    current.append(reopener)
+                    current_len += len(reopener)
+
+            # Single line exceeds max_len -> hard-split.
+            if len(line_with_nl) > max_len:
+                for i in range(0, len(line), max_len):
+                    chunks.append(line[i : i + max_len])
+            else:
+                current.append(line_with_nl)
+                current_len += len(line_with_nl)
+
+        if current:
+            chunks.append("".join(current).rstrip("\n"))
+
+        return [c for c in chunks if c.strip()]
+
     async def send(
         self,
         to_handle: str,
@@ -297,6 +366,8 @@ class DiscordChannel(BaseChannel):
             1) meta["channel_id"]  -> send to that channel
             2) meta["user_id"]     -> DM that user (opens/uses DM channel)
         - If neither is provided, this raises ValueError.
+        - Messages exceeding 2000 chars are automatically split into
+            multiple messages preserving markdown code fences.
         """
         if not self.enabled:
             return
@@ -310,7 +381,8 @@ class DiscordChannel(BaseChannel):
                 "DiscordChannel.send requires meta['channel_id']"
                 " or meta['user_id']",
             )
-        await target.send(text)
+        for chunk in self._chunk_text(text, self._DISCORD_MAX_LEN):
+            await target.send(chunk)
 
     async def send_content_parts(
         self,
@@ -473,7 +545,7 @@ class DiscordChannel(BaseChannel):
         return session_id
 
     def _route_from_handle(self, to_handle: str) -> dict:
-        # to_handle: discord:ch:<channel_id> 或 discord:dm:<user_id>
+        # to_handle format: discord:ch:<channel_id> or discord:dm:<user_id>
         parts = (to_handle or "").split(":")
         if len(parts) >= 3 and parts[0] == "discord":
             kind, ident = parts[1], parts[2]


### PR DESCRIPTION
## Description

Discord's API rejects messages longer than 2000 characters. When CoPaw generates a long response (e.g. code blocks, detailed explanations), the [send()](cci:1://file:///C:/Users/Administrator/Downloads/Antigravity/%E9%A1%B9%E7%9B%AE/CoPaw/_upstream_discord_channel.py:283:4-312:31) call fails with 400 Bad Request, leaving the user with no reply.

This PR adds automatic message chunking to [DiscordChannel](cci:2://file:///C:/Users/Administrator/Downloads/Antigravity/%E9%A1%B9%E7%9B%AE/CoPaw/src/copaw/app/channels/discord_/channel.py:34:0-537:17):
- Adds `_DISCORD_MAX_LEN` class constant (2000 chars)
- Adds `_chunk_text()` static method that splits at newline boundaries to preserve markdown formatting.
- **Fence-aware Chunking**: Tracks the open/close state of markdown code fences ( \`\`\` and ~~~) via `_FENCE_RE`. If a chunk splits in the middle of a code block, it automatically appends a closing fence to the current message and prepends an opening fence to the next message. **This ensures code syntax highlighting is never broken across messages.**
- Updated [send()](cci:1://file:///C:/Users/Administrator/Downloads/Antigravity/%E9%A1%B9%E7%9B%AE/CoPaw/_upstream_discord_channel.py:283:4-312:31) to iterate over chunks for both channel and DM targets.

**Related Issue:** N/A (discovered in production)

**Security Considerations:** None — only affects outbound message formatting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Connect CoPaw to a Discord server
2. Ask the bot a question that generates a large code block > 2000 chars (e.g. "write a very long python backend script").
3. **Before fix:** Bot fails to reply (400 Bad Request on Discord API).
4. **After fix:** Bot replies with sequential messages. If the split happens inside a code block, both messages will render as properly formatted code blocks.

## Additional Notes

- All other Discord features, including access control logic, meta passing, and media sending, remain entirely untouched and pure. 
- The file was rewritten from a clean upstream base to guarantee LF endings and no UTF-16/BOM artifacts.
