### PR TITLE
fix(qq): broaden URL sanitization for C2C/group to prevent 40054010

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -70,6 +70,13 @@ MAX_QUICK_DISCONNECT_COUNT = 3
 DEFAULT_API_BASE = "https://api.sgroup.qq.com"
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
 _URL_PATTERN = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+_BROAD_URL_PATTERN = re.compile(
+    r"https?://[^\s\]\)\uff09]+"
+    r"|ftp://[^\s\]\)\uff09]+"
+    r"|www\.[^\s\]\)\uff09]+"
+    r"|[a-zA-Z0-9][-a-zA-Z0-9]{0,62}\.(?:com|org|net|cn|io|dev|app|edu|gov|info|cc|me|tv|co|uk|jp|top|xyz|site|online|tech|store|cloud|ai)(?:[/\?#][^\s\]\)\uff09]*)?",
+    re.IGNORECASE,
+)
 _IMAGE_TAG_PATTERN = re.compile(r"\[Image: (https?://[^\]]+)\]", re.IGNORECASE)
 
 # Rich media paths
@@ -87,14 +94,25 @@ class QQApiError(RuntimeError):
 
 
 def _sanitize_qq_text(text: str) -> tuple[str, bool]:
-    """QQ API disallows URL links in plain messages.
+    """QQ API disallows URL links in C2C / group messages.
+
+    Uses a broad pattern that covers http(s), ftp, www., and bare
+    domains with common TLDs — matching QQ's server-side URL detector.
+    Also strips markdown-style links ``[text](url)``.
 
     Return the sanitized text and whether any URL was removed.
     """
     if not text:
         return "", False
-    sanitized, count = _URL_PATTERN.subn("[链接已省略]", text)
-    return sanitized, count > 0
+    # First strip markdown links [text](url) -> text
+    md_link = re.compile(r"\[([^\]]*)]\(([^)]+)\)")
+    sanitized, md_count = md_link.subn(r"\1", text)
+    # Then strip remaining broad URL patterns
+    sanitized, url_count = _BROAD_URL_PATTERN.subn("", sanitized)
+    # Collapse any resulting multiple spaces / blank lines
+    sanitized = re.sub(r"[ \t]{2,}", " ", sanitized)
+    sanitized = re.sub(r"\n{3,}", "\n\n", sanitized)
+    return sanitized.strip(), (md_count + url_count) > 0
 
 
 def _as_bool(value: Any) -> bool:
@@ -111,6 +129,15 @@ def _should_plaintext_fallback_from_markdown(exc: Exception) -> bool:
         return False
     if exc.status < 400 or exc.status >= 500:
         return False
+    err_code = None
+    if isinstance(exc.data, dict):
+        err_code = (
+            exc.data.get("code")
+            or exc.data.get("err_code")
+            or exc.data.get("errCode")
+        )
+    if str(err_code) == "40054010":
+        return True
     try:
         payload_text = json.dumps(exc.data, ensure_ascii=False).lower()
     except Exception:
@@ -120,6 +147,9 @@ def _should_plaintext_fallback_from_markdown(exc: Exception) -> bool:
         or "msg_type" in payload_text
         or "msg type" in payload_text
         or "message type" in payload_text
+        or "不允许发送url" in payload_text
+        or "not allow send url" in payload_text
+        or "not allowed to send url" in payload_text
     )
 
 
@@ -679,6 +709,15 @@ class QQChannel(BaseChannel):
         image_urls = _IMAGE_TAG_PATTERN.findall(text)
         # Remove [Image: ] tags from text
         clean_text = _IMAGE_TAG_PATTERN.sub("", text).strip()
+        # QQ C2C / group API blocks ALL URLs (even in markdown mode).
+        # Always sanitize for these message types.
+        if clean_text and message_type in ("c2c", "group"):
+            clean_text, had_url = _sanitize_qq_text(clean_text)
+            if had_url:
+                logger.info(
+                    "qq send: stripped URL content for c2c/group "
+                    "API compatibility",
+                )
 
         # Send text content if not empty
         text_sent = False


### PR DESCRIPTION
**Title:** `fix(qq): broaden URL sanitization for C2C/group messages`  

**Commits:**
- Add `_BROAD_URL_PATTERN` covering `www.`, bare domains, `ftp://`
- Always sanitize URLs for C2C/group (QQ blocks URLs in all msg_types)
- Strip markdown links `[text](url)` before URL removal
- Recognize err_code `40054010` for markdown→plaintext fallback

---

## Description

QQ Bot's C2C and group message APIs reject any message containing a URL with error code `40054010`. The previous implementation only stripped `https?://` prefixed URLs and only when `use_markdown=False`, which was insufficient — QQ's server-side URL detector also catches `www.` links, bare domain names (e.g. `github.com/user/repo`), and markdown-formatted links `[text](url)`, even when markdown mode is enabled.

This PR fixes URL sanitization to be comprehensive and always active for C2C and group message types.

**Related Issue:** N/A

**Security Considerations:** None — this change only affects outbound message text processing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Configure a QQ Bot with `QQ_APP_ID` and `QQ_CLIENT_SECRET`
2. Enable markdown mode (`QQ_MARKDOWN_ENABLED=1`, default)
3. Ask the bot a question that triggers a response containing URLs (e.g. "what is the GitHub repo?")
4. Send both C2C (private) and group messages
5. **Before fix:** messages fail with `QQApiError: 400 {'code': 40054010, 'message': '不允许发送url'}`
6. **After fix:** URLs are silently stripped, messages deliver successfully; log shows:
   ```
   INFO  qq send: stripped URL content for c2c/group API compatibility
   ```

## Local Verification Evidence

```bash
pre-commit run --all-files
# Note: pre-commit not configured in local dev environment

pytest tests/ --ignore=tests/integrated
# Note: existing test suite has collection errors on ModuleNotFoundError
# unrelated to this change (pytest not installed in project venv by default).
# The changed module src/copaw/app/channels/qq/channel.py has no dedicated
# unit tests in the current test suite.
```

Manual verification performed by observing live QQ Bot behavior:

**Before (error log):**
```
ERROR copaw.app.channels.qq.channel - send text failed with markdown; skip fallback
copaw.app.channels.qq.channel.QQApiError: API /v2/users/.../messages 400:
{'code': 40054010, 'message': '不允许发送url'}
```

**After (normal log):**
```
INFO  copaw.app.channels.qq.channel - qq send: stripped URL content for c2c/group API compatibility
INFO  copaw.app.channels.qq.channel - qq recv c2c from=<openid> text='...'
```

## Additional Notes

- Guild (forum channel) messages are **not** affected — QQ's guild API allows URLs
- The `_URL_PATTERN` constant is retained for potential future use but `_sanitize_qq_text` now uses the broader `_BROAD_URL_PATTERN`
- Markdown links `[text](url)` are degraded to plain text `text` (preserving readability) before URL removal, rather than being deleted entirely