### PR TITLE
fix(console): correct active provider highlight in models page

### DIFF
--- a/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import { Card, Button, Tag } from "@agentscope-ai/design";
 import { AppstoreOutlined } from "@ant-design/icons";
-import type { ProviderInfo } from "../../../../../api/types";
+import type { ProviderInfo, ActiveModelsInfo } from "../../../../../api/types";
 import { ModelManageModal } from "../modals/ModelManageModal";
 import { useTranslation } from "react-i18next";
 import styles from "../../index.module.less";
 
 interface LocalProviderCardProps {
   provider: ProviderInfo;
+  activeModels: ActiveModelsInfo | null;
   onSaved: () => void;
   isHover: boolean;
   onMouseEnter: () => void;
@@ -16,6 +17,7 @@ interface LocalProviderCardProps {
 
 export function LocalProviderCard({
   provider,
+  activeModels,
   onSaved,
   isHover,
   onMouseEnter,
@@ -25,7 +27,12 @@ export function LocalProviderCard({
   const [modelManageOpen, setModelManageOpen] = useState(false);
 
   const totalCount = provider.models.length + provider.extra_models.length;
-  const statusReady = totalCount > 0;
+  const isActiveLlmProvider =
+    activeModels?.active_llm?.provider_id === provider.id;
+  const hasActiveModel =
+    isActiveLlmProvider && !!activeModels?.active_llm?.model;
+  const statusReady = totalCount > 0 || hasActiveModel;
+  const displayCount = totalCount > 0 ? totalCount : hasActiveModel ? 1 : 0;
   const statusLabel = statusReady
     ? t("models.available")
     : t("models.unavailable");
@@ -36,7 +43,7 @@ export function LocalProviderCard({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={`${styles.providerCard} ${
-        statusReady ? styles.enabledCard : ""
+        isActiveLlmProvider ? styles.enabledCard : ""
       } ${isHover ? styles.hover : styles.normal}`}
     >
       <div style={{ marginBottom: 16 }}>
@@ -79,8 +86,8 @@ export function LocalProviderCard({
           <div className={styles.infoRow}>
             <span className={styles.infoLabel}>{t("models.model")}:</span>
             <span className={styles.infoValue}>
-              {totalCount > 0
-                ? t("models.modelsCount", { count: totalCount })
+              {displayCount > 0
+                ? t("models.modelsCount", { count: displayCount })
                 : t("models.localDownloadFirst")}
             </span>
           </div>

--- a/console/src/pages/Settings/Models/components/cards/ProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/ProviderCard.tsx
@@ -23,6 +23,7 @@ export function ProviderCard({
     return (
       <LocalProviderCard
         provider={provider}
+        activeModels={activeModels}
         onSaved={onSaved}
         isHover={isHover}
         onMouseEnter={onMouseEnter}

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -58,6 +58,11 @@ export function RemoteProviderCard({
   };
 
   const totalCount = provider.models.length + provider.extra_models.length;
+  const isActiveLlmProvider =
+    activeModels?.active_llm?.provider_id === provider.id;
+  const hasActiveModel =
+    isActiveLlmProvider && !!activeModels?.active_llm?.model;
+  const displayCount = totalCount > 0 ? totalCount : hasActiveModel ? 1 : 0;
 
   let isConfigured = false;
 
@@ -71,7 +76,7 @@ export function RemoteProviderCard({
     isConfigured = true;
   }
 
-  const hasModels = totalCount > 0;
+  const hasModels = totalCount > 0 || hasActiveModel;
   const isAvailable = isConfigured && hasModels;
 
   const providerTag = provider.is_custom ? (
@@ -111,7 +116,7 @@ export function RemoteProviderCard({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={`${styles.providerCard} ${
-        isAvailable ? styles.enabledCard : ""
+        isActiveLlmProvider ? styles.enabledCard : ""
       } ${isHover ? styles.hover : styles.normal}`}
     >
       <div style={{ marginBottom: 16 }}>
@@ -166,8 +171,8 @@ export function RemoteProviderCard({
           <div className={styles.infoRow}>
             <span className={styles.infoLabel}>{t("models.model")}:</span>
             <span className={styles.infoValue}>
-              {totalCount > 0
-                ? t("models.modelsCount", { count: totalCount })
+              {displayCount > 0
+                ? t("models.modelsCount", { count: displayCount })
                 : t("models.noModels")}
             </span>
           </div>

--- a/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
+++ b/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
@@ -47,16 +47,17 @@ export function ModelsSection({
   const eligible = useMemo(
     () =>
       providers.filter((p) => {
+        const isCurrentActiveProvider = p.id === currentSlot?.provider_id;
         const hasModels =
           (p.models?.length ?? 0) + (p.extra_models?.length ?? 0) > 0;
-        if (!hasModels) return false;
+        if (!hasModels && !isCurrentActiveProvider) return false;
         if (p.is_local) return true;
         if (p.require_api_key === false) return !!p.base_url;
         if (p.is_custom) return !!p.base_url;
         if (p.require_api_key ?? true) return !!p.api_key;
         return true;
       }),
-    [providers],
+    [providers, currentSlot?.provider_id],
   );
 
   useEffect(() => {
@@ -65,13 +66,27 @@ export function ModelsSection({
       setSelectedModel(currentSlot.model || undefined);
     }
     setDirty(false);
-  }, [currentSlot?.provider_id, currentSlot?.model]);
+  }, [currentSlot]);
 
   const chosenProvider = providers.find((p) => p.id === selectedProviderId);
   const modelOptions = [
     ...(chosenProvider?.models ?? []),
     ...(chosenProvider?.extra_models ?? []),
   ];
+  const hasCurrentActiveModelOption =
+    !!currentSlot?.model &&
+    modelOptions.some((model) => model.id === currentSlot.model);
+  if (
+    selectedProviderId &&
+    currentSlot?.provider_id === selectedProviderId &&
+    currentSlot.model &&
+    !hasCurrentActiveModelOption
+  ) {
+    modelOptions.unshift({
+      id: currentSlot.model,
+      name: currentSlot.model,
+    });
+  }
   const hasModels = modelOptions.length > 0;
 
   const handleProviderChange = (pid: string) => {


### PR DESCRIPTION
## Description

Fixes model management page status inconsistencies for active LLM provider display.

This PR ensures the active provider highlight follows active_llm.provider_id instead of general availability status, and adds fallback handling so the currently active model/provider is still represented even when provider model lists are temporarily stale.

Related Issue: Relates to #(issue_number)

Security Considerations: No security-impacting changes. This update only adjusts frontend display/state logic for provider status rendering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit run --all-files locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (pytest or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Manual verification:
1. Set active LLM provider/model to ollama in Models page.
2. Confirm active highlight appears on Ollama card (not LM Studio).
3. Confirm Ollama is not incorrectly shown as no-model/not-ready when active_llm points to Ollama model.
4. Confirm active model remains selectable/visible in LLM configuration even if provider model list is temporarily stale.

## Local Verification Evidence

pre-commit run --all-files
- check python ast: Passed
- check yaml/xml/toml/json: Passed
- mypy: Passed
- black: Passed
- flake8: Passed
- pylint: Passed
- prettier: Passed

pytest
- collected 0 items
- no tests ran in 0.02s

## Additional Notes

This PR is prepared on a clean branch based on upstream/main:
- branch: feat/upstream/models-active-provider-fix
- commit: cf64ead
