### PR TITLE
fix(cron): reject invalid cron expressions on write path, closes #1443

### DIFF
--- a/docs/cron-invalid-schedule-proposal.md
+++ b/docs/cron-invalid-schedule-proposal.md
@@ -1,0 +1,121 @@
+# Cron Invalid Schedule Handling Proposal
+
+## Scope
+
+- Upstream target: agentscope-ai/CoPaw main
+- Local fork impact: keep in sync after upstream discussion/merge
+
+This proposal addresses a startup stability gap: invalid cron expressions in persisted jobs should not fail app startup.
+
+## Problem Statement
+
+When a persisted cron job contains an expression that passes basic shape checks (5 fields) but fails APScheduler semantic validation, app startup can fail during cron registration.
+
+Example:
+- cron: 0 */30 8-18 * 1-5
+- failure: step value 30 exceeds hour range 0-23
+
+Observed effect:
+- app fails in lifespan startup
+- noisy secondary shutdown errors may appear from other async subsystems
+
+## Why This Matters
+
+- Reliability: one bad job should not block all services.
+- Operability: users need clear visibility of invalid jobs and easy recovery.
+- Roadmap alignment: fits self-healing/daemon direction.
+
+## Proposed Design
+
+### 1) Startup resilience (task-level)
+
+At startup, register cron jobs one by one:
+- if valid: schedule normally
+- if invalid: skip scheduling that job, set runtime state to error, keep app startup successful
+
+Status shape (existing model can be reused):
+- last_status = error
+- last_error = invalid schedule: <validation message>
+- next_run_at = null
+
+### 2) Validation on create/update
+
+Add semantic validation before persistence for all write paths:
+- API create/replace cron job
+- CLI cron create (and any edit/replace command path)
+- Console form submit path (server-side is authoritative)
+
+Validation rule:
+- build APScheduler trigger with provided cron/timezone
+- if trigger build fails, reject request with clear 4xx error and actionable message
+
+### 3) Recovery UX
+
+Expose invalid jobs clearly in list/state views:
+- display error status and message
+- provide edit/resave flow to fix and reactivate
+
+No auto-rewrite of expressions in backend.
+
+## Non-Goals
+
+- Automatic transformation of invalid cron expressions
+- Backfilling complex migration for historical job data beyond state marking
+
+## Compatibility
+
+- Backward compatible for valid jobs
+- Invalid historical jobs no longer crash startup
+- Existing storage format remains usable
+
+## Acceptance Criteria
+
+1. App starts successfully even when persisted jobs include invalid cron entries.
+2. Invalid jobs are marked error and omitted from scheduler registration.
+3. Creating/replacing a job with invalid cron returns a clear validation error.
+4. Unit tests cover:
+- startup skip invalid + keep valid jobs
+- API/CLI write-path validation failures
+5. Integration startup test passes with mixed valid/invalid jobs.
+
+## Risks and Mitigations
+
+- Risk: users do not notice skipped jobs
+- Mitigation: explicit warning log + error state surfaced in API/Console
+
+- Risk: validation behavior differs across entry points
+- Mitigation: centralize validation helper used by manager/API/CLI
+
+## Suggested Upstream Issue Draft
+
+Title:
+- Bug: Invalid persisted cron schedule can fail app startup; should degrade to per-job error
+
+Body:
+- Background:
+  - Persisted cron jobs are loaded on startup.
+  - Certain expressions pass field-count checks but fail APScheduler semantic validation.
+- Repro:
+  1. Persist a cron job with expression like 0 */30 8-18 * 1-5
+  2. Start app
+  3. Observe startup failure in lifespan during cron registration
+- Actual:
+  - Startup fails; service unavailable.
+- Expected:
+  - Startup succeeds.
+  - Invalid job is skipped and marked error.
+  - Create/update paths reject invalid cron with clear message.
+- Proposed fix:
+  - Startup task-level fault isolation + write-path semantic validation + invalid state visibility.
+- Acceptance criteria:
+  - (copy from the section above)
+
+## Ownership Split
+
+- Upstream:
+  - Cron startup fault isolation
+  - Create/update semantic validation
+  - Test coverage
+- Local/Fork:
+  - Temporary operational guidance and migration notes if needed
+  - Optional local alerting conventions

