### PR TITLE
feat: add chat routing selector

### DIFF
--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -4,6 +4,7 @@ import type {
   ProviderConfigRequest,
   ActiveModelsInfo,
   ModelSlotRequest,
+  LLMRoutingConfig,
   CreateCustomProviderRequest,
   AddModelRequest,
   TestConnectionResponse,
@@ -25,6 +26,15 @@ export const providerApi = {
 
   setActiveLlm: (body: ModelSlotRequest) =>
     request<ActiveModelsInfo>("/models/active", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+
+  getLlmRoutingConfig: () =>
+    request<LLMRoutingConfig>("/config/agents/llm-routing"),
+
+  setLlmRoutingConfig: (body: LLMRoutingConfig) =>
+    request<LLMRoutingConfig>("/config/agents/llm-routing", {
       method: "PUT",
       body: JSON.stringify(body),
     }),

--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -39,6 +39,15 @@ export interface ModelSlotConfig {
   model: string;
 }
 
+export type LLMRoutingMode = "local_first" | "cloud_first";
+
+export interface LLMRoutingConfig {
+  enabled: boolean;
+  mode: LLMRoutingMode;
+  local: ModelSlotConfig;
+  cloud: ModelSlotConfig | null;
+}
+
 export interface ActiveModelsInfo {
   active_llm?: ModelSlotConfig;
 }

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -685,6 +685,20 @@
     "configureNow": "Configure Model",
     "modelNotConfigured": "Please configure a model in Settings before using chat"
   },
+  "chatModelSelector": {
+    "triggerRouting": "Routing",
+    "routingGroup": "Routing",
+    "localModel": "Local model",
+    "cloudModel": "Cloud model",
+    "localFirst": "Local first",
+    "cloudFirst": "Cloud first",
+    "routingLocalFirstEnabled": "Routing enabled: local first",
+    "routingCloudFirstEnabled": "Routing enabled: cloud first",
+    "routingModelUpdated": "Routing model updated",
+    "routingDisabled": "Routing disabled; active model updated",
+    "configureRoutingFirst": "Routing needs one local model and one cloud model.",
+    "updateFailed": "Failed to update chat model selection"
+  },
   "header": {
     "changelog": "Changelog",
     "docs": "Doc",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -637,6 +637,20 @@
     "configureNow": "モデルを設定",
     "modelNotConfigured": "チャットを使用する前に設定でモデルを設定してください"
   },
+  "chatModelSelector": {
+    "triggerRouting": "Routing",
+    "routingGroup": "Routing",
+    "localModel": "ローカルモデル",
+    "cloudModel": "クラウドモデル",
+    "localFirst": "ローカル優先",
+    "cloudFirst": "クラウド優先",
+    "routingLocalFirstEnabled": "Routing を有効化しました：ローカル優先",
+    "routingCloudFirstEnabled": "Routing を有効化しました：クラウド優先",
+    "routingModelUpdated": "Routing モデルを更新しました",
+    "routingDisabled": "Routing を無効化し、アクティブモデルを更新しました",
+    "configureRoutingFirst": "Routing にはローカルモデルとクラウドモデルが 1 つずつ必要です。",
+    "updateFailed": "チャットのモデル選択を更新できませんでした"
+  },
   "header": {
     "changelog": "変更履歴",
     "docs": "ドキュメント",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -642,6 +642,20 @@
     "configureNow": "Настроить модель",
     "modelNotConfigured": "Перед использованием чата настройте модель в разделе «Настройки»"
   },
+  "chatModelSelector": {
+    "triggerRouting": "Routing",
+    "routingGroup": "Routing",
+    "localModel": "Локальная модель",
+    "cloudModel": "Облачная модель",
+    "localFirst": "Сначала локальная",
+    "cloudFirst": "Сначала облачная",
+    "routingLocalFirstEnabled": "Routing включён: сначала локальная",
+    "routingCloudFirstEnabled": "Routing включён: сначала облачная",
+    "routingModelUpdated": "Модель для routing обновлена",
+    "routingDisabled": "Routing отключён; активная модель обновлена",
+    "configureRoutingFirst": "Для routing нужна одна локальная и одна облачная модель.",
+    "updateFailed": "Не удалось обновить выбор модели в чате"
+  },
   "header": {
     "changelog": "Список изменений",
     "docs": "Документация",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -651,6 +651,20 @@
     "configureNow": "配置模型",
     "modelNotConfigured": "请先在设置中配置模型后再使用聊天功能"
   },
+  "chatModelSelector": {
+    "triggerRouting": "Routing",
+    "routingGroup": "Routing",
+    "localModel": "本地模型",
+    "cloudModel": "云端模型",
+    "localFirst": "本地优先",
+    "cloudFirst": "云端优先",
+    "routingLocalFirstEnabled": "已开启 routing：本地优先",
+    "routingCloudFirstEnabled": "已开启 routing：云端优先",
+    "routingModelUpdated": "Routing 模型已更新",
+    "routingDisabled": "已关闭 routing，并更新当前模型",
+    "configureRoutingFirst": "Routing 需要一个本地模型和一个云端模型。",
+    "updateFailed": "更新聊天模型选择失败"
+  },
   "header": {
     "changelog": "更新日志",
     "docs": "文档",

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -30,6 +30,12 @@
   max-width: 180px;
 }
 
+.triggerIcon {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: #615ced;
+}
+
 .triggerArrow {
   flex-shrink: 0;
   font-size: 16px;
@@ -168,6 +174,21 @@
   padding: 10px 14px;
   font-size: 16px;
   color: #bbb;
+}
+
+.sectionDivider {
+  height: 1px;
+  margin: 6px 8px;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.sectionTitle {
+  padding: 4px 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .spinWrapper {

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -1,44 +1,73 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Dropdown, message, Spin } from "antd";
 import {
-  DownOutlined,
+  ApartmentOutlined,
   CheckOutlined,
+  DownOutlined,
   LoadingOutlined,
   RightOutlined,
 } from "@ant-design/icons";
 import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { providerApi } from "../../../api/modules/provider";
-import type { ProviderInfo, ActiveModelsInfo } from "../../../api/types";
+import type {
+  ProviderInfo,
+  ActiveModelsInfo,
+  LLMRoutingConfig,
+  LLMRoutingMode,
+  ModelSlotConfig,
+} from "../../../api/types";
 import styles from "./index.module.less";
 
 interface EligibleProvider {
   id: string;
   name: string;
+  is_local: boolean;
   models: Array<{ id: string; name: string }>;
+}
+
+function hasConfiguredSlot(
+  slot?: ModelSlotConfig | null,
+): slot is ModelSlotConfig {
+  return Boolean(slot?.provider_id && slot?.model);
+}
+
+function encodeSlot(slot: ModelSlotConfig): string {
+  return `${encodeURIComponent(slot.provider_id)}:${encodeURIComponent(
+    slot.model,
+  )}`;
+}
+
+function emptySlot(): ModelSlotConfig {
+  return { provider_id: "", model: "" };
 }
 
 export default function ModelSelector() {
   const { t } = useTranslation();
+  const location = useLocation();
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [activeModels, setActiveModels] = useState<ActiveModelsInfo | null>(
+    null,
+  );
+  const [routingConfig, setRoutingConfig] = useState<LLMRoutingConfig | null>(
     null,
   );
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [open, setOpen] = useState(false);
   const savingRef = useRef(false);
-  const location = useLocation();
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const [provData, activeData] = await Promise.all([
+      const [provData, activeData, routingData] = await Promise.all([
         providerApi.listProviders(),
         providerApi.getActiveModels(),
+        providerApi.getLlmRoutingConfig(),
       ]);
       if (Array.isArray(provData)) setProviders(provData);
       if (activeData) setActiveModels(activeData);
+      if (routingData) setRoutingConfig(routingData);
     } catch (err) {
       console.error("ModelSelector: failed to load data", err);
     } finally {
@@ -47,76 +76,129 @@ export default function ModelSelector() {
   }, []);
 
   useEffect(() => {
-    fetchData();
+    void fetchData();
   }, [fetchData]);
 
-  // Re-sync active model whenever the route switches back to /chat
   const prevPathRef = useRef(location.pathname);
   useEffect(() => {
     const prev = prevPathRef.current;
     const curr = location.pathname;
     prevPathRef.current = curr;
     const comingToChat = curr.startsWith("/chat") && !prev.startsWith("/chat");
-    if (comingToChat) {
-      providerApi
-        .getActiveModels()
-        .then((activeData) => {
-          if (activeData) setActiveModels(activeData);
-        })
-        .catch(() => {});
-    }
+    if (!comingToChat) return;
+    providerApi
+      .getActiveModels()
+      .then((activeData) => {
+        if (activeData) setActiveModels(activeData);
+      })
+      .catch(() => {});
+    providerApi
+      .getLlmRoutingConfig()
+      .then((nextRouting) => {
+        if (nextRouting) setRoutingConfig(nextRouting);
+      })
+      .catch(() => {});
   }, [location.pathname]);
 
-  // Eligible providers: configured + has models
-  const eligibleProviders: EligibleProvider[] = providers
-    .filter((p) => {
-      const hasModels =
-        (p.models?.length ?? 0) + (p.extra_models?.length ?? 0) > 0;
-      if (!hasModels) return false;
-      if (p.is_local) return true;
-      if (p.require_api_key === false) return !!p.base_url;
-      if (p.is_custom) return !!p.base_url;
-      if (p.require_api_key ?? true) return !!p.api_key;
-      return true;
-    })
-    .map((p) => ({
-      id: p.id,
-      name: p.name,
-      models: [...(p.models ?? []), ...(p.extra_models ?? [])],
-    }));
+  const eligibleProviders: EligibleProvider[] = useMemo(
+    () =>
+      providers
+        .filter((p) => {
+          const hasModels =
+            (p.models?.length ?? 0) + (p.extra_models?.length ?? 0) > 0;
+          if (!hasModels) return false;
+          if (p.is_local) return true;
+          if (p.require_api_key === false) return !!p.base_url;
+          if (p.is_custom) return !!p.base_url;
+          if (p.require_api_key ?? true) return !!p.api_key;
+          return true;
+        })
+        .map((p) => ({
+          id: p.id,
+          name: p.name,
+          is_local: p.is_local,
+          models: [...(p.models ?? []), ...(p.extra_models ?? [])],
+        })),
+    [providers],
+  );
 
   const activeProviderId = activeModels?.active_llm?.provider_id;
   const activeModelId = activeModels?.active_llm?.model;
 
-  // Display label for trigger button
+  const localOptions = useMemo(
+    () =>
+      eligibleProviders
+        .filter((p) => p.is_local)
+        .flatMap((p) =>
+          p.models.map((m) => ({
+            key: encodeSlot({ provider_id: p.id, model: m.id }),
+            label: `${p.name} / ${m.name || m.id}`,
+            slot: { provider_id: p.id, model: m.id },
+          })),
+        ),
+    [eligibleProviders],
+  );
+
+  const cloudOptions = useMemo(
+    () =>
+      eligibleProviders
+        .filter((p) => !p.is_local)
+        .flatMap((p) =>
+          p.models.map((m) => ({
+            key: encodeSlot({ provider_id: p.id, model: m.id }),
+            label: `${p.name} / ${m.name || m.id}`,
+            slot: { provider_id: p.id, model: m.id },
+          })),
+        ),
+    [eligibleProviders],
+  );
+
+  const effectiveLocalSlot =
+    routingConfig?.local && hasConfiguredSlot(routingConfig.local)
+      ? routingConfig.local
+      : localOptions[0]?.slot ?? null;
+
+  const effectiveCloudSlot =
+    routingConfig?.cloud && hasConfiguredSlot(routingConfig.cloud)
+      ? routingConfig.cloud
+      : cloudOptions[0]?.slot ?? null;
+
   const activeModelName = (() => {
-    if (!activeProviderId || !activeModelId)
+    if (routingConfig?.enabled) return t("chatModelSelector.triggerRouting");
+    if (!activeProviderId || !activeModelId) {
       return t("modelSelector.selectModel");
+    }
     for (const p of eligibleProviders) {
       if (p.id === activeProviderId) {
-        const m = p.models.find((m) => m.id === activeModelId);
+        const m = p.models.find((model) => model.id === activeModelId);
         if (m) return m.name || m.id;
       }
     }
     return activeModelId;
   })();
 
-  const handleOpenChange = useCallback(async (next: boolean) => {
-    setOpen(next);
-    if (next) {
-      // Re-fetch active model every time the dropdown opens
-      try {
-        const activeData = await providerApi.getActiveModels();
-        if (activeData) setActiveModels(activeData);
-      } catch {
-        // ignore
-      }
+  const handleOpenChange = useCallback(async (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) return;
+    try {
+      const [activeData, nextRouting] = await Promise.all([
+        providerApi.getActiveModels(),
+        providerApi.getLlmRoutingConfig(),
+      ]);
+      if (activeData) setActiveModels(activeData);
+      if (nextRouting) setRoutingConfig(nextRouting);
+    } catch {
+      // ignore refresh errors when opening the dropdown
     }
   }, []);
 
-  const handleSelect = async (providerId: string, modelId: string) => {
+  const handleSelectModel = async (providerId: string, modelId: string) => {
     if (savingRef.current) return;
-    if (providerId === activeProviderId && modelId === activeModelId) {
+    if (
+      !routingConfig?.enabled &&
+      providerId === activeProviderId &&
+      modelId === activeModelId
+    ) {
       setOpen(false);
       return;
     }
@@ -124,21 +206,197 @@ export default function ModelSelector() {
     setSaving(true);
     setOpen(false);
     try {
-      await providerApi.setActiveLlm({
-        provider_id: providerId,
-        model: modelId,
-      });
+      const requests: Array<Promise<unknown>> = [
+        providerApi.setActiveLlm({
+          provider_id: providerId,
+          model: modelId,
+        }),
+      ];
+      if (routingConfig?.enabled) {
+        requests.push(
+          providerApi.setLlmRoutingConfig({
+            ...routingConfig,
+            enabled: false,
+          }),
+        );
+      }
+      await Promise.all(requests);
       setActiveModels({
         active_llm: { provider_id: providerId, model: modelId },
       });
+      if (routingConfig?.enabled) {
+        setRoutingConfig({ ...routingConfig, enabled: false });
+      }
+      message.success(
+        routingConfig?.enabled
+          ? t("chatModelSelector.routingDisabled")
+          : t("models.llmModelUpdated"),
+      );
     } catch (err) {
       const msg =
-        err instanceof Error ? err.message : t("modelSelector.switchFailed");
+        err instanceof Error
+          ? err.message
+          : t("chatModelSelector.updateFailed");
       message.error(msg);
     } finally {
       setSaving(false);
       savingRef.current = false;
     }
+  };
+
+  const handleSelectRoutingMode = async (mode: LLMRoutingMode) => {
+    if (savingRef.current) return;
+    if (
+      !hasConfiguredSlot(effectiveLocalSlot) ||
+      !hasConfiguredSlot(effectiveCloudSlot)
+    ) {
+      message.warning(t("chatModelSelector.configureRoutingFirst"));
+      return;
+    }
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      const nextRouting: LLMRoutingConfig = {
+        enabled: true,
+        mode,
+        local: effectiveLocalSlot,
+        cloud: effectiveCloudSlot,
+      };
+      await providerApi.setLlmRoutingConfig(nextRouting);
+      setRoutingConfig(nextRouting);
+      message.success(
+        t(
+          mode === "cloud_first"
+            ? "chatModelSelector.routingCloudFirstEnabled"
+            : "chatModelSelector.routingLocalFirstEnabled",
+        ),
+      );
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t("chatModelSelector.updateFailed");
+      message.error(msg);
+    } finally {
+      setSaving(false);
+      savingRef.current = false;
+    }
+  };
+
+  const handleSelectRoutingSlot = async (
+    kind: "local" | "cloud",
+    slot: ModelSlotConfig,
+  ) => {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      const nextLocal =
+        kind === "local"
+          ? slot
+          : effectiveLocalSlot ?? routingConfig?.local ?? emptySlot();
+      const nextCloud =
+        kind === "cloud"
+          ? slot
+          : effectiveCloudSlot ?? routingConfig?.cloud ?? null;
+
+      const nextRouting: LLMRoutingConfig = {
+        enabled: routingConfig?.enabled ?? false,
+        mode: routingConfig?.mode ?? "local_first",
+        local: nextLocal,
+        cloud: nextCloud,
+      };
+      await providerApi.setLlmRoutingConfig(nextRouting);
+      setRoutingConfig(nextRouting);
+      message.success(t("chatModelSelector.routingModelUpdated"));
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t("chatModelSelector.updateFailed");
+      message.error(msg);
+    } finally {
+      setSaving(false);
+      savingRef.current = false;
+    }
+  };
+
+  const renderModelProviders = eligibleProviders.map((provider) => {
+    const isProviderActive =
+      !routingConfig?.enabled && provider.id === activeProviderId;
+    return (
+      <div
+        key={provider.id}
+        className={[
+          styles.providerItem,
+          isProviderActive ? styles.providerItemActive : "",
+        ].join(" ")}
+      >
+        <span className={styles.providerName}>{provider.name}</span>
+        <RightOutlined className={styles.providerArrow} />
+        <div className={`${styles.submenu} modelSubmenu`}>
+          {provider.models.map((model) => {
+            const isActive =
+              !routingConfig?.enabled &&
+              isProviderActive &&
+              model.id === activeModelId;
+            return (
+              <div
+                key={model.id}
+                className={[
+                  styles.modelItem,
+                  isActive ? styles.modelItemActive : "",
+                ].join(" ")}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void handleSelectModel(provider.id, model.id);
+                }}
+              >
+                <span className={styles.modelName}>
+                  {model.name || model.id}
+                </span>
+                {isActive && <CheckOutlined className={styles.checkIcon} />}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  });
+
+  const renderRoutingSlot = (
+    label: string,
+    options: Array<{ key: string; label: string; slot: ModelSlotConfig }>,
+    selectedKey: string,
+    kind: "local" | "cloud",
+  ) => {
+    if (options.length <= 1) return null;
+    return (
+      <div className={styles.providerItem}>
+        <span className={styles.providerName}>{label}</span>
+        <RightOutlined className={styles.providerArrow} />
+        <div className={`${styles.submenu} modelSubmenu`}>
+          {options.map((option) => (
+            <div
+              key={option.key}
+              className={[
+                styles.modelItem,
+                selectedKey === option.key ? styles.modelItemActive : "",
+              ].join(" ")}
+              onClick={(e) => {
+                e.stopPropagation();
+                void handleSelectRoutingSlot(kind, option.slot);
+              }}
+            >
+              <span className={styles.modelName}>{option.label}</span>
+              {selectedKey === option.key && (
+                <CheckOutlined className={styles.checkIcon} />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   };
 
   const dropdownContent = (
@@ -152,55 +410,74 @@ export default function ModelSelector() {
           {t("modelSelector.noConfiguredModels")}
         </div>
       ) : (
-        eligibleProviders.map((provider) => {
-          const isProviderActive = provider.id === activeProviderId;
-          return (
-            <div
-              key={provider.id}
-              className={[
-                styles.providerItem,
-                isProviderActive ? styles.providerItemActive : "",
-              ].join(" ")}
-            >
-              <span className={styles.providerName}>{provider.name}</span>
-              <RightOutlined className={styles.providerArrow} />
-
-              {/* Level-2 submenu — shown on parent hover via CSS */}
-              <div className={`${styles.submenu} modelSubmenu`}>
-                {provider.models.map((model) => {
-                  const isActive =
-                    isProviderActive && model.id === activeModelId;
-                  return (
-                    <div
-                      key={model.id}
-                      className={[
-                        styles.modelItem,
-                        isActive ? styles.modelItemActive : "",
-                      ].join(" ")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleSelect(provider.id, model.id);
-                      }}
-                    >
-                      <span className={styles.modelName}>
-                        {model.name || model.id}
-                      </span>
-                      {isActive && (
-                        <CheckOutlined className={styles.checkIcon} />
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })
+        <>
+          {renderModelProviders}
+          <div className={styles.sectionDivider} />
+          <div className={styles.sectionTitle}>
+            {t("chatModelSelector.routingGroup")}
+          </div>
+          <div
+            className={[
+              styles.modelItem,
+              routingConfig?.enabled && routingConfig.mode === "local_first"
+                ? styles.modelItemActive
+                : "",
+            ].join(" ")}
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleSelectRoutingMode("local_first");
+            }}
+          >
+            <span className={styles.modelName}>
+              {t("chatModelSelector.localFirst")}
+            </span>
+            {routingConfig?.enabled && routingConfig.mode === "local_first" && (
+              <CheckOutlined className={styles.checkIcon} />
+            )}
+          </div>
+          <div
+            className={[
+              styles.modelItem,
+              routingConfig?.enabled && routingConfig.mode === "cloud_first"
+                ? styles.modelItemActive
+                : "",
+            ].join(" ")}
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleSelectRoutingMode("cloud_first");
+            }}
+          >
+            <span className={styles.modelName}>
+              {t("chatModelSelector.cloudFirst")}
+            </span>
+            {routingConfig?.enabled && routingConfig.mode === "cloud_first" && (
+              <CheckOutlined className={styles.checkIcon} />
+            )}
+          </div>
+          {renderRoutingSlot(
+            t("chatModelSelector.localModel"),
+            localOptions,
+            hasConfiguredSlot(effectiveLocalSlot)
+              ? encodeSlot(effectiveLocalSlot)
+              : "",
+            "local",
+          )}
+          {renderRoutingSlot(
+            t("chatModelSelector.cloudModel"),
+            cloudOptions,
+            hasConfiguredSlot(effectiveCloudSlot)
+              ? encodeSlot(effectiveCloudSlot)
+              : "",
+            "cloud",
+          )}
+        </>
       )}
     </div>
   );
 
   return (
     <Dropdown
+      menu={{ selectable: true, multiple: true }}
       open={open}
       onOpenChange={handleOpenChange}
       dropdownRender={() => dropdownContent}
@@ -213,6 +490,7 @@ export default function ModelSelector() {
         {saving && (
           <LoadingOutlined style={{ fontSize: 11, color: "#615ced" }} />
         )}
+        <ApartmentOutlined className={styles.triggerIcon} />
         <span className={styles.triggerName}>{activeModelName}</span>
         <DownOutlined
           className={[

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -20,6 +20,11 @@ import { useTheme } from "../../contexts/ThemeContext";
 import { useAgentStore } from "../../stores/agentStore";
 import { useChatAnywhereInput } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereInputContext.js";
 import styles from "./index.module.less";
+import type {
+  ActiveModelsInfo,
+  LLMRoutingConfig,
+  ModelSlotConfig,
+} from "../../api/types/provider";
 import { Tooltip } from "antd";
 import { IconButton } from "@agentscope-ai/design";
 import { SparkAttachmentLine } from "@agentscope-ai/icons";
@@ -153,6 +158,23 @@ function RuntimeLoadingBridge({
   }, [getLoading, setLoading, bridgeRef]);
 
   return null;
+}
+
+function hasConfiguredSlot(slot?: ModelSlotConfig | null): boolean {
+  return Boolean(slot?.provider_id && slot?.model);
+}
+
+function canSendRequest(
+  activeModels: ActiveModelsInfo | null,
+  routingConfig: LLMRoutingConfig | null,
+): boolean {
+  if (routingConfig?.enabled) {
+    return (
+      hasConfiguredSlot(routingConfig.local) &&
+      hasConfiguredSlot(routingConfig.cloud)
+    );
+  }
+  return hasConfiguredSlot(activeModels?.active_llm);
 }
 
 export default function ChatPage() {
@@ -350,11 +372,12 @@ export default function ChatPage() {
       };
 
       try {
-        const activeModels = await providerApi.getActiveModels();
-        if (
-          !activeModels?.active_llm?.provider_id ||
-          !activeModels?.active_llm?.model
-        ) {
+        const [activeModels, routingConfig] = await Promise.all([
+          providerApi.getActiveModels(),
+          providerApi.getLlmRoutingConfig(),
+        ]);
+
+        if (!canSendRequest(activeModels, routingConfig)) {
           setShowModelPrompt(true);
           return buildModelError();
         }

--- a/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
+++ b/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useMemo } from "react";
 import { SaveOutlined } from "@ant-design/icons";
 import { Select, Button, message } from "@agentscope-ai/design";
-import type { ModelSlotRequest } from "../../../../../api/types";
+import type {
+  LLMRoutingConfig,
+  ModelSlotRequest,
+} from "../../../../../api/types";
 import api from "../../../../../api";
 import { useTranslation } from "react-i18next";
 import styles from "../../index.module.less";
@@ -24,12 +27,20 @@ interface ModelsSectionProps {
       model?: string;
     };
   } | null;
+  routingConfig: LLMRoutingConfig | null;
   onSaved: () => void;
+}
+
+function hasConfiguredSlot(
+  slot?: { provider_id?: string; model?: string } | null,
+): slot is { provider_id: string; model: string } {
+  return Boolean(slot?.provider_id && slot?.model);
 }
 
 export function ModelsSection({
   providers,
   activeModels,
+  routingConfig,
   onSaved,
 }: ModelsSectionProps) {
   const { t } = useTranslation();
@@ -43,6 +54,19 @@ export function ModelsSection({
   const [dirty, setDirty] = useState(false);
 
   const currentSlot = activeModels?.active_llm;
+  const preferredRoutingSlot = useMemo(() => {
+    if (!routingConfig?.enabled) {
+      return null;
+    }
+    const preferredSlot =
+      routingConfig.mode === "cloud_first"
+        ? routingConfig.cloud
+        : routingConfig.local;
+    if (hasConfiguredSlot(preferredSlot)) {
+      return preferredSlot;
+    }
+    return hasConfiguredSlot(currentSlot) ? currentSlot : null;
+  }, [currentSlot, routingConfig]);
 
   const eligible = useMemo(
     () =>
@@ -60,12 +84,20 @@ export function ModelsSection({
   );
 
   useEffect(() => {
-    if (currentSlot) {
-      setSelectedProviderId(currentSlot.provider_id || undefined);
-      setSelectedModel(currentSlot.model || undefined);
+    const visibleSlot = routingConfig?.enabled
+      ? preferredRoutingSlot
+      : currentSlot;
+    if (visibleSlot) {
+      setSelectedProviderId(visibleSlot.provider_id || undefined);
+      setSelectedModel(visibleSlot.model || undefined);
     }
     setDirty(false);
-  }, [currentSlot?.provider_id, currentSlot?.model]);
+  }, [
+    currentSlot?.provider_id,
+    currentSlot?.model,
+    preferredRoutingSlot,
+    routingConfig?.enabled,
+  ]);
 
   const chosenProvider = providers.find((p) => p.id === selectedProviderId);
   const modelOptions = [
@@ -95,7 +127,16 @@ export function ModelsSection({
 
     setSaving(true);
     try {
-      await api.setActiveLlm(body);
+      const requests: Array<Promise<unknown>> = [api.setActiveLlm(body)];
+      if (routingConfig?.enabled) {
+        requests.push(
+          api.setLlmRoutingConfig({
+            ...routingConfig,
+            enabled: false,
+          }),
+        );
+      }
+      await Promise.all(requests);
       message.success(t("models.llmModelUpdated"));
       setDirty(false);
       onSaved();
@@ -112,7 +153,11 @@ export function ModelsSection({
     currentSlot &&
     currentSlot.provider_id === selectedProviderId &&
     currentSlot.model === selectedModel;
-  const canSave = dirty && !!selectedProviderId && !!selectedModel;
+  const canSave =
+    !!selectedProviderId &&
+    !!selectedModel &&
+    (dirty || Boolean(routingConfig?.enabled));
+  const showSaved = isActive && !routingConfig?.enabled;
 
   return (
     <div className={styles.slotSection}>
@@ -177,7 +222,7 @@ export function ModelsSection({
             block
             icon={<SaveOutlined />}
           >
-            {isActive ? t("models.saved") : t("models.save")}
+            {showSaved ? t("models.saved") : t("models.save")}
           </Button>
         </div>
       </div>

--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -6,6 +6,7 @@ import {
   PageHeader,
   LoadingState,
   ProviderCard,
+  ModelsSection,
   CustomProviderModal,
 } from "./components";
 import { useTranslation } from "react-i18next";
@@ -18,7 +19,8 @@ import styles from "./index.module.less";
 
 function ModelsPage() {
   const { t } = useTranslation();
-  const { providers, activeModels, loading, error, fetchAll } = useProviders();
+  const { providers, activeModels, routingConfig, loading, error, fetchAll } =
+    useProviders();
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -76,7 +78,19 @@ function ModelsPage() {
         <LoadingState message={error} error onRetry={fetchAll} />
       ) : (
         <>
-          {/* ---- Providers Section ---- */}
+          {/* ---- LLM Section (top) ---- */}
+          <PageHeader
+            title={t("models.llmTitle")}
+            description={t("models.llmDescription")}
+          />
+          <ModelsSection
+            providers={providers}
+            activeModels={activeModels}
+            routingConfig={routingConfig}
+            onSaved={fetchAll}
+          />
+
+          {/* ---- Providers Section (below) ---- */}
           <div className={styles.providersBlock}>
             <div className={styles.sectionHeaderRow}>
               <PageHeader

--- a/console/src/pages/Settings/Models/useProviders.ts
+++ b/console/src/pages/Settings/Models/useProviders.ts
@@ -1,11 +1,18 @@
 import { useState, useEffect, useCallback } from "react";
 import api from "../../../api";
-import type { ProviderInfo, ActiveModelsInfo } from "../../../api/types";
+import type {
+  ProviderInfo,
+  ActiveModelsInfo,
+  LLMRoutingConfig,
+} from "../../../api/types";
 import { useAgentStore } from "../../../stores/agentStore";
 
 export function useProviders() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [activeModels, setActiveModels] = useState<ActiveModelsInfo | null>(
+    null,
+  );
+  const [routingConfig, setRoutingConfig] = useState<LLMRoutingConfig | null>(
     null,
   );
   const [loading, setLoading] = useState(true);
@@ -18,9 +25,10 @@ export function useProviders() {
     }
     setError(null);
     try {
-      const [provData, activeData] = await Promise.all([
+      const [provData, activeData, routingData] = await Promise.all([
         api.listProviders(),
         api.getActiveModels(),
+        api.getLlmRoutingConfig(),
       ]);
       if (!Array.isArray(provData)) {
         throw new Error(
@@ -29,6 +37,7 @@ export function useProviders() {
       }
       setProviders(provData);
       if (activeData) setActiveModels(activeData);
+      if (routingData) setRoutingConfig(routingData);
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Failed to load provider data";
@@ -48,6 +57,7 @@ export function useProviders() {
   return {
     providers,
     activeModels,
+    routingConfig,
     loading,
     error,
     fetchAll,

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -338,7 +338,9 @@ def _create_routing_model_and_formatter(
 ) -> Tuple[ChatModelBase, FormatterBase] | None:
     from .routing_chat_model import RoutingChatModel
 
-    cloud_slot = routing_cfg.cloud or cloud_fallback_slot or manager.get_active_model()
+    cloud_slot = (
+        routing_cfg.cloud or cloud_fallback_slot or manager.get_active_model()
+    )
     local_resolved = _resolve_routing_slot(
         routing_cfg.local,
         manager=manager,

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -31,6 +31,8 @@ except ImportError:  # pragma: no cover - compatibility fallback
     GeminiChatModel = None
 
 from .utils.tool_message_utils import _sanitize_tool_messages
+from ..config.utils import load_config
+from ..local_models import create_local_chat_model
 from ..providers import ProviderManager
 from ..providers.retry_chat_model import RetryChatModel
 from ..token_usage import TokenRecordingModelWrapper
@@ -277,6 +279,97 @@ def _strip_top_level_message_name(
     return messages
 
 
+def _resolve_routing_slot(
+    slot,
+    *,
+    manager: ProviderManager,
+):
+    provider_id = getattr(slot, "provider_id", "")
+    model_name = getattr(slot, "model", "")
+    if not provider_id or not model_name:
+        return None
+
+    provider = manager.get_provider(provider_id)
+    if provider is None or not provider.has_model(model_name):
+        return None
+    return provider, model_name
+
+
+def _create_routing_endpoint(
+    provider,
+    model_name: str,
+):
+    from .routing_chat_model import RoutingEndpoint
+
+    chat_model_class = provider.get_chat_model_cls()
+
+    def _load_endpoint() -> tuple[ChatModelBase, FormatterBase]:
+        if provider.is_local:
+            model = create_local_chat_model(
+                model_id=model_name,
+                stream=True,
+                generate_kwargs={"max_tokens": None},
+            )
+        else:
+            model = provider.get_chat_model_instance(model_name)
+        formatter = _create_formatter_instance(chat_model_class)
+        return model, formatter
+
+    return RoutingEndpoint(
+        provider_id=provider.id,
+        model_name=model_name,
+        formatter_family=_get_formatter_for_chat_model(chat_model_class),
+        loader=_load_endpoint,
+    )
+
+
+def _create_formatter_from_family(
+    formatter_family: Type[FormatterBase],
+) -> FormatterBase:
+    formatter_class = _create_file_block_support_formatter(formatter_family)
+    return formatter_class()
+
+
+def _create_routing_model_and_formatter(
+    *,
+    manager: ProviderManager,
+    routing_cfg,
+    cloud_fallback_slot=None,
+) -> Tuple[ChatModelBase, FormatterBase] | None:
+    from .routing_chat_model import RoutingChatModel
+
+    cloud_slot = routing_cfg.cloud or cloud_fallback_slot or manager.get_active_model()
+    local_resolved = _resolve_routing_slot(
+        routing_cfg.local,
+        manager=manager,
+    )
+    cloud_resolved = _resolve_routing_slot(
+        cloud_slot,
+        manager=manager,
+    )
+    if local_resolved is None or cloud_resolved is None:
+        return None
+
+    local_endpoint = _create_routing_endpoint(*local_resolved)
+    cloud_endpoint = _create_routing_endpoint(*cloud_resolved)
+    if local_endpoint.formatter_family is not cloud_endpoint.formatter_family:
+        logger.warning(
+            "Skipping routing model because local/cloud formatter families "
+            "do not match: %s vs %s",
+            local_endpoint.formatter_family.__name__,
+            cloud_endpoint.formatter_family.__name__,
+        )
+        return None
+
+    model = RoutingChatModel(
+        local_endpoint=local_endpoint,
+        cloud_endpoint=cloud_endpoint,
+        routing_cfg=routing_cfg,
+    )
+    formatter = _create_formatter_from_family(local_endpoint.formatter_family)
+    return RetryChatModel(model), formatter
+
+
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
 ) -> Tuple[ChatModelBase, FormatterBase]:
@@ -298,6 +391,8 @@ def create_model_and_formatter(
     from ..app.agent_context import get_current_agent_id
     from ..config.config import load_agent_config
 
+    manager = ProviderManager.get_instance()
+
     # Determine agent_id (parameter > context > None)
     if agent_id is None:
         try:
@@ -314,10 +409,23 @@ def create_model_and_formatter(
         except Exception:
             pass
 
+    routing_cfg = load_config().agents.llm_routing
+    if (
+        routing_cfg.enabled
+        and routing_cfg.local.provider_id
+        and routing_cfg.local.model
+    ):
+        routed_model = _create_routing_model_and_formatter(
+            manager=manager,
+            routing_cfg=routing_cfg,
+            cloud_fallback_slot=model_slot,
+        )
+        if routed_model is not None:
+            return routed_model
+
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:
         # Use agent-specific model
-        manager = ProviderManager.get_instance()
         provider = manager.get_provider(model_slot.provider_id)
         if provider is None:
             raise ValueError(

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -36,7 +36,6 @@ from ..local_models import create_local_chat_model
 from ..providers import ProviderManager
 from ..providers.retry_chat_model import RetryChatModel
 from ..token_usage import TokenRecordingModelWrapper
-from ..local_models import create_local_chat_model
 
 
 def _file_url_to_path(url: str) -> str:

--- a/src/copaw/agents/routing_chat_model.py
+++ b/src/copaw/agents/routing_chat_model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, AsyncGenerator, Literal, Type
+from typing import Any, AsyncGenerator, Callable, Literal, Type
 
 from agentscope.formatter import FormatterBase
 from agentscope.model import ChatModelBase
@@ -57,9 +57,33 @@ class RoutingPolicy:
 class RoutingEndpoint:
     provider_id: str
     model_name: str
-    model: ChatModelBase
-    formatter: FormatterBase
     formatter_family: Type[FormatterBase]
+    loader: Callable[[], tuple[ChatModelBase, FormatterBase]]
+    _model: ChatModelBase | None = field(default=None, init=False, repr=False)
+    _formatter: FormatterBase | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None and self._formatter is not None:
+            return
+        model, formatter = self.loader()
+        object.__setattr__(self, "_model", model)
+        object.__setattr__(self, "_formatter", formatter)
+
+    @property
+    def model(self) -> ChatModelBase:
+        self._ensure_loaded()
+        assert self._model is not None
+        return self._model
+
+    @property
+    def formatter(self) -> FormatterBase:
+        self._ensure_loaded()
+        assert self._formatter is not None
+        return self._formatter
 
 
 class RoutingChatModel(ChatModelBase):
@@ -74,7 +98,7 @@ class RoutingChatModel(ChatModelBase):
     ) -> None:
         super().__init__(
             model_name="routing",
-            stream=bool(getattr(local_endpoint.model, "stream", True)),
+            stream=True,
         )
         self.local_endpoint = local_endpoint
         self.cloud_endpoint = cloud_endpoint

--- a/tests/test_routing_model_factory.py
+++ b/tests/test_routing_model_factory.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+from agentscope.model import OpenAIChatModel
+
+from copaw.agents import model_factory
+from copaw.agents.routing_chat_model import RoutingChatModel
+from copaw.config.config import AgentsLLMRoutingConfig
+from copaw.providers.models import ModelSlotConfig
+
+
+class FakeProvider:
+    def __init__(
+        self,
+        *,
+        provider_id: str,
+        models: list[str],
+        is_local: bool = False,
+        chat_model_class=OpenAIChatModel,
+    ) -> None:
+        self.id = provider_id
+        self._models = set(models)
+        self.is_local = is_local
+        self._chat_model_class = chat_model_class
+
+    def has_model(self, model_id: str) -> bool:
+        return model_id in self._models
+
+    def get_chat_model_cls(self):
+        return self._chat_model_class
+
+    def get_chat_model_instance(self, model_id: str):
+        raise NotImplementedError
+
+
+class FakeManager:
+    def __init__(self, providers: dict[str, FakeProvider], active_llm) -> None:
+        self._providers = providers
+        self._active_llm = active_llm
+
+    def get_provider(self, provider_id: str):
+        return self._providers.get(provider_id)
+
+    def get_active_model(self):
+        return self._active_llm
+
+    def get_active_chat_model(self):
+        raise AssertionError("routing path should be used")
+
+
+def _patch_common_routing_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, str, bool]]:
+    created: list[tuple[str, str, bool]] = []
+
+    class FakeChatModel:
+        def __init__(self, provider_id: str, model_name: str, is_local: bool):
+            self.provider_id = provider_id
+            self.model_name = model_name
+            self.is_local = is_local
+            self.stream = True
+
+        async def __call__(self, *args, **kwargs):
+            return SimpleNamespace(
+                provider_id=self.provider_id,
+                model_name=self.model_name,
+                is_local=self.is_local,
+                args=args,
+                kwargs=kwargs,
+            )
+
+    def fake_create_local_chat_model(*, model_id, **kwargs):
+        del kwargs
+        created.append(("llamacpp", model_id, True))
+        return FakeChatModel("llamacpp", model_id, True)
+
+    def fake_create_formatter_instance(chat_model_class):
+        return SimpleNamespace(formatter_for=chat_model_class.__name__)
+
+    def fake_create_formatter_from_family(formatter_family):
+        return SimpleNamespace(formatter_for=formatter_family.__name__)
+
+    def fake_get_chat_model_instance(self, model_id: str):
+        created.append((self.id, model_id, False))
+        return FakeChatModel(self.id, model_id, False)
+
+    monkeypatch.setattr(
+        model_factory,
+        "create_local_chat_model",
+        fake_create_local_chat_model,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        fake_create_formatter_instance,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_from_family",
+        fake_create_formatter_from_family,
+    )
+    monkeypatch.setattr(
+        FakeProvider,
+        "get_chat_model_instance",
+        fake_get_chat_model_instance,
+        raising=False,
+    )
+    return created
+
+
+def _routing_manager(active_llm: ModelSlotConfig) -> FakeManager:
+    providers = {
+        "llamacpp": FakeProvider(
+            provider_id="llamacpp",
+            models=["Qwen2.5-0.5B-Instruct-GGUF"],
+            is_local=True,
+        ),
+        "mlx": FakeProvider(
+            provider_id="mlx",
+            models=["Qwen3-4B"],
+            is_local=True,
+        ),
+        "openai": FakeProvider(
+            provider_id="openai",
+            models=["gpt-5", "gpt-5-mini"],
+        ),
+        "aliyun-codingplan": FakeProvider(
+            provider_id="aliyun-codingplan",
+            models=["qwen3.5-plus"],
+        ),
+    }
+    return FakeManager(providers, active_llm)
+
+
+def _unwrap_retry_model(model):
+    return getattr(model, "_inner", model)
+
+
+def test_create_model_and_formatter_uses_routing_with_active_cloud_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="local_first",
+        local=ModelSlotConfig(
+            provider_id="llamacpp",
+            model="Qwen2.5-0.5B-Instruct-GGUF",
+        ),
+        cloud=None,
+    )
+    created = _patch_common_routing_mocks(monkeypatch)
+
+    monkeypatch.setattr(
+        model_factory,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=routing_cfg),
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(
+            lambda: _routing_manager(
+                ModelSlotConfig(provider_id="openai", model="gpt-5"),
+            ),
+        ),
+    )
+
+    model, formatter = model_factory.create_model_and_formatter()
+    inner_model = _unwrap_retry_model(model)
+
+    assert isinstance(inner_model, RoutingChatModel)
+    assert inner_model.local_endpoint.provider_id == "llamacpp"
+    assert (
+        inner_model.local_endpoint.model_name == "Qwen2.5-0.5B-Instruct-GGUF"
+    )
+    assert inner_model.cloud_endpoint.provider_id == "openai"
+    assert inner_model.cloud_endpoint.model_name == "gpt-5"
+    assert formatter.formatter_for == "OpenAIChatFormatter"
+    assert not created
+
+
+@pytest.mark.asyncio
+async def test_create_model_and_formatter_loads_only_selected_cloud_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="cloud_first",
+        local=ModelSlotConfig(provider_id="mlx", model="Qwen3-4B"),
+        cloud=ModelSlotConfig(
+            provider_id="aliyun-codingplan",
+            model="qwen3.5-plus",
+        ),
+    )
+    created = _patch_common_routing_mocks(monkeypatch)
+
+    monkeypatch.setattr(
+        model_factory,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=routing_cfg),
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(
+            lambda: _routing_manager(
+                ModelSlotConfig(provider_id="mlx", model="Qwen3-4B"),
+            ),
+        ),
+    )
+
+    model, _ = model_factory.create_model_and_formatter()
+    inner_model = _unwrap_retry_model(model)
+
+    assert isinstance(inner_model, RoutingChatModel)
+    assert not created
+
+    response = await model(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+    )
+
+    assert response.provider_id == "aliyun-codingplan"
+    assert response.model_name == "qwen3.5-plus"
+    assert created == [("aliyun-codingplan", "qwen3.5-plus", False)]
+
+
+@pytest.mark.asyncio
+async def test_create_model_and_formatter_loads_local_route_on_first_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="local_first",
+        local=ModelSlotConfig(
+            provider_id="llamacpp",
+            model="Qwen2.5-0.5B-Instruct-GGUF",
+        ),
+        cloud=None,
+    )
+    created = _patch_common_routing_mocks(monkeypatch)
+
+    monkeypatch.setattr(
+        model_factory,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=routing_cfg),
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(
+            lambda: _routing_manager(
+                ModelSlotConfig(provider_id="openai", model="gpt-5"),
+            ),
+        ),
+    )
+
+    model, _ = model_factory.create_model_and_formatter()
+    inner_model = _unwrap_retry_model(model)
+
+    assert isinstance(inner_model, RoutingChatModel)
+    assert not created
+
+    response = await model(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+    )
+
+    assert response.provider_id == "llamacpp"
+    assert response.model_name == "Qwen2.5-0.5B-Instruct-GGUF"
+    assert created == [("llamacpp", "Qwen2.5-0.5B-Instruct-GGUF", True)]
+
+
+def test_create_model_and_formatter_uses_explicit_cloud_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="cloud_first",
+        local=ModelSlotConfig(provider_id="mlx", model="Qwen3-4B"),
+        cloud=ModelSlotConfig(
+            provider_id="aliyun-codingplan",
+            model="qwen3.5-plus",
+        ),
+    )
+    created = _patch_common_routing_mocks(monkeypatch)
+
+    monkeypatch.setattr(
+        model_factory,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=routing_cfg),
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(
+            lambda: _routing_manager(
+                ModelSlotConfig(provider_id="mlx", model="Qwen3-4B"),
+            ),
+        ),
+    )
+
+    model, _ = model_factory.create_model_and_formatter()
+    inner_model = _unwrap_retry_model(model)
+
+    assert isinstance(inner_model, RoutingChatModel)
+    assert inner_model.local_endpoint.provider_id == "mlx"
+    assert inner_model.cloud_endpoint.provider_id == "aliyun-codingplan"
+    assert inner_model.routing_cfg.mode == "cloud_first"
+    assert not created


### PR DESCRIPTION
## Summary
This PR adds the routing entry point to the chat UI and wires the existing `agents.llm_routing` config into chat runtime, so the feature is actually usable end-to-end.

## What changed
- add a chat header selector that supports:
  - switching to an explicit model
  - enabling `Routing: Local first`
  - enabling `Routing: Cloud first`
  - choosing the local/cloud counterpart models from the same menu when multiple options exist
- keep `Settings -> Models -> LLM Configuration` aligned with routing state:
  - when routing is enabled, it shows the preferred routed model
  - clicking `Save` turns that selection into a normal `active_llm` and disables routing
- wire `agents.llm_routing` into `create_model_and_formatter()` so chat requests actually honor routing
- make routing endpoints lazy-loaded, so `cloud_first` does not eagerly initialize the local backend and consume memory before it is used

## Scope
This PR is intentionally scoped to web/chat UX plus the minimal runtime wiring needed for that UX to work.

It does **not** add or update:
- CLI routing commands
- onboarding/init routing setup
- provider-specific fixes such as Aliyun Coding Plan compatibility
- extra fallback / approval flows when a local backend is unavailable

## Testing
- `npm run build`
- `npm run format:check`
- `uv run --python 3.13 --extra dev python -m pytest tests/test_routing_model_factory.py`
- `uv run --python 3.13 --extra dev pre-commit run --files src/copaw/agents/model_factory.py src/copaw/agents/routing_chat_model.py tests/test_routing_model_factory.py`