### PR TITLE
feat(nextcloud-talk): Add Nextcloud Talk channel integration with webhook support

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -67,6 +67,15 @@ export interface MatrixConfig extends BaseChannelConfig {
   access_token: string;
 }
 
+export interface NextcloudTalkConfig extends BaseChannelConfig {
+  webhook_secret: string;
+  webhook_host: string;
+  webhook_port: number;
+  webhook_path: string;
+  username: string;
+  password: string;
+}
+
 export type ConsoleConfig = BaseChannelConfig;
 
 export interface VoiceChannelConfig extends BaseChannelConfig {
@@ -90,6 +99,7 @@ export interface ChannelConfig {
   telegram: TelegramConfig;
   mqtt: MQTTConfig;
   matrix: MatrixConfig;
+  nextcloud_talk: NextcloudTalkConfig;
   console: ConsoleConfig;
   voice: VoiceChannelConfig;
 }
@@ -104,4 +114,5 @@ export type SingleChannelConfig =
   | TelegramConfig
   | MQTTConfig
   | MatrixConfig
+  | NextcloudTalkConfig
   | VoiceChannelConfig;

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -21,6 +21,7 @@ const CHANNELS_WITH_ACCESS_CONTROL: ChannelKey[] = [
   "feishu",
   "mattermost",
   "matrix",
+  "nextcloud_talk",
 ];
 
 interface ChannelDrawerProps {
@@ -431,6 +432,60 @@ export function ChannelDrawer({
               label={t("channels.welcomeGreeting")}
             >
               <Input.TextArea rows={2} />
+            </Form.Item>
+          </>
+        );
+      case "nextcloud_talk":
+        return (
+          <>
+            <Form.Item
+              name="webhook_secret"
+              label="Webhook Secret"
+              rules={[{ required: true }]}
+              tooltip="Must match the secret used when installing the Nextcloud bot"
+            >
+              <Input.Password placeholder="Generate with: openssl rand -hex 32" />
+            </Form.Item>
+            <Form.Item
+              name="webhook_host"
+              label="Webhook Host"
+              tooltip="Listen address for the webhook server"
+            >
+              <Input placeholder="0.0.0.0" />
+            </Form.Item>
+            <Form.Item
+              name="webhook_port"
+              label="Webhook Port"
+              rules={[{ required: true }]}
+              tooltip="Port for the webhook server"
+            >
+              <InputNumber
+                min={1}
+                max={65535}
+                style={{ width: "100%" }}
+                placeholder="8765"
+              />
+            </Form.Item>
+            <Form.Item
+              name="webhook_path"
+              label="Webhook Path"
+              tooltip="Endpoint path for Nextcloud webhook"
+            >
+              <Input placeholder="/webhook/nextcloud_talk" />
+            </Form.Item>
+            <Form.Item
+              name="username"
+              label="Username"
+              tooltip="Nextcloud username for WebDAV file download (usually the bot account)"
+            >
+              <Input placeholder="copaw" />
+            </Form.Item>
+            <Form.Item
+              name="password"
+              label="Password"
+              tooltip="Nextcloud app password for WebDAV authentication"
+            >
+              <Input.Password placeholder="App password from Nextcloud Security settings" />
             </Form.Item>
           </>
         );

--- a/console/src/pages/Control/Channels/components/constants.ts
+++ b/console/src/pages/Control/Channels/components/constants.ts
@@ -12,6 +12,7 @@ export const CHANNEL_LABELS: Record<string, string> = {
   mqtt: "MQTT",
   mattermost: "Mattermost",
   matrix: "Matrix",
+  nextcloud_talk: "Nextcloud Talk",
   console: "Console",
   voice: "Twilio",
 };

--- a/console/src/pages/Control/Sessions/components/constants.ts
+++ b/console/src/pages/Control/Sessions/components/constants.ts
@@ -13,6 +13,7 @@ export const CHANNEL_COLORS: Record<string, string> = {
   telegram: "geekblue",
   mqtt: "gold",
   console: "green",
+  nextcloud_talk: "#0082c9", // Nextcloud brand blue
 } as const;
 
 /**

--- a/src/copaw/app/channels/nextcloud_talk/__init__.py
+++ b/src/copaw/app/channels/nextcloud_talk/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Nextcloud Talk channel package."""
+from .channel import NextcloudTalkChannel
+
+__all__ = ["NextcloudTalkChannel"]

--- a/src/copaw/app/channels/nextcloud_talk/channel.py
+++ b/src/copaw/app/channels/nextcloud_talk/channel.py
@@ -1,0 +1,1298 @@
+# -*- coding: utf-8 -*-
+"""Nextcloud Talk Channel.
+
+Nextcloud Talk (Spreed) Bot integration via Webhook API.
+
+Features:
+- Receive chat messages via webhook
+- Send messages/reactions via bot API
+- HMAC-SHA256 signature verification
+- Support for Markdown messages
+- Session management for proactive/cron sends
+
+Bot Installation:
+    Requires Nextcloud admin to run:
+    ./occ talk:bot:install <name> <webhook-url> [--secret=<secret>]
+
+API Documentation:
+    https://nextcloud-talk.readthedocs.io/en/latest/bots/
+"""
+
+# pylint: disable=C0301  # line-too-long
+# pylint: disable=C0413  # wrong-import-position
+# pylint: disable=W1202  # logging-format-interpolation
+# pylint: disable=C0209  # consider-using-f-string
+# pylint: disable=R0912  # too-many-branches
+# pylint: disable=R0915  # too-many-statements
+# pylint: disable=W0621  # redefined-outer-name
+# pylint: disable=W0404  # reimported
+# pylint: disable=W0611  # unused-import
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import aiohttp
+
+from ..base import (
+    BaseChannel,
+    ContentType,
+    OnReplySent,
+    ProcessHandler,
+)
+
+if TYPE_CHECKING:
+    from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
+
+from .constants import (
+    NEXTCLOUD_TALK_DEBOUNCE_SECONDS,
+    SESSION_ID_SUFFIX_LEN,
+)
+from .content_utils import (
+    NextcloudTalkContentParser,
+    session_param_from_token,
+)
+from .files_client import NextcloudFilesClient, create_nextcloud_files_client
+from .handler_stdlib import StdlibWebhookServer
+from .utils import (
+    generate_bot_signature,
+    normalize_nextcloud_url,
+    build_bot_headers,
+    get_token_store_path,
+    load_token_store,
+    save_token_store,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NextcloudTalkChannel(BaseChannel):
+    """
+    Nextcloud Talk Channel: Webhook -> Incoming -> to_agent_request ->
+    process -> send_response -> Nextcloud API.
+
+    Proactive send (stored backend_url):
+    - We store backend_url from incoming messages in memory and disk
+    - Key uses conversation token for lookup
+    - to_handle "nextcloud_talk:token:<token>" stores by conversation
+    """
+
+    channel = "nextcloud_talk"
+
+    def __init__(
+        self,
+        process: ProcessHandler,
+        enabled: bool,
+        webhook_secret: str,
+        webhook_host: str = "0.0.0.0",
+        webhook_port: int = 8765,
+        webhook_path: str = "/webhook/nextcloud_talk",
+        bot_prefix: str = "[BOT] ",
+        username: str = "",
+        password: str = "",
+        media_dir: str = "~/.copaw/media/nextcloud_talk",
+        on_reply_sent: OnReplySent = None,
+        show_tool_details: bool = True,
+        filter_tool_messages: bool = False,
+        filter_thinking: bool = False,
+    ):
+        super().__init__(
+            process,
+            on_reply_sent=on_reply_sent,
+            show_tool_details=show_tool_details,
+            filter_tool_messages=filter_tool_messages,
+            filter_thinking=filter_thinking,
+        )
+        self.enabled = enabled
+        self.webhook_secret = webhook_secret
+
+        # Store credentials for file downloads
+        self.nc_username = username
+        self.nc_password = password
+
+        # Setup media directory for downloaded files
+        self._media_dir = Path(media_dir).expanduser()
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+
+        # Log secret length for debugging (don't log the actual secret)
+        logger.info(
+            f"nextcloud_talk channel initialized: "
+            f"enabled={enabled} secret_len={len(webhook_secret)} "
+            f"host={webhook_host} port={webhook_port}",
+        )
+        self.webhook_host = webhook_host
+        self.webhook_port = webhook_port
+        self.webhook_path = webhook_path or "/webhook/nextcloud_talk"
+        self.bot_prefix = bot_prefix
+
+        # Webhook server (using Python standard library, no FastAPI)
+        self._webhook_server: Optional[StdlibWebhookServer] = None
+
+        # HTTP client (using aiohttp - already used by other channels)
+        self._http: Optional[aiohttp.ClientSession] = None
+
+        # Backend URL store for proactive sends
+        # Maps conversation/token suffix to backend URL for cron jobs
+        self._backend_url_store: Dict[str, str] = {}
+        self._backend_url_lock = asyncio.Lock()
+
+        # Time debounce (disabled, manager handles)
+        self._debounce_seconds = 0.0
+
+        # API user for WebDAV access
+        # This is the bot account username used to construct WebDAV
+        # URLs for downloading files via
+        # /remote.php/dav/files/{api_user}/{file_path}
+        # Use username as api_user for WebDAV access
+        self.api_user = username
+
+        # Rate limiting: track last send time per session
+        self._last_send_time: Dict[str, float] = {}
+        self._send_lock = asyncio.Lock()
+
+        # Minimum interval between sends (seconds)
+        self._min_send_interval = 2.0
+
+    @classmethod
+    def from_env(
+        cls,
+        process: ProcessHandler,
+        on_reply_sent: OnReplySent = None,
+    ) -> "NextcloudTalkChannel":
+        return cls(
+            process=process,
+            enabled=os.getenv("NEXTCLOUD_TALK_CHANNEL_ENABLED", "1") == "1",
+            webhook_secret=os.getenv("NEXTCLOUD_TALK_WEBHOOK_SECRET", ""),
+            webhook_host=os.getenv("NEXTCLOUD_TALK_WEBHOOK_HOST", "0.0.0.0"),
+            webhook_port=int(os.getenv("NEXTCLOUD_TALK_WEBHOOK_PORT", "8765")),
+            webhook_path=os.getenv(
+                "NEXTCLOUD_TALK_WEBHOOK_PATH",
+                "/webhook/nextcloud_talk",
+            ),
+            bot_prefix=os.getenv("NEXTCLOUD_TALK_BOT_PREFIX", "[BOT] "),
+            username=os.getenv("NEXTCLOUD_USERNAME", ""),
+            password=os.getenv("NEXTCLOUD_PASSWORD", ""),
+            on_reply_sent=on_reply_sent,
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        process: ProcessHandler,
+        config: Any,
+        on_reply_sent: OnReplySent = None,
+        show_tool_details: bool = True,
+        filter_tool_messages: bool = False,
+        filter_thinking: bool = False,
+    ) -> "NextcloudTalkChannel":
+        return cls(
+            process=process,
+            enabled=config.enabled,
+            webhook_secret=getattr(config, "webhook_secret", ""),
+            webhook_host=getattr(config, "webhook_host", "0.0.0.0"),
+            webhook_port=getattr(config, "webhook_port", 8765),
+            webhook_path=getattr(
+                config,
+                "webhook_path",
+                "/webhook/nextcloud_talk",
+            ),
+            bot_prefix=getattr(config, "bot_prefix", "[BOT] "),
+            username=getattr(config, "username", ""),
+            password=getattr(config, "password", ""),
+            on_reply_sent=on_reply_sent,
+            show_tool_details=show_tool_details,
+            filter_tool_messages=filter_tool_messages,
+            filter_thinking=filter_thinking,
+        )
+
+    # ---------------------------
+    # Session and backend URL management
+    # ---------------------------
+
+    def resolve_session_id(
+        self,
+        sender_id: str,
+        channel_meta: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Session_id = conversation token for consistent conversation tracking.
+        """
+        meta = channel_meta or {}
+        conversation_token = meta.get("conversation_token", "")
+        if conversation_token:
+            # Use conversation token as session
+            return f"{self.channel}:{conversation_token}"
+        return f"{self.channel}:{sender_id}"
+
+    def get_debounce_key(self, payload: Any) -> str:
+        """Use conversation_token for debouncing."""
+        if isinstance(payload, dict):
+            token = (payload.get("meta") or {}).get("conversation_token", "")
+            return token or payload.get("sender_id", "")
+        return ""
+
+    def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
+        """
+        Resolve cron dispatch target to channel-specific to_handle.
+
+        Format: "nextcloud_talk:token:<conversation_token>"
+        """
+        # session_id format: "nextcloud_talk:<conversation_token>"
+        if session_id and session_id.startswith(f"{self.channel}:"):
+            token = session_id[len(self.channel) + 1 :]
+            return f"nextcloud_talk:token:{token}"
+        return f"nextcloud_talk:token:{user_id}"
+
+    def _route_from_handle(self, to_handle: str) -> dict:
+        """
+        Parse to_handle to extract conversation token and backend URL.
+
+        Supported formats:
+        - "nextcloud_talk:token:<token>" -> lookup backend URL from store
+        - "http://..." -> direct backend URL
+        """
+        s = (to_handle or "").strip()
+
+        # Direct URL
+        if s.startswith("http://") or s.startswith("https://"):
+            return {"backend_url": s}
+
+        # Token format
+        if s.startswith("nextcloud_talk:token:"):
+            token = s[len("nextcloud_talk:token:") :]
+            return {"conversation_token": token}
+
+        return {}
+
+    async def _save_backend_url(
+        self,
+        conversation_token: str,
+        backend_url: str,
+    ) -> None:
+        """Store backend URL for a conversation."""
+        if not conversation_token or not backend_url:
+            return
+
+        # Generate key from token suffix (same as session_id suffix)
+        key = session_param_from_token(conversation_token)
+
+        async with self._backend_url_lock:
+            self._backend_url_store[key] = backend_url
+
+        logger.debug(f"saved backend_url for token_suffix={key}")
+
+    async def _get_backend_url_from_token(
+        self,
+        conversation_token: str,
+    ) -> Optional[str]:
+        """
+        Lookup backend URL for a conversation token.
+
+        Uses token suffix for lookup (consistent with session_id).
+        """
+        key = session_param_from_token(conversation_token)
+
+        async with self._backend_url_lock:
+            return self._backend_url_store.get(key)
+
+    # ---------------------------
+    # Build AgentRequest from native
+    # ---------------------------
+
+    def build_agent_request_from_native(
+        self,
+        native_payload: Any,
+    ) -> Any:
+        """
+        Build AgentRequest from Nextcloud Talk native dict.
+        """
+        payload = native_payload if isinstance(native_payload, dict) else {}
+        channel_id = payload.get("channel_id") or self.channel
+        sender_id = payload.get("sender_id") or ""
+        content_parts = payload.get("content_parts") or []
+        meta = dict(payload.get("meta") or {})
+
+        # Fix: Ensure file content_parts have file_url populated from metadata
+        # Use file_url field instead of source.url, because Message construction  # noqa: E501
+        # converts dict to FileContent and only recognizes file_url attribute
+        converted_parts = []
+        for part in content_parts:
+            if isinstance(part, dict) and part.get("type") == "file":
+                # Check if file_url is already set (e.g., local path from
+                # webhook handler)
+                existing_file_url = part.get("file_url")
+
+                metadata = part.get("metadata", {})
+                share_link = metadata.get("share-token") or metadata.get(
+                    "link",
+                )
+
+                logger.info(
+                    "Processing file: filename={}, "
+                    "existing_file_url={}, metadata_keys={}, "
+                    "share_link={}".format(
+                        part.get("filename"),
+                        existing_file_url,
+                        list(metadata.keys()),
+                        share_link,
+                    ),
+                )
+
+                # Build dict with file_url field for FileContent conversion
+                # Message constructor will convert this to FileContent with
+                # file_url set
+
+                # Prefer existing file_url (local path), then WebDAV URL, then
+                # share link
+                webdav_url = metadata.get("webdav_url")
+                share_link = metadata.get("share-token") or metadata.get(
+                    "link",
+                )
+
+                file_part = {
+                    "type": "file",
+                    "filename": part.get("file_name")
+                    or part.get("filename", ""),
+                }
+
+                # Preserve file_type if already set (e.g., "image", "video",
+                # "audio")
+                if part.get("file_type"):
+                    file_part["file_type"] = part.get("file_type")
+
+                # Use existing file_url if available (local path from download)
+                if existing_file_url:
+                    file_part["file_url"] = existing_file_url
+                    logger.info(
+                        "Using existing file_url (local path) for "
+                        "file: {} -> {}".format(
+                            file_part.get("filename"),
+                            existing_file_url,
+                        ),
+                    )
+                elif webdav_url:
+                    file_part["file_url"] = webdav_url
+                    logger.info(
+                        "Populated file_url with WebDAV URL for "
+                        "file: {} -> {}".format(
+                            file_part.get("filename"),
+                            webdav_url,
+                        ),
+                    )
+                elif share_link:
+                    file_part["file_url"] = share_link
+                    logger.info(
+                        "Populated file_url for file: {} -> {}".format(
+                            file_part.get("filename"),
+                            share_link,
+                        ),
+                    )
+                else:
+                    logger.warning(
+                        f"No WebDAV URL or share link found for file: {file_part.get('filename')}",  # noqa: E501
+                    )
+
+                converted_parts.append(file_part)
+            else:
+                # Keep other content parts as-is
+                converted_parts.append(part)
+
+        content_parts = converted_parts
+        logger.info(
+            f"build_agent_request_from_native: final content_parts={content_parts}",  # noqa: E501
+        )
+
+        # Extract and store backend URL for proactive sends
+        backend_url = meta.get("backend_url") or payload.get(
+            "session_webhook",
+            "",
+        )
+        conversation_token = meta.get("conversation_token", "")
+        if backend_url and conversation_token:
+            asyncio.create_task(
+                self._save_backend_url(conversation_token, backend_url),
+            )
+
+        session_id = self.resolve_session_id(sender_id, meta)
+
+        request = self.build_agent_request_from_user_content(
+            channel_id=channel_id,
+            sender_id=sender_id,
+            session_id=session_id,
+            content_parts=content_parts,
+            channel_meta=meta,
+        )
+
+        # Preserve original content_parts in meta for later use
+        if meta is None:
+            meta = {}
+        meta["original_content_parts"] = content_parts
+
+        if hasattr(request, "channel_meta"):
+            request.channel_meta = meta
+
+        # 检查request中的实际内容
+        has_actual_content = False
+        if hasattr(request, "input") and request.input:
+            first_msg = request.input[0]
+            if hasattr(first_msg, "content") and first_msg.content:
+                has_actual_content = True
+                logger.info(
+                    f"build_agent_request_from_native: request has content: {[getattr(c, 'type', 'unknown') for c in first_msg.content]}",  # noqa: E501
+                )
+
+        logger.info(
+            f"build_agent_request_from_native: request created, has content_parts={has_actual_content}",  # noqa: E501
+        )
+        return request
+
+    # ---------------------------
+    # Message processing
+    # ---------------------------
+
+    def _content_has_media(self, content_parts: List[Any]) -> bool:
+        """
+        Check if content_parts has media files (images, videos, audio).
+        """
+        if not content_parts:
+            return False
+        for c in content_parts:
+            # Check type attribute
+            t = getattr(c, "type", None)
+
+            # Case 1: type is string 'file'
+            if t == "file":
+                return True
+
+            # Case 2: type is ContentType.FILE enum (if available)
+            try:
+                from agentscope_runtime.engine.schemas.message_schemas import (
+                    ContentType,
+                )
+
+                if t == ContentType.FILE:
+                    return True
+            except ImportError:
+                # If the module is not available, skip this check
+                pass
+
+            # Case 3: type has name attribute (Enum)
+            if hasattr(t, "name") and t.name == "FILE":
+                return True
+
+            # Case 4: dict format
+            if isinstance(c, dict) and c.get("type") == "file":
+                return True
+        return False
+
+    def _apply_no_text_debounce(
+        self,
+        session_id: str,
+        content_parts: List[Any],
+    ) -> tuple[bool, List[Any]]:
+        """
+        Override base class: process media files immediately even without text.
+        Only debounce when there's no text AND no media.
+        """
+        logger.info(
+            f"_apply_no_text_debounce: called with content_parts={content_parts}",  # noqa: E501
+        )
+
+        # If has media, process immediately
+        if self._content_has_media(content_parts):
+            logger.info("Media detected, processing immediately")
+            return (True, list(content_parts))
+
+        # Otherwise use default logic (debounce if no text)
+        result = super()._apply_no_text_debounce(session_id, content_parts)
+        logger.info(f"_apply_no_text_debounce: result={result}")
+        return result
+
+    def _setup_webhook_server(self):
+        """Setup webhook server using Python standard library."""
+        self._webhook_server = StdlibWebhookServer(
+            host=self.webhook_host,
+            port=self.webhook_port,
+            webhook_path=self.webhook_path,
+        )
+
+        # Set callback and config
+        self._webhook_server.set_enqueue_callback(self.consume_one)
+        self._webhook_server.set_webhook_secret(self.webhook_secret)
+        self._webhook_server.set_bot_prefix(self.bot_prefix)
+        self._webhook_server.set_api_user(self.api_user)
+        self._webhook_server.set_credentials(
+            self.nc_username,
+            self.nc_password,
+        )
+
+    # ---------------------------
+    # Lifecycle
+    # ---------------------------
+
+    async def consume_one(self, payload: Any) -> None:
+        """
+        Process one payload from the manager-owned queue.
+        """
+        logger.info(f"consume_one: CALLED with payload type={type(payload)}")
+        await super().consume_one(payload)
+
+    async def _consume_one_request(self, payload: Any) -> None:
+        """
+        Convert payload to request, apply no-text debounce, run _process,
+        send messages, handle errors and on_reply_sent.
+        """
+        logger.info(
+            f"_consume_one_request: CALLED with payload type={type(payload)}",
+        )
+
+        # Call parent implementation
+        await super()._consume_one_request(payload)
+
+        logger.info("_consume_one_request: COMPLETED")
+
+    async def start(self) -> None:
+        if not self.enabled:
+            logger.debug("nextcloud_talk channel disabled")
+            return
+
+        # Load backend URL store from disk
+        self._backend_url_store = load_token_store() or {}
+
+        # Create HTTP session (aiohttp is already used by other channels)
+        self._http = aiohttp.ClientSession()
+
+        # Setup and start webhook server (using stdlib, no new dependency)
+        self._setup_webhook_server()
+        self._webhook_server.start()
+
+        logger.info(
+            f"nextcloud_talk channel started: webhook at "
+            f"{self.webhook_host}:{self.webhook_port}{self.webhook_path}",
+        )
+
+    async def stop(self) -> None:
+        if not self.enabled:
+            return
+
+        # Stop webhook server
+        if self._webhook_server:
+            self._webhook_server.stop()
+            self._webhook_server = None
+
+        # Close HTTP session
+        if self._http:
+            await self._http.close()
+            self._http = None
+
+        # Persist the backend URL store for cron jobs
+        if self._backend_url_store:
+            try:
+                save_token_store(self._backend_url_store)
+                logger.info(
+                    f"persisted backend_url_store with {len(self._backend_url_store)} entries",  # noqa: E501
+                )
+            except Exception:
+                logger.exception("failed to persist backend_url_store")
+
+        logger.info("nextcloud_talk channel stopped")
+
+    # ---------------------------
+    # Sending messages
+    # ---------------------------
+
+    async def send(
+        self,
+        to_handle: str,
+        text: str,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send a message to Nextcloud Talk.
+
+        NOTE: This endpoint expects the webhook_secret to be configured
+        in the config.json file. The bot must use the same secret that
+        was used during installation.
+
+        The backend URL and conversation token must be properly configured.
+        """
+        if not self.enabled:
+            return
+
+        if not self._http:
+            logger.warning("nextcloud_talk http session not available")
+            return
+
+        # Rate limiting: ensure minimum interval between sends
+        session_id = to_handle
+        async with self._send_lock:
+            last_time = self._last_send_time.get(session_id, 0)
+            current_time = asyncio.get_event_loop().time()
+            elapsed = current_time - last_time
+
+            if elapsed < self._min_send_interval:
+                delay = self._min_send_interval - elapsed
+                logger.debug(
+                    f"nextcloud_talk rate limiting: waiting {delay:.1f}s before sending",  # noqa: E501
+                )
+                await asyncio.sleep(delay)
+
+            self._last_send_time[session_id] = asyncio.get_event_loop().time()
+
+        # Truncate message if too long (Nextcloud Talk has message length
+        # limits)
+        max_length = 4000  # Reasonable limit for chat messages
+        if len(text) > max_length:
+            text = text[: max_length - 3] + "..."
+            logger.warning(
+                f"nextcloud_talk message truncated to {max_length} chars",
+            )
+
+        # Get conversation token from meta
+        meta = meta or {}
+        meta_token = meta.get("conversation_token", "")
+
+        # Resolve backend URL and token
+        route = self._route_from_handle(to_handle)
+
+        # Try to get backend URL from meta
+        backend_url = meta.get("backend_url") or meta.get(
+            "session_webhook",
+            "",
+        )
+
+        # If not in meta, try lookup from token
+        if not backend_url and "conversation_token" in route:
+            token = route["conversation_token"]
+            backend_url = await self._get_backend_url_from_token(token)
+            if not backend_url:
+                # Use meta_token as fallback
+                if meta_token:
+                    backend_url = await self._get_backend_url_from_token(
+                        meta_token,
+                    )
+
+        if not backend_url:
+            logger.warning(
+                f"nextcloud_talk cannot send: no backend_url for to_handle={to_handle}",  # noqa: E501
+            )
+            return
+
+        # Get conversation token (for API request)
+        conversation_token = route.get("conversation_token", meta_token)
+
+        if not conversation_token:
+            logger.warning(
+                f"nextcloud_talk cannot send: no conversation token for to_handle={to_handle}",  # noqa: E501
+            )
+            return
+
+        # Normalize backend URL
+        backend_url = normalize_nextcloud_url(backend_url)
+
+        # Build request body following Nextcloud Talk Bot API spec:
+        # { "message": "<text>" }
+        # Note: conversation token is in the URL path, not body
+        body = {
+            "message": text,
+        }
+        body_str = json.dumps(body, ensure_ascii=False, separators=(",", ":"))
+
+        # Generate signature on the message text (not full JSON body)
+        # According to Nextcloud Talk Bot API verification logic:
+        # signature = HMAC(random_header + message_text, secret)
+        headers = build_bot_headers(self.webhook_secret, text)
+
+        headers.update(
+            {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+
+        # Send message
+        url = f"{backend_url}ocs/v2.php/apps/spreed/api/v1/bot/{conversation_token}/message"  # noqa: E501
+
+        # Debug logging - show full values for verification
+        random_val = headers.get("X-Nextcloud-Talk-Bot-Random", "N/A")
+        signature_val = headers.get("X-Nextcloud-Talk-Bot-Signature", "N/A")
+        logger.info(
+            f"nextcloud_talk send: url={url} "
+            f"secret_len={len(self.webhook_secret)} "
+            f"random={random_val} "
+            f"signature={signature_val} "
+            f"body={body_str}",
+        )
+
+        try:
+            # Use data=body_str to ensure exact same body is sent (for signature verification)  # noqa: E501
+            # 创建新的ClientSession避免继承的timeout配置问题
+            import aiohttp
+
+            timeout = aiohttp.ClientTimeout(total=30)  # 30秒超时
+            async with aiohttp.ClientSession(timeout=timeout) as temp_session:
+                resp = await temp_session.post(
+                    url,
+                    data=body_str.encode("utf-8"),
+                    headers=headers,
+                )
+                resp_text = await resp.text()
+
+            if resp.status >= 400:
+                logger.warning(
+                    f"nextcloud_talk send failed: status={resp.status} "
+                    f"url={url} "
+                    f"secret_len={len(self.webhook_secret)} "
+                    f"body={resp_text[:200]}",
+                )
+                return
+
+            # Try to parse JSON response
+            try:
+                resp_data = json.loads(resp_text) if resp_text else {}
+            except json.JSONDecodeError:
+                resp_data = {}
+
+            ocs = resp_data.get("ocs", {})
+            resp_meta = ocs.get("meta", {})
+
+            if resp_meta.get("statuscode") != 200:
+                logger.warning(
+                    f"nextcloud_talk send API error: "
+                    f"statuscode={resp_meta.get('statuscode')} "
+                    f"message={resp_meta.get('message')}",
+                )
+                return
+
+            logger.info(
+                f"nextcloud_talk send ok: conversation={conversation_token} len={len(text)}",  # noqa: E501
+            )
+
+        except Exception:
+            logger.exception(
+                f"nextcloud_talk send failed for conversation={conversation_token}",  # noqa: E501
+            )
+
+    async def send_content_parts(
+        self,
+        to_handle: str,
+        parts: List[Any],
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send content parts (text, images, etc.) to Nextcloud Talk.
+
+        Supports text, images, videos, and audio files.
+        For media files, combines text with media links following OpenClaw pattern.  # noqa: E501
+        """
+        # Extract text parts
+        text_parts = []
+        media_parts = []
+
+        for p in parts:
+            t = getattr(p, "type", None)
+            if t == ContentType.TEXT and getattr(p, "text", None):
+                text_parts.append(p.text or "")
+            elif t == ContentType.REFUSAL and getattr(p, "refusal", None):
+                text_parts.append(p.refusal or "")
+            elif t in (
+                ContentType.IMAGE,
+                ContentType.VIDEO,
+                ContentType.AUDIO,
+                ContentType.FILE,
+            ):
+                media_parts.append(p)
+
+        # Build main text body
+        body = "\n".join(text_parts) if text_parts else ""
+        prefix = (meta or {}).get("bot_prefix", "")
+        if prefix and body:
+            body = prefix + body
+        elif prefix and not body:
+            body = prefix
+
+        # Add media attachments following OpenClaw pattern
+        for m in media_parts:
+            t = getattr(m, "type", None)
+            if t == ContentType.FILE:
+                # For file content, extract file information
+                file_name = getattr(m, "filename", "unknown_file")
+                file_url = getattr(m, "file_url", None)
+                if file_url:
+                    body += f"\n\nAttachment: {file_name} - {file_url}"
+                else:
+                    # Fallback to file name only
+                    body += f"\n\nFile: {file_name}"
+            elif t == ContentType.IMAGE and getattr(m, "image_url", None):
+                body += f"\n\nImage: {m.image_url}"
+            elif t == ContentType.VIDEO and getattr(m, "video_url", None):
+                body += f"\n\nVideo: {m.video_url}"
+            elif t == ContentType.AUDIO:
+                body += "\n\nAudio attachment"
+
+        if body.strip():
+            await self.send(to_handle, body.strip(), meta)
+
+    async def _build_media_message(
+        self,
+        file_info: Dict[str, Any],
+        backend_url: str,
+    ) -> str:
+        """
+        Build a message for media file sharing.
+
+        Args:
+            file_info: File information from extract_media_file
+            backend_url: Nextcloud backend URL
+
+        Returns:
+            Formatted message string
+        """
+        media_type = file_info.get("type", "file")
+        file_name = file_info.get("name", "unknown")
+        file_size = file_info.get("size", 0)
+        # mime_type not used
+        file_path = file_info.get("path", "")
+        metadata = file_info.get("metadata", {})
+        preview_available = file_info.get("preview_available", False)
+
+        # Format file size
+        if file_size > 1024 * 1024:
+            size_str = f"{file_size / (1024 * 1024):.1f} MB"
+        elif file_size > 1024:
+            size_str = f"{file_size / 1024:.1f} KB"
+        else:
+            size_str = f"{file_size} B"
+
+        # Determine emoji based on type
+        emoji_map = {
+            "image": "🖼️",
+            "video": "🎥",
+            "audio": "🎵",
+        }
+        emoji = emoji_map.get(media_type, "📄")
+
+        # Get additional metadata for better description
+        width = metadata.get("width", "")
+        height = metadata.get("height", "")
+        duration = metadata.get("duration", "")
+
+        # Build dimension/duration info
+        extra_info = []
+        if width and height and media_type == "image":
+            extra_info.append(f"{width}×{height}px")
+        elif duration and media_type in ["video", "audio"]:
+            # Format duration nicely
+            try:
+                dur_seconds = int(float(duration))
+                minutes = dur_seconds // 60
+                seconds = dur_seconds % 60
+                if minutes > 0:
+                    extra_info.append(f"{minutes}m{seconds}s")
+                else:
+                    extra_info.append(f"{seconds}s")
+            except (ValueError, TypeError):
+                pass
+
+        # Try to get share link from metadata
+        share_token = (
+            metadata.get("share-token")
+            or metadata.get("token")
+            or metadata.get("link")
+        )
+        if share_token:
+            # Use public share link
+            try:
+                files_client = NextcloudFilesClient(backend_url)
+                share_link = await files_client.get_public_share_link(
+                    share_token,
+                    file_path,
+                )
+                if share_link:
+                    info_part = f"**{file_name}** ({size_str})"
+                    if extra_info:
+                        info_part += f" [{', '.join(extra_info)}]"
+                    # 修复链接格式问题
+                    clean_link = (
+                        share_link.split("/files?")[0]
+                        if "/files?" in share_link
+                        else share_link
+                    )
+                    # 更友好的文件分享消息格式
+                    return (
+                        f"{emoji} 用户分享了一个文件：{info_part}\n🔗 点击链接查看：{clean_link}"
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to get share link: {e}")
+
+        # Fallback: just describe the file with preview info
+        type_names = {
+            "image": "图片",
+            "video": "视频",
+            "audio": "音频文件",
+        }
+        type_name = type_names.get(media_type, "文件")
+
+        info_part = f"**{file_name}** ({size_str})"
+        if extra_info:
+            info_part += f" [{', '.join(extra_info)}]"
+
+        preview_status = "✅ 可预览" if preview_available else "❌ 无预览"
+
+        # 更友好的文件描述消息
+        return f"{emoji} 用户分享了{type_name}：{info_part} ({preview_status})"
+
+    async def _handle_media_content_parts(
+        self,
+        to_handle: str,
+        parts: list,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Handle media content parts (files, images, videos, audio).
+
+        Args:
+            to_handle: Destination handle
+            parts: List of content parts with file information
+            meta: Additional metadata
+        """
+        backend_url = (meta or {}).get("backend_url", "")
+        if not backend_url:
+            logger.warning("Cannot handle media file: no backend_url")
+            return
+
+        # Try to get original content_parts from meta first
+        original_parts = (meta or {}).get("original_content_parts", [])
+        if original_parts:
+            parts = original_parts
+            logger.info(
+                f"Using original content_parts: {[p.get('file_name', 'unknown') if isinstance(p, dict) else 'FileContent' for p in parts]}",  # noqa: E501
+            )
+        else:
+            # Fallback: try to get from request content if parts are
+            # FileContent objects
+            logger.info(
+                "No original content_parts in meta, using current parts",
+            )
+            logger.info(
+                f"Current parts type: {[type(p).__name__ for p in parts]}",
+            )
+            for i, part in enumerate(parts):
+                logger.info(f"Part {i}: {part}")
+
+        for part in parts:
+            part_type = (
+                getattr(part, "type", None)
+                if hasattr(part, "type")
+                else part.get("type")
+            )
+
+            # Handle both dict and FileContent object
+            is_file = (
+                (
+                    hasattr(part, "type")
+                    and hasattr(part.type, "name")
+                    and part.type.name == "FILE"
+                )
+                or (hasattr(part, "type") and part.type == ContentType.FILE)
+                or part_type == "file"
+                or part_type == ContentType.FILE
+            )
+
+            if is_file:
+                # Extract file information from FileContent object or dict
+                # Handle both FileContent objects and dictionaries
+                if hasattr(part, "__dict__"):
+                    # FileContent object - try multiple attribute names
+                    logger.info(f"FileContent attributes: {dir(part)}")
+
+                    # Debug: Check actual attribute values
+                    filename_val = getattr(part, "filename", "NOT_FOUND")
+                    file_name_val = getattr(part, "file_name", "NOT_FOUND")
+                    logger.info(f"filename attribute value: {filename_val}")
+                    logger.info(f"file_name attribute value: {file_name_val}")
+
+                    file_info = {
+                        "type": getattr(part, "file_type", None)
+                        or getattr(part, "type", "file"),
+                        "name": getattr(part, "file_name", None)
+                        or getattr(part, "filename", None)
+                        or "unknown",
+                        "path": getattr(part, "file_path", None)
+                        or getattr(part, "filepath", None)
+                        or getattr(part, "path", ""),
+                        "size": getattr(part, "size", 0),
+                        "mime_type": getattr(part, "mime_type", None)
+                        or getattr(part, "mimetype", ""),
+                        "preview_available": getattr(
+                            part,
+                            "preview_available",
+                            False,
+                        ),
+                        "metadata": getattr(part, "metadata", {}),
+                    }
+                    logger.info(
+                        f"Extracted file_info: name={file_info['name']}, size={file_info['size']}",  # noqa: E501
+                    )
+                else:
+                    # Dictionary format
+                    file_info = {
+                        "type": part.get(
+                            "file_type",
+                            part.get("type", "file"),
+                        ),
+                        "name": part.get(
+                            "file_name",
+                            part.get("filename", "unknown"),
+                        ),
+                        "path": part.get(
+                            "file_path",
+                            part.get("filepath", ""),
+                        ),
+                        "size": part.get("size", 0),
+                        "mime_type": part.get("mime_type", ""),
+                        "preview_available": part.get(
+                            "preview_available",
+                            False,
+                        ),
+                        "metadata": part.get("metadata", {}),
+                    }
+
+                logger.info(f"Handling media file: {file_info['name']}")
+
+                # Build and send media message
+                media_message = await self._build_media_message(
+                    file_info,
+                    backend_url,
+                )
+                await self.send(to_handle, media_message, meta)
+
+    async def _run_process_loop(
+        self,
+        request: "AgentRequest",
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """
+        Override _run_process_loop to batch messages for rate limiting.
+        Nextcloud Talk Bot API has rate limits, so we collect all messages
+        and send them at the end as a single message.
+        Also handles media files (images, videos, audio).
+        """
+        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
+
+        logger.info(f"_run_process_loop: STARTED for to_handle={to_handle}")
+
+        # session_id not used, "session_id", "") or ""
+        bot_prefix = send_meta.get("bot_prefix", "") or getattr(
+            self,
+            "bot_prefix",
+            "",
+        )
+
+        # Check if this is a media file request
+        # content_parts are stored in request.input[0].content (Message.content)  # noqa: E501
+        # But we should use the original content_parts from the payload to
+        # preserve file info
+        content_parts = []
+
+        # First try to get from original payload meta (preserved original dict
+        # data)
+        original_content_parts = (send_meta or {}).get(
+            "original_content_parts",
+            [],
+        )
+        if original_content_parts:
+            content_parts = original_content_parts
+            logger.info(
+                f"Using preserved original content_parts: {len(content_parts)} items",  # noqa: E501
+            )
+        else:
+            # Fallback: try to extract from request input
+            if (
+                hasattr(request, "input")
+                and request.input
+                and len(request.input) > 0
+            ):
+                first_message = request.input[0]
+                if hasattr(first_message, "content"):
+                    content_parts = first_message.content or []
+                    logger.info(
+                        f"Using request content: {len(content_parts)} items",
+                    )
+
+            # Last resort: try to get file info directly from send_meta
+            if not content_parts and send_meta:
+                # Look for file information in meta
+                file_info = send_meta.get("file_info")
+                if file_info:
+                    content_parts = [file_info]
+                    logger.info(f"Using file_info from meta: {file_info}")
+
+        logger.info(
+            f"_run_process_loop: content_parts from message.content={content_parts}",  # noqa: E501
+        )
+
+        # Convert dict content_parts to runtime Content objects if needed
+        # But preserve original dict data for media files to avoid property
+        # loss
+        converted_parts = []
+        for p in content_parts:
+            if isinstance(p, dict):
+                # Convert dict to appropriate Content type
+                part_type = p.get("type")
+                if part_type == "file":
+                    # For media files, keep the original dict to preserve all
+                    # properties
+                    converted_parts.append(p)  # Keep as dict
+                elif part_type == "text":
+                    from agentscope_runtime.engine.schemas.message_schemas import (  # noqa: E501
+                        TextContent,
+                    )
+
+                    converted_parts.append(
+                        TextContent(
+                            type=ContentType.TEXT,
+                            text=p.get("text", ""),
+                        ),
+                    )
+                else:
+                    logger.warning(f"Unknown content part type: {part_type}")
+                    converted_parts.append(p)  # Keep original
+            else:
+                converted_parts.append(p)
+
+        content_parts = converted_parts
+        logger.info(
+            f"_run_process_loop: converted content_parts={content_parts}",
+        )
+
+        has_media = any(
+            (
+                getattr(p, "type", None) == ContentType.FILE
+                or (
+                    hasattr(p, "type")
+                    and getattr(p.type, "name", None) == "FILE"
+                )
+                or (isinstance(p, dict) and p.get("type") == "file")
+            )
+            for p in content_parts
+        )
+        logger.info(f"_run_process_loop: has_media={has_media}")
+
+        # 移除直接的媒体处理，让Agent参与处理包含媒体文件的消息
+        # if has_media:
+        #     # Handle media files directly
+        #     await self._handle_media_content_parts(to_handle, content_parts, send_meta)  # noqa: E501
+        #     return
+
+        # Collect all messages
+        all_messages: List[str] = []
+        last_response = None
+
+        try:
+            async for event in self._process(request):
+                obj = getattr(event, "object", None)
+                status = getattr(event, "status", None)
+
+                if obj == "message" and status == RunStatus.Completed:
+                    # Extract text from event
+                    text = self._extract_text_from_event(event)
+                    if text:
+                        all_messages.append(text)
+
+                elif obj == "response":
+                    last_response = event
+                    await self.on_event_response(request, event)
+
+            # Send all collected messages as a single message
+            if all_messages:
+                final_message = "\n\n".join(all_messages)
+                if bot_prefix:
+                    final_message = bot_prefix + final_message
+                await self.send(to_handle, final_message, send_meta)
+
+            if last_response and getattr(last_response, "error", None):
+                err = getattr(
+                    last_response.error,
+                    "message",
+                    str(last_response.error),
+                )
+                err_text = (bot_prefix or "") + f"Error: {err}"
+                await self._on_consume_error(request, to_handle, err_text)
+
+            if self._on_reply_sent:
+                args = self.get_on_reply_sent_args(request, to_handle)
+                self._on_reply_sent(self.channel, *args)
+
+        except Exception:
+            logger.exception("channel consume_one failed")
+            await self._on_consume_error(
+                request,
+                to_handle,
+                "An error occurred while processing your request.",
+            )
+
+    def _extract_text_from_event(self, event: Any) -> str:
+        """Extract text content from a message event.
+
+        For Nextcloud Talk, we filter out technical details like tool calls
+        and only return the final user-facing message.
+        """
+        # Try to get content from event
+        content = getattr(event, "content", None)
+        if not content:
+            return ""
+
+        # Check if this is a tool call message (contains 🔧 or similar markers)
+        full_text = ""
+        for part in content:
+            part_type = getattr(part, "type", None)
+            if part_type == "text":
+                text = getattr(part, "text", "")
+                if text:
+                    full_text += text
+            elif part_type == "refusal":
+                refusal = getattr(part, "refusal", "")
+                if refusal:
+                    full_text += refusal
+
+        # Filter out technical messages (tool calls, errors, etc.)
+        # Only keep messages that don't look like technical internals
+        if full_text:
+            # Skip tool call messages (contain 🔧 or specific patterns)
+            if "🔧 **" in full_text and "**\n```" in full_text:
+                return ""  # Skip tool call messages
+
+            # Skip error messages that are internal
+            if full_text.startswith("✅ **") and "Error:" in full_text:
+                return ""  # Skip internal error messages
+
+            # Skip thinking/planning messages
+            if (
+                any(
+                    pattern in full_text
+                    for pattern in [
+                        "用户问",
+                        "我可以",
+                        "让我",
+                        "我需要",
+                        "我应该",
+                        "我来",
+                        "思考一下",
+                        "计算一下",
+                    ]
+                )
+                and len(full_text) < 100
+            ):
+                # This looks like internal thinking, skip it
+                return ""
+
+            return full_text
+
+        return ""

--- a/src/copaw/app/channels/nextcloud_talk/constants.py
+++ b/src/copaw/app/channels/nextcloud_talk/constants.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Nextcloud Talk channel constants."""
+
+# HTTP header names for incoming webhook requests
+HEADER_SIGNATURE = "X-Nextcloud-Talk-Signature"
+HEADER_RANDOM = "X-Nextcloud-Talk-Random"
+HEADER_BACKEND = "X-Nextcloud-Talk-Backend"
+
+# Signature length (SHA256 hex digest)
+SIGNATURE_LENGTH = 64
+
+# Random string length
+RANDOM_LENGTH = 64
+
+# Time debounce (300ms)
+NEXTCLOUD_TALK_DEBOUNCE_SECONDS = 0.3
+
+# Session ID suffix length (for cron compatibility)
+SESSION_ID_SUFFIX_LEN = 8
+
+# Activity Streams types
+ACTIVITY_TYPE_CREATE = "Create"
+ACTIVITY_TYPE_JOIN = "Join"
+ACTIVITY_TYPE_LEAVE = "Leave"
+ACTIVITY_TYPE_LIKE = "Like"
+ACTIVITY_TYPE_UNDO = "Undo"
+
+# Actor types
+ACTOR_TYPE_PERSON = "Person"
+ACTOR_TYPE_APPLICATION = "Application"
+ACTOR_TYPE_BOT = "Application"  # Bots actor type in Nextcloud Talk
+
+# Message object types
+OBJECT_TYPE_NOTE = "Note"
+OBJECT_TYPE_COLLECTION = "Collection"
+
+# Message name for regular messages
+MESSAGE_NAME_NORMAL = "message"
+
+# Media types
+MEDIA_TYPE_MARKDOWN = "text/markdown"
+MEDIA_TYPE_PLAIN = "text/plain"
+
+# Bot signature headers for outgoing requests
+BOT_HEADER_RANDOM = "X-Nextcloud-Talk-Bot-Random"
+BOT_HEADER_SIGNATURE = "X-Nextcloud-Talk-Bot-Signature"
+OCS_API_REQUEST_HEADER = "OCS-APIRequest"

--- a/src/copaw/app/channels/nextcloud_talk/content_utils.py
+++ b/src/copaw/app/channels/nextcloud_talk/content_utils.py
@@ -1,0 +1,617 @@
+# -*- coding: utf-8 -*-
+"""Content parsing utilities for Nextcloud Talk channel."""
+
+# pylint: disable=C0301  # line-too-long
+# pylint: disable=W0613  # unused-argument
+# pylint: disable=W0621  # redefined-outer-name
+# pylint: disable=W0404  # reimported
+# pylint: disable=R0912  # too-many-branches
+# pylint: disable=R0915  # too-many-statements
+# pylint: disable=R0911  # too-many-return-statements
+# pylint: disable=W0611  # unused-import
+
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from .constants import (
+    ACTIVITY_TYPE_CREATE,
+    ACTIVITY_TYPE_JOIN,
+    ACTIVITY_TYPE_LEAVE,
+    ACTIVITY_TYPE_LIKE,
+    ACTIVITY_TYPE_UNDO,
+    ACTOR_TYPE_PERSON,
+    ACTOR_TYPE_APPLICATION,
+    OBJECT_TYPE_NOTE,
+    MESSAGE_NAME_NORMAL,
+    MEDIA_TYPE_MARKDOWN,
+    MEDIA_TYPE_PLAIN,
+    SESSION_ID_SUFFIX_LEN,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NextcloudTalkContentParser:
+    """Parser for Nextcloud Talk Activity Streams 2.0 messages."""
+
+    @staticmethod
+    def parse_actor(actor: Dict[str, Any]) -> Tuple[str, str, str]:
+        """
+        Parse actor from Activity Streams payload.
+
+        Returns:
+            Tuple of (actor_id, actor_name, actor_type)
+            - actor_id: "users/username" or "bots/bot-id"
+            - actor_name: Display name
+            - actor_type: "user", "guest", "bot"
+        """
+        actor_id = actor.get("id", "")
+        actor_name = actor.get("name", "")
+        actor_type_raw = actor.get("type", "")
+
+        # Extract agent type from ID
+        if actor_type_raw == ACTOR_TYPE_APPLICATION:
+            actor_type = "bot"
+        elif actor_type_raw == ACTOR_TYPE_PERSON:
+            if actor_id.startswith("users/"):
+                actor_type = "user"
+            elif actor_id.startswith("guests/"):
+                actor_type = "guest"
+            else:
+                actor_type = "unknown"
+        else:
+            actor_type = "unknown"
+
+        # Extract username from ID (not used but keep logic for reference)
+        # if "/" in actor_id:
+        #     username = actor_id.split("/", 1)[1]
+        # else:
+        #     username = actor_id
+
+        logger.debug(
+            f"parsed actor: id={actor_id} name={actor_name} type={actor_type}",
+        )
+
+        return (actor_id, actor_name, actor_type)
+
+    @staticmethod
+    def parse_message_content(
+        content_str: str,
+        media_type: str = MEDIA_TYPE_PLAIN,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """
+        Parse message content string.
+
+        The content is a JSON-encoded string with "message" and "parameters" keys.  # noqa: E501
+        Parameters contain rich object data for mentions, calls, files, etc.
+
+        Returns:
+            Tuple of (message_text, parameters_dict)
+        """
+        try:
+            content_data = json.loads(content_str)
+            message = content_data.get("message", "")
+            parameters = content_data.get("parameters", {})
+
+            # 确保 parameters 是字典类型
+            if not isinstance(parameters, dict):
+                logger.debug(
+                    f"parameters is not dict, converting from {type(parameters)}",  # noqa: E501
+                )
+                parameters = {}
+
+        except json.JSONDecodeError:
+            # If not JSON, use content string directly
+            message = content_str
+            parameters = {}
+
+        logger.debug(
+            f"parsed message content: message_len={len(message)} "
+            f"params_type={type(parameters).__name__} params_keys={list(parameters.keys()) if isinstance(parameters, dict) else 'N/A'}",  # noqa: E501
+        )
+
+        return (message, parameters)
+
+    @staticmethod
+    def replace_mentions(text: str, parameters: Dict[str, Any]) -> str:
+        """
+        Replace placeholders in message text with actual mentions.
+
+        Example: "hi {mention-call1}!" -> "hi @world!"
+        """
+        # 安全地处理 parameters，确保它是字典类型
+        if not isinstance(parameters, dict):
+            logger.debug(
+                f"replace_mentions: parameters is not dict, type={type(parameters)}",  # noqa: E501
+            )
+            return text
+
+        for key, value in parameters.items():
+            placeholder = "{" + key + "}"
+            if placeholder in text:
+                if isinstance(value, dict):
+                    name = value.get("name", "")
+                    mention_type = value.get("type", "")
+                    if mention_type == "call":
+                        text = text.replace(placeholder, f"@{name}")
+                    elif mention_type == "user":
+                        text = text.replace(placeholder, f"@{name}")
+                    elif mention_type == "guest":
+                        text = text.replace(placeholder, f"@{name}")
+                    else:
+                        # Generic fallback
+                        text = text.replace(placeholder, name)
+                else:
+                    text = text.replace(placeholder, str(value))
+
+        return text
+
+    @staticmethod
+    def parse_conversation(target: Dict[str, Any]) -> Tuple[str, str]:
+        """
+        Parse conversation/target from payload.
+
+        Returns:
+            Tuple of (conversation_token, conversation_name)
+        """
+        conversation_token = target.get("id", "")
+        conversation_name = target.get("name", "")
+
+        return (conversation_token, conversation_name)
+
+    @staticmethod
+    def is_regular_message(object_data: Dict[str, Any]) -> bool:
+        """
+        Check if the object represents a regular user message (not system message).  # noqa: E501
+        """
+        object_name = object_data.get("name", "")
+
+        # Handle bug fix: empty string for attachments before Nextcloud 33
+        if object_name == MESSAGE_NAME_NORMAL:
+            return True
+
+        # Some system messages have specific names
+        system_names = [
+            "message_deleted",
+            "message_modified",
+            "conversation_renamed",
+            "conversation_avatar_changed",
+            "user_joined",
+            "user_left",
+            "password_set",
+            "call_started",
+            "call_ended",
+        ]
+
+        # If object_name is empty or matches system name pattern, it's not
+        # regular
+        if not object_name or object_name in system_names:
+            return False
+
+        # If it's not explicitly a system message, assume it's regular
+        return True
+
+    @staticmethod
+    def extract_message_text(payload: Dict[str, Any]) -> Optional[str]:
+        """
+        Extract message text from Activity Streams payload.
+
+        Returns None if payload doesn't contain a regular message.
+        """
+        activity_type = payload.get("type")
+        actor = payload.get("actor", {})
+        obj = payload.get("object", {})
+
+        # Only handle Create activities from persons (users)
+        if activity_type != ACTIVITY_TYPE_CREATE:
+            return None
+
+        actor_type_raw = actor.get("type", "")
+        if actor_type_raw != ACTOR_TYPE_PERSON:
+            return None
+
+        # Check if it's a regular message
+        if not NextcloudTalkContentParser.is_regular_message(obj):
+            return None
+
+        # Extract content
+        content_str = obj.get("content", "")
+        media_type = obj.get("mediaType", MEDIA_TYPE_PLAIN)
+
+        message, parameters = NextcloudTalkContentParser.parse_message_content(
+            content_str,
+            media_type,
+        )
+
+        # Replace mentions
+        message = NextcloudTalkContentParser.replace_mentions(
+            message,
+            parameters,
+        )
+
+        return message if message else None
+
+    @staticmethod
+    def extract_media_file(
+        payload: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Extract media file information from Activity Streams payload.
+
+        Handles file_shared events for images, videos, and audio files.
+        Supports multiple Nextcloud versions and payload formats.
+
+        Returns:
+            Dictionary with file information or None
+            {
+                "type": "image" | "video" | "audio",
+                "name": str,
+                "path": str,
+                "size": int,
+                "mime_type": str,
+                "preview_available": bool,
+                "metadata": dict,  # All original file metadata
+            }
+        """
+        activity_type = payload.get("type")
+        obj = payload.get("object", {})
+
+        # Log activity type for debugging
+        import logging
+
+        logger_debug = logging.getLogger(__name__)
+        logger_debug.debug(
+            f"extract_media_file: activity_type={activity_type}, object_name={obj.get('name', '')}",  # noqa: E501
+        )
+
+        # Log full object for debugging file extract
+        logger_debug.debug(
+            f"extract_media_file: object keys={list(obj.keys())}",
+        )
+
+        # Handle various activity types that might contain file sharing
+        # Some Nextcloud versions use 'Activity' instead of 'Create'
+        valid_activity_types = [ACTIVITY_TYPE_CREATE, "system", "Activity"]
+        if activity_type not in valid_activity_types:
+            logger_debug.debug(
+                f"Skipping unsupported activity type: {activity_type}",
+            )
+            return None
+
+        object_name = obj.get("name", "")
+
+        # Try multiple approaches to find file data:
+        # 1. Direct file_shared event (object.name == "file_shared")
+        # 2. Mixed message with file in parameters (object.name == "message" + content.parameters.file)  # noqa: E501
+        # 3. Embedded file data in object properties
+        # 4. Legacy formats and fallbacks
+
+        file_data = None
+
+        # Approach 1: Check for file_shared system message
+        if object_name == "file_shared":
+            parameters = obj.get("parameters", {})
+            file_data = parameters.get("file", {}) or parameters.get(
+                "share",
+                {},
+            )
+            logger_debug.debug(
+                f"Found file_shared event with file data: {bool(file_data)}",
+            )
+            # Log file_data structure for debugging
+            if file_data:
+                logger_debug.debug(
+                    f"file_shared file_data keys: {list(file_data.keys())}",
+                )
+                logger_debug.debug(
+                    f"file_shared file_data path: {file_data.get('path')}, name: {file_data.get('name')}",  # noqa: E501
+                )
+
+        # Approach 2: Check for file in content.parameters (mixed message)
+        elif object_name == "message":
+            content_str = obj.get("content", "")
+            if content_str:
+                try:
+                    import json as json_lib
+
+                    content_json = json_lib.loads(content_str)
+                    parameters = content_json.get("parameters", {})
+                    # Look for file in various parameter locations
+                    file_data = (
+                        parameters.get("file", {})
+                        or parameters.get("attachment", {})
+                        or parameters.get("upload", {})
+                    )
+                    if file_data:
+                        logger_debug.debug(
+                            f"Found file in content.parameters: {file_data.get('name')}",  # noqa: E501
+                        )
+                except Exception as e:
+                    logger_debug.debug(f"Failed to parse content JSON: {e}")
+
+        # Approach 3: Check for embedded file data in object properties
+        if not file_data:
+            # Look directly in object for file-like properties
+            logger_debug.debug("Checking object fields for file data")
+            potential_file_fields = ["file", "attachment", "upload", "media"]
+            for field in potential_file_fields:
+                candidate = obj.get(field, {})
+                if isinstance(candidate, dict) and candidate.get("name"):
+                    file_data = candidate
+                    logger_debug.debug(
+                        f"Found file in object.{field}: {file_data.get('name')}",  # noqa: E501
+                    )
+                    logger_debug.debug(
+                        f"object.{field} keys: {list(file_data.keys())}",
+                    )
+                    logger_debug.debug(
+                        f"object.{field} path: {file_data.get('path')}, name: {file_data.get('name')}",  # noqa: E501
+                    )
+                    break
+
+        # Approach 4: Try to find file data in meta as fallback
+        if not file_data:
+            meta = payload.get("meta", {})
+            file_data = meta.get("file", {}) or meta.get("attachment", {})
+            if file_data:
+                logger_debug.debug(
+                    f"Found file in meta: {file_data.get('name')}",
+                )
+
+        # Final fallback: check for file information in actor parameters
+        if not file_data:
+            actor = payload.get("actor", {})
+            actor_params = (
+                actor.get("parameters", {}) if isinstance(actor, dict) else {}
+            )
+            file_data = actor_params.get("file", {})
+            if file_data:
+                logger_debug.debug(
+                    f"Found file in actor parameters: {file_data.get('name')}",
+                )
+
+        if not file_data or not isinstance(file_data, dict):
+            logger_debug.debug("No valid file data found in payload")
+            return None
+
+        # Extract file metadata with multiple fallbacks
+        file_name = (
+            file_data.get("name")
+            or file_data.get("filename")
+            or file_data.get("displayName")
+            or "unknown_file"
+        )
+
+        file_path = (
+            file_data.get("path")
+            or file_data.get("filepath")
+            or file_data.get("location")
+            or file_name
+        )
+
+        # Special handling: if file_path doesn't contain a path separator (just filename),  # noqa: E501
+        # assume it's in the Talk directory (Nextcloud Talk default storage
+        # location)
+        if file_path and "/" not in file_path:
+            logger_debug.debug(
+                f"file_path is just filename: {file_path}, assuming Talk/ directory",  # noqa: E501
+            )
+            file_path = f"Talk/{file_path}"
+
+        # Handle size parsing with fallbacks
+        file_size_raw = file_data.get("size")
+        try:
+            if isinstance(file_size_raw, str):
+                file_size = int(file_size_raw)
+            else:
+                file_size = int(file_size_raw or 0)
+        except (ValueError, TypeError):
+            file_size = 0
+
+        mime_type = (
+            file_data.get("mimetype")
+            or file_data.get("mime-type")
+            or file_data.get("contentType")
+            or "application/octet-stream"
+        )
+
+        # Determine media type from mime type
+        mime_type_lower = mime_type.lower()
+        if mime_type_lower.startswith("image/"):
+            media_type = "image"
+        elif mime_type_lower.startswith("video/"):
+            media_type = "video"
+        elif mime_type_lower.startswith("audio/"):
+            media_type = "audio"
+        else:
+            # Try to guess from file extension
+            import os
+
+            _, ext = os.path.splitext(file_name.lower())
+            if ext in [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"]:
+                media_type = "image"
+            elif ext in [".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv"]:
+                media_type = "video"
+            elif ext in [".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"]:
+                media_type = "audio"
+            else:
+                # Unknown type, skip
+                logger_debug.debug(
+                    f"Unknown file mime type and extension: {mime_type}, {ext}",  # noqa: E501
+                )
+                return None
+
+        # Check if preview is available with multiple sources
+        preview_available = bool(
+            file_data.get("preview-available")
+            or file_data.get("has-preview")
+            or file_data.get("preview")
+            or mime_type_lower.startswith("image/")
+            or file_data.get("thumbnail"),
+        )
+
+        # Extract additional metadata
+        additional_metadata = {
+            "id": file_data.get("id", ""),
+            "etag": file_data.get("etag", ""),
+            "permissions": file_data.get("permissions", ""),
+            "width": file_data.get("width", ""),
+            "height": file_data.get("height", ""),
+            "duration": file_data.get("duration", ""),
+            "share-token": (
+                file_data.get("share-token")
+                or file_data.get("token")
+                or file_data.get("link", "")
+            ),
+            "hide-download": file_data.get("hide-download", "no"),
+        }
+
+        # Merge with original metadata
+        complete_metadata = {**file_data, **additional_metadata}
+
+        result = {
+            "type": media_type,
+            "name": file_name,
+            "path": file_path,
+            "size": file_size,
+            "mime_type": mime_type,
+            "preview_available": preview_available,
+            "metadata": complete_metadata,
+        }
+
+        logger_debug.debug(
+            f"Successfully extracted media file: {result['name']} ({result['type']})",  # noqa: E501
+        )
+        return result
+
+    @staticmethod
+    def extract_reaction(payload: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+        """
+        Extract reaction from Activity Streams payload.
+
+        Returns:
+            Tuple of (reaction_emoji, message_id) or None
+        """
+        activity_type = payload.get("type")
+
+        if activity_type == ACTIVITY_TYPE_LIKE:
+            # Reaction added
+            emoji = payload.get("content", "")
+            obj = payload.get("object", {})
+            message_id = obj.get("id", "")
+            return (emoji, message_id) if emoji and message_id else None
+        elif activity_type == ACTIVITY_TYPE_UNDO:
+            # Reaction removed
+            obj = payload.get("object", {})
+            if obj.get("type") == ACTIVITY_TYPE_LIKE:
+                # The object being undone is a Like
+                emoji = obj.get("content", "")
+                target = obj.get("target", {})
+                # In Undo, the original object is nested
+                message_id = target.get("id", "") or obj.get("id", "")
+                return (emoji, message_id) if emoji and message_id else None
+
+        return None
+
+    @staticmethod
+    def extract_conversation_event(payload: Dict[str, Any]) -> Optional[str]:
+        """
+        Extract conversation event type (bot added/removed).
+
+        Returns:
+            "added" or "removed" or None
+        """
+        activity_type = payload.get("type")
+        actor = payload.get("actor", {})
+
+        # Check if actor is a bot (Application type with bots/ prefix)
+        actor_type_raw = actor.get("type", "")
+        actor_id = actor.get("id", "")
+
+        if actor_type_raw != ACTOR_TYPE_APPLICATION:
+            return None
+
+        if not actor_id.startswith("bots/"):
+            return None
+
+        if activity_type == ACTIVITY_TYPE_JOIN:
+            return "added"
+        elif activity_type == ACTIVITY_TYPE_LEAVE:
+            return "removed"
+
+        return None
+
+
+def parse_data_url(url: str) -> Tuple[Optional[bytes], Optional[str]]:
+    """Parse data URL (data:mime/type;base64,encoded_data)."""
+    if not url.startswith("data:"):
+        return (None, None)
+
+    try:
+        # Parse data URL
+        header, data = url.split(",", 1)
+        # Remove "data:" prefix
+        header = header[5:]
+
+        # Extract mime type and encoding
+        parts = header.split(";")
+        mime_type = parts[0] if parts else "application/octet-stream"
+
+        # Check if base64
+        is_base64 = any(p.strip() == "base64" for p in parts)
+
+        if is_base64:
+            import base64
+
+            decoded = base64.b64decode(data)
+            return (decoded, mime_type)
+        else:
+            # URL encoded
+            from urllib.parse import unquote
+
+            decoded = unquote(data).encode("utf-8")
+            return (decoded, mime_type)
+    except Exception:
+        logger.exception("Failed to parse data URL")
+        return (None, None)
+
+
+def session_param_from_token(token: str) -> str:
+    """Extract session identifier from conversation token."""
+    # token is typically an alphanumeric string, use suffix for session
+    if len(token) > SESSION_ID_SUFFIX_LEN:
+        return token[-SESSION_ID_SUFFIX_LEN:]
+    return token
+
+
+def is_public_url(url: Optional[str]) -> bool:
+    """Check if URL is a public HTTP/HTTPS URL."""
+    if not url or not isinstance(url, str):
+        return False
+    url = url.strip()
+    return url.startswith("http://") or url.startswith("https://")
+
+
+def guess_suffix_from_content(data: bytes) -> str:
+    """Guess file suffix from content using magic bytes."""
+    if not data:
+        return ".bin"
+
+    # Check common magic bytes
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return ".png"
+    elif data.startswith(b"\xff\xd8\xff"):
+        return ".jpg"
+    elif data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return ".gif"
+    elif data.startswith(b"RIFF") and len(data) > 8 and data[8:12] == b"WEBP":
+        return ".webp"
+    elif data.startswith(b"%PDF"):
+        return ".pdf"
+    elif data.startswith(b"PK\x03\x04"):
+        return ".zip"
+    elif data.startswith(b"\x1f\x8b"):
+        return ".gz"
+
+    return ".bin"

--- a/src/copaw/app/channels/nextcloud_talk/files_client.py
+++ b/src/copaw/app/channels/nextcloud_talk/files_client.py
@@ -1,0 +1,584 @@
+# -*- coding: utf-8 -*-
+"""Nextcloud Files API client for accessing shared files."""
+
+# pylint: disable=C0301  # line-too-long
+# pylint: disable=W0621  # redefined-outer-name
+# pylint: disable=W0404  # reimported
+# pylint: disable=R0912  # too-many-branches
+# pylint: disable=R0915  # too-many-statements
+# pylint: disable=W0611  # unused-import
+
+import os
+import logging
+from pathlib import Path
+from typing import Optional, Dict, Any
+from urllib.parse import quote
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class NextcloudFilesClient:
+    """
+    Client for Nextcloud Files API (WebDAV).
+
+    Used to access file metadata and download links for files shared in Talk.
+    """
+
+    def __init__(self, base_url: str, username: str = "", password: str = ""):
+        """
+        Initialize Nextcloud Files client.
+
+        Args:
+            base_url: Base URL of Nextcloud server (e.g., https://example.com/nextcloud)  # noqa: E501
+            username: Username for authentication (optional for public shares)
+            password: Password or app token for authentication
+        """
+        self.base_url = base_url.rstrip("/")
+        self.username = username
+        self.password = password
+        self._session: Optional[aiohttp.ClientSession] = None
+
+        # Load credentials from config if not provided
+        if not username or not password:
+            self._load_credentials_from_config()
+
+    def _load_credentials_from_config(self):
+        """Load Nextcloud credentials from config file."""
+        try:
+            import json
+            from pathlib import Path
+
+            config_path = Path.home() / ".copaw" / "config.json"
+            if config_path.exists():
+                with open(config_path, "r", encoding="utf-8") as f:
+                    config = json.load(f)
+
+                nc_config = config.get("channels", {}).get(
+                    "nextcloud_talk",
+                    {},
+                )
+                if nc_config:
+                    self.username = nc_config.get("username", "")
+                    self.password = nc_config.get("password", "")
+
+                    if self.username and self.password:
+                        logger.info(
+                            f"Loaded Nextcloud credentials from config: username={self.username[:3]}...",  # noqa: E501
+                        )
+                    else:
+                        logger.warning(
+                            "Nextcloud credentials not found in config",
+                        )
+            else:
+                logger.warning(f"Config file not found: {config_path}")
+
+        except Exception as e:
+            logger.error(
+                f"Failed to load Nextcloud credentials from config: {e}",
+            )
+
+    def build_webdav_url(self, api_user: str, file_path: str) -> Optional[str]:
+        """
+        Build a WebDAV download URL for a Nextcloud file.
+
+        Uses the format: {base_url}/remote.php/dav/files/{api_user}/{file_path}
+        Following OpenClaw PR #29256 implementation.
+
+        Args:
+            api_user: API username for the bot account
+            file_path: File path relative to user's files root (e.g., Talk/image.jpg)  # noqa: E501
+
+        Returns:
+            WebDAV URL or None if parameters are insufficient
+
+        Example:
+            >>> client.build_webdav_url("bot-user", "Talk/image.jpg")
+            'https://cloud.example.com/nextcloud/remote.php/dav/files/bot-user/Talk/image.jpg'
+        """
+        if not self.base_url or not api_user or not file_path:
+            return None
+
+        # Normalize base URL
+        base_url = self.base_url.rstrip("/")
+
+        # Encode file path: split by "/" and encode each segment
+        # This ensures spaces and special characters are properly encoded
+        encoded_path_segments = [
+            quote(segment) for segment in file_path.split("/")
+        ]
+        encoded_path = "/".join(encoded_path_segments)
+
+        # Encode the username
+        encoded_user = quote(api_user)
+
+        # Build WebDAV URL
+        webdav_url = (
+            f"{base_url}/remote.php/dav/files/{encoded_user}/{encoded_path}"
+        )
+
+        return webdav_url
+
+    async def get_session(self) -> aiohttp.ClientSession:
+        """Get or create HTTP session."""
+        if self._session is None:
+            logger.info(
+                f"Creating session with username='{self.username}', password present={bool(self.password)})",  # noqa: E501
+            )
+
+            # Debug environment variables
+            env_username = os.environ.get("NEXTCLOUD_USERNAME", "NOT_SET")
+            env_password = os.environ.get("NEXTCLOUD_PASSWORD", "NOT_SET")
+            logger.info(
+                f"Environment vars: NEXTCLOUD_USERNAME={env_username[:3]}..., NEXTCLOUD_PASSWORD={'SET' if env_password != 'NOT_SET' else 'NOT_SET'})",  # noqa: E501
+            )
+
+            auth = (
+                aiohttp.BasicAuth(self.username, self.password)
+                if self.username
+                else None
+            )
+            if auth:
+                logger.info(
+                    f"Created BasicAuth with username: {self.username[:3]}...",
+                )
+            else:
+                logger.warning("No authentication credentials provided")
+
+            self._session = aiohttp.ClientSession(auth=auth)
+        return self._session
+
+    async def close(self):
+        """Close the session."""
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def get_file_info(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """
+        Get file information via WebDAV PROPFIND request.
+
+        Args:
+            file_path: Path to file relative to user's files root
+
+        Returns:
+            File information dict or None
+        """
+        try:
+            session = await self.get_session()
+
+            # Build WebDAV URL
+            dav_url = f"{self.base_url}/remote.php/dav/files/{quote(file_path.lstrip('/'))}"  # noqa: E501
+
+            # PROPFIND request to get file properties
+            propfind_body = """<?xml version="1.0"?>
+            <d:propfind xmlns:d="DAV:" xmlns:nc="http://nextcloud.org/ns" xmlns:oc="http://owncloud.org/ns">  # noqa: E501
+                <d:prop>
+                    <d:getlastmodified/>
+                    <d:getcontentlength/>
+                    <d:getcontenttype/>
+                    <d:resourcetype/>
+                    <oc:id/>
+                    <oc:owner-id/>
+                    <oc:owner-display-name/>
+                    <nc:has-preview/>
+                </d:prop>
+            </d:propfind>"""
+
+            headers = {
+                "Depth": "0",
+                "Content-Type": "application/xml",
+            }
+
+            async with session.propfind(
+                dav_url,
+                data=propfind_body,
+                headers=headers,
+            ) as resp:
+                if resp.status == 207:  # Multi-Status
+                    await resp.text()  # consume response
+                    # Parse XML response (simplified)
+                    logger.debug(f"Got file info for {file_path}")
+                    return {
+                        "path": file_path,
+                        "success": True,
+                    }
+                else:
+                    logger.warning(f"Failed to get file info: {resp.status}")
+                    return None
+
+        except Exception as e:
+            logger.exception(f"Error getting file info: {e}")
+            return None
+
+    async def get_file_download_url(self, file_path: str) -> Optional[str]:
+        """
+        Get direct download URL for a file.
+
+        Args:
+            file_path: Path to file relative to user's files root
+
+        Returns:
+            Download URL or None
+        """
+        try:
+            # For authenticated access, use WebDAV endpoint
+            download_url = f"{self.base_url}/remote.php/dav/files/{quote(file_path.lstrip('/'))}"  # noqa: E501
+            logger.debug(f"Generated download URL for {file_path}")
+            return download_url
+
+        except Exception as e:
+            logger.exception(f"Error generating download URL: {e}")
+            return None
+
+    async def get_file_preview_url(
+        self,
+        file_path: str,
+        max_width: int = 384,
+        max_height: int = 384,
+    ) -> Optional[str]:
+        """
+        Get preview image URL for a file (if available).
+
+        Args:
+            file_path: Path to file
+            max_width: Maximum preview width
+            max_height: Maximum preview height
+
+        Returns:
+            Preview URL or None
+        """
+        try:
+            # Use Nextcloud preview endpoint
+            preview_url = (
+                f"{self.base_url}/index.php/core/preview.png?"
+                f"file={quote(file_path)}&"
+                f"x={max_width}&y={max_height}&a=1"
+            )
+            logger.debug(f"Generated preview URL for {file_path}")
+            return preview_url
+
+        except Exception as e:
+            logger.exception(f"Error generating preview URL: {e}")
+            return None
+
+    async def get_public_share_link(
+        self,
+        share_token: str,
+        path: str = "",
+    ) -> Optional[str]:
+        """
+        Get public share link for a file.
+
+        Args:
+            share_token: Share token (from file_shared event parameters)
+            path: Optional path within the share
+
+        Returns:
+            Public share URL or None
+        """
+        try:
+            if path:
+                share_url = f"{self.base_url}/index.php/s/{share_token}/files?path={quote(path)}"  # noqa: E501
+            else:
+                share_url = f"{self.base_url}/index.php/s/{share_token}"
+
+            logger.debug(f"Generated share link: {share_url}")
+            return share_url
+
+        except Exception as e:
+            logger.exception(f"Error generating share link: {e}")
+            return None
+
+    async def download_file(self, url: str, local_path: str) -> bool:
+        """
+        Download file from URL to local path, handling Nextcloud authentication.  # noqa: E501
+
+        For Nextcloud share URLs (/s/...) and WebDAV URLs, this method uses
+        Basic Auth if credentials are available.
+
+        Args:
+            url: URL to download from
+            local_path: Local file path to save to
+
+        Returns:
+            True if successful, False otherwise
+        """
+        logger.info(
+            f"NextcloudFilesClient.download_file: url={url[:50]}..., local_path={local_path}",  # noqa: E501
+        )
+
+        try:
+            session = await self.get_session()
+
+            logger.info(
+                f"Downloading file from Nextcloud: url={url} -> {local_path}",
+            )
+
+            # Check if this is a Nextcloud URL that needs auth
+            is_share_url = "/s/" in url
+            is_webdav_url = "/remote.php/dav/files/" in url
+            needs_auth = (
+                (is_share_url or is_webdav_url)
+                and self.username
+                and self.password
+            )
+
+            logger.info(
+                f"Nextcloud download auth: is_share={is_share_url}, is_webdav={is_webdav_url}, needs_auth={needs_auth}, username={self.username[:2]}...",  # noqa: E501
+            )
+
+            # Prepare headers - DON'T add Authorization header when session already has auth  # noqa: E501
+            headers = {}
+            # For share URLs, we need to add Authorization header manually
+            # But for WebDAV URLs, the session already has BasicAuth configured
+            if needs_auth and is_share_url:
+                import base64
+
+                credentials = f"{self.username}:{self.password}"
+                encoded_credentials = base64.b64encode(
+                    credentials.encode("utf-8"),
+                ).decode("ascii")
+                headers["Authorization"] = f"Basic {encoded_credentials}"
+                logger.info(
+                    "Added Authorization header for share URL download",
+                )
+            elif needs_auth and is_webdav_url:
+                logger.info("Using session BasicAuth for WebDAV URL download")
+
+            # Download with aiohttp (using the authenticated session)
+            timeout = aiohttp.ClientTimeout(total=60)
+            logger.info(f"Making authenticated request to: {url}")
+            logger.info(
+                f"Using session auth: username={self.username[:3]}..., password present={bool(self.password)})",  # noqa: E501
+            )
+
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=timeout,
+            ) as resp:
+                logger.info(f"Response status: {resp.status}")
+                logger.info(f"Response headers: {dict(resp.headers)}")
+
+                if resp.status != 200:
+                    resp_text = await resp.text()
+                    logger.error(
+                        f"Failed to download file: status={resp.status}, resp={resp_text[:500]}",  # noqa: E501
+                    )
+
+                    # Log more details for debugging
+                    if resp.status == 401:
+                        logger.error(
+                            "401 Unauthorized - Authentication failed",
+                        )
+                    elif resp.status == 404:
+                        logger.error("404 Not Found - File not found")
+                    elif resp.status == 403:
+                        logger.error("403 Forbidden - Access denied")
+
+                    return False
+
+                # Verify content is not HTML (login page)
+                content = await resp.read()
+                logger.info(f"Downloaded content size: {len(content)} bytes")
+
+                # Detailed content analysis
+                if content.startswith(b"<!DOCTYPE") or content.startswith(
+                    b"<html",
+                ):
+                    logger.error(
+                        f"Downloaded content is HTML (login page), not binary file: url={url}",  # noqa: E501
+                    )
+                    logger.error(
+                        f"First 500 bytes of content: {content[:500]}",
+                    )
+                    return False
+
+                # Check for XML error responses
+                if content.startswith(b"<?xml"):
+                    logger.error(
+                        f"Downloaded content is XML (likely error response): url={url}",  # noqa: E501
+                    )
+                    logger.error(
+                        f"First 500 bytes of XML content: {content[:500]}",
+                    )
+                    return False
+
+                # Validate image file signatures
+                if url.lower().endswith(
+                    (".png", ".jpg", ".jpeg", ".gif", ".webp"),
+                ):
+                    # PNG signature: \x89PNG
+                    # JPEG signature: \xff\xd8\xff
+                    # GIF signature: GIF87a or GIF89a
+                    png_sig = b"\x89PNG\r\n\x1a\n"
+                    jpg_sig = b"\xff\xd8\xff"
+                    gif_sig = b"GIF8"
+                    webp_sig = b"RIFF"
+
+                    valid_image = (
+                        content.startswith(png_sig)
+                        or content.startswith(jpg_sig)
+                        or content.startswith(gif_sig)
+                        or content.startswith(webp_sig)
+                    )
+
+                    if not valid_image:
+                        logger.error(
+                            f"Downloaded content doesn't match expected image format: url={url}",  # noqa: E501
+                        )
+                        logger.error(f"Content starts with: {content[:20]}")
+                        logger.error("Expected image signatures not found")
+                        return False
+                    else:
+                        logger.info(
+                            f"Valid image file signature confirmed for: {url}",
+                        )
+
+                # Check content type
+                content_type = resp.headers.get("content-type", "unknown")
+                logger.info(f"Content-Type: {content_type}")
+
+                # Additional validation for image files
+                if "image" in content_type.lower():
+                    logger.info(
+                        f"Confirmed image content type: {content_type}",
+                    )
+
+                # Save to file
+                local_path_obj = Path(local_path)
+                local_path_obj.parent.mkdir(parents=True, exist_ok=True)
+                with open(local_path_obj, "wb") as f:
+                    f.write(content)
+
+                logger.info(
+                    f"Successfully downloaded file to {local_path} ({len(content)} bytes)",  # noqa: E501
+                )
+                return True
+
+        except Exception as e:
+            logger.exception(f"Error downloading file from Nextcloud: {e}")
+            return False
+
+    async def download_file_via_webdav(
+        self,
+        api_user: str,
+        file_path: str,
+        local_path: str,
+    ) -> bool:
+        """
+        Download file using WebDAV URL with authentication.
+
+        This follows the OpenClaw PR #29256 implementation, using:
+        {base_url}/remote.php/dav/files/{api_user}/{file_path}
+
+        Args:
+            api_user: API username for the bot account
+            file_path: File path relative to user's files root
+            local_path: Local file path to save to
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            # Build WebDAV URL
+            webdav_url = self.build_webdav_url(api_user, file_path)
+            if not webdav_url:
+                logger.error("Failed to build WebDAV URL")
+                return False
+
+            logger.info(
+                f"Downloading via WebDAV: {webdav_url} -> {local_path}",
+            )
+
+            # Get session with authenticated Basic Auth
+            session = await self.get_session()
+
+            # Download file
+            timeout = aiohttp.ClientTimeout(total=60)
+            logger.info(f"WebDAV request to: {webdav_url}")
+            logger.info(
+                f"Using session with auth: username={self.username[:2]}... password={'*' * len(self.password) if self.password else 'None'}",  # noqa: E501
+            )
+
+            async with session.get(webdav_url, timeout=timeout) as resp:
+                logger.info(f"WebDAV Response status: {resp.status}")
+                logger.info(f"WebDAV Response headers: {dict(resp.headers)}")
+
+                if resp.status != 200:
+                    resp_text = await resp.text()
+                    logger.error(
+                        f"WebDAV download failed: status={resp.status}, url={webdav_url}, resp={resp_text[:500]}",  # noqa: E501
+                    )
+
+                    # More detailed error logging
+                    if resp.status == 401:
+                        logger.error(
+                            "WebDAV 401 Unauthorized - Check username/password",  # noqa: E501
+                        )
+                    elif resp.status == 404:
+                        logger.error(
+                            "WebDAV 404 Not Found - File path may be incorrect",  # noqa: E501
+                        )
+                    elif resp.status == 403:
+                        logger.error(
+                            "WebDAV 403 Forbidden - Insufficient permissions",
+                        )
+
+                    return False
+
+                # Read content
+                content = await resp.read()
+                logger.info(
+                    f"WebDAV downloaded content size: {len(content)} bytes",
+                )
+
+                # Verify content is not HTML (shouldn't happen with WebDAV)
+                if content.startswith(b"<!DOCTYPE") or content.startswith(
+                    b"<html",
+                ):
+                    logger.error(
+                        f"WebDAV downloaded content is HTML (unexpected): url={webdav_url}",  # noqa: E501
+                    )
+                    logger.error(f"First 200 bytes: {content[:200]}")
+                    return False
+
+                # Check content type
+                content_type = resp.headers.get("content-type", "unknown")
+                logger.info(f"WebDAV Content-Type: {content_type}")
+
+                # Save to file
+                local_path_obj = Path(local_path)
+                local_path_obj.parent.mkdir(parents=True, exist_ok=True)
+                with open(local_path_obj, "wb") as f:
+                    f.write(content)
+
+                logger.info(
+                    f"Successfully downloaded via WebDAV: {local_path} ({len(content)} bytes)",  # noqa: E501
+                )
+                return True
+
+        except Exception as e:
+            logger.exception(f"Error downloading file via WebDAV: {e}")
+            return False
+
+
+async def create_nextcloud_files_client(
+    backend_url: str,
+    username: str = "",
+    password: str = "",
+) -> NextcloudFilesClient:
+    """
+    Create a Nextcloud Files client instance.
+
+    Args:
+        backend_url: Nextcloud backend URL
+        username: Optional username
+        password: Optional password/token
+
+    Returns:
+        NextcloudFilesClient instance
+    """
+    return NextcloudFilesClient(backend_url, username, password)

--- a/src/copaw/app/channels/nextcloud_talk/handler_stdlib.py
+++ b/src/copaw/app/channels/nextcloud_talk/handler_stdlib.py
@@ -1,0 +1,655 @@
+# -*- coding: utf-8 -*-
+"""Python standard library HTTP handler for Nextcloud Talk webhook."""
+
+# pylint: disable=C0301  # line-too-long
+# pylint: disable=W0622  # redefined-builtin
+# pylint: disable=W0613  # unused-argument
+# pylint: disable=W0621  # redefined-outer-name
+# pylint: disable=W0404  # reimported
+# pylint: disable=E1102  # not-callable (false positive with properties)
+# pylint: disable=E0102  # function-redefined
+# pylint: disable=R0911  # too-many-return-statements
+# pylint: disable=R0912  # too-many-branches
+# pylint: disable=R0915  # too-many-statements
+# pylint: disable=W0611  # unused-import
+# pylint: disable=W0212  # protected-access
+
+import asyncio
+import json
+import logging
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Any, Callable, Dict, Optional
+
+from .content_utils import (
+    NextcloudTalkContentParser,
+    session_param_from_token,
+)
+from .files_client import NextcloudFilesClient
+from .utils import (
+    verify_request_signature,
+    extract_backend_url,
+)
+from .constants import (
+    HEADER_SIGNATURE,
+    HEADER_RANDOM,
+    HEADER_BACKEND,
+)
+
+logger = logging.getLogger(__name__)
+
+# Download filename hint by type (e.g. image -> .png, video -> .mp4)
+FILENAME_HINT_BY_TYPE = {
+    "image": ".png",
+    "video": ".mp4",
+    "audio": ".mp3",
+}
+DEFAULT_FILENAME_HINT = ".file"
+
+
+def nextcloud_content_from_type(
+    media_type: str,
+    local_path: str,
+    filename: str = "",
+) -> dict:
+    """
+    Build content part from Nextcloud media type and local path.
+
+    Args:
+        media_type: "image", "video", "audio", or "file"
+        local_path: Local file path (already downloaded)
+        filename: Filename for the file
+
+    Returns:
+        Dict compatible with content_parts format
+    """
+    base = {
+        "type": "file",
+        "filename": filename or f"file_{media_type}",
+        "file_url": local_path,  # Local path, not remote URL!
+    }
+
+    if media_type == "image":
+        base["file_type"] = "image"
+    elif media_type == "video":
+        base["file_type"] = "video"
+    elif media_type == "audio":
+        base["file_type"] = "audio"
+    else:
+        base["file_type"] = "file"
+
+    return base
+
+
+class NextcloudTalkWebhookHandler(BaseHTTPRequestHandler):
+    """
+    HTTP webhook handler for Nextcloud Talk using Python standard library.
+
+    Receives POST requests from Nextcloud Talk,
+    verifies signatures, and forwards to the channel's enqueue callback.
+    """
+
+    # Class-level attributes (set by channel)
+    _enqueue_callback: Any = None
+    _webhook_secret: str = ""
+    _bot_prefix: str = ""
+    _api_user: str = ""  # Same as username (BOT account for WebDAV access)
+    _nc_username: str = ""  # Nextcloud username for authentication
+    _nc_password: str = ""  # Nextcloud password for authentication
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize handler.
+
+        Class-level attributes (set by channel):
+        - _enqueue_callback: Function to enqueue payloads to channel
+        - _webhook_secret: Shared secret for signature verification
+        - _bot_prefix: Bot message prefix
+        - _api_user: Bot account username for WebDAV access (alias for username)  # noqa: E501
+        """
+        self._enqueue_callback = self.__class__._enqueue_callback
+        self._webhook_secret = self.__class__._webhook_secret
+        self._bot_prefix = self.__class__._bot_prefix
+        self._api_user = self.__class__._api_user
+        self._nc_username = self.__class__._nc_username
+        self._nc_password = self.__class__._nc_password
+        super().__init__(*args, **kwargs)
+
+    def log_message(self, format, *args):
+        """Suppress default http.server logging"""
+        logger.info(f"nextcloud_talk webhook: {format % args}")
+
+    def do_POST(self):
+        """Handle POST requests from Nextcloud Talk."""
+        # Only handle the webhook path
+        if not self.path.startswith("/webhook/nextcloud_talk"):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'{"error":"Not found"}')
+            return
+
+        try:
+            # Extract headers
+            signature = self.headers.get(HEADER_SIGNATURE, "")
+            random = self.headers.get(HEADER_RANDOM, "")
+            backend = self.headers.get(HEADER_BACKEND, "")
+
+            logger.info(
+                f"nextcloud_talk webhook: backend_suffix={backend[-20:] if backend else 'None'} "  # noqa: E501
+                f"signature_len={len(signature)} random_len={len(random)}",
+            )
+
+            # Read request body
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+
+            # Verify signature
+            if not verify_request_signature(
+                body,
+                signature,
+                random,
+                self._webhook_secret,
+            ):
+                logger.warning(
+                    "nextcloud_talk webhook: signature verification failed",
+                )
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b'{"error":"Invalid signature"}')
+                return
+
+            # Parse JSON payload
+            try:
+                payload = json.loads(body.decode("utf-8", errors="ignore"))
+            except json.JSONDecodeError:
+                logger.error("nextcloud_talk webhook: invalid JSON payload")
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b'{"error":"Invalid JSON"}')
+                return
+
+            # Normalize backend URL
+            normalized_backend = extract_backend_url(backend)
+
+            # Process payload
+            self._process_payload(payload, normalized_backend)
+
+            # Return 200 OK
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+
+        except Exception:
+            logger.exception("nextcloud_talk webhook: handling failed")
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b'{"error":"Internal server error"}')
+
+    async def _download_media_to_local(
+        self,
+        url: str,
+        filename: str,
+        media_type: str,
+        mime_type: str,
+        api_user: str,
+        file_path: str,
+        username: str,
+        password: str,
+        backend_url: str,
+    ) -> str | None:
+        """
+        Download media from Nextcloud to local media_dir.
+        Returns local path or None on failure.
+        """
+        if not url:
+            logger.warning("download_media_to_local: empty URL")
+            return None
+
+        try:
+            # Prepare local path
+            from pathlib import Path
+
+            media_dir = Path("~/.copaw/media/nextcloud_talk").expanduser()
+            media_dir.mkdir(parents=True, exist_ok=True)
+
+            # Determine filename with extension
+            if not filename:
+                filename = f"file_{media_type}"
+
+            # Add extension based on mime_type or media_type
+            ext_map = {
+                "image/png": ".png",
+                "image/jpeg": ".jpg",
+                "image/gif": ".gif",
+                "image/webp": ".webp",
+                "video/mp4": ".mp4",
+                "video/webm": ".webm",
+                "audio/mpeg": ".mp3",
+                "audio/wav": ".wav",
+                "audio/ogg": ".ogg",
+            }
+            suffix = ext_map.get(
+                mime_type.lower(),
+            ) or FILENAME_HINT_BY_TYPE.get(media_type, DEFAULT_FILENAME_HINT)
+
+            # Generate safe filename
+            from hashlib import md5
+
+            safe_name = md5(url.encode()).hexdigest()[:16]
+            path = media_dir / f"{safe_name}{suffix}"
+
+            logger.info(f"Downloading Nextcloud media: {url} -> {path}")
+            logger.info(
+                f"Using credentials: username={username[:3] if username else 'None'}... password_present={bool(password)}",  # noqa: E501
+            )
+            logger.info(f"Using backend_url: {backend_url[:20]}...")
+
+            # Use NextcloudFilesClient for authenticated download
+            # Prefer the passed backend_url, fallback to self._backend_url if available  # noqa: E501
+            client = NextcloudFilesClient(
+                backend_url,
+                username,
+                password,
+            )
+
+            # Download using NextcloudFilesClient
+            success = await client.download_file(url, str(path))
+            await client.close()
+
+            if success and path.exists():
+                logger.info(f"Downloaded successfully: {path}")
+                return str(path)
+            else:
+                logger.warning(
+                    f"Download failed or path doesn't exist: {path}",
+                )
+                return None
+
+        except Exception as e:
+            logger.exception(f"nextcloud_talk media download failed: {e}")
+            return None
+
+    def _process_payload(self, payload: dict, backend_url: str) -> bool:
+        """
+        Process the Activity Streams payload and enqueue for processing.
+
+        Returns True if message was enqueued, False otherwise.
+        """
+        # Extract activity type - handle both direct and nested structures
+        activity_type = payload.get("type", "")
+
+        # Extract object first (needed for subsequent checks)
+        obj = payload.get("object", {})
+
+        # Some Nextcloud versions wrap the real activity in an "Activity" type
+        # If the type is "Activity", try to extract the real activity from object or meta  # noqa: E501
+        if activity_type == "Activity":
+            logger.debug(
+                "Detected wrapped Activity type, checking for nested structure",  # noqa: E501
+            )
+            # Try to get actual activity from object's summary or other fields
+            obj_summary = obj.get("summary", "")
+            if obj_summary:
+                logger.debug(f"Activity summary: {obj_summary}")
+
+            # Log full object for debugging
+            logger.info(
+                f"Activity object name: {obj.get('name')}, type: {obj.get('type')}",  # noqa: E501
+            )
+            logger.info(f"Activity object keys: {list(obj.keys())}")
+
+            # Log content field which may contain file info
+            obj_content = obj.get("content", "")
+            if obj_content:
+                logger.info(
+                    f"Activity object content (first 200 chars): {str(obj_content)[:200]}",  # noqa: E501
+                )
+                # Try to parse as JSON to see if it contains file data
+                try:
+                    import json as json_lib
+
+                    content_json = json_lib.loads(obj_content)
+                    logger.info(
+                        f"Activity content parsed: {list(content_json.keys()) if isinstance(content_json, dict) else type(content_json)}",  # noqa: E501
+                    )
+                    if "parameters" in content_json:
+                        logger.info(
+                            f"Activity has parameters: {list(content_json['parameters'].keys())}",  # noqa: E501
+                        )
+                except Exception as e:
+                    logger.debug(f"Content is not JSON: {e}")
+
+        # Extract actor information
+        actor = payload.get("actor", {})
+        (
+            actor_id,
+            actor_name,
+            actor_type,
+        ) = NextcloudTalkContentParser.parse_actor(actor)
+
+        # Extract target (conversation)
+        target = payload.get("target", {})
+        (
+            conversation_token,
+            conversation_name,
+        ) = NextcloudTalkContentParser.parse_conversation(target)
+
+        # 添加详细日志用于调试
+        logger.info(
+            f"nextcloud_talk webhook: activity={activity_type} "
+            f"actor={actor_id[:20]}... type={actor_type} "
+            f"conversation={conversation_name[:30] if len(conversation_name) > 30 else conversation_name}",  # noqa: E501
+        )
+        logger.debug(f"Full payload keys: {list(payload.keys())}")
+        logger.debug(
+            f"Object details: name={obj.get('name')}, content={str(obj.get('content', ''))[:100]}",  # noqa: E501
+        )
+        logger.debug(
+            f"Full payload preview: {json.dumps(payload, indent=2)[:500]}",
+        )
+
+        # 检查对话事件（bot added/removed）
+        conversation_event = (
+            NextcloudTalkContentParser.extract_conversation_event(payload)
+        )
+        if conversation_event:
+            logger.info(
+                f"nextcloud_talk webhook: bot {conversation_event} to conversation",  # noqa: E501
+            )
+            return False  # 不需要处理
+
+        # 检查反应
+        reaction_data = NextcloudTalkContentParser.extract_reaction(payload)
+        if reaction_data:
+            emoji, message_id = reaction_data
+            logger.info(
+                f"nextcloud_talk webhook: reaction emoji={emoji} message_id={message_id}",  # noqa: E501
+            )
+            return False  # 不处理反应
+
+        # 检查多媒体文件（图片、视频、音频）
+        media_info = NextcloudTalkContentParser.extract_media_file(payload)
+        if media_info:
+            logger.info(
+                f"nextcloud_talk webhook: media file type={media_info['type']} "  # noqa: E501
+                f"name={media_info['name']} size={media_info['size']}",
+            )
+
+            # 导入 webdav 工具函数
+            from .webdav import build_webdav_url
+            from .utils import extract_backend_url
+
+            # Normalize backend_url (remove /s/... suffix)
+            backend_url = extract_backend_url(backend_url)
+
+            # 尝试构建 WebDAV URL（如果 api_user 可用）
+            webdav_url = None
+            if self._api_user and media_info.get("path"):
+                # Try to extract filename from metadata
+                metadata = media_info.get("metadata", {})
+                filename = media_info.get("name", metadata.get("name", ""))
+                file_path = media_info.get("path", "")
+
+                logger.info(
+                    f"Building WebDAV URL: base_url={backend_url}, api_user={self._api_user}, file_path={file_path}, filename={filename}",  # noqa: E501
+                )
+
+                # Build WebDAV URL with file_path and filename
+                # Use NextcloudFilesClient to build URL with proper credentials
+                client = NextcloudFilesClient(
+                    backend_url,
+                    self._nc_username,
+                    self._nc_password,
+                )
+                webdav_url = client.build_webdav_url(self._api_user, file_path)
+                if webdav_url:
+                    logger.info(f"Built WebDAV URL: {webdav_url}")
+                else:
+                    logger.warning(
+                        f"Failed to build WebDAV URL for path: {file_path}, api_user: {self._api_user}",  # noqa: E501
+                    )
+
+            # Extract share link from metadata for agent to access the file
+            metadata = media_info.get("metadata", {})
+            share_link = metadata.get("share-token") or metadata.get("link")
+
+            # 优先使用 WebDAV URL，fallback 到分享链接
+            download_url = webdav_url
+            if not download_url and share_link:
+                download_url = share_link
+
+            # Ensure download_url is not None
+            if not download_url:
+                logger.warning("No download URL available for media file")
+                return False
+
+            # Download file directly to local path (like DingTalk does)
+            # Use asyncio.run to call async method from sync context
+            local_file_path = asyncio.run(
+                self._download_media_to_local(
+                    download_url,
+                    media_info["name"],
+                    media_info["type"],
+                    media_info["mime_type"],
+                    self._api_user,
+                    media_info.get("path", ""),
+                    self._nc_username,
+                    self._nc_password,
+                    backend_url,  # Pass backend_url for NextcloudFilesClient
+                ),
+            )
+
+            if local_file_path:
+                # Create content part with local path (not remote URL!)
+                file_part = nextcloud_content_from_type(
+                    media_info["type"],
+                    local_file_path,
+                    media_info["name"],
+                )
+
+                channel_payload = {
+                    "channel_id": "nextcloud_talk",
+                    "sender_id": actor_id,
+                    "session_webhook": backend_url,
+                    "content_parts": [file_part],
+                    "meta": {
+                        "actor_id": actor_id,
+                        "actor_name": actor_name,
+                        "actor_type": actor_type,
+                        "conversation_token": conversation_token,
+                        "conversation_name": conversation_name,
+                        "message_id": obj.get("id", ""),
+                        "backend_url": backend_url,
+                        "bot_prefix": self._bot_prefix,
+                        "media_info": media_info,
+                        "api_user": self._api_user,
+                        "local_file_path": local_file_path,  # Add local path for verification  # noqa: E501
+                    },
+                }
+            else:
+                logger.warning(
+                    f"Failed to download media: {media_info['name']}",
+                )
+                return False
+
+            # 入队
+            logger.info(
+                f"Checking enqueue callback: {self._enqueue_callback is not None}",  # noqa: E501
+            )
+            if self._enqueue_callback:
+                logger.info(f"Enqueueing media file: {media_info['name']}")
+                # Schedule the async callback in the main event loop
+                try:
+                    # 获取主事件循环（由应用启动时创建）
+                    loop = asyncio.get_running_loop()
+                    # 在主线程的事件循环中调度协程
+                    asyncio.run_coroutine_threadsafe(
+                        self._enqueue_callback(channel_payload),
+                        loop,
+                    )
+                except RuntimeError:
+                    # 如果没有运行中的事件循环，在新线程中运行
+                    def run_in_thread():
+                        asyncio.run(self._enqueue_callback(channel_payload))
+
+                    thread = threading.Thread(
+                        target=run_in_thread,
+                        daemon=True,
+                    )
+                    thread.start()
+                return True
+            else:
+                logger.warning(
+                    "nextcloud_talk webhook: no enqueue callback set",
+                )
+                return False
+        else:
+            # 添加调试日志，查看 payload 结构
+            logger.debug(
+                f"Not a media file. activity_type={payload.get('type')}, object_name={obj.get('name')}",  # noqa: E501
+            )
+
+        # 检查普通消息
+        message = NextcloudTalkContentParser.extract_message_text(payload)
+        if message is None:
+            logger.debug(
+                "nextcloud_talk webhook: not a regular message, ignoring",
+            )
+            return False
+
+        # 构建用于 channel 处理的 payload
+        channel_payload = {
+            "channel_id": "nextcloud_talk",
+            "sender_id": actor_id,
+            "session_webhook": backend_url,
+            "content_parts": [{"type": "text", "text": message}],
+            "meta": {
+                "actor_id": actor_id,
+                "actor_name": actor_name,
+                "actor_type": actor_type,
+                "conversation_token": conversation_token,
+                "conversation_name": conversation_name,
+                "message_id": obj.get("id", ""),
+                "backend_url": backend_url,
+                "bot_prefix": self._bot_prefix,
+            },
+        }
+
+        logger.info(
+            f"nextcloud_talk webhook: enqueueing message from {actor_name}",
+        )
+
+        # 入队
+        if self._enqueue_callback:
+            # Schedule the async callback in the main event loop
+            try:
+                # 获取主事件循环（由应用启动时创建）
+                loop = asyncio.get_running_loop()
+                # 在主线程的事件循环中调度协程
+                asyncio.run_coroutine_threadsafe(
+                    self._enqueue_callback(channel_payload),
+                    loop,
+                )
+                logger.info(f"Scheduled message processing for: {actor_name}")
+            except RuntimeError:
+                # 如果没有运行中的事件循环，在新线程中运行
+                def run_in_thread():
+                    asyncio.run(self._enqueue_callback(channel_payload))
+
+                thread = threading.Thread(target=run_in_thread, daemon=True)
+                thread.start()
+                logger.info(
+                    f"Started thread for message processing: {actor_name}",
+                )
+            return True
+        else:
+            logger.warning("nextcloud_talk webhook: no enqueue callback set")
+            return False
+
+
+class StdlibWebhookServer:
+    """
+    Webhook server using Python standard library http.server.
+
+    Runs in a separate thread to avoid blocking the main event loop.
+    """
+
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+        webhook_path: str = "/webhook/nextcloud_talk",
+    ):
+        """
+        Initialize server.
+
+        Args:
+            host: Server host (default "0.0.0.0" for all interfaces)
+            port: Server port (default 8765)
+            webhook_path: Webhook endpoint path
+        """
+        self.host = host
+        self.port = port
+        self.webhook_path = webhook_path
+
+        self._server: Optional[HTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def set_enqueue_callback(self, callback: Callable):
+        """Set the enqueue callback for the handler."""
+        NextcloudTalkWebhookHandler._enqueue_callback = callback
+
+    def set_webhook_secret(self, secret: str):
+        """Set the webhook secret for signature verification."""
+        NextcloudTalkWebhookHandler._webhook_secret = secret
+
+    def set_bot_prefix(self, prefix: str):
+        """Set the bot message prefix."""
+        NextcloudTalkWebhookHandler._bot_prefix = prefix
+
+    def set_api_user(self, api_user: str):
+        """Set the bot API user for WebDAV access."""
+        NextcloudTalkWebhookHandler._api_user = api_user
+
+    def set_credentials(self, username: str, password: str):
+        """Set Nextcloud credentials for file downloads."""
+        NextcloudTalkWebhookHandler._nc_username = username
+        NextcloudTalkWebhookHandler._nc_password = password
+
+    def start(self):
+        """Start the webhook server in a background thread."""
+        if self._server is not None:
+            logger.warning("nextcloud_talk webhook server already running")
+            return
+
+        def run_server():
+            self._server = HTTPServer(
+                (self.host, self.port),
+                NextcloudTalkWebhookHandler,
+            )
+            logger.info(
+                f"nextcloud_talk webhook server listening on {self.host}:{self.port}",  # noqa: E501
+            )
+            self._server.serve_forever()
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=run_server, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the webhook server."""
+        if self._server is None:
+            return
+
+        self._stop_event.set()
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None
+
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+        logger.info("nextcloud_talk webhook server stopped")

--- a/src/copaw/app/channels/nextcloud_talk/utils.py
+++ b/src/copaw/app/channels/nextcloud_talk/utils.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for Nextcloud Talk channel."""
+
+# pylint: disable=W0611  # unused-import
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from .constants import (
+    HEADER_SIGNATURE,
+    HEADER_RANDOM,
+    HEADER_BACKEND,
+    SIGNATURE_LENGTH,
+    RANDOM_LENGTH,
+    BOT_HEADER_RANDOM,
+    BOT_HEADER_SIGNATURE,
+    OCS_API_REQUEST_HEADER,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def verify_request_signature(
+    body: bytes,
+    signature_header: str,
+    random_header: str,
+    secret: str,
+) -> bool:
+    """
+    Verify HMAC-SHA256 signature for incoming webhook request.
+
+    Args:
+        body: Raw request body (bytes)
+        signature_header: Value from X-Nextcloud-Talk-Signature header
+        random_header: Value from X-Nextcloud-Talk-Random header
+        secret: Shared secret configured for the bot
+
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    if not signature_header or not random_header:
+        logger.warning("Missing signature or random header")
+        return False
+
+    # Validate lengths
+    if len(signature_header) != SIGNATURE_LENGTH:
+        logger.warning(f"Invalid signature length: {len(signature_header)}")
+        return False
+
+    if len(random_header) != RANDOM_LENGTH:
+        logger.warning(f"Invalid random length: {len(random_header)}")
+        return False
+
+    try:
+        # Calculate expected signature
+        # Signature is HMAC-SHA256 of RANDOM + BODY
+        message_to_sign = random_header.encode("utf-8") + body
+
+        expected_digest = hmac.new(
+            secret.encode("utf-8"),
+            message_to_sign,
+            hashlib.sha256,
+        ).hexdigest()
+
+        # Compare using constant-time comparison
+        is_valid = hmac.compare_digest(
+            signature_header.lower(),
+            expected_digest.lower(),
+        )
+
+        if not is_valid:
+            logger.warning("Signature verification failed")
+
+        return is_valid
+
+    except Exception as e:
+        logger.exception(f"Signature verification error: {e}")
+        return False
+
+
+def generate_bot_signature(
+    message_text: str,
+    secret: str,
+) -> tuple[str, str]:
+    """
+    Generate HMAC-SHA256 signature for outgoing bot request.
+
+    Args:
+        message_text: The message text value (not the full JSON body)
+        secret: Shared secret configured for the bot
+
+    Returns:
+        Tuple of (random_value, signature)
+    """
+    import secrets
+
+    # Generate random value
+    random_value = secrets.token_hex(32)
+
+    # Calculate signature using random + message text (not full JSON body)
+    # This matches Nextcloud Talk Bot API verification logic
+    message_to_sign = random_value + message_text
+
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        message_to_sign.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return (random_value, signature)
+
+
+def get_media_url(
+    nextcloud_url: str,
+    media_id: str,
+) -> str:
+    """
+    Build URL to access uploaded media.
+
+    For Nextcloud Talk, media can be shared via the Files app.
+    """
+    return f"{nextcloud_url.rstrip('/')}/index.php/f/{media_id}"
+
+
+def normalize_nextcloud_url(url: str) -> str:
+    """
+    Normalize Nextcloud base URL, ensuring it has a trailing slash.
+    """
+    if not url:
+        return ""
+    url = url.rstrip("/")
+    if not url.startswith(("http://", "https://")):
+        # Assume https if not specified
+        url = "https://" + url
+    return url + "/"
+
+
+def get_config_path() -> Path:
+    """Get the CoPaw config directory path."""
+    config_home = os.environ.get("CO_AW_CONFIG_HOME")
+    if config_home:
+        return Path(config_home)
+    data_home = os.environ.get("XDG_DATA_HOME")
+    if data_home:
+        return Path(data_home) / ".copaw"
+    return Path.home() / ".copaw"
+
+
+def get_token_store_path() -> Path:
+    """Get the path to the bot token store file."""
+    config_path = get_config_path()
+    return config_path / "nextcloud_talk_tokens.json"
+
+
+def load_token_store() -> Dict[str, Any]:
+    """Load bot token store from disk."""
+    path = get_token_store_path()
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        logger.warning(f"Failed to load token store from {path}")
+        return {}
+
+
+def save_token_store(store: Dict[str, Any]) -> None:
+    """Save bot token store to disk."""
+    path = get_token_store_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(store, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.warning(f"Failed to save token store to {path}: {e}")
+
+
+def extract_backend_url(backend_header: str) -> str:
+    """
+    Extract and normalize backend URL from header.
+    """
+    return normalize_nextcloud_url(backend_header)
+
+
+def build_bot_headers(
+    secret: str,
+    message_text: str,
+) -> Dict[str, str]:
+    """
+    Build headers for outgoing bot API request.
+
+    Args:
+        secret: Shared secret configured for the bot
+        message_text: The message text value (not the full JSON body)
+
+    Returns:
+        Dictionary with X-Nextcloud-Talk-Bot-Random,
+        X-Nextcloud-Talk-Bot-Signature, and OCS-APIRequest headers
+    """
+    random_val, signature = generate_bot_signature(message_text, secret)
+
+    return {
+        BOT_HEADER_RANDOM: random_val,
+        BOT_HEADER_SIGNATURE: signature,
+        OCS_API_REQUEST_HEADER: "true",
+    }

--- a/src/copaw/app/channels/nextcloud_talk/webdav.py
+++ b/src/copaw/app/channels/nextcloud_talk/webdav.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Nextcloud WebDAV URL construction utilities."""
+
+# pylint: disable=W0611  # unused-import
+
+from urllib.parse import quote
+
+
+def build_webdav_url(
+    base_url: str,
+    api_user: str,
+    file_path_or_full: str,
+) -> str | None:
+    """
+    Build a WebDAV download URL for a Nextcloud file.
+
+    Uses the format: {base_url}/remote.php/dav/files/{api_user}/{file_path}
+    Following OpenClaw PR #29256 implementation.
+
+    The file_path_or_full parameter contains either:
+    - A directory path (e.g., "Talk" or "Photos") when filename is provided separately  # noqa: E501
+    - A full path with filename (e.g., "Talk/image.jpg") if no separate filename  # noqa: E501
+
+    Args:
+        base_url: Nextcloud base URL (e.g., https://example.com/nextcloud)
+        api_user: API username for the bot account
+        file_path_or_full: File path (directory or full path with filename)
+
+    Returns:
+        WebDAV URL or None if parameters are insufficient
+
+    Example:
+        >>> build_webdav_url(
+        ...     "https://cloud.example.com/nextcloud",
+        ...     "bot-user",
+        ...     "Talk/image.jpg"
+        ... )
+        'https://cloud.example.com/nextcloud/remote.php/dav/files/bot-user/Talk/image.jpg'
+    """
+    # Normalize base URL
+    base_url = base_url.rstrip("/")
+
+    # Check required parameters
+    if not base_url or not api_user or not file_path_or_full:
+        return None
+
+    # Use file_path_or_full directly (already contains full path)
+    # Do NOT append filename again to avoid duplication
+    webdav_path = file_path_or_full.lstrip("/")
+
+    # Encode path: split by "/" and encode each segment
+    # This ensures spaces and special characters are properly encoded
+    encoded_path_segments = [
+        quote(segment) for segment in webdav_path.split("/")
+    ]
+    encoded_path = "/".join(encoded_path_segments)
+
+    # Encode the username
+    encoded_user = quote(api_user)
+
+    # Build WebDAV URL
+    webdav_url = (
+        f"{base_url}/remote.php/dav/files/{encoded_user}/{encoded_path}"
+    )
+
+    return webdav_url

--- a/src/copaw/app/channels/registry.py
+++ b/src/copaw/app/channels/registry.py
@@ -25,6 +25,7 @@ _BUILTIN_SPECS: dict[str, tuple[str, str]] = {
     "telegram": (".telegram", "TelegramChannel"),
     "mattermost": (".mattermost", "MattermostChannel"),
     "mqtt": (".mqtt", "MQTTChannel"),
+    "nextcloud_talk": (".nextcloud_talk", "NextcloudTalkChannel"),
     "console": (".console", "ConsoleChannel"),
     "matrix": (".matrix", "MatrixChannel"),
     "voice": (".voice", "VoiceChannel"),

--- a/src/copaw/app/channels/schema.py
+++ b/src/copaw/app/channels/schema.py
@@ -35,8 +35,11 @@ BUILTIN_CHANNEL_TYPES = (
     "feishu",
     "qq",
     "telegram",
+    "mattermost",
     "mqtt",
+    "nextcloud_talk",
     "console",
+    "matrix",
     "voice",
 )
 

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -26,6 +26,7 @@ from ...config.config import (
     MatrixConfig,
     MattermostConfig,
     MQTTConfig,
+    NextcloudTalkConfig,
     QQConfig,
     TelegramConfig,
     VoiceChannelConfig,
@@ -48,6 +49,7 @@ _CHANNEL_CONFIG_CLASS_MAP = {
     "mattermost": MattermostConfig,
     "mqtt": MQTTConfig,
     "matrix": MatrixConfig,
+    "nextcloud_talk": NextcloudTalkConfig,
 }
 
 

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=C0301  # line-too-long
+
 import os
 from typing import Optional, Union, Dict, List, Literal
 from pydantic import BaseModel, Field, ConfigDict, model_validator
@@ -96,6 +98,20 @@ class MattermostConfig(BaseChannelConfig):
     thread_follow_without_mention: bool = False
 
 
+class NextcloudTalkConfig(BaseChannelConfig):
+    """
+    Nextcloud Talk (Spreed) channel: webhook_secret, webhook configuration.
+    Webhook settings control the HTTP server that receives messages from Nextcloud Talk.  # noqa: E501
+    """
+
+    webhook_secret: str = ""
+    webhook_host: str = "0.0.0.0"
+    webhook_port: int = 8765
+    webhook_path: str = "/webhook/nextcloud_talk"
+    username: str = ""
+    password: str = ""
+
+
 class ConsoleConfig(BaseChannelConfig):
     """Console channel: prints agent responses to stdout."""
 
@@ -134,6 +150,7 @@ class ChannelConfig(BaseModel):
     dingtalk: DingTalkConfig = DingTalkConfig()
     feishu: FeishuConfig = FeishuConfig()
     qq: QQConfig = QQConfig()
+    nextcloud_talk: NextcloudTalkConfig = NextcloudTalkConfig()
     telegram: TelegramConfig = TelegramConfig()
     mattermost: MattermostConfig = MattermostConfig()
     mqtt: MQTTConfig = MQTTConfig()
@@ -495,6 +512,7 @@ ChannelConfigUnion = Union[
     DingTalkConfig,
     FeishuConfig,
     QQConfig,
+    NextcloudTalkConfig,
     TelegramConfig,
     MattermostConfig,
     MQTTConfig,

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -641,20 +641,102 @@ Invite the bot to a room or send it a direct message from any Matrix client (e.g
 
 ---
 
+## Nextcloud Talk
+
+Nextcloud Talk (formerly Spreed) is Nextcloud's built-in chat application. CoPaw receives messages via the **Webhook Bot API** and sends replies via the **Bot API**, supporting both direct messages and group chats.
+
+### Prerequisites
+
+- Admin access to your Nextcloud server (or ask an admin to install the Bot)
+- Nextcloud Talk app enabled
+
+### Install the Bot
+
+1. On your Nextcloud server, run the following command as an admin to install the Bot:
+
+   ```bash
+   ./occ talk:bot:install copaw "http://your-server:8765/webhook/nextcloud_talk" --secret=your-secret
+   ```
+
+   Parameters:
+
+   - `copaw` — Bot name (customizable)
+   - `http://your-server:8765/webhook/nextcloud_talk` — Webhook URL; replace `your-server` with the address of the server running CoPaw
+   - `--secret=your-secret` — Secret for signature verification (customizable; recommend using a random string)
+
+2. Note the **Bot ID** returned after installation.
+
+### Get Nextcloud credentials
+
+To support receiving images, files, and other media, CoPaw needs to download files from the Nextcloud server via WebDAV:
+
+1. Prepare a Nextcloud user account (can be a regular user)
+2. Note the **username** and **password** (or an app password)
+
+> **Tip:** It's recommended to create an **app password** in Nextcloud personal settings instead of using the account's main password.
+
+### Configure the channel
+
+**Method 1:** Configure in the Console
+
+Go to **Control → Channels**, click **Nextcloud Talk**, enable it and fill in:
+
+- **Webhook Secret** — The secret set when installing the Bot
+- **Webhook Host** — Webhook listening address, default `0.0.0.0` (listen on all interfaces)
+- **Webhook Port** — Webhook port, default `8765`
+- **Webhook Path** — Webhook path, default `/webhook/nextcloud_talk`
+- **Username** — Nextcloud username (for downloading media files)
+- **Password** — Nextcloud password or app password
+
+**Method 2:** Edit `~/.copaw/config.json`
+
+Find `channels.nextcloud_talk` in `config.json`:
+
+```json
+"nextcloud_talk": {
+  "enabled": true,
+  "bot_prefix": "[BOT]",
+  "webhook_secret": "your-secret",
+  "webhook_host": "0.0.0.0",
+  "webhook_port": 8765,
+  "webhook_path": "/webhook/nextcloud_talk",
+  "username": "nextcloud-username",
+  "password": "nextcloud-password"
+}
+```
+
+Save the file; the channel will reload automatically if CoPaw is already running.
+
+### Verify the setup
+
+1. Start CoPaw: `copaw app`
+2. Find the installed Bot in Nextcloud Talk and send a message
+3. CoPaw should reply automatically
+
+### Notes
+
+- **Network reachability:** The Nextcloud server must be able to reach CoPaw's webhook address. If CoPaw runs on an internal network, configure port forwarding or a reverse proxy.
+- **Firewall:** Ensure the webhook port (default 8765) is open in your firewall.
+- **Media files:** To receive images, files, etc., you must configure `username` and `password`; otherwise, media downloads will fail.
+- **Signature verification:** The `webhook_secret` must match the `--secret` parameter set when installing the Bot, otherwise signature verification will fail.
+
+---
+
 ## Appendix
 
 ### Config overview
 
-| Channel    | Config key | Main fields                                                             |
-| ---------- | ---------- | ----------------------------------------------------------------------- |
-| DingTalk   | dingtalk   | client_id, client_secret                                                |
-| Feishu     | feishu     | app_id, app_secret; optional encrypt_key, verification_token, media_dir |
-| iMessage   | imessage   | db_path, poll_sec (macOS only)                                          |
-| Discord    | discord    | bot_token; optional http_proxy, http_proxy_auth                         |
-| QQ         | qq         | app_id, client_secret                                                   |
-| Telegram   | telegram   | bot_token; optional http_proxy, http_proxy_auth                         |
-| Mattermost | mattermost | url, bot_token; optional show_typing, dm_policy, allow_from             |
-| Matrix     | matrix     | homeserver, user_id, access_token                                       |
+| Channel       | Config key     | Main fields                                                             |
+| ------------- | -------------- | ----------------------------------------------------------------------- |
+| DingTalk      | dingtalk       | client_id, client_secret                                                |
+| Feishu        | feishu         | app_id, app_secret; optional encrypt_key, verification_token, media_dir |
+| iMessage      | imessage       | db_path, poll_sec (macOS only)                                          |
+| Discord       | discord        | bot_token; optional http_proxy, http_proxy_auth                         |
+| QQ            | qq             | app_id, client_secret                                                   |
+| Telegram      | telegram       | bot_token; optional http_proxy, http_proxy_auth                         |
+| Mattermost    | mattermost     | url, bot_token; optional show_typing, dm_policy, allow_from             |
+| Matrix        | matrix         | homeserver, user_id, access_token                                       |
+| NextcloudTalk | nextcloud_talk | webhook_secret; optional webhook_host, webhook_port, username, password |
 
 Field details and structure are in the tables above and [Config & working dir](./config).
 
@@ -665,16 +747,17 @@ video, audio, and file varies by channel.
 **✓** = supported. **🚧** = under construction (implementable but not yet
 done). **✗** = not supported (not possible on this channel).
 
-| Channel    | Recv text | Recv image | Recv video | Recv audio | Recv file | Send text | Send image | Send video | Send audio | Send file |
-| ---------- | --------- | ---------- | ---------- | ---------- | --------- | --------- | ---------- | ---------- | ---------- | --------- |
-| DingTalk   | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
-| Feishu     | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
-| Discord    | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
-| iMessage   | ✓         | ✗          | ✗          | ✗          | ✗         | ✓         | ✗          | ✗          | ✗          | ✗         |
-| QQ         | ✓         | 🚧         | 🚧         | 🚧         | 🚧        | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
-| Telegram   | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
-| Mattermost | ✓         | ✓          | 🚧         | 🚧         | ✓         | ✓         | ✓          | 🚧         | 🚧         | ✓         |
-| Matrix     | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
+| Channel       | Recv text | Recv image | Recv video | Recv audio | Recv file | Send text | Send image | Send video | Send audio | Send file |
+| ------------- | --------- | ---------- | ---------- | ---------- | --------- | --------- | ---------- | ---------- | ---------- | --------- |
+| DingTalk      | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
+| Feishu        | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
+| Discord       | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
+| iMessage      | ✓         | ✗          | ✗          | ✗          | ✗         | ✓         | ✗          | ✗          | ✗          | ✗         |
+| QQ            | ✓         | 🚧         | 🚧         | 🚧         | 🚧        | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
+| Telegram      | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
+| Mattermost    | ✓         | ✓          | 🚧         | 🚧         | ✓         | ✓         | ✓          | 🚧         | 🚧         | ✓         |
+| Matrix        | ✓         | ✓          | ✓          | ✓          | ✓         | ✓         | ✓          | ✓          | ✓          | ✓         |
+| NextcloudTalk | ✓         | ✓          | 🚧         | 🚧         | ✓         | ✓         | 🚧         | 🚧         | 🚧         | 🚧        |
 
 Notes:
 
@@ -691,6 +774,7 @@ Notes:
   currently text + link-only.
 - **Telegram**: Attachments are parsed as files on receive and can be opened in the corresponding format (image / voice / video / file) within the Telegram chat interface.
 - **Matrix**: Receives image, video, audio, and file attachments via `mxc://` media URLs. Sends media by uploading to the homeserver and sending native Matrix media messages (`m.image`, `m.video`, `m.audio`, `m.file`).
+- **NextcloudTalk**: Receives messages via Webhook; images/files are downloaded via WebDAV; sending media attachments is 🚧 (currently text-only replies).
 
 ### Changing config via HTTP
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -637,20 +637,102 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Co
 
 ---
 
+## Nextcloud Talk
+
+Nextcloud Talk（原名 Spreed）是 Nextcloud 的内置聊天应用。CoPaw 通过 **Webhook Bot API** 接收消息，通过 **Bot API** 发送回复，支持私聊和群聊。
+
+### 前提条件
+
+- 拥有 Nextcloud 服务器的管理员权限（或联系管理员安装 Bot）
+- Nextcloud Talk 应用已启用
+
+### 安装 Bot
+
+1. 在 Nextcloud 服务器上，以管理员身份运行以下命令安装 Bot：
+
+   ```bash
+   ./occ talk:bot:install copaw "http://your-server:8765/webhook/nextcloud_talk" --secret=your-secret
+   ```
+
+   参数说明：
+
+   - `copaw` — Bot 名称（可自定义）
+   - `http://your-server:8765/webhook/nextcloud_talk` — Webhook URL，`your-server` 替换为运行 CoPaw 的服务器地址
+   - `--secret=your-secret` — 用于签名验证的密钥（可自定义，建议使用随机字符串）
+
+2. 记录安装完成后返回的 **Bot ID**。
+
+### 获取 Nextcloud 凭证
+
+为了支持接收图片、文件等媒体内容，CoPaw 需要通过 WebDAV 下载 Nextcloud 服务器上的文件：
+
+1. 准备一个 Nextcloud 用户账号（可以是普通用户）
+2. 记录该用户的 **用户名** 和 **密码**（或应用密码）
+
+> **提示：** 建议在 Nextcloud 个人设置中创建 **应用密码**，而非使用账号主密码。
+
+### 配置频道
+
+**方式一：** 在 Console 中配置
+
+前往 **控制 → 频道**，点击 **Nextcloud Talk**，启用后填写：
+
+- **Webhook Secret** — 安装 Bot 时设置的密钥
+- **Webhook Host** — Webhook 监听地址，默认 `0.0.0.0`（监听所有网卡）
+- **Webhook Port** — Webhook 端口，默认 `8765`
+- **Webhook Path** — Webhook 路径，默认 `/webhook/nextcloud_talk`
+- **Username** — Nextcloud 用户名（用于下载媒体文件）
+- **Password** — Nextcloud 密码或应用密码
+
+**方式二：** 编辑 `~/.copaw/config.json`
+
+在 `config.json` 中找到 `channels.nextcloud_talk`：
+
+```json
+"nextcloud_talk": {
+  "enabled": true,
+  "bot_prefix": "[BOT]",
+  "webhook_secret": "your-secret",
+  "webhook_host": "0.0.0.0",
+  "webhook_port": 8765,
+  "webhook_path": "/webhook/nextcloud_talk",
+  "username": "nextcloud-username",
+  "password": "nextcloud-password"
+}
+```
+
+保存后，若 CoPaw 已在运行，频道会自动重载。
+
+### 验证配置
+
+1. 启动 CoPaw：`copaw app`
+2. 在 Nextcloud Talk 中找到安装的 Bot，发送消息
+3. CoPaw 应该会自动回复
+
+### 注意事项
+
+- **网络可达性**：Nextcloud 服务器必须能够访问 CoPaw 的 Webhook 地址。如果 CoPaw 运行在内网，需要配置端口转发或反向代理。
+- **防火墙**：确保 Webhook 端口（默认 8765）在防火墙中开放。
+- **媒体文件**：如需接收图片、文件等，必须配置 `username` 和 `password`，否则媒体下载会失败。
+- **签名验证**：`webhook_secret` 必须与安装 Bot 时设置的 `--secret` 参数一致，否则签名验证会失败。
+
+---
+
 ## 附录
 
 ### 配置总览
 
-| 频道       | 配置键     | 必填/主要字段                                                       |
-| ---------- | ---------- | ------------------------------------------------------------------- |
-| 钉钉       | dingtalk   | client_id, client_secret                                            |
-| 飞书       | feishu     | app_id, app_secret；可选 encrypt_key, verification_token, media_dir |
-| iMessage   | imessage   | db_path, poll_sec（仅 macOS）                                       |
-| Discord    | discord    | bot_token；可选 http_proxy, http_proxy_auth                         |
-| QQ         | qq         | app_id, client_secret                                               |
-| Telegram   | telegram   | bot_token；可选 http_proxy, http_proxy_auth                         |
-| Mattermost | mattermost | url, bot_token; 可选 show_typing, dm_policy, allow_from             |
-| Matrix     | matrix     | homeserver, user_id, access_token                                   |
+| 频道          | 配置键         | 必填/主要字段                                                       |
+| ------------- | -------------- | ------------------------------------------------------------------- |
+| 钉钉          | dingtalk       | client_id, client_secret                                            |
+| 飞书          | feishu         | app_id, app_secret；可选 encrypt_key, verification_token, media_dir |
+| iMessage      | imessage       | db_path, poll_sec（仅 macOS）                                       |
+| Discord       | discord        | bot_token；可选 http_proxy, http_proxy_auth                         |
+| QQ            | qq             | app_id, client_secret                                               |
+| Telegram      | telegram       | bot_token；可选 http_proxy, http_proxy_auth                         |
+| Mattermost    | mattermost     | url, bot_token; 可选 show_typing, dm_policy, allow_from             |
+| Matrix        | matrix         | homeserver, user_id, access_token                                   |
+| NextcloudTalk | nextcloud_talk | webhook_secret；可选 webhook_host, webhook_port, username, password |
 
 各频道字段与完整结构见上文表格及 [配置与工作目录](./config)。
 
@@ -659,16 +741,17 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Co
 不同频道对「文本 / 图片 / 视频 / 音频 / 文件」的**接收**（用户发给机器人）与**发送**（机器人回复用户）支持程度如下。
 「✓」= 已支持；「🚧」= 施工中（可实现但尚未实现）；「✗」= 不支持（该频道本身无法支持）。
 
-| 频道       | 接收文本 | 接收图片 | 接收视频 | 接收音频 | 接收文件 | 发送文本 | 发送图片 | 发送视频 | 发送音频 | 发送文件 |
-| ---------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
-| 钉钉       | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
-| 飞书       | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
-| Discord    | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
-| iMessage   | ✓        | ✗        | ✗        | ✗        | ✗        | ✓        | ✗        | ✗        | ✗        | ✗        |
-| QQ         | ✓        | 🚧       | 🚧       | 🚧       | 🚧       | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
-| Telegram   | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
-| Mattermost | ✓        | ✓        | 🚧       | 🚧       | ✓        | ✓        | ✓        | 🚧       | 🚧       | ✓        |
-| Matrix     | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
+| 频道          | 接收文本 | 接收图片 | 接收视频 | 接收音频 | 接收文件 | 发送文本 | 发送图片 | 发送视频 | 发送音频 | 发送文件 |
+| ------------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
+| 钉钉          | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
+| 飞书          | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
+| Discord       | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
+| iMessage      | ✓        | ✗        | ✗        | ✗        | ✗        | ✓        | ✗        | ✗        | ✗        | ✗        |
+| QQ            | ✓        | 🚧       | 🚧       | 🚧       | 🚧       | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
+| Telegram      | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
+| Mattermost    | ✓        | ✓        | 🚧       | 🚧       | ✓        | ✓        | ✓        | 🚧       | 🚧       | ✓        |
+| Matrix        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        | ✓        |
+| NextcloudTalk | ✓        | ✓        | 🚧       | 🚧       | ✓        | ✓        | 🚧       | 🚧       | 🚧       | 🚧       |
 
 说明：
 
@@ -679,6 +762,7 @@ Matrix 频道通过 [matrix-nio](https://github.com/poljar/matrix-nio) 库将 Co
 - **QQ**：接收侧附件解析为多模态、发送侧真实媒体均为 🚧 施工中，当前仅文本 + 链接形式。
 - **Telegram**：接收时附件会解析为文件并传入，可在telegram对话界面以对应格式打开（图片 / 语音 / 视频 / 文件）
 - **Matrix**：接收图片 / 视频 / 音频 / 文件（通过 `mxc://` 媒体 URL）；发送时将文件上传至服务器后以原生 Matrix 媒体消息（`m.image`、`m.video`、`m.audio`、`m.file`）发出。
+- **NextcloudTalk**：通过 Webhook 接收消息；接收图片/文件通过 WebDAV 下载；发送侧媒体附件为 🚧 施工中，当前仅支持文本回复。
 
 ### 通过 HTTP 修改配置
 


### PR DESCRIPTION
## Description

Add Nextcloud Talk (Spreed) channel integration via Webhook Bot API.

**Features:**
- Receive chat messages via webhook with HMAC-SHA256 signature verification
- Send messages via Nextcloud Talk Bot API
- Image/media download via WebDAV with Basic Auth


**Configuration:**
- `webhook_secret`: Shared secret for signature verification
- `webhook_host/port/path`: Webhook server settings
- `username/password`: Nextcloud credentials for WebDAV file download

**Documentation:**
- Added configuration guide to `channels.zh.md` and `channels.en.md`

**Security Considerations:**
- HMAC-SHA256 signature verification for webhook requests
- Credentials stored in config.json (user's local machine)
- Optional app password support for WebDAV access

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Documentation (website)
- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Skills
- [ ] CLI
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Configure webhook settings in `~/.copaw/config.json`:
```json
"nextcloud_talk": {
  "enabled": true,
  "webhook_secret": "your-secret",
  "username": "nextcloud-username",
  "password": "nextcloud-password"
}
```

2. Install bot on Nextcloud server:
```bash
./occ talk:bot:install copaw "http://your-server:8765/webhook/nextcloud_talk" --secret=your-secret
```

3. Start CoPaw: `copaw app`

4. Send a message to the bot in Nextcloud Talk and verify reply

## Local Verification Evidence

```bash
pre-commit run --all-files
[INFO] Installing environment for https://github.com/PyCQA/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pylint-dev/pylint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

pytest
======================================================================================== test session starts ========================================================================================
platform win32 -- Python 3.11.7, pytest-9.0.2, pluggy-1.6.0
rootdir: E:\ai\CoPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.7, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 64 items

tests\integrated\test_app_startup.py .                                                                                                                                                         [  1%]
tests\integrated\test_version.py ...                                                                                                                                                           [  6%]
tests\test_cli_version.py .                                                                                                                                                                    [  7%]
tests\unit\providers\test_anthropic_provider.py .......                                                                                                                                        [ 18%]
tests\unit\providers\test_default_provider.py ..                                                                                                                                               [ 21%]
tests\unit\providers\test_minimax_provider.py .......                                                                                                                                          [ 32%]
tests\unit\providers\test_ollama_manager_timeout.py .                                                                                                                                          [ 34%]
tests\unit\providers\test_ollama_provider.py ..............                                                                                                                                    [ 56%]
tests\unit\providers\test_openai_provider.py ...........                                                                                                                                       [ 73%]
tests\unit\providers\test_openai_stream_toolcall_compat.py ..                                                                                                                                  [ 76%]
tests\unit\providers\test_provider_manager.py ...............                                                                                                                                  [100%]

======================================================================================== 64 passed in 37.13s =======================================================================================
```

## Additional Notes

- Network requirement: Nextcloud server must be able to reach CoPaw's webhook address
- For media file support, `username` and `password` must be configured
- Tested with Nextcloud Talk on Nextcloud 28+