### PR TITLE
feat(DIngTalk):stop DingTalk channel cleanly when auth fails

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -1542,9 +1542,9 @@ class DingTalkChannel(BaseChannel):
                     await client.websocket.close()
                 except Exception:
                     pass
-            await asyncio.sleep(0.2)
-            if not main_task.done():
+            while not main_task.done():
                 main_task.cancel()
+                await asyncio.sleep(0.1)
 
         watcher_task = asyncio.create_task(stop_watcher())
         try:


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #1027 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
