### PR TITLE
fix(chat): copy text content instead of raw response JSON

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1,21 +1,28 @@
 import {
   AgentScopeRuntimeWebUI,
-  type IAgentScopeRuntimeWebUIOptions,
+  IAgentScopeRuntimeWebUIOptions,
 } from "@agentscope-ai/chat";
-import { useCallback, useMemo, useState } from "react";
-import { Modal, Button, Result, message } from "antd";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, Modal, Result, message } from "antd";
 import { ExclamationCircleOutlined, SettingOutlined } from "@ant-design/icons";
 import { SparkCopyLine } from "@agentscope-ai/icons";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import sessionApi from "./sessionApi";
-import defaultConfig from "./OptionsPanel/defaultConfig";
+import defaultConfig, { getDefaultConfig } from "./OptionsPanel/defaultConfig";
 import Weather from "./Weather";
-import { getApiUrl, getApiToken } from "../../api/config";
+import { getApiToken, getApiUrl } from "../../api/config";
 import { providerApi } from "../../api/modules/provider";
 import ModelSelector from "./ModelSelector";
 import "./index.module.less";
 
+interface CustomWindow extends Window {
+  currentSessionId?: string;
+  currentUserId?: string;
+  currentChannel?: string;
+}
+
+declare const window: CustomWindow;
 type CopyableContent =
   | { type?: string; text?: string }
   | { type?: string; refusal?: string };
