### PR TITLE
feat(feishu): add Card V2 format for rich text+image messages

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -23,6 +23,7 @@ import threading
 import time
 import types
 from collections import OrderedDict
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 


### PR DESCRIPTION
## Summary
Add Feishu Card V2 (Schema 2.0) support for rich messages combining text and images.

## Relationship with existing features
- PR #1009: \`build_interactive_content()\` for markdown table rendering
- This PR: Card V2 for combined text+image messages
- Both can coexist for different use cases

## Changes
- \`_build_card_v2_content()\` - Build Card V2 structure with schema 2.0
- \`_send_card_v2()\` - Send Card V2 messages via interactive type
- \`send_text()\` - Updated to use Card V2 format
- \`send_content_parts()\` - Updated to use Card V2 for text+image responses
- \`send()\` - Updated to use Card V2 format

## Benefits
- Better visual presentation for responses containing both text and images
- Configurable header colors (green, red, blue, orange, indigo, grey)
- Support for multiple images in a single card

## Note
This PR modifies \`channel.py\` and may conflict with other PRs touching the same file. Suggest merging PR #3 first.

## Related
Split from PR #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)