### PR TITLE
feat(security): add detection rules for destructive shell commands

### DIFF
--- a/src/copaw/security/tool_guard/rules/dangerous_shell_commands.yaml
+++ b/src/copaw/security/tool_guard/rules/dangerous_shell_commands.yaml
@@ -53,7 +53,7 @@
   severity: CRITICAL
   patterns:
     - ":\\s*\\(\\s*\\)\\s*\\{\\s*:\\s*\\|\\s*:\\s*&\\s*\\}\\s*;\\s*:"
-    - "\\bkill\\s+-9\\s+(-1|1\\b)"
+    - "\\bkill\\s+-9\\s+(-1\\b|1\\b)"
   description: "Detects classic Bash fork bombs and mass process termination"
   remediation: "Block immediately. These commands will crash the host system."
 


### PR DESCRIPTION
## Description

Add  YAML detection rules for dangerous shell commands beyond the existing `rm` and `mv` guards. New rules cover filesystem destruction (mkfs, dd), destructive Git operations (reset --hard, push --force), fork bombs, curl|bash pipes, reverse shells, crontab/sudoers tampering, unsafe permissions (chmod 777), and base64-obfuscated execution. Each rule includes severity, pattern matching, and remediation guidance so the user is always prompted or blocked before execution.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:**  These rules are defensive — they add tool_guard rules to prevent agents from executing destructive, privilege-escalating, or obfuscated shell commands without user confirmation. No existing rules are removed or weakened.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

1. Verify YAML syntax is valid.
2. For each new rule, confirm the regex patterns match expected dangerous commands (e.g. `mkfs /dev/sda`, `git reset --hard`, `curl ... | bash`) and do not false-positive on safe usage (e.g. `git push origin main` without `--force`).
3. Confirm existing `TOOL_CMD_DANGEROUS_RM` and `TOOL_CMD_DANGEROUS_MV` rules still work as before.


## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```
pytest
====================================== test session starts ======================================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/pzla/projects/CoPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 64 items                                                                              

tests/integrated/test_app_startup.py .                                                    [  1%]
tests/integrated/test_version.py ...                                                      [  6%]
tests/test_cli_version.py .                                                               [  7%]
tests/unit/providers/test_anthropic_provider.py .......                                   [ 18%]
tests/unit/providers/test_default_provider.py ..                                          [ 21%]
tests/unit/providers/test_minimax_provider.py .......                                     [ 32%]
tests/unit/providers/test_ollama_manager_timeout.py .                                     [ 34%]
tests/unit/providers/test_ollama_provider.py ..............                               [ 56%]
tests/unit/providers/test_openai_provider.py ...........                                  [ 73%]
tests/unit/providers/test_openai_stream_toolcall_compat.py ..                             [ 76%]
tests/unit/providers/test_provider_manager.py ...............                             [100%]

====================================== 64 passed in 9.17s =======================================
```

## Additional Notes

[Optional: any other context]
