### PR TITLE
fix(runner): use shutil.move for cross-disk write on Windows

### DIFF
--- a/src/copaw/app/crons/repo/json_repo.py
+++ b/src/copaw/app/crons/repo/json_repo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 from .base import BaseJobRepository
@@ -40,4 +41,4 @@ class JsonJobRepository(BaseJobRepository):
             json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
             encoding="utf-8",
         )
-        tmp_path.replace(self._path)
+        shutil.move(str(tmp_path), str(self._path))

--- a/src/copaw/app/runner/repo/json_repo.py
+++ b/src/copaw/app/runner/repo/json_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 from .base import BaseChatRepository
@@ -65,5 +66,5 @@ class JsonChatRepository(BaseChatRepository):
             encoding="utf-8",
         )
 
-        # Atomic replace
-        tmp_path.replace(self._path)
+        # Atomic replace (shutil.move handles cross-disk on Windows)
+        shutil.move(str(tmp_path), str(self._path))


### PR DESCRIPTION
## Description

Use shutil.move to handle cross-disk write on Windows

**Related Issue:** Fixes https://github.com/agentscope-ai/CoPaw/issues/1431

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review
