### PR TITLE
fix(tools,channels): fix shell check=True on Windows and use file_url_to_local_path in Telegram/Discord

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -23,6 +23,7 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
 
 from ....config.config import DiscordConfig as DiscordChannelConfig
 
+from ..utils import file_url_to_local_path
 from ..base import (
     BaseChannel,
     OnReplySent,
@@ -436,9 +437,7 @@ class DiscordChannel(BaseChannel):
         meta: Optional[dict] = None,
     ) -> None:
         """Send a media part as a Discord file attachment."""
-        if not self.enabled or not self._client:
-            return
-        if not self._client.is_ready():
+        if not self.enabled or not self._client or not self._client.is_ready():
             return
         import discord
 
@@ -460,7 +459,14 @@ class DiscordChannel(BaseChannel):
 
         temp_path = None
         if url.startswith("file://"):
-            file = discord.File(url[7:])
+            local_path = file_url_to_local_path(url)
+            if not local_path:
+                logger.warning(
+                    "discord send_media: invalid file URL %s",
+                    url,
+                )
+                return
+            file = discord.File(local_path)
         elif url.startswith(("http://", "https://")):
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as resp:


### PR DESCRIPTION
## What

Three small fixes:

1. **shell.py Windows path `check=True` bug**: `_execute_subprocess_sync` uses `subprocess.run` with `check=True`, which throws `CalledProcessError` on any non-zero exit code, losing stdout/stderr entirely. For example, when the Agent runs `grep` with no match or `git diff` with changes, all it gets back is "returned non-zero exit status 1" with no actual output. Changed to `check=False` to match the Linux path behavior.

2. **Telegram `send_media` file path parsing**: Was using `url.replace("file://", "")` to convert `file://` URLs to local paths. The project already has `file_url_to_local_path()` which handles edge cases (Windows drive letters, URL encoding, etc.) and is used by DingTalk, Feishu, and iMessage channels. Switched Telegram to use it too.

3. **Discord `send_media` file path parsing**: Same issue as Telegram — was using `url[7:]` to strip the `file://` prefix, which breaks on Windows drive letters and URL-encoded paths. Switched to `file_url_to_local_path()` for consistency.

## Verification

Fix 1:
```
# Before: non-zero exit loses stdout
code=-1 out='' err="Command 'echo hello && exit 1' returned non-zero exit status 1."
# After: output preserved
code=1 out='hello' err=''
```

Fix 2 & 3: `file_url_to_local_path` tested on Windows/Unix/remote URLs. All channels now use the same shared utility.

pre-commit all passed, existing tests unaffected.