### PR TITLE
feature(telegram): auto-reconnect polling on network failure

### DIFF
--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -937,29 +937,29 @@ class TelegramChannel(BaseChannel):
         delay = _RECONNECT_INITIAL_S
         while True:
             try:
-                app = self._build_application()
-                self._application = app
-                await self._polling_cycle(app)
+                self._application = self._build_application()
+                await self._polling_cycle(self._application)
+                delay = _RECONNECT_INITIAL_S
             except asyncio.CancelledError:
                 logger.debug("telegram: polling cancelled")
-                await self._teardown_application(self._application)
                 raise
             except InvalidToken:
                 logger.error(
                     "telegram: invalid bot token — not retrying",
                 )
-                await self._teardown_application(self._application)
                 return
             except Exception:
                 logger.exception(
                     "telegram: polling failed (check token, network, "
                     "proxy; in China you may need TELEGRAM_HTTP_PROXY)",
                 )
-            else:
-                delay = _RECONNECT_INITIAL_S
+            finally:
+                if self._application:
+                    await self._teardown_application(
+                        self._application,
+                    )
+                    self._application = None
 
-            if self._application:
-                await self._teardown_application(self._application)
             logger.info(
                 "telegram: reconnecting in %.1fs",
                 delay,


### PR DESCRIPTION
## Description                                                                                                                                                 
                                                                                                                                                               
Add automatic reconnect with exponential backoff (2s→30s) to Telegram polling. Previously, any network disruption (common in proxy-dependent environments) would permanently kill the bot, requiring a full CoPaw restart. Now the bot auto-recovers by rebuilding the Application instance and resuming polling.         
                                                                                                                                                               
**Related Issue:** Fixes #1415 

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- Verified bot starts and receives messages normally
- Simulated network loss: bot logs reconnect attempts with increasing delay, resumes on recovery
- Invalid token: bot logs error and exits without retry loop
- Clean shutdown: no hanging asyncio tasks