### PR TITLE
fix(skills): dedupe duplicated built-in skill listings

### DIFF
--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -5,6 +5,7 @@ import filecmp
 import logging
 import shutil
 from collections.abc import Iterable
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any
 from pydantic import BaseModel
@@ -43,12 +44,28 @@ def _iter_relevant_directory_entries(
     if not directory.exists():
         return
 
-    for item in sorted(directory.rglob("*"), key=lambda p: p.relative_to(directory).as_posix()):
+    yield from _iter_relevant_directory_entries_from(
+        root_dir=directory,
+        current_dir=directory,
+    )
+
+
+def _iter_relevant_directory_entries_from(
+    root_dir: Path,
+    current_dir: Path,
+) -> Iterable[tuple[Path, Path]]:
+    """Yield sorted non-generated directory entries without buffering."""
+    for item in sorted(current_dir.iterdir(), key=lambda path: path.name):
         if _should_ignore_runtime_artifact(item):
             continue
-        if any(_should_ignore_runtime_artifact(parent) for parent in item.parents if parent != directory):
-            continue
-        yield item.relative_to(directory), item
+
+        yield item.relative_to(root_dir), item
+
+        if item.is_dir():
+            yield from _iter_relevant_directory_entries_from(
+                root_dir=root_dir,
+                current_dir=item,
+            )
 
 
 def _directories_match_ignoring_runtime_artifacts(
@@ -59,15 +76,17 @@ def _directories_match_ignoring_runtime_artifacts(
     if not dir1.exists() or not dir2.exists():
         return False
 
-    dir1_entries = dict(_iter_relevant_directory_entries(dir1))
-    dir2_entries = dict(_iter_relevant_directory_entries(dir2))
+    for entry1, entry2 in zip_longest(
+        _iter_relevant_directory_entries(dir1),
+        _iter_relevant_directory_entries(dir2),
+    ):
+        if entry1 is None or entry2 is None:
+            return False
 
-    if set(dir1_entries) != set(dir2_entries):
-        return False
-
-    for relative_path in dir1_entries:
-        left = dir1_entries[relative_path]
-        right = dir2_entries[relative_path]
+        relative_path1, left = entry1
+        relative_path2, right = entry2
+        if relative_path1 != relative_path2:
+            return False
         if left.is_dir() != right.is_dir():
             return False
         if left.is_file() and not filecmp.cmp(left, right, shallow=False):
@@ -274,53 +293,6 @@ def sync_skills_to_working_dir(
             )
 
     return synced_count, skipped_count
-
-
-def _is_directory_same(dir1: Path, dir2: Path) -> bool:
-    """
-    Check if two directories have the same content.
-
-    Args:
-        dir1: First directory path.
-        dir2: Second directory path.
-
-    Returns:
-        True if directories have the same structure and file contents.
-    """
-    if not dir1.exists() or not dir2.exists():
-        return False
-
-    dcmp = filecmp.dircmp(dir1, dir2)
-
-    if dcmp.left_only or dcmp.right_only or dcmp.funny_files:
-        return False
-
-    if dcmp.diff_files:
-        return False
-
-    for sub_dcmp in dcmp.subdirs.values():
-        if not _compare_dircmp(sub_dcmp):
-            return False
-
-    return True
-
-
-def _compare_dircmp(dcmp: "filecmp.dircmp") -> bool:
-    """Helper to recursively compare dircmp objects."""
-    has_diff = any(
-        [
-            dcmp.left_only,
-            dcmp.right_only,
-            dcmp.funny_files,
-            dcmp.diff_files,
-        ],
-    )
-    if has_diff:
-        return False
-    for sub_dcmp in dcmp.subdirs.values():
-        if not _compare_dircmp(sub_dcmp):
-            return False
-    return True
 
 
 def sync_skills_from_active_to_customized(

--- a/tests/unit/agents/test_skills_manager.py
+++ b/tests/unit/agents/test_skills_manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 import sys
 import types
@@ -25,10 +26,9 @@ def _install_frontmatter_stub() -> None:
     sys.modules["frontmatter"] = types.SimpleNamespace(loads=loads)
 
 
-_install_frontmatter_stub()
-
-import copaw.agents.skills_manager as skills_manager_module
-from copaw.agents.skills_manager import SkillService
+def _load_skills_manager_module():
+    _install_frontmatter_stub()
+    return importlib.import_module("copaw.agents.skills_manager")
 
 
 SKILL_TEMPLATE = """---
@@ -61,6 +61,7 @@ def _write_skill(
 
 def _patch_skill_dirs(
     monkeypatch,
+    skills_manager_module,
     *,
     builtin_dir: Path,
     customized_dir: Path,
@@ -87,6 +88,7 @@ def test_sync_from_active_to_customized_ignores_runtime_artifacts(
     monkeypatch,
     tmp_path,
 ) -> None:
+    skills_manager_module = _load_skills_manager_module()
     builtin_dir = tmp_path / "builtin"
     customized_dir = tmp_path / "customized"
     active_dir = tmp_path / "active"
@@ -100,12 +102,16 @@ def test_sync_from_active_to_customized_ignores_runtime_artifacts(
 
     _patch_skill_dirs(
         monkeypatch,
+        skills_manager_module,
         builtin_dir=builtin_dir,
         customized_dir=customized_dir,
         active_dir=active_dir,
     )
 
-    synced, skipped = skills_manager_module.sync_skills_from_active_to_customized()
+    (
+        synced,
+        skipped,
+    ) = skills_manager_module.sync_skills_from_active_to_customized()
 
     assert synced == 0
     assert skipped == 1
@@ -116,6 +122,7 @@ def test_sync_from_active_to_customized_keeps_real_builtin_edits(
     monkeypatch,
     tmp_path,
 ) -> None:
+    skills_manager_module = _load_skills_manager_module()
     builtin_dir = tmp_path / "builtin"
     customized_dir = tmp_path / "customized"
     active_dir = tmp_path / "active"
@@ -129,24 +136,31 @@ def test_sync_from_active_to_customized_keeps_real_builtin_edits(
 
     _patch_skill_dirs(
         monkeypatch,
+        skills_manager_module,
         builtin_dir=builtin_dir,
         customized_dir=customized_dir,
         active_dir=active_dir,
     )
 
-    synced, skipped = skills_manager_module.sync_skills_from_active_to_customized()
+    (
+        synced,
+        skipped,
+    ) = skills_manager_module.sync_skills_from_active_to_customized()
 
     assert synced == 1
     assert skipped == 0
     copied_skill = customized_dir / active_skill.name
     assert copied_skill.exists()
-    assert (copied_skill / "scripts" / "main.py").read_text(encoding="utf-8") == "print(2)\n"
+    assert (copied_skill / "scripts" / "main.py").read_text(
+        encoding="utf-8",
+    ) == "print(2)\n"
 
 
 def test_list_all_skills_prefers_customized_over_builtin_duplicates(
     monkeypatch,
     tmp_path,
 ) -> None:
+    skills_manager_module = _load_skills_manager_module()
     builtin_dir = tmp_path / "builtin"
     customized_dir = tmp_path / "customized"
     active_dir = tmp_path / "active"
@@ -157,12 +171,13 @@ def test_list_all_skills_prefers_customized_over_builtin_duplicates(
 
     _patch_skill_dirs(
         monkeypatch,
+        skills_manager_module,
         builtin_dir=builtin_dir,
         customized_dir=customized_dir,
         active_dir=active_dir,
     )
 
-    skills = SkillService.list_all_skills()
+    skills = skills_manager_module.SkillService.list_all_skills()
 
     assert [skill.name for skill in skills] == ["calendar", "mail", "notes"]
     skills_by_name = {skill.name: skill for skill in skills}


### PR DESCRIPTION
## Summary
- fix duplicate skill entries caused by syncing active built-in skills with generated runtime artifacts into `customized_skills`
- dedupe the API/UI skill listing by skill name so customized skills override built-ins cleanly
- add regression tests covering runtime-artifact sync, real built-in edits, and deduped listing behavior

## Why this fix
`list_all_skills()` syncs active skills back into `customized_skills` before building the UI/API list. When an active built-in skill only differs by generated files like `__pycache__` or `.pyc`, the old directory comparison treats it as modified and copies it into `customized_skills`, which then makes the skill show up twice. This patch ignores runtime artifacts during sync comparison and returns a single logical skill entry per name.

## Validation
- `PYTHONPATH=src python -m pytest tests/unit/agents/test_skills_manager.py -q` -> `3 passed`

Closes #1370