### PR TITLE
feat: add MiniMax as a built-in provider

### DIFF
--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -87,6 +87,11 @@ AZURE_OPENAI_MODELS: List[ModelInfo] = [
 
 ANTHROPIC_MODELS: List[ModelInfo] = []
 
+MINIMAX_MODELS: List[ModelInfo] = [
+    ModelInfo(id="MiniMax-M2.5", name="MiniMax M2.5"),
+    ModelInfo(id="MiniMax-M2.5-highspeed", name="MiniMax M2.5 Highspeed"),
+]
+
 PROVIDER_MODELSCOPE = OpenAIProvider(
     id="modelscope",
     name="ModelScope",
@@ -169,6 +174,15 @@ PROVIDER_LMSTUDIO = LMStudioProvider(
     models=[],
 )
 
+PROVIDER_MINIMAX = OpenAIProvider(
+    id="minimax",
+    name="MiniMax",
+    base_url="https://api.minimaxi.com/v1",
+    api_key_prefix="",
+    models=MINIMAX_MODELS,
+    freeze_url=True,
+)
+
 
 class ModelSlotConfig(BaseModel):
     provider_id: str = Field(
@@ -229,6 +243,7 @@ class ProviderManager:
         self._add_builtin(PROVIDER_LMSTUDIO)
         self._add_builtin(PROVIDER_LLAMACPP)
         self._add_builtin(PROVIDER_MLX)
+        self._add_builtin(PROVIDER_MINIMAX)
 
     def _add_builtin(self, provider: Provider):
         self.builtin_providers[provider.id] = provider

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -8,7 +8,6 @@ import pytest
 
 import copaw.providers.provider_manager as provider_manager_module
 from copaw.providers.openai_provider import OpenAIProvider
-from copaw.providers.provider import ModelInfo
 from copaw.providers.provider_manager import (
     MINIMAX_MODELS,
     PROVIDER_MINIMAX,

--- a/tests/unit/providers/test_minimax_provider.py
+++ b/tests/unit/providers/test_minimax_provider.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import copaw.providers.provider_manager as provider_manager_module
+from copaw.providers.openai_provider import OpenAIProvider
+from copaw.providers.provider import ModelInfo
+from copaw.providers.provider_manager import (
+    MINIMAX_MODELS,
+    PROVIDER_MINIMAX,
+    ProviderManager,
+)
+
+
+def test_minimax_provider_definition():
+    assert PROVIDER_MINIMAX.id == "minimax"
+    assert PROVIDER_MINIMAX.name == "MiniMax"
+    assert PROVIDER_MINIMAX.base_url == "https://api.minimaxi.com/v1"
+    assert PROVIDER_MINIMAX.chat_model == "OpenAIChatModel"
+    assert PROVIDER_MINIMAX.freeze_url is True
+    assert isinstance(PROVIDER_MINIMAX, OpenAIProvider)
+
+
+def test_minimax_models():
+    assert len(MINIMAX_MODELS) == 2
+    model_ids = [m.id for m in MINIMAX_MODELS]
+    assert "MiniMax-M2.5" in model_ids
+    assert "MiniMax-M2.5-highspeed" in model_ids
+
+
+@pytest.fixture
+def isolated_secret_dir(monkeypatch, tmp_path):
+    secret_dir = tmp_path / ".copaw.secret"
+    monkeypatch.setattr(provider_manager_module, "SECRET_DIR", secret_dir)
+    return secret_dir
+
+
+def test_minimax_registered_as_builtin(isolated_secret_dir):
+    manager = ProviderManager()
+    provider = manager.get_provider("minimax")
+
+    assert provider is not None
+    assert provider.id == "minimax"
+    assert provider.name == "MiniMax"
+    assert isinstance(provider, OpenAIProvider)
+    assert provider is PROVIDER_MINIMAX
+
+
+async def test_minimax_listed_in_providers(isolated_secret_dir):
+    manager = ProviderManager()
+    infos = await manager.list_provider_info()
+    provider_ids = [info.id for info in infos]
+
+    assert "minimax" in provider_ids
+
+
+def test_minimax_has_correct_models(isolated_secret_dir):
+    manager = ProviderManager()
+    provider = manager.get_provider("minimax")
+
+    assert provider is not None
+    assert provider.has_model("MiniMax-M2.5")
+    assert provider.has_model("MiniMax-M2.5-highspeed")
+    assert not provider.has_model("nonexistent-model")
+
+
+def test_minimax_update_api_key_persists(isolated_secret_dir):
+    manager = ProviderManager()
+
+    ok = manager.update_provider("minimax", {"api_key": "test-minimax-key"})
+
+    assert ok is True
+
+    persisted = manager.load_provider("minimax", is_builtin=True)
+    assert persisted is not None
+    assert isinstance(persisted, OpenAIProvider)
+    assert persisted.api_key == "test-minimax-key"
+    assert persisted.base_url == "https://api.minimaxi.com/v1"
+
+
+async def test_minimax_check_connection(monkeypatch, isolated_secret_dir):
+    manager = ProviderManager()
+    provider = manager.get_provider("minimax")
+
+    class FakeModels:
+        async def list(self, timeout=None):
+            return SimpleNamespace(data=[])
+
+    fake_client = SimpleNamespace(models=FakeModels())
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, msg = await provider.check_connection(timeout=2)
+
+    assert ok is True
+    assert msg == ""
+
+
+async def test_minimax_activate_model(monkeypatch, isolated_secret_dir):
+    manager = ProviderManager()
+
+    await manager.activate_model("minimax", "MiniMax-M2.5")
+
+    assert manager.active_model is not None
+    assert manager.active_model.provider_id == "minimax"
+    assert manager.active_model.model == "MiniMax-M2.5"
+
+    reloaded = ProviderManager()
+    assert reloaded.active_model is not None
+    assert reloaded.active_model.provider_id == "minimax"
+    assert reloaded.active_model.model == "MiniMax-M2.5"
+
+
+async def test_minimax_activate_invalid_model_raises(isolated_secret_dir):
+    manager = ProviderManager()
+
+    with pytest.raises(ValueError, match="Model 'invalid' not found"):
+        await manager.activate_model("minimax", "invalid")


### PR DESCRIPTION
## Summary

* Add MiniMax as a new built-in provider with OpenAI-compatible API support
* Adapted to the refactored provider architecture (Provider class hierarchy + ProviderManager)
* Register two models: `MiniMax-M2.5` (default) and `MiniMax-M2.5-highspeed`
* Add comprehensive unit tests for MiniMax provider integration

## Supported Models

| Model ID | Description |
| --- | --- |
| MiniMax-M2.5 | Peak Performance. Ultimate Value. Master the Complex |
| MiniMax-M2.5-highspeed | Same performance, faster and more agile |

Both models support **204,800 tokens** context window.

## Changes

* `src/copaw/providers/provider_manager.py`: Add `MINIMAX_MODELS` list, create `PROVIDER_MINIMAX` as `OpenAIProvider` instance, register in `_init_builtins()`
* `tests/unit/providers/test_minimax_provider.py`: Add unit tests covering provider definition, model list, registry, persistence, and activation

All 62 provider tests pass (9 new + 53 existing).