@@ -28,15 +35,6 @@ type CopyableMessage = {
 type CopyableResponse = {
   output?: CopyableMessage[];
 };
-
-interface CustomWindow extends Window {
-  currentSessionId?: string;
-  currentUserId?: string;
-  currentChannel?: string;
-}
-
-declare const window: CustomWindow;
-
 function extractCopyableText(response: CopyableResponse): string {
   const collectText = (assistantOnly: boolean) => {
     const chunks = (response.output || []).flatMap((item: CopyableMessage) => {
@@ -88,11 +86,159 @@ async function copyText(text: string) {
   }
 }
 
+function buildModelError(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "Model not configured",
+      message: "Please configure a model first",
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } },
+  );
+}
+
 export default function ChatPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
+  const chatId = useMemo(() => {
+    const match = location.pathname.match(/^\/chat\/(.+)$/);
+    return match?.[1];
+  }, [location.pathname]);
   const [showModelPrompt, setShowModelPrompt] = useState(false);
-  const optionsConfig = defaultConfig;
+
+  const isComposingRef = useRef(false);
+  const isChatActiveRef = useRef(false);
+  isChatActiveRef.current =
+    location.pathname === "/" || location.pathname.startsWith("/chat");
+
+  const lastSessionIdRef = useRef<string | null>(null);
+  const chatIdRef = useRef(chatId);
+  const navigateRef = useRef(navigate);
+  chatIdRef.current = chatId;
+  navigateRef.current = navigate;
+
+  useEffect(() => {
+    const handleCompositionStart = () => {
+      if (!isChatActiveRef.current) return;
+      isComposingRef.current = true;
+    };
+
+    const handleCompositionEnd = () => {
+      if (!isChatActiveRef.current) return;
+      setTimeout(() => {
+        isComposingRef.current = false;
+      }, 150);
+    };
+
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (!isChatActiveRef.current) return;
+      const target = e.target as HTMLElement;
+      if (target?.tagName === "TEXTAREA" && e.key === "Enter" && !e.shiftKey) {
+        if (isComposingRef.current || (e as any).isComposing) {
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          return false;
+        }
+      }
+    };
+
+    document.addEventListener("compositionstart", handleCompositionStart, true);
+    document.addEventListener("compositionend", handleCompositionEnd, true);
+    document.addEventListener("keypress", handleKeyPress, true);
+
+    return () => {
+      document.removeEventListener(
+        "compositionstart",
+        handleCompositionStart,
+        true,
+      );
+      document.removeEventListener(
+        "compositionend",
+        handleCompositionEnd,
+        true,
+      );
+      document.removeEventListener("keypress", handleKeyPress, true);
+    };
+  }, []);
+
+  useEffect(() => {
+    sessionApi.onSessionIdResolved = (tempId, realId) => {
+      if (!isChatActiveRef.current) return;
+      if (chatIdRef.current === tempId) {
+        lastSessionIdRef.current = realId;
+        navigateRef.current(`/chat/${realId}`, { replace: true });
+      }
+    };
+
+    sessionApi.onSessionRemoved = (removedId) => {
+      if (!isChatActiveRef.current) return;
+      if (chatIdRef.current === removedId) {
+        lastSessionIdRef.current = null;
+        navigateRef.current("/chat", { replace: true });
+      }
+    };
+
+    return () => {
+      sessionApi.onSessionIdResolved = null;
+      sessionApi.onSessionRemoved = null;
+    };
+  }, []);
+
+  const getSessionListWrapped = useCallback(async () => {
+    const sessions = await sessionApi.getSessionList();
+    const currentChatId = chatIdRef.current;
+
+    if (currentChatId) {
+      const idx = sessions.findIndex((s) => s.id === currentChatId);
+      if (idx > 0) {
+        return [
+          sessions[idx],
+          ...sessions.slice(0, idx),
+          ...sessions.slice(idx + 1),
+        ];
+      }
+    }
+
+    return sessions;
+  }, []);
+
+  const getSessionWrapped = useCallback(async (sessionId: string) => {
+    const currentChatId = chatIdRef.current;
+
+    if (
+      isChatActiveRef.current &&
+      sessionId &&
+      sessionId !== lastSessionIdRef.current &&
+      sessionId !== currentChatId
+    ) {
+      const urlId = sessionApi.getRealIdForSession(sessionId) ?? sessionId;
+      lastSessionIdRef.current = urlId;
+      navigateRef.current(`/chat/${urlId}`, { replace: true });
+    }
+
+    return sessionApi.getSession(sessionId);
+  }, []);
+
+  const createSessionWrapped = useCallback(async (session: any) => {
+    const result = await sessionApi.createSession(session);
+    const newSessionId = result[0]?.id;
+    if (isChatActiveRef.current && newSessionId) {
+      lastSessionIdRef.current = newSessionId;
+      navigateRef.current(`/chat/${newSessionId}`, { replace: true });
+    }
+    return result;
+  }, []);
+
+  const wrappedSessionApi = useMemo(
+    () => ({
+      getSessionList: getSessionListWrapped,
+      getSession: getSessionWrapped,
+      createSession: createSessionWrapped,
+      updateSession: sessionApi.updateSession.bind(sessionApi),
+      removeSession: sessionApi.removeSession.bind(sessionApi),
+    }),
+    [],
+  );
 
   const copyResponse = useCallback(
     async (response: CopyableResponse) => {
@@ -106,99 +252,75 @@ export default function ChatPage() {
     [t],
   );
 
-  const handleConfigureModel = () => {
-    setShowModelPrompt(false);
-    navigate("/models");
-  };
-
-  const handleSkipConfiguration = () => {
-    setShowModelPrompt(false);
-  };
-
-  const options = useMemo(() => {
-    const handleModelError = () => {
-      setShowModelPrompt(true);
-      return new Response(
-        JSON.stringify({
-          error: "Model not configured",
-          message: "Please configure a model first",
-        }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    };
-
-    const customFetch = async (data: {
+  const customFetch = useCallback(
+    async (data: {
       input: any[];
       biz_params?: any;
       signal?: AbortSignal;
     }): Promise<Response> => {
       try {
         const activeModels = await providerApi.getActiveModels();
-
         if (
           !activeModels?.active_llm?.provider_id ||
           !activeModels?.active_llm?.model
         ) {
-          return handleModelError();
+          setShowModelPrompt(true);
+          return buildModelError();
         }
-      } catch (error) {
-        console.error("Failed to check model configuration:", error);
-        return handleModelError();
+      } catch {
+        setShowModelPrompt(true);
+        return buildModelError();
       }
 
       const { input, biz_params } = data;
-
-      const lastMessage = input[input.length - 1];
-      const session = lastMessage?.session || {};
-
-      const session_id = window.currentSessionId || session?.session_id || "";
-      const user_id = window.currentUserId || session?.user_id || "default";
-      const channel = window.currentChannel || session?.channel || "console";
+      const session = input[input.length - 1]?.session || {};
 
       const requestBody = {
         input: input.slice(-1),
-        session_id,
-        user_id,
-        channel,
+        session_id: window.currentSessionId || session?.session_id || "",
+        user_id: window.currentUserId || session?.user_id || "default",
+        channel: window.currentChannel || session?.channel || "console",
         stream: true,
         ...biz_params,
       };
 
-      const headers: HeadersInit = {
+      const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };
-
       const token = getApiToken();
-      if (token) {
-        (headers as Record<string, string>).Authorization = `Bearer ${token}`;
-      }
+      if (token) headers.Authorization = `Bearer ${token}`;
 
-      const url = optionsConfig?.api?.baseURL || getApiUrl("/agent/process");
-      const response = await fetch(url, {
+      return fetch(defaultConfig?.api?.baseURL || getApiUrl("/agent/process"), {
         method: "POST",
         headers,
         body: JSON.stringify(requestBody),
         signal: data.signal,
       });
+    },
+    [],
+  );
 
-      return response;
+  const options = useMemo(() => {
+    const i18nConfig = getDefaultConfig(t);
+
+    const handleBeforeSubmit = async () => {
+      if (isComposingRef.current) return false;
+      return true;
     };
 
     return {
-      ...optionsConfig,
-      session: {
-        multiple: true,
-        api: sessionApi,
-      },
+      ...i18nConfig,
       theme: {
-        ...optionsConfig.theme,
+        ...defaultConfig.theme,
         rightHeader: <ModelSelector />,
       },
+      sender: {
+        ...(i18nConfig as any)?.sender,
+        beforeSubmit: handleBeforeSubmit,
+      },
+      session: { multiple: true, api: wrappedSessionApi },
       api: {
-        ...optionsConfig.api,
+        ...defaultConfig.api,
         fetch: customFetch,
         cancel(data: { session_id: string }) {
           console.log(data);
@@ -223,7 +345,7 @@ export default function ChatPage() {
         "weather search mock": Weather,
       },
     } as unknown as IAgentScopeRuntimeWebUIOptions;
-  }, [optionsConfig, copyResponse, t]);
+  }, [wrappedSessionApi, customFetch, copyResponse, t]);
 
   return (
     <div style={{ height: "100%", width: "100%" }}>
@@ -235,14 +357,17 @@ export default function ChatPage() {
           title={t("modelConfig.promptTitle")}
           subTitle={t("modelConfig.promptMessage")}
           extra={[
-            <Button key="skip" onClick={handleSkipConfiguration}>
+            <Button key="skip" onClick={() => setShowModelPrompt(false)}>
               {t("modelConfig.skipButton")}
             </Button>,
             <Button
               key="configure"
               type="primary"
               icon={<SettingOutlined />}
-              onClick={handleConfigureModel}
+              onClick={() => {
+                setShowModelPrompt(false);
+                navigate("/models");
+              }}
             >
               {t("modelConfig.configureButton")}
             </Button>,


### PR DESCRIPTION
## Summary
- override the console reply copy action so it copies assistant-readable text instead of the full response JSON payload
- extract assistant `text` and `refusal` content first, and fall back to JSON only when no copyable text exists
- keep the regenerate action and reuse the existing copy success and failure toasts

## Testing
- `uv tool run --from pre-commit pre-commit run --all-files`
- `uv tool run --with pytest --with pytest-asyncio --with pytest-cov pytest` *(fails during collection in the current environment because required project dependencies like `copaw`, `httpx`, and `click` are not installed)*