### PR TITLE
Fix Discord channel failing on long messages

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -8,7 +8,7 @@ import asyncio
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional, cast
 
 import aiohttp
 from agentscope_runtime.engine.schemas.agent_schemas import (
@@ -328,7 +328,11 @@ class DiscordChannel(BaseChannel):
             raise RuntimeError("Discord client is not initialized")
         if not self._client.is_ready():
             raise RuntimeError("Discord client is not ready yet")
-        target = await self._resolve_target(to_handle, meta)
+        resolve_target = cast(
+            Callable[[str, Optional[dict]], Awaitable[Any]],
+            self._resolve_target,
+        )
+        target = await resolve_target(to_handle, meta)
         if not target:
             raise ValueError(
                 "DiscordChannel.send requires meta['channel_id']"
@@ -388,7 +392,11 @@ class DiscordChannel(BaseChannel):
         if not url:
             return
 
-        target = await self._resolve_target(to_handle, meta)
+        resolve_target = cast(
+            Callable[[str, Optional[dict]], Awaitable[Any]],
+            self._resolve_target,
+        )
+        target = await resolve_target(to_handle, meta)
         if not target:
             logger.warning(
                 "discord send_media: cannot resolve target",

--- a/tests/channels/test_discord_chunking.py
+++ b/tests/channels/test_discord_chunking.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
 
 from types import MethodType
 


### PR DESCRIPTION
## Summary
- split Discord messages into chunks under the platform message length limit before sending
- reuse the same newline/whitespace-aware chunking strategy already used by Telegram
- add channel tests covering chunking and multi-message sends

## Testing
- PYTHONPATH=/home/jinny/copaw-upstream/src:/home/jinny/.copaw/venv/lib/python3.12/site-packages /tmp/copaw-pr-venv/bin/python -m pytest tests/channels/test_discord_chunking.py

## Notes
- This fixes Discord replies failing with `400 Bad Request` when CoPaw sends long analyses or file listings.
- In the local Discord bot path here, the API rejected replies above `2000` characters with `Must be 2000 or fewer in length`.
- I also tried running `tests/channels/test_qq_url_sanitize.py`, but local collection currently fails because `aiofiles` is not installed in this test environment.