### PR TITLE
feat: per docker ci

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,5 +1,5 @@
 # Build CoPaw multi-arch Docker image and push to DockerHub + Aliyun ACR on release.
-# Beta release: update <version> and pre only.
+# Pre-release: update <version> and pre only.
 # Formal release: update <version>, pre and latest.
 name: Docker Build and Push on Release
 
@@ -12,8 +12,8 @@ on:
         description: "Image tag (e.g. v1.2.3 or v1.2.3-beta.1)"
         required: true
         type: string
-      is_beta:
-        description: "Beta release (do not update latest)"
+      is_prerelease:
+        description: "Pre-release (do not update latest tag)"
         required: false
         type: boolean
         default: false
@@ -48,38 +48,38 @@ jobs:
           username: ${{ secrets.ALIYUN_ACR_USERNAME }}
           password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
 
-      - name: Set version and beta flag
+      - name: Set version and prerelease flag
         id: vars
         run: |
           if [ -n "${{ github.event.release.tag_name }}" ]; then
             VERSION="${{ github.event.release.tag_name }}"
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            
+
             # Parse version to determine if it's a pre-release
             # Beta/alpha/rc/dev are pre-releases, but .post is NOT
             if [[ "$VERSION" =~ (beta|alpha|rc|dev) ]]; then
-              echo "is_beta=true" >> $GITHUB_OUTPUT
+              echo "is_prerelease=true" >> $GITHUB_OUTPUT
             elif [[ "$VERSION" =~ post ]]; then
               # .post versions should update latest (post-release patches)
-              echo "is_beta=false" >> $GITHUB_OUTPUT
+              echo "is_prerelease=false" >> $GITHUB_OUTPUT
             else
               # Use GitHub's prerelease flag as fallback
-              echo "is_beta=${{ github.event.release.prerelease }}" >> $GITHUB_OUTPUT
+              echo "is_prerelease=${{ github.event.release.prerelease }}" >> $GITHUB_OUTPUT
             fi
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-            echo "is_beta=${{ github.event.inputs.is_beta }}" >> $GITHUB_OUTPUT
+            echo "is_prerelease=${{ github.event.inputs.is_prerelease }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push multi-arch (version + pre [+ latest])
         env:
           VERSION: ${{ steps.vars.outputs.version }}
-          IS_BETA: ${{ steps.vars.outputs.is_beta }}
+          IS_PRERELEASE: ${{ steps.vars.outputs.is_prerelease }}
           COPAW_ENABLED_CHANNELS: "discord,telegram,dingtalk,feishu,qq,console"
         run: |
           TAGS="-t ${ACR_REGISTRY}/${IMAGE}:${VERSION} -t ${ACR_REGISTRY}/${IMAGE}:pre"
           TAGS="${TAGS} -t docker.io/${IMAGE}:${VERSION} -t docker.io/${IMAGE}:pre"
-          if [ "${IS_BETA}" != "true" ]; then
+          if [ "${IS_PRERELEASE}" != "true" ]; then
             TAGS="${TAGS} -t ${ACR_REGISTRY}/${IMAGE}:latest -t docker.io/${IMAGE}:latest"
           fi
           docker buildx build --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
## Summary

- Fix Docker `latest` tag not being updated for `.post` releases (e.g., `v0.0.5.post1`)
- Add version parsing logic to distinguish between pre-release and stable releases
- Pre-release versions (`beta`, `alpha`, `rc`, `dev`) will NOT update `latest` tag
- Post-release versions (`.post`) will update `latest` tag as stable releases

## Changes

Previously, the workflow relied solely on GitHub's `prerelease` checkbox, which caused `.post` versions to be incorrectly treated as pre-releases if manually flagged.

Now the workflow automatically parses the version string:
- Versions containing `beta`, `alpha`, `rc`, or `dev` → treated as pre-release (no `latest` update)
- Versions containing `post` → treated as stable release (updates `latest`)
- Other versions → fallback to GitHub's `prerelease` flag

This aligns with PEP 440 versioning semantics where `.post` versions are stable post-release patches.
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
