### PR TITLE
fix(console): stabilize provider card header layout across locales

### DIFF
--- a/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
@@ -64,7 +64,8 @@ export function LocalProviderCard({
     titleWords.length > 1 ? titleWords.slice(0, -1).join(" ") : provider.name;
   const wrappedTitleLine2 =
     titleWords.length > 1 ? titleWords[titleWords.length - 1] : "";
-  const shouldUseWrappedTitleLayout = isTitleWrapped && titleWords.length > 1;
+  const shouldUseWrappedTitleLayout = isTitleWrapped;
+  const hasWrappedTitleLine2 = wrappedTitleLine2.length > 0;
 
   return (
     <Card
@@ -91,9 +92,14 @@ export function LocalProviderCard({
                   {wrappedTitleLine1}
                 </span>
                 <span className={styles.cardNameLine2Wrap}>
-                  <span className={styles.cardNameLine2} title={provider.name}>
-                    {wrappedTitleLine2}
-                  </span>
+                  {hasWrappedTitleLine2 && (
+                    <span
+                      className={styles.cardNameLine2}
+                      title={provider.name}
+                    >
+                      {wrappedTitleLine2}
+                    </span>
+                  )}
                   <span className={styles.cardTagRow}>
                     <Tag color="purple" style={{ fontSize: 11 }}>
                       {t("models.local")}

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -140,7 +140,8 @@ export function RemoteProviderCard({
     titleWords.length > 1 ? titleWords.slice(0, -1).join(" ") : provider.name;
   const wrappedTitleLine2 =
     titleWords.length > 1 ? titleWords[titleWords.length - 1] : "";
-  const shouldUseWrappedTitleLayout = isTitleWrapped && titleWords.length > 1;
+  const shouldUseWrappedTitleLayout = isTitleWrapped;
+  const hasWrappedTitleLine2 = wrappedTitleLine2.length > 0;
 
   const statusLabelMatch = statusLabel.match(/^(.+?)\s*([（(])(.+)([）)])\s*$/);
   const statusMainText = statusLabelMatch?.[1]?.trim() ?? statusLabel;
@@ -173,9 +174,14 @@ export function RemoteProviderCard({
                   {wrappedTitleLine1}
                 </span>
                 <span className={styles.cardNameLine2Wrap}>
-                  <span className={styles.cardNameLine2} title={provider.name}>
-                    {wrappedTitleLine2}
-                  </span>
+                  {hasWrappedTitleLine2 && (
+                    <span
+                      className={styles.cardNameLine2}
+                      title={provider.name}
+                    >
+                      {wrappedTitleLine2}
+                    </span>
+                  )}
                   <span className={styles.cardTagRow}>{providerTag}</span>
                 </span>
               </>

--- a/console/src/pages/Settings/Models/index.module.less
+++ b/console/src/pages/Settings/Models/index.module.less
@@ -220,7 +220,7 @@
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 8px;
   min-width: 0;
 }


### PR DESCRIPTION
## Description

Improve layout consistency of Models > Providers cards across locales (English/Chinese/Japanese/Russian) while preserving narrow-width usability.
<img width="2520" height="1764" alt="CleanShot 2026-03-13 at 09 31 14@2x" src="https://github.com/user-attachments/assets/ac4400cf-ad61-4bb9-8e12-8aee108ba086" />
<img width="1914" height="1502" alt="CleanShot 2026-03-14 at 10 20 25@2x" src="https://github.com/user-attachments/assets/94166eb9-88ed-40b8-b670-75d307409217" />
<img width="1944" height="1650" alt="CleanShot 2026-03-14 at 09 59 51@2x" src="https://github.com/user-attachments/assets/e0e3d86d-006b-4cea-8d6f-7e3e87fb0344" />

This PR focuses on stable, predictable card structure in multilingual scenarios:
- Keep provider action buttons on one line and prevent overflow in narrow card widths.
- Keep custom provider delete action compact on narrow cards (Delete Provider → Delete).
- Make provider header layout consistent across locales:
  - Status block alignment is stable.
  - Wrapped titles and provider tags follow consistent placement rules.
  - Vertical spacing is tuned to avoid uneven visual rhythm between cards.
<img width="1960" height="1606" alt="CleanShot 2026-03-14 at 11 46 18@2x" src="https://github.com/user-attachments/assets/d67ab035-088e-46bf-b188-f7ff6923b576" />

Security Considerations: N/A (UI layout/text behavior only, no auth/config/data-path changes)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit run --all-files locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (pytest or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Manual:
1. Open Models > Providers page.
2. Verify card layout under multiple locales (at least English, Chinese, Japanese, Russian).
3. Verify title/status/tag/action placement remains consistent across cards.
4. Resize browser width to narrow layout and confirm action area does not overflow.
5. Confirm custom provider delete text compacts only in narrow widths.

Build:
- Frontend production build succeeds.

## Local Verification Evidence

pre-commit run --all-files
- Passed locally.

pytest
- Passed locally.

npm run build (console)
- Passed locally.

## Additional Notes

This change is intentionally scoped to console UI layout consistency and does not alter provider APIs or backend behavior.