### PR TITLE
fix: multiple chat requests for details

### DIFF
--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -237,6 +237,15 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     null;
 
   /**
+   * Deduplicates concurrent getSession calls for the same sessionId.
+   * Key: sessionId, Value: in-flight promise for getSession.
+   */
+  private sessionRequests: Map<
+    string,
+    Promise<IAgentScopeRuntimeWebUISession>
+  > = new Map();
+
+  /**
    * Called when a temporary timestamp session id is resolved to a real backend
    * UUID. Consumers (e.g. Chat/index.tsx) can register here to update the URL.
    */
@@ -324,6 +333,24 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   }
 
   async getSession(sessionId: string) {
+    // Deduplicate: reuse the in-flight request if one is already running
+    // for the same sessionId so concurrent calls share one network request.
+    const existingRequest = this.sessionRequests.get(sessionId);
+    if (existingRequest) return existingRequest;
+
+    const requestPromise = this._doGetSession(sessionId);
+    this.sessionRequests.set(sessionId, requestPromise);
+
+    try {
+      return await requestPromise;
+    } finally {
+      this.sessionRequests.delete(sessionId);
+    }
+  }
+
+  private async _doGetSession(
+    sessionId: string,
+  ): Promise<IAgentScopeRuntimeWebUISession> {
     // --- Local timestamp ID (New Chat before first reply) ---
     if (isLocalTimestamp(sessionId)) {
       const fromList = this.sessionList.find((s) => s.id === sessionId) as


### PR DESCRIPTION
## Description

Add deduplication logic to handle multiple chat request details.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
