### PR TITLE
fix(discord): prevent cross-channel message merging due to sender_id debounce key

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -8,7 +8,7 @@ import asyncio
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from agentscope_runtime.engine.schemas.agent_schemas import (
@@ -427,6 +427,60 @@ class DiscordChannel(BaseChannel):
         if self._client:
             await self._client.close()
 
+    # ------------------------------------------------------------------
+    # Debounce: use per-channel keys so concurrent messages from the same
+    # user in different channels/threads are NOT merged together.
+    # ------------------------------------------------------------------
+
+    def get_debounce_key(self, payload: Any) -> str:
+        """Return a debounce key scoped to the Discord channel or DM.
+
+        The base class falls back to ``sender_id``, which causes
+        ``ChannelManager._drain_same_key()`` to incorrectly merge
+        messages when the same user sends to multiple channels at the
+        same time.  This override uses ``resolve_session_id`` so each
+        channel/thread gets its own isolated debounce bucket.
+        """
+        if isinstance(payload, dict):
+            meta = payload.get("meta") or {}
+            sender_id = payload.get("sender_id") or ""
+            return self.resolve_session_id(sender_id, meta)
+        return getattr(payload, "session_id", "") or ""
+
+    def merge_native_items(self, items: List[Any]) -> Any:
+        """Merge native payloads while preserving Discord metadata.
+
+        Extends the base implementation to also carry over
+        Discord-specific meta keys (``channel_id``, ``message_id``,
+        ``guild_id``, ``is_dm``, ``is_group``) from the first item.
+        """
+        if not items:
+            return None
+        first = items[0] if isinstance(items[0], dict) else {}
+        merged_parts: List[Any] = []
+        merged_meta: Dict[str, Any] = dict(first.get("meta") or {})
+        for it in items:
+            p = it if isinstance(it, dict) else {}
+            merged_parts.extend(p.get("content_parts") or [])
+            m = p.get("meta") or {}
+            for k in (
+                "reply_future",
+                "reply_loop",
+                "incoming_message",
+                "conversation_id",
+                "message_id",
+            ):
+                if k in m:
+                    merged_meta[k] = m[k]
+        return {
+            "channel_id": first.get("channel_id") or self.channel,
+            "sender_id": first.get("sender_id") or "",
+            "content_parts": merged_parts,
+            "meta": merged_meta,
+        }
+
+    # ------------------------------------------------------------------
+
     def resolve_session_id(
         self,
         sender_id: str,
@@ -473,7 +527,7 @@ class DiscordChannel(BaseChannel):
         return session_id
 
     def _route_from_handle(self, to_handle: str) -> dict:
-        # to_handle: discord:ch:<channel_id> 或 discord:dm:<user_id>
+        # to_handle format: discord:ch:<channel_id> or discord:dm:<user_id>
         parts = (to_handle or "").split(":")
         if len(parts) >= 3 and parts[0] == "discord":
             kind, ident = parts[1], parts[2]


### PR DESCRIPTION
## Description

`BaseChannel.get_debounce_key()` falls back to `sender_id` for native dict payloads. When the same user sends messages to multiple Discord channels or threads concurrently, `ChannelManager._drain_same_key()` sees the same debounce key and incorrectly merges them into a single request.

**Result:** Messages from different channels get concatenated together. Some channels receive no reply, others receive an "empty content" error.

**Fix:** Override [get_debounce_key()](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:172:4-182:48) and [merge_native_items()](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:184:4-205:9) in [DiscordChannel](cci:2://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:26:0-444:17):
- [get_debounce_key()](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:172:4-182:48): uses [resolve_session_id(sender_id, meta)](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel_pr1_message_chunking.py:355:4-369:38) which returns `discord:ch:<channel_id>` for guild channels/threads, ensuring per-channel debounce isolation
- [merge_native_items()](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:184:4-205:9): correctly concatenates [content_parts](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/base.py:626:4-677:53) while preserving Discord metadata

**Related Issue:** N/A (discovered in production)

**Security Considerations:** None — only affects message routing and debounce key generation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Connect CoPaw to a Discord server with multiple channels or threads
2. Send messages to 2+ channels simultaneously from the same user account
3. **Before fix:** One channel gets a merged/garbled response, the other gets no reply or "empty content"
4. **After fix:** Each channel gets its own independent, correct response

## Additional Notes

The root cause affects any channel implementation that uses [BaseChannel](cci:2://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/base.py:67:0-793:63)'s default [get_debounce_key()](cci:1://file:///C:/ProgramData/miniconda3/envs/zxs_py312/Lib/site-packages/copaw/app/channels/discord_/channel.py:172:4-182:48) with native dict payloads. Other channel types (Feishu, Telegram, etc.) may benefit from similar overrides if they experience the same issue.
