### PR TITLE
Allow base URL override for built-in aliyun-codingplan

### DIFF
--- a/src/copaw/app/routers/providers.py
+++ b/src/copaw/app/routers/providers.py
@@ -207,7 +207,11 @@ async def test_provider(
         ok = await tmp_provider.check_connection()
         return TestConnectionResponse(
             success=ok,
-            message="Connection successful" if ok else "Connection failed",
+            message=(
+                "Connection successful"
+                if ok
+                else "Connection failed. Verify API key and Base URL."
+            ),
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -268,7 +272,14 @@ async def test_model(
         ok = await provider.check_model_connection(model_id=body.model_id)
         return TestConnectionResponse(
             success=ok,
-            message="Connection successful" if ok else "Connection failed",
+            message=(
+                "Connection successful"
+                if ok
+                else (
+                    "Connection failed. Verify model ID, API key, and "
+                    "Base URL."
+                )
+            ),
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -110,7 +110,7 @@ PROVIDER_ALIYUN_CODINGPLAN = OpenAIProvider(
     base_url="https://coding.dashscope.aliyuncs.com/v1",
     api_key_prefix="sk-sp",
     models=ALIYUN_CODINGPLAN_MODELS,
-    freeze_url=True,
+    freeze_url=False,
 )
 
 PROVIDER_LLAMACPP = DefaultProvider(

--- a/tests/providers/test_provider_manager.py
+++ b/tests/providers/test_provider_manager.py
@@ -269,6 +269,26 @@ def test_update_provider_for_builtin_persists_to_builtin_path(
     assert persisted_azure.base_url == "https://azure-updated.example/v1"
     assert persisted_azure.api_key == "sk-azure-updated"
 
+    ok = manager.update_provider(
+        "aliyun-codingplan",
+        {
+            "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
+            "api_key": "sk-sp-updated",
+        },
+    )
+    assert ok is True
+    persisted_aliyun = manager.load_provider(
+        "aliyun-codingplan",
+        is_builtin=True,
+    )
+    assert persisted_aliyun is not None
+    assert isinstance(persisted_aliyun, OpenAIProvider)
+    assert (
+        persisted_aliyun.base_url
+        == "https://coding-intl.dashscope.aliyuncs.com/v1"
+    )
+    assert persisted_aliyun.api_key == "sk-sp-updated"
+
 
 def test_update_provider_for_unknown_returns_false(
     isolated_secret_dir,


### PR DESCRIPTION
# Title
Allow base URL override for built-in `aliyun-codingplan` and improve connection diagnostics

# Summary
This PR keeps the existing preset defaults unchanged, but makes the built-in `aliyun-codingplan` provider recoverable when a user needs to override the base URL.

It also improves the error messages returned by provider/model connection tests so that base URL mismatches are less likely to be misread as API key failures.

# Why
- `aliyun-codingplan` is a built-in provider, but its base URL cannot currently be overridden through the same config path/UI used for other providers that support custom endpoints.
- When provider-level and model-level tests hit different endpoints, users can end up with a misleading `invalid API key` error even when the issue is the configured base URL.
- This PR is intentionally conservative: it does not change the preset default or model list.

# Changes
- Set `freeze_url=False` for the built-in `aliyun-codingplan` provider so `base_url` updates are not discarded.
- Improve provider/model test failure messages to mention Base URL verification explicitly.
- Add a regression test showing that `aliyun-codingplan` persists an overridden `base_url`.

# Scope
- No preset default URL change
- No model list change
- No provider protocol change

# Repro
1. Configure the built-in `aliyun-codingplan` provider.
2. Override the Base URL via the API/UI.
3. On current `main`, the provider keeps the built-in URL because the preset is frozen.
4. If the built-in endpoint is not correct for the account/region, provider/model tests fail and the UI gives little guidance about checking the Base URL.

# Notes
This patch is useful even if the current default is correct for some users, because it improves recovery and diagnostics without changing existing defaults.

# Validation
- Targeted test planned: `tests/providers/test_provider_manager.py`
- I could not run `pytest` in my local repro environment because the packaged CoPaw venv did not include `pytest`.
