### PR TITLE
fix: disable pylint E0611 false positive for concurrent.futures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,72 +3,71 @@ repos:
     rev: v4.3.0
     hooks:
       - id: check-ast
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: sort-simple-yaml
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: check-yaml
         exclude: |
           (?x)^(
               meta.yaml
           )$
       - id: check-xml
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: check-toml
       - id: check-docstring-first
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: check-json
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: fix-encoding-pragma
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
       - id: detect-private-key
       - id: trailing-whitespace
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
   - repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0
     hooks:
       - id: add-trailing-comma
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.0
     hooks:
       - id: mypy
-        exclude:
-          (?x)(
+        exclude: (?x)(
           pb2\.py$
           | grpc\.py$
           | ^docs
           | \.html$
           | .*/skills/.*
           )
-        args: [
-          --ignore-missing-imports,
-          --disable-error-code=var-annotated,
-          --disable-error-code=union-attr,
-          --disable-error-code=assignment,
-          --disable-error-code=attr-defined,
-          --disable-error-code=import-untyped,
-          --disable-error-code=truthy-function,
-          --follow-imports=skip,
-          --explicit-package-bases,
-        ]
+        args:
+          [
+            --ignore-missing-imports,
+            --disable-error-code=var-annotated,
+            --disable-error-code=union-attr,
+            --disable-error-code=assignment,
+            --disable-error-code=attr-defined,
+            --disable-error-code=import-untyped,
+            --disable-error-code=truthy-function,
+            --follow-imports=skip,
+            --explicit-package-bases,
+          ]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-        args: [ --line-length=79 ]
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        args: [--line-length=79]
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
-        args: [ "--extend-ignore=E203"]
-        exclude: '(?x)(.*/skills/.*|^scripts/pack/)'
+        args: ["--extend-ignore=E203"]
+        exclude: "(?x)(.*/skills/.*|^scripts/pack/)"
   - repo: https://github.com/pylint-dev/pylint
     rev: v3.0.2
     hooks:
       - id: pylint
-        exclude:
-          (?x)(
+        exclude: (?x)(
           ^docs
           | pb2\.py$
           | grpc\.py$
@@ -78,43 +77,44 @@ repos:
           | .*/skills/.*
           )
         args: [
-          --disable=W0511,
-          --disable=W0718,
-          --disable=W0122,
-          --disable=C0103,
-          --disable=R0913,
-          --disable=E0401,
-          --disable=E1101,
-          --disable=C0415,
-          --disable=W0603,
-          --disable=R1705,
-          --disable=R0914,
-          --disable=E0601,
-          --disable=W0602,
-          --disable=W0604,
-          --disable=R0801,
-          --disable=R0902,
-          --disable=R0903,
-          --disable=C0123,
-          --disable=W0231,
-          --disable=W1113,
-          --disable=W0221,
-          --disable=R0401,
-          --disable=W0632,
-          --disable=W0123,
-          --disable=C3001,
-          --disable=W0201,
-          --disable=C0302,
-          --disable=W1203,
-          --disable=C2801,
-          --disable=C0114,  # Disable missing module docstring for quick dev
-          --disable=C0115,  # Disable missing class docstring for quick dev
-          --disable=C0116,  # Disable missing function or method docstring for quick dev
-        ]
+            --disable=W0511,
+            --disable=W0718,
+            --disable=W0122,
+            --disable=C0103,
+            --disable=R0913,
+            --disable=E0401,
+            --disable=E1101,
+            --disable=C0415,
+            --disable=W0603,
+            --disable=R1705,
+            --disable=R0914,
+            --disable=E0601,
+            --disable=W0602,
+            --disable=W0604,
+            --disable=R0801,
+            --disable=R0902,
+            --disable=R0903,
+            --disable=C0123,
+            --disable=W0231,
+            --disable=W1113,
+            --disable=W0221,
+            --disable=R0401,
+            --disable=W0632,
+            --disable=W0123,
+            --disable=C3001,
+            --disable=W0201,
+            --disable=C0302,
+            --disable=W1203,
+            --disable=C2801,
+            --disable=C0114, # Disable missing module docstring for quick dev
+            --disable=C0115, # Disable missing class docstring for quick dev
+            --disable=C0116, # Disable missing function or method docstring for quick dev
+            --disable=E0611, # Disable no-name-in-module (pylint false positive for concurrent.futures)
+          ]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.0.0'
+    rev: "v3.0.0"
     hooks:
       - id: prettier
-        additional_dependencies: [ 'prettier@3.0.0' ]
+        additional_dependencies: ["prettier@3.0.0"]
         files: \.(tsx?)$
-        exclude: '(?x)(^web/|^console/|/dist/|.*/skills/.*|^scripts/pack/)'
+        exclude: "(?x)(^web/|^console/|/dist/|.*/skills/.*|^scripts/pack/)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "CoPaw is a **personal assistant** that runs in your own environme
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "agentscope==1.0.16.dev0",
+    "agentscope==1.0.16",
     "agentscope-runtime==1.1.0",
     "httpx>=0.27.0",
     "discord-py>=2.3",
@@ -15,7 +15,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.3.0.6b2",
+    "reme-ai==0.3.0.5",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "copaw.__version__.__version__"}
+version = { attr = "copaw.__version__.__version__" }
 
 [tool.setuptools]
 packages = { find = { where = ["src"] } }
@@ -58,20 +58,10 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest-cov>=6.2.1",
 ]
-local = [
-    "huggingface_hub>=0.20.0",
-]
-llamacpp = [
-    "copaw[local]",
-    "llama-cpp-python>=0.3.0",
-]
-mlx = [
-    "copaw[local]",
-    "mlx-lm>=0.10.0; sys_platform == 'darwin'",
-]
-ollama = [
-    "ollama>=0.6.1",
-]
+local = ["huggingface_hub>=0.20.0"]
+llamacpp = ["copaw[local]", "llama-cpp-python>=0.3.0"]
+mlx = ["copaw[local]", "mlx-lm>=0.10.0; sys_platform == 'darwin'"]
+ollama = ["ollama>=0.6.1"]
 full = [
     "copaw[local,ollama,llamacpp]",
     "mlx-lm>=0.10.0; sys_platform == 'darwin'",
@@ -80,6 +70,4 @@ full = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-]
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]


### PR DESCRIPTION
1. 修复 `uv sync` 执行报错
2. 屏蔽 pre-commit 时 pylint 报错: Add --disable=E0611 to suppress pylint's incorrect no-name-in-module error when importing ThreadPoolExecutor from concurrent.futures.

Made-with: Cursor

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #1106 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
(copaw) zhangsan@mc CoPaw % pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

```

## Additional Notes

[Optional: any other context]
