### PR TITLE
fix(agents): sanitize local paths in formatter normalization

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -387,7 +387,10 @@ def _sanitize_local_media_in_value(value: Any) -> tuple[Any, bool]:
 
 
 _LOCAL_PATH_TEXT_RE = re.compile(
-    r"(?i)(file://\S+|(?:[A-Za-z]:[\\/]|/|\./|\.\./|~/)\S+)",
+    r"(?i)("
+    r"file://\S+|"
+    r"(?<!\S)(?:[A-Za-z]:[\\/]|/(?!/)|\./|\.\./|~/)\S+"
+    r")",
 )
 
 
@@ -434,7 +437,7 @@ def _normalize_messages_for_model(msgs: list[Msg]) -> list[Msg]:
                     changed = True
                     continue
 
-                fixed_blocks.append(block)
+                fixed_blocks.append(deepcopy(block))
 
             if changed:
                 new_content = fixed_blocks

--- a/tests/test_model_factory_message_normalization.py
+++ b/tests/test_model_factory_message_normalization.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from agentscope.message import Msg
 
-from copaw.agents.model_factory import _normalize_messages_for_model
+from copaw.agents.model_factory import (
+    _normalize_messages_for_model,
+)
 
 
 def test_normalize_string_content_to_text_block() -> None:
@@ -353,3 +355,43 @@ def test_normalize_string_content_with_local_path_redacted() -> None:
             "text": "saved at [LOCAL_PATH] and [LOCAL_PATH]",
         },
     ]
+
+
+def test_normalize_string_content_keeps_https_url() -> None:
+    msg = Msg(
+        name="assistant",
+        content="see https://example.com/a.png and /tmp/a.png",
+        role="assistant",
+    )
+
+    normalized = _normalize_messages_for_model([msg])
+
+    assert normalized[0].content == [
+        {
+            "type": "text",
+            "text": "see https://example.com/a.png and [LOCAL_PATH]",
+        },
+    ]
+
+
+def test_normalize_preserves_message_content_isolation() -> None:
+    msg = Msg(
+        name="assistant",
+        content=[
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/a.png",
+                },
+            },
+            {"type": "text", "text": "hello"},
+        ],
+        role="assistant",
+    )
+    original_text_block = msg.content[1]
+
+    normalized = _normalize_messages_for_model([msg])
+
+    assert normalized[0].content[1] == original_text_block
+    assert normalized[0].content[1] is not original_text_block


### PR DESCRIPTION
## Summary
- Normalize messages before formatter processing to avoid invalid payloads reaching model providers.
- Convert malformed message content (string/non-dict blocks) into safe text blocks.
- Replace local `file://` media/file blocks with text placeholders before model formatting, preventing provider-side 400 errors caused by unsupported local URLs.
- Add regression tests for message normalization and local file URL handling (including Windows file URL normalization).

## Why
When conversation history includes local media/file blocks (especially via channel workflows such as Feishu file delivery), some providers reject requests containing `file://` URLs or malformed message blocks. This causes user-facing `BadRequestError` failures even for simple follow-up text messages.

## Changes
- `src/copaw/agents/model_factory.py`
  - Added `_normalize_messages_for_model(msgs)` to sanitize message content before formatter conversion.
  - Hooked normalization into `FileBlockSupportFormatter._format` before tool-message sanitization.
- `tests/test_model_factory_message_normalization.py`
  - Added coverage for:
    - string content -> text block normalization
    - non-dict block fallback conversion
    - local `file://` image block sanitization
    - local `file://` generic file block sanitization
    - Windows `file:///C:/...` path normalization

## Test Plan
- Targeted tests passed:
  - `uv run --extra dev --python /home/lcy/.copaw/venv/bin/python pytest -q tests/test_model_factory_message_normalization.py tests/test_openai_stream_toolcall_compat.py tests/test_react_agent_tool_choice.py`
- Full suite was also executed and still has pre-existing unrelated failures in ollama and memory compaction tests in this environment.