### PR TITLE
perf: fix magic commands silently destroy session state

### DIFF
--- a/src/copaw/app/runner/command_dispatch.py
+++ b/src/copaw/app/runner/command_dispatch.py
@@ -146,7 +146,7 @@ async def run_command_path(
     if session_id and user_id:
         await runner.session.update_session_state(
             session_id=session_id,
-            key="memory",
+            key="agent.memory",
             value=memory.state_dict(),
             user_id=user_id,
         )

--- a/src/copaw/app/runner/session.py
+++ b/src/copaw/app/runner/session.py
@@ -11,6 +11,8 @@ import re
 import json
 import logging
 
+from typing import Union, Sequence
+
 from agentscope.session import JSONSession
 
 logger = logging.getLogger(__name__)
@@ -57,12 +59,11 @@ class SafeJSONSession(JSONSession):
     async def update_session_state(
         self,
         session_id: str,
-        key: str,
+        key: Union[str, Sequence[str]],
         value,
         user_id: str = "",
         create_if_not_exist: bool = True,
     ) -> None:
-        """Update a top-level key in the session JSON file."""
         session_save_path = self._get_save_path(session_id, user_id=user_id)
 
         if os.path.exists(session_save_path):
@@ -71,8 +72,8 @@ class SafeJSONSession(JSONSession):
                 "r",
                 encoding="utf-8",
                 errors="surrogatepass",
-            ) as file:
-                states = json.load(file)
+            ) as f:
+                states = json.load(f)
         else:
             if not create_if_not_exist:
                 raise ValueError(
@@ -80,15 +81,25 @@ class SafeJSONSession(JSONSession):
                 )
             states = {}
 
-        states[key] = value
+        path = key.split(".") if isinstance(key, str) else list(key)
+        if not path:
+            raise ValueError("key path is empty")
+
+        cur = states
+        for k in path[:-1]:
+            if k not in cur or not isinstance(cur[k], dict):
+                cur[k] = {}
+            cur = cur[k]
+
+        cur[path[-1]] = value
 
         with open(
             session_save_path,
             "w",
             encoding="utf-8",
             errors="surrogatepass",
-        ) as file:
-            json.dump(states, file, ensure_ascii=False)
+        ) as f:
+            json.dump(states, f, ensure_ascii=False)
 
         logger.info(
             "Updated session state key '%s' in %s successfully.",


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
