### PR TITLE
feat(Feishu): display the markdown table in the form of message cards

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import mimetypes
+import re
 import sys
 import threading
 import time
@@ -1211,9 +1212,7 @@ class FeishuChannel(BaseChannel):
     ) -> bool:
         """Send text as post (md) or interactive card (when body has tables).
         Body already has bot_prefix if needed."""
-        import re as _re
-
-        has_table = bool(_re.search(r"^\s*\|", body, _re.MULTILINE))
+        has_table = bool(re.search(r"^\s*\|", body, re.MULTILINE))
         loop = asyncio.get_running_loop()
         if has_table:
             content = build_interactive_content(body)

--- a/src/copaw/app/channels/feishu/utils.py
+++ b/src/copaw/app/channels/feishu/utils.py
@@ -82,13 +82,35 @@ def _parse_md_table(table_lines: List[str]) -> Optional[Dict[str, Any]]:
     # Build column keys (safe ASCII slugs)
     col_keys = [f"col{i}" for i in range(len(headers))]
 
-    # Build column definitions with auto width.
+    # Parse alignment from separator line (e.g., |:---|:--:|---:|)
+    def parse_alignment(sep_line: str) -> List[str]:
+        cells = split_row(sep_line)
+        alignments = []
+        for cell in cells:
+            stripped = cell.strip()
+            if stripped.startswith(":") and stripped.endswith(":"):
+                alignments.append("center")
+            elif stripped.endswith(":"):
+                alignments.append("right")
+            else:
+                alignments.append("left")
+        return alignments
+
+    alignments = (
+        parse_alignment(lines[sep_idx])
+        if sep_idx is not None
+        else ["left"] * len(headers)
+    )
+
+    # Build column definitions with auto width and parsed alignment.
     columns = [
         {
             "name": col_keys[i],
             "display_name": headers[i],
             "width": "auto",
-            "horizontal_align": "left",
+            "horizontal_align": alignments[i]
+            if i < len(alignments)
+            else "left",
         }
         for i in range(len(headers))
     ]
@@ -98,15 +120,15 @@ def _parse_md_table(table_lines: List[str]) -> Optional[Dict[str, Any]]:
         row: Dict[str, Any] = {}
         for i, key in enumerate(col_keys):
             cell_text = cells[i] if i < len(cells) else ""
-            # Strip Markdown markers; table cells are plain strings.
-            cell_text = re.sub(r"\*{1,2}(.+?)\*{1,2}", r"\1", cell_text)
+            # Strip Markdown emphasis; table cells are plain strings.
+            cell_text = re.sub(r"[*_]{1,2}(.+?)[*_]{1,2}", r"\1", cell_text)
             row[key] = cell_text
         rows.append(row)
     if not rows:
         return None
     return {
         "tag": "table",
-        "page_size": max(len(rows), 10),
+        "page_size": min(max(len(rows), 10), 50),
         "columns": columns,
         "rows": rows,
     }


### PR DESCRIPTION
## Description

Due to Feishu not supporting the display of native markdown table format, the table will be converted to the table format supported by Feishu message cards for display.
<img width="646" height="346" alt="image" src="https://github.com/user-attachments/assets/5f31532e-0684-429b-b8c1-d9439d07753c" />


**Related Issue:** Fixes #961 #937 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
