### PR TITLE
fix(provider): Fix ollama and LMStudio context length

### DIFF
--- a/src/copaw/providers/ollama_provider.py
+++ b/src/copaw/providers/ollama_provider.py
@@ -128,7 +128,7 @@ class OllamaProvider(Provider):
         "registry/model:tag" or "registry/model".
         """
         if model_info.id in {
-            model.id for model in self.models  # type: ignore [has-type]
+            model.id for model in self.extra_models  # type: ignore [has-type]
         }:
             return False, f"Model '{model_info.id}' already exists"
         client = self._client(timeout=timeout)
@@ -140,7 +140,7 @@ class OllamaProvider(Provider):
             return False, f"Failed to connect to Ollama at `{self.base_url}`"
         except Exception:
             return False, f"Failed to pull model '{model_info.id}'"
-        self.models = await self.fetch_models()
+        self.extra_models = await self.fetch_models()
         return True, ""
 
     async def delete_model(
@@ -157,7 +157,7 @@ class OllamaProvider(Provider):
             return False, f"Failed to connect to Ollama at `{self.base_url}`"
         except Exception:
             return False, f"Failed to delete model '{model_id}'"
-        self.models = await self.fetch_models()
+        self.extra_models = await self.fetch_models()
         return True, ""
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:

--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -159,6 +159,7 @@ PROVIDER_OLLAMA = OllamaProvider(
     name="Ollama",
     require_api_key=False,
     support_model_discovery=True,
+    generate_kwargs={"max_tokens": None},
 )
 
 PROVIDER_LMSTUDIO = OpenAIProvider(
@@ -168,6 +169,7 @@ PROVIDER_LMSTUDIO = OpenAIProvider(
     require_api_key=False,
     api_key_prefix="",
     support_model_discovery=True,
+    generate_kwargs={"max_tokens": None},
 )
 
 
@@ -286,7 +288,7 @@ class ProviderManager:
             return []
         try:
             models = await provider.fetch_models()
-            provider.models = models
+            provider.extra_models = models
             self._save_provider(
                 provider,
                 is_builtin=provider_id in self.builtin_providers,
@@ -436,7 +438,7 @@ class ProviderManager:
 
         if provider_id == "anthropic" or chat_model == "AnthropicChatModel":
             return AnthropicProvider.model_validate(data)
-        if provider_id == "ollama" or chat_model == "OllamaChatModel":
+        if provider_id == "ollama":
             return OllamaProvider.model_validate(data)
         if data.get("is_local", False):
             return DefaultProvider.model_validate(data)
@@ -544,7 +546,7 @@ class ProviderManager:
                 builtin.base_url = provider.base_url
                 builtin.api_key = provider.api_key
                 builtin.extra_models = provider.extra_models
-                builtin.generate_kwargs = provider.generate_kwargs
+                builtin.generate_kwargs.update(provider.generate_kwargs)
         # Load custom providers
         for provider_file in self.custom_path.glob("*.json"):
             provider = self.load_provider(provider_file.stem, is_builtin=False)

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -285,14 +285,19 @@ async def test_update_config_keeps_chat_model_for_non_custom_provider(
 async def test_add_model_calls_pull(monkeypatch) -> None:
     provider = _make_provider()
     called = {"timeout": [], "model": None, "list_count": 0}
+    payload = {"models": []}
 
     class FakeClient:
+        def __init__(self) -> None:
+            self.payload = payload
+
         async def pull(self, model: str):
             called["model"] = model
+            self.payload["models"].append(SimpleNamespace(model=model, name=model))
 
         async def list(self):
             called["list_count"] += 1
-            return {"models": []}
+            return self.payload
 
     def _fake_client(timeout=5):
         called["timeout"].append(timeout)
@@ -305,6 +310,8 @@ async def test_add_model_calls_pull(monkeypatch) -> None:
         timeout=8.0,
     )
 
+    assert provider.extra_models == [ModelInfo(id="qwen2:7b", name="qwen2:7b")]
+
     assert called == {
         "timeout": [8.0, 5],
         "model": "qwen2:7b",
@@ -315,14 +322,28 @@ async def test_add_model_calls_pull(monkeypatch) -> None:
 async def test_delete_model_calls_delete(monkeypatch) -> None:
     provider = _make_provider()
     called = {"timeout": [], "model": None, "list_count": 0}
+    payload = {
+        "models": [
+            SimpleNamespace(model="qwen3:8b"),
+            SimpleNamespace(model="qwen3:4b"),
+        ]
+    }
 
     class FakeClient:
+
+        def __init__(self):
+            self.payload = payload
+
         async def delete(self, model: str):
             called["model"] = model
+            for m in self.payload["models"]:
+                if m.model == model:
+                    self.payload["models"].remove(m)
+                    break
 
         async def list(self):
             called["list_count"] += 1
-            return {"models": []}
+            return self.payload
 
     def _fake_client(timeout=5):
         called["timeout"].append(timeout)
@@ -330,10 +351,12 @@ async def test_delete_model_calls_delete(monkeypatch) -> None:
 
     monkeypatch.setattr(provider, "_client", _fake_client)
 
-    await provider.delete_model("qwen2:7b", timeout=6.0)
+    await provider.delete_model("qwen3:8b", timeout=6.0)
 
     assert called == {
         "timeout": [6.0, 5],
-        "model": "qwen2:7b",
+        "model": "qwen3:8b",
         "list_count": 1,
     }
+
+    assert provider.extra_models == [ModelInfo(id="qwen3:4b", name="qwen3:4b")]

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -294,7 +294,7 @@ async def test_add_model_calls_pull(monkeypatch) -> None:
         async def pull(self, model: str):
             called["model"] = model
             self.payload["models"].append(
-                SimpleNamespace(model=model, name=model)
+                SimpleNamespace(model=model, name=model),
             )
 
         async def list(self):

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -293,7 +293,9 @@ async def test_add_model_calls_pull(monkeypatch) -> None:
 
         async def pull(self, model: str):
             called["model"] = model
-            self.payload["models"].append(SimpleNamespace(model=model, name=model))
+            self.payload["models"].append(
+                SimpleNamespace(model=model, name=model)
+            )
 
         async def list(self):
             called["list_count"] += 1
@@ -326,11 +328,10 @@ async def test_delete_model_calls_delete(monkeypatch) -> None:
         "models": [
             SimpleNamespace(model="qwen3:8b"),
             SimpleNamespace(model="qwen3:4b"),
-        ]
+        ],
     }
 
     class FakeClient:
-
         def __init__(self):
             self.payload = payload
 

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -354,21 +354,6 @@ def test_provider_from_data_dispatch_to_anthropic(isolated_secret_dir) -> None:
     assert isinstance(provider, AnthropicProvider)
 
 
-def test_provider_from_data_dispatch_to_ollama(isolated_secret_dir) -> None:
-    manager = ProviderManager()
-
-    provider = manager._provider_from_data(
-        {
-            "id": "custom-ollama",
-            "name": "Custom Ollama",
-            "chat_model": "OllamaChatModel",
-            "base_url": "http://localhost:11434",
-        },
-    )
-
-    assert isinstance(provider, OllamaProvider)
-
-
 def test_provider_from_data_dispatch_to_default_local(
     isolated_secret_dir,
 ) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -9,7 +9,6 @@ import pytest
 
 import copaw.providers.provider_manager as provider_manager_module
 from copaw.providers.anthropic_provider import AnthropicProvider
-from copaw.providers.ollama_provider import OllamaProvider
 from copaw.providers.openai_provider import OpenAIProvider
 from copaw.providers.provider import DefaultProvider, ModelInfo
 from copaw.providers.provider_manager import ProviderManager


### PR DESCRIPTION
## Description

Ollama and LMStudio usually have a small default response length, which often causes agents to hit the maximu length before completing their tasks. In previous versions, we addressed this by forcibly setting `max_tokens` in `generate_kwargs` to `null` to remove this limitation. However, PR #1170 introduced a `generate_kwargs` field with a default value of `{}`, which reverted the behavior to the original state. As a result, Ollama models are once again unable to handle complex tasks.

**Related Issue:** Fixes #1416 #1137 #1390

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
