### PR TITLE
fix(channels): filter empty text blocks from DingTalk rich text (#1303)

### DIFF
--- a/src/copaw/app/channels/base.py
+++ b/src/copaw/app/channels/base.py
@@ -342,10 +342,24 @@ class BaseChannel(ABC):
             Role,
         )
 
-        if not content_parts:
-            content_parts = [
-                TextContent(type=ContentType.TEXT, text=""),
-            ]
+        # Filter out empty TEXT / REFUSAL blocks that some channels may
+        # produce (e.g. DingTalk richText with whitespace-only items).
+        # Remaining empty list is fine: debounce will buffer it until a
+        # text-bearing message arrives.
+        content_parts = [
+            c
+            for c in content_parts
+            if not (
+                (
+                    getattr(c, "type", None) == ContentType.TEXT
+                    and not (getattr(c, "text", None) or "").strip()
+                )
+                or (
+                    getattr(c, "type", None) == ContentType.REFUSAL
+                    and not (getattr(c, "refusal", None) or "").strip()
+                )
+            )
+        ]
         msg = Message(
             type=MessageType.MESSAGE,
             role=Role.USER,

--- a/src/copaw/app/channels/dingtalk/handler.py
+++ b/src/copaw/app/channels/dingtalk/handler.py
@@ -121,12 +121,14 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
                 # Text may be under "text" or "content" (API variation).
                 item_text = item.get("text") or item.get("content")
                 if item_text is not None:
-                    content.append(
-                        TextContent(
-                            type=ContentType.TEXT,
-                            text=(item_text or "").strip(),
-                        ),
-                    )
+                    stripped_text = (item_text or "").strip()
+                    if stripped_text:
+                        content.append(
+                            TextContent(
+                                type=ContentType.TEXT,
+                                text=stripped_text,
+                            ),
+                        )
                 # Picture items may use pictureDownloadCode or downloadCode.
                 dl_code = (
                     item.get("downloadCode")


### PR DESCRIPTION



## Description

  - Skip whitespace-only text items in DingTalk richText parsing to prevent creating TextContent(text="") that triggers LLM API error "messages: text content blocks must be non-empty"

  - Move empty TEXT/REFUSAL filtering into shared build_agent_request_from_user_content so all 12 channels are protected, not just DingTalk

  - Remove fallback that re-injected TextContent(text="") when content_parts was empty; empty list is safe and handled by existing debounce buffering

  - Fixes session-level corruption where the error persisted across subsequent valid messages until manual session file deletion

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

  Fixes #1303


**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
