### PR TITLE
fix(ollama): default to 127.0.0.1 and surface original connection errors

### DIFF
--- a/src/copaw/cli/providers_cmd.py
+++ b/src/copaw/cli/providers_cmd.py
@@ -60,7 +60,7 @@ def _get_ollama_host() -> str:
     manager = _manager()
     provider = manager.get_provider("ollama")
     if provider is None or not provider.base_url:
-        return "http://localhost:11434"
+        return "http://127.0.0.1:11434"
     return provider.base_url
 
 

--- a/src/copaw/providers/ollama_provider.py
+++ b/src/copaw/providers/ollama_provider.py
@@ -22,7 +22,7 @@ class OllamaProvider(Provider):
     def model_post_init(self, __context: Any) -> None:
         if not self.base_url:  # type: ignore
             self.base_url = (
-                os.environ.get("OLLAMA_HOST") or "http://localhost:11434"
+                os.environ.get("OLLAMA_HOST") or "http://127.0.0.1:11434"
             )
         if self.base_url.endswith("/v1"):
             # For backwards compatibility, if the URL ends with /v1,
@@ -76,10 +76,10 @@ class OllamaProvider(Provider):
             return False, "Ollama Python SDK is not installed"
         except ConnectionError:
             return False, f"Failed to connect to Ollama at `{self.base_url}`"
-        except Exception:
+        except Exception as exc:
             return (
                 False,
-                f"Unknown exception when connecting to `{self.base_url}`",
+                f"Failed to connect to Ollama at `{self.base_url}`: {exc}",
             )
 
     async def fetch_models(self, timeout: float = 5) -> List[ModelInfo]:
@@ -113,8 +113,8 @@ class OllamaProvider(Provider):
             return False, "Ollama Python SDK is not installed"
         except ConnectionError:
             return False, f"Failed to connect to Ollama at `{self.base_url}`"
-        except Exception:
-            return False, f"Unknown exception when connecting to `{target}`"
+        except Exception as exc:
+            return False, f"Model connection failed for `{target}`: {exc}"
 
     async def add_model(
         self,

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -79,7 +79,7 @@ async def test_check_connection_error_returns_false(monkeypatch) -> None:
     ok, msg = await provider.check_connection(timeout=1.0)
 
     assert ok is False
-    assert msg == f"Unknown exception when connecting to `{provider.base_url}`"
+    assert msg == f"Failed to connect to Ollama at `{provider.base_url}`: boom"
 
 
 async def test_fetch_models_normalizes_and_deduplicates(monkeypatch) -> None:
@@ -171,7 +171,7 @@ async def test_check_model_connection_error_returns_false(monkeypatch) -> None:
     ok, msg = await provider.check_model_connection("qwen2:7b", timeout=4.0)
 
     assert ok is False
-    assert msg == "Unknown exception when connecting to `qwen2:7b`"
+    assert msg == "Model connection failed for `qwen2:7b`: failed"
 
 
 async def test_update_config_updates_non_none_values_and_get_info(


### PR DESCRIPTION


## Description

This PR improves Ollama connectivity reliability and diagnostics on environments where localhost resolves to IPv6 (::1) before IPv4 (127.0.0.1).

On some systems, this causes the Ollama Python SDK to time out even when Ollama is running normally on 127.0.0.1:11434.

Changes included:
- Use http://127.0.0.1:11434 as the default Ollama base URL in provider and CLI flows.
- Return original exception details in check_connection and check_model_connection instead of a generic Unknown exception message.
- Update unit test assertions to match the new error-message format.

Related Issue: Relates to #(issue_number)

Security Considerations: No credential or auth changes. This update only adjusts default endpoint resolution and error reporting for better operability.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran pre-commit run --all-files locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (pytest or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start Ollama locally on default port 11434.
2. Leave Ollama host unset in CoPaw and run provider connection check.
3. Verify default endpoint resolves to http://127.0.0.1:11434 and connection succeeds.
4. Simulate failure (wrong host / stopped Ollama) and verify returned message includes the original exception text.
5. Run unit tests for Ollama provider.

## Local Verification Evidence

pytest test_ollama_provider.py -v
14 passed

## Additional Notes

This is intentionally scoped as a non-breaking bug fix to improve cross-platform localhost behavior and troubleshooting quality.

