### PR TITLE
fix(tests): add trust_env=False to prevent Windows proxy issues

### DIFF
--- a/tests/integrated/test_app_startup.py
+++ b/tests/integrated/test_app_startup.py
@@ -70,7 +70,7 @@ def test_app_startup_and_console() -> None:
         backend_ready = False
         last_error = None
 
-        with httpx.Client(timeout=5.0) as client:
+        with httpx.Client(timeout=5.0, trust_env=False) as client:
             while time.time() - start_time < max_wait:
                 if process.poll() is not None:
                     logs = "".join(log_lines)[-4000:]


### PR DESCRIPTION
## Description
On Windows, `httpx` 0.28+ automatically detects system proxy settings from environment variables. This causes the integration test `test_app_startup_and_console` to fail with 502 Bad Gateway errors when system proxy is configured.

Adding `trust_env=False` to `httpx.Client()` disables automatic proxy detection during tests, ensuring consistent test behavior regardless of system proxy configuration.

## Related Issue
N/A - This is a Windows compatibility improvement discovered during local development.

## Security Considerations
N/A - This change only affects test code and disables proxy detection in the test client.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist
- [x] I have tested this change locally on Windows with system proxy enabled
- [x] The test passes without proxy configuration as well
- [x] Commit message follows conventional commits format