### PR TITLE
fix: ensure info function is defined before being called in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,22 @@
 # Users do NOT need Python pre-installed — uv handles everything.
 set -euo pipefail
 
+# ── Colors ────────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+    BOLD="\033[1m"
+    GREEN="\033[0;32m"
+    YELLOW="\033[0;33m"
+    RED="\033[0;31m"
+    RESET="\033[0m"
+else
+    BOLD="" GREEN="" YELLOW="" RED="" RESET=""
+fi
+
+info()  { printf "${GREEN}[copaw]${RESET} %s\n" "$*"; }
+warn()  { printf "${YELLOW}[copaw]${RESET} %s\n" "$*"; }
+error() { printf "${RED}[copaw]${RESET} %s\n" "$*" >&2; }
+die()   { error "$@"; exit 1; }
+
 # ── Defaults ──────────────────────────────────────────────────────────────────
 COPAW_HOME="${COPAW_HOME:-$HOME/.copaw}"
 COPAW_VENV="$COPAW_HOME/venv"
@@ -37,22 +53,6 @@ VERSION=""
 FROM_SOURCE=false
 SOURCE_DIR=""
 EXTRAS=""
-
-# ── Colors ────────────────────────────────────────────────────────────────────
-if [ -t 1 ]; then
-    BOLD="\033[1m"
-    GREEN="\033[0;32m"
-    YELLOW="\033[0;33m"
-    RED="\033[0;31m"
-    RESET="\033[0m"
-else
-    BOLD="" GREEN="" YELLOW="" RED="" RESET=""
-fi
-
-info()  { printf "${GREEN}[copaw]${RESET} %s\n" "$*"; }
-warn()  { printf "${YELLOW}[copaw]${RESET} %s\n" "$*"; }
-error() { printf "${RED}[copaw]${RESET} %s\n" "$*" >&2; }
-die()   { error "$@"; exit 1; }
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
The installer script calls the `info` function before it is defined, which causes:

line 22: info: command not found

This change moves the function definition before it is used.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #1291



## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

curl -fsSL https://copaw.agentscope.io/install.sh | bash

