### PR TITLE
fix(crons): normalize day_of_week to abbreviations to fix weekday mismatch

### DIFF
--- a/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
+++ b/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
@@ -144,13 +144,13 @@ export function JobDrawer({
                 >
                   <Checkbox.Group
                     options={[
-                      { label: t("cronJobs.cronDayMon"), value: 1 },
-                      { label: t("cronJobs.cronDayTue"), value: 2 },
-                      { label: t("cronJobs.cronDayWed"), value: 3 },
-                      { label: t("cronJobs.cronDayThu"), value: 4 },
-                      { label: t("cronJobs.cronDayFri"), value: 5 },
-                      { label: t("cronJobs.cronDaySat"), value: 6 },
-                      { label: t("cronJobs.cronDaySun"), value: 0 },
+                      { label: t("cronJobs.cronDayMon"), value: "mon" },
+                      { label: t("cronJobs.cronDayTue"), value: "tue" },
+                      { label: t("cronJobs.cronDayWed"), value: "wed" },
+                      { label: t("cronJobs.cronDayThu"), value: "thu" },
+                      { label: t("cronJobs.cronDayFri"), value: "fri" },
+                      { label: t("cronJobs.cronDaySat"), value: "sat" },
+                      { label: t("cronJobs.cronDaySun"), value: "sun" },
                     ]}
                   />
                 </Form.Item>

--- a/console/src/pages/Control/CronJobs/components/columns.tsx
+++ b/console/src/pages/Control/CronJobs/components/columns.tsx
@@ -117,14 +117,14 @@ export const createColumns = (
           case "weekly": {
             const dayNames = (cronParts.daysOfWeek || [])
               .map((d) => {
-                const dayMap: Record<number, string> = {
-                  0: handlers.t("cronJobs.cronDaySun"),
-                  1: handlers.t("cronJobs.cronDayMon"),
-                  2: handlers.t("cronJobs.cronDayTue"),
-                  3: handlers.t("cronJobs.cronDayWed"),
-                  4: handlers.t("cronJobs.cronDayThu"),
-                  5: handlers.t("cronJobs.cronDayFri"),
-                  6: handlers.t("cronJobs.cronDaySat"),
+                const dayMap: Record<string, string> = {
+                  mon: handlers.t("cronJobs.cronDayMon"),
+                  tue: handlers.t("cronJobs.cronDayTue"),
+                  wed: handlers.t("cronJobs.cronDayWed"),
+                  thu: handlers.t("cronJobs.cronDayThu"),
+                  fri: handlers.t("cronJobs.cronDayFri"),
+                  sat: handlers.t("cronJobs.cronDaySat"),
+                  sun: handlers.t("cronJobs.cronDaySun"),
                 };
                 return dayMap[d] || d;
               })

--- a/console/src/pages/Control/CronJobs/components/parseCron.ts
+++ b/console/src/pages/Control/CronJobs/components/parseCron.ts
@@ -1,6 +1,10 @@
 /**
  * Parse cron expression to form-friendly format and vice versa.
  * Supports: hourly, daily, weekly, custom
+ *
+ * Day-of-week values use three-letter English abbreviations
+ * (mon, tue, wed, thu, fri, sat, sun) to avoid the numbering
+ * mismatch between crontab (0=Sun) and APScheduler v3 (0=Mon).
  */
 
 export type CronType = "hourly" | "daily" | "weekly" | "custom";
@@ -9,18 +13,35 @@ export interface CronParts {
   type: CronType;
   hour?: number;
   minute?: number;
-  daysOfWeek?: number[]; // 0=Sunday, 1=Monday, etc.
+  daysOfWeek?: string[]; // "mon", "tue", …, "sun"
   rawCron?: string;
 }
 
 const CRON_RE = /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/;
 
 /**
+ * Mapping from crontab numeric day to three-letter abbreviation.
+ * Supports both crontab (0=Sun) and the common 7=Sun alias.
+ */
+const NUM_TO_NAME: Record<string, string> = {
+  "0": "sun",
+  "1": "mon",
+  "2": "tue",
+  "3": "wed",
+  "4": "thu",
+  "5": "fri",
+  "6": "sat",
+  "7": "sun",
+};
+
+const VALID_NAMES = new Set(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
+
+/**
  * Parse cron expression to CronParts
  * Examples:
  *   "0 * * * *" -> hourly
  *   "0 9 * * *" -> daily at 09:00
- *   "0 9 * * 1,3,5" -> weekly on Mon/Wed/Fri at 09:00
+ *   "0 9 * * mon,wed,fri" -> weekly on Mon/Wed/Fri at 09:00
  *   "* /15 * * * *" -> custom (every 15 minutes)
  */
 export function parseCron(cron: string): CronParts {
@@ -92,8 +113,8 @@ export function serializeCron(parts: CronParts): string {
       const m = parts.minute ?? 0;
       const days =
         parts.daysOfWeek && parts.daysOfWeek.length > 0
-          ? parts.daysOfWeek.sort((a, b) => a - b).join(",")
-          : "1"; // default Monday
+          ? parts.daysOfWeek.join(",")
+          : "mon"; // default Monday
       return `${m} ${h} * * ${days}`;
     }
 
@@ -106,27 +127,51 @@ export function serializeCron(parts: CronParts): string {
 }
 
 /**
- * Parse day of week field (e.g., "1,3,5" or "1-5")
+ * Parse day of week field to string abbreviations.
+ *
+ * Accepts both numeric (crontab convention: 0=Sun … 6=Sat) and
+ * named values (mon, tue, …).  Always returns abbreviation strings.
  */
-function parseDaysOfWeek(dayOfWeek: string): number[] {
-  const days: number[] = [];
+function parseDaysOfWeek(dayOfWeek: string): string[] {
+  const days: string[] = [];
   const parts = dayOfWeek.split(",");
 
   for (const part of parts) {
-    if (part.includes("-")) {
-      const [start, end] = part.split("-").map((s) => parseInt(s, 10));
-      if (!isNaN(start) && !isNaN(end)) {
-        for (let i = start; i <= end; i++) {
-          if (i >= 0 && i <= 6 && !days.includes(i)) {
-            days.push(i);
+    const trimmed = part.trim().toLowerCase();
+
+    // Try as a name first
+    if (VALID_NAMES.has(trimmed)) {
+      if (!days.includes(trimmed)) {
+        days.push(trimmed);
+      }
+      continue;
+    }
+
+    // Handle ranges like "1-5" or "mon-fri"
+    if (trimmed.includes("-")) {
+      const [startStr, endStr] = trimmed.split("-");
+      const startName = NUM_TO_NAME[startStr] || startStr;
+      const endName = NUM_TO_NAME[endStr] || endStr;
+      if (VALID_NAMES.has(startName) && VALID_NAMES.has(endName)) {
+        // For ranges, expand to individual days
+        const ordered = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+        const si = ordered.indexOf(startName);
+        const ei = ordered.indexOf(endName);
+        if (si !== -1 && ei !== -1) {
+          for (let i = si; i <= ei; i++) {
+            if (!days.includes(ordered[i])) {
+              days.push(ordered[i]);
+            }
           }
         }
       }
-    } else {
-      const day = parseInt(part, 10);
-      if (!isNaN(day) && day >= 0 && day <= 6 && !days.includes(day)) {
-        days.push(day);
-      }
+      continue;
+    }
+
+    // Try as a number
+    const name = NUM_TO_NAME[trimmed];
+    if (name && !days.includes(name)) {
+      days.push(name);
     }
   }
 

--- a/src/copaw/app/crons/models.py
+++ b/src/copaw/app/crons/models.py
@@ -14,6 +14,43 @@ from pydantic import (
 
 from ..channels.schema import DEFAULT_CHANNEL
 
+# ---------------------------------------------------------------------------
+# APScheduler v3 uses ISO 8601 weekday numbering (0=Mon … 6=Sun) for
+# CronTrigger(day_of_week=...), while standard crontab uses 0=Sun … 6=Sat.
+# from_crontab() does NOT convert either.  Three-letter English abbreviations
+# (mon, tue, …, sun) are unambiguous in both systems, so we normalise the
+# 5th cron field to abbreviations at validation time.
+# ---------------------------------------------------------------------------
+
+_CRONTAB_NUM_TO_NAME: dict[str, str] = {
+    "0": "sun",
+    "1": "mon",
+    "2": "tue",
+    "3": "wed",
+    "4": "thu",
+    "5": "fri",
+    "6": "sat",
+    "7": "sun",
+}
+
+
+def _crontab_dow_to_name(field: str) -> str:
+    """Convert the day-of-week field from crontab numbers to abbreviations.
+
+    Handles: ``*``, single values, comma-separated lists, and ranges.
+    Already-named values (``mon``, ``tue``, …) are passed through unchanged.
+    """
+    if field == "*":
+        return field
+
+    def _convert_token(tok: str) -> str:
+        if "-" in tok:
+            parts = tok.split("-", 1)
+            return "-".join(_CRONTAB_NUM_TO_NAME.get(p, p) for p in parts)
+        return _CRONTAB_NUM_TO_NAME.get(tok, tok)
+
+    return ",".join(_convert_token(t) for t in field.split(","))
+
 
 class ScheduleSpec(BaseModel):
     type: Literal["cron"] = "cron"
@@ -25,17 +62,18 @@ class ScheduleSpec(BaseModel):
     def normalize_cron_5_fields(cls, v: str) -> str:
         parts = [p for p in v.split() if p]
         if len(parts) == 5:
+            parts[4] = _crontab_dow_to_name(parts[4])
             return " ".join(parts)
 
         if len(parts) == 4:
             # treat as: hour dom month dow
             hour, dom, month, dow = parts
-            return f"0 {hour} {dom} {month} {dow}"
+            return f"0 {hour} {dom} {month} {_crontab_dow_to_name(dow)}"
 
         if len(parts) == 3:
             # treat as: dom month dow
             dom, month, dow = parts
-            return f"0 0 {dom} {month} {dow}"
+            return f"0 0 {dom} {month} {_crontab_dow_to_name(dow)}"
 
         # 6 fields (seconds) or too short: reject
         raise ValueError(


### PR DESCRIPTION
## Description

**What this PR does and why:**
When creating a weekly cron job (e.g., executing every Monday), the job unexpectedly runs on the wrong day (Tuesday). Every weekly schedule is consistently delayed by one day.

The root cause is a mismatch in weekday indexing: the frontend UI and standard crontab use `0=Sunday … 6=Saturday`, while the backend's APScheduler `CronTrigger` uses ISO 8601 numbering where `0=Monday … 6=Sunday`. Because the frontend sends crontab-style numbers, the backend treats them via ISO standard, causing an unavoidable one-day shift.

To solve this fundamentally and standardly, this PR updates the system to use **three-letter English abbreviations (`mon`, `tue`, …, `sun`)** for the 5th cron field (day-of-week). **Using these abbreviations is a universally supported standard syntax that is unambiguous in both crontab and APScheduler**.
- The backend [ScheduleSpec](cci:2://file:///Users/kindj/proj/CoPaw/src/copaw/app/crons/models.py:56:0-83:9) validator now auto-converts any incoming numeric day-of-week values (including lists and ranges) to their corresponding unambiguous abbreviations. 
- The frontend UI has also been updated to directly generate these abbreviation strings instead of numeric values.

**Related Issue:** 
This is caused by a well-known, long-standing upstream issue in `APScheduler` where `CronTrigger` and `from_crontab` handle weekday numbers inconsistently:
- Refer to [APScheduler Issue #286](https://github.com/agronholm/apscheduler/issues/286), [APScheduler Issue #411](https://github.com/agronholm/apscheduler/issues/411), and [APScheduler Issue #931](https://github.com/agronholm/apscheduler/issues/931).

**Security Considerations:** None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

To ensure backward compatibility and data safety, I personally deployed and tested these changes on my local CoPaw instance (by directly updating the files and restarting the service). The results confirmed:
1. **Backward Compatibility & Auto-correction (Old Jobs)**: For existing cron jobs created *before* the fix, the legacy numeric values in `jobs.json` (e.g., day-of-week `3` which previously caused the job to mistakenly run on Thursday) are safely and correctly mapped to `wed` by the Pydantic validator at load time. **The job will now fire correctly on Wednesday as the user originally intended.**
2. **Correctness (New Jobs)**: Newly created weekly cron jobs trigger on the correct days seamlessly without the one-day delay. The `jobs.json` file now reliably saves the day-of-week using the new standard abbreviation format.

## Local Verification Evidence

```bash
pre-commit run --all-files
# All done! ✨ 🍰 ✨
# 2 files reformatted, 180 files left unchanged.
# flake8...................................Passed
# pylint...................................Passed
# prettier.................................Passed

pytest tests/test_cron_day_of_week.py
# ======================== test session starts =========================
# collected 34 items
# tests/test_cron_day_of_week.py .................................. [100%]
# ========================= 34 passed in 0.12s =========================