--- a/src/copaw/app/crons/api.py
+++ b/src/copaw/app/crons/api.py
@@ -41,7 +41,10 @@ async def create_job(
     # server generates id; ignore client-provided spec.id
     job_id = str(uuid.uuid4())
     created = spec.model_copy(update={"id": job_id})
-    await mgr.create_or_replace_job(created)
+    try:
+        await mgr.create_or_replace_job(created)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
     return created
 
 
@@ -53,7 +56,10 @@ async def replace_job(
 ):
     if spec.id != job_id:
         raise HTTPException(status_code=400, detail="job_id mismatch")
-    await mgr.create_or_replace_job(spec)
+    try:
+        await mgr.create_or_replace_job(spec)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
     return spec
 
 

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -24,6 +24,30 @@ HEARTBEAT_JOB_ID = "_heartbeat"
 logger = logging.getLogger(__name__)
 
 
+def validate_cron_trigger(cron: str, timezone: str = "UTC") -> None:
+    """Validate that *cron* + *timezone* can build a valid CronTrigger.
+
+    Raises:
+        ValueError: if the expression is structurally or semantically invalid.
+    """
+    parts = [p for p in cron.split() if p]
+    if len(parts) != 5:
+        raise ValueError(
+            f"cron must have 5 fields (minute hour day month weekday),"
+            f" got {len(parts)}: {cron!r}",
+        )
+    minute, hour, day, month, day_of_week = parts
+    # Let APScheduler be the authoritative validator; discard the object.
+    CronTrigger(
+        minute=minute,
+        hour=hour,
+        day=day,
+        month=month,
+        day_of_week=day_of_week,
+        timezone=timezone,
+    )
+
+
 @dataclass
 class _Runtime:
     sem: asyncio.Semaphore
@@ -60,7 +84,22 @@ class CronManager:
 
             self._scheduler.start()
             for job in jobs_file.jobs:
-                await self._register_or_update(job)
+                try:
+                    await self._register_or_update(job)
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning(
+                        "Skip invalid cron job during startup: "
+                        "job_id=%s name=%s cron=%s error=%s",
+                        job.id,
+                        job.name,
+                        job.schedule.cron,
+                        e,
+                    )
+                    st = self._states.get(job.id, CronJobState())
+                    st.last_status = "error"
+                    st.last_error = f"invalid schedule: {e}"
+                    self._states[job.id] = st
+                    self._rt.pop(job.id, None)
 
             # Heartbeat: one interval job when enabled in config
             hb = get_heartbeat_config()
@@ -96,6 +135,8 @@ class CronManager:
     # ----- write/control -----
 
     async def create_or_replace_job(self, spec: CronJobSpec) -> None:
+        # Validate before touching storage so invalid cron is never persisted.
+        validate_cron_trigger(spec.schedule.cron, spec.schedule.timezone)
         async with self._lock:
             await self._repo.upsert_job(spec)
             if self._started:

--- a/src/copaw/cli/cron_cmd.py
+++ b/src/copaw/cli/cron_cmd.py
@@ -9,6 +9,7 @@ import click
 
 from .http import client, print_json
 from ..app.channels.schema import DEFAULT_CHANNEL
+from ..app.crons.manager import validate_cron_trigger
 
 
 def _base_url(ctx: click.Context, base_url: Optional[str]) -> str:
@@ -309,6 +310,15 @@ def create_job(
             enabled=enabled,
             mode=mode,
         )
+    # Early local validation: catch obvious errors before hitting the server.
+    schedule = payload.get("schedule", {})
+    try:
+        validate_cron_trigger(
+            schedule.get("cron", ""),
+            schedule.get("timezone", "UTC"),
+        )
+    except ValueError as e:
+        raise click.UsageError(f"Invalid cron expression: {e}") from e
     with client(base_url) as c:
         r = c.post("/cron/jobs", json=payload)
         r.raise_for_status()

--- a/tests/unit/app/crons/test_manager.py
+++ b/tests/unit/app/crons/test_manager.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from copaw.app.crons.manager import CronManager
+from copaw.app.crons.models import (
+    CronJobRequest,
+    CronJobSpec,
+    DispatchSpec,
+    DispatchTarget,
+    JobsFile,
+    ScheduleSpec,
+)
+from copaw.app.crons.repo.base import BaseJobRepository
+
+
+class _InMemoryRepo(BaseJobRepository):
+    def __init__(self, jobs_file: JobsFile):
+        self._jobs_file = jobs_file
+
+    async def load(self) -> JobsFile:
+        return self._jobs_file
+
+    async def save(self, jobs_file: JobsFile) -> None:
+        self._jobs_file = jobs_file
+
+
+@pytest.mark.asyncio
+async def test_start_skips_invalid_cron_and_keeps_valid_job() -> None:
+    valid_job = CronJobSpec(
+        id="job-valid",
+        name="valid",
+        schedule=ScheduleSpec(cron="*/5 * * * *", timezone="UTC"),
+        task_type="agent",
+        request=CronJobRequest(input="ping"),
+        dispatch=DispatchSpec(
+            channel="console",
+            target=DispatchTarget(user_id="u1", session_id="s1"),
+        ),
+    )
+    # 5 fields but invalid for APScheduler hour field (step > 23).
+    invalid_job = CronJobSpec(
+        id="job-invalid",
+        name="invalid",
+        schedule=ScheduleSpec(cron="0 */30 * * *", timezone="UTC"),
+        task_type="agent",
+        request=CronJobRequest(input="ping"),
+        dispatch=DispatchSpec(
+            channel="console",
+            target=DispatchTarget(user_id="u2", session_id="s2"),
+        ),
+    )
+
+    repo = _InMemoryRepo(JobsFile(jobs=[valid_job, invalid_job]))
+    manager = CronManager(repo=repo, runner=None, channel_manager=None)
+
+    await manager.start()
+    try:
+        state_valid = manager.get_state("job-valid")
+        state_invalid = manager.get_state("job-invalid")
+
+        assert state_valid.next_run_at is not None
+        assert state_valid.last_status is None
+
+        assert state_invalid.next_run_at is None
+        assert state_invalid.last_status == "error"
+        assert state_invalid.last_error is not None
+        assert "invalid schedule" in state_invalid.last_error
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_create_or_replace_raises_on_invalid_cron() -> None:
+    """create_or_replace_job must reject an invalid cron before persisting."""
+    repo = _InMemoryRepo(JobsFile(jobs=[]))
+    manager = CronManager(repo=repo, runner=None, channel_manager=None)
+    await manager.start()
+    try:
+        invalid = CronJobSpec(
+            id="job-bad",
+            name="bad-cron",
+            schedule=ScheduleSpec(cron="0 */30 * * *", timezone="UTC"),
+            task_type="agent",
+            request=CronJobRequest(input="ping"),
+            dispatch=DispatchSpec(
+                channel="console",
+                target=DispatchTarget(user_id="u1", session_id="s1"),
+            ),
+        )
+        with pytest.raises(ValueError):
+            await manager.create_or_replace_job(invalid)
+
+        # Nothing should have been persisted
+        saved = await repo.list_jobs()
+        assert len(saved) == 0
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_create_or_replace_raises_without_started() -> None:
+    """Validation runs even when the manager has not been started."""
+    repo = _InMemoryRepo(JobsFile(jobs=[]))
+    manager = CronManager(repo=repo, runner=None, channel_manager=None)
+    # Do NOT call start()
+    invalid = CronJobSpec(
+        id="job-bad2",
+        name="bad-cron-2",
+        schedule=ScheduleSpec(cron="0 */30 * * *", timezone="UTC"),
+        task_type="agent",
+        request=CronJobRequest(input="ping"),
+        dispatch=DispatchSpec(
+            channel="console",
+            target=DispatchTarget(user_id="u1", session_id="s1"),
+        ),
+    )
+    with pytest.raises(ValueError):
+        await manager.create_or_replace_job(invalid)
+
+    saved = await repo.list_jobs()
+    assert len(saved) == 0


### PR DESCRIPTION
Phase 1 (startup resilience):
- CronManager.start() wraps per-job _register_or_update() in try/except; invalid jobs are marked last_status=error and startup continues.

Phase 2 (write-path validation):
- Add module-level validate_cron_trigger(cron, timezone) that delegates to APScheduler CronTrigger as the authoritative validator.
- Call it in create_or_replace_job() before upsert_job(), so invalid cron expressions are never persisted to jobs.json.
- api.py: POST /cron/jobs and PUT /cron/jobs/{id} now catch ValueError and return HTTP 422 with a descriptive detail message.
- cron_cmd.py: CLI create command performs early local validation before sending, giving immediate feedback without a server round-trip.

Tests:
- test_start_skips_invalid_cron_and_keeps_valid_job
- test_create_or_replace_raises_on_invalid_cron
- test_create_or_replace_raises_without_started

## Description

Invalid cron expressions (e.g. `*/30` in the hour field) were silently accepted by the Pydantic model validator (which only normalises field count) but then rejected by APScheduler's `CronTrigger` at startup, causing `Application startup failed. Exiting.`.

This PR fixes the crash (Phase 1) and closes the write-path gap that allowed the bad expression to be persisted in the first place (Phase 2).

**Related Issue:** Fixes #1443

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Run the unit tests:

```bash
pytest tests/unit/app/crons/ -v
```

To reproduce the original crash: persist a job with `cron: "0 */30 * * *"` to `~/.copaw/jobs.json`, then start the app. After this fix the app starts normally and the invalid job shows as `last_status=error`.

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast.........................................................Passed
# check yaml...............................................................Passed
# fix python encoding pragma...............................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed
# prettier.................................................................Passed

pytest tests/unit/app/crons/ -v
# tests/unit/app/crons/test_manager.py::test_start_skips_invalid_cron_and_keeps_valid_job PASSED
# tests/unit/app/crons/test_manager.py::test_create_or_replace_raises_on_invalid_cron PASSED
# tests/unit/app/crons/test_manager.py::test_create_or_replace_raises_without_started PASSED
# 3 passed in 1.06s
```

## Additional Notes

The root cause: `ScheduleSpec.normalize_cron_5_fields` (Pydantic validator) only checks field count; it does not validate APScheduler semantics. A step like `*/30` on the hour field (range 0–23) is structurally valid but semantically rejected by APScheduler. The new `validate_cron_trigger()` helper uses APScheduler itself as the authoritative gate on every write path.
