### PR TITLE
feat: add provider deepseek

### DIFF
--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -90,6 +90,11 @@ MINIMAX_MODELS: List[ModelInfo] = [
     ModelInfo(id="MiniMax-M2.5-highspeed", name="MiniMax M2.5 Highspeed"),
 ]
 
+DEEPSEEK_MODELS: List[ModelInfo] = [
+    ModelInfo(id="deepseek-chat", name="DeepSeek Chat"),
+    ModelInfo(id="deepseek-reasoner", name="DeepSeek Reasoner"),
+]
+
 ANTHROPIC_MODELS: List[ModelInfo] = []
 
 PROVIDER_MODELSCOPE = OpenAIProvider(
@@ -157,6 +162,15 @@ PROVIDER_MINIMAX = OpenAIProvider(
     models=MINIMAX_MODELS,
     freeze_url=True,
     generate_kwargs={"temperature": 1.0},
+)
+
+PROVIDER_DEEPSEEK = OpenAIProvider(
+    id="deepseek",
+    name="DeepSeek",
+    base_url="https://api.deepseek.com",
+    api_key_prefix="sk-",
+    models=DEEPSEEK_MODELS,
+    freeze_url=True,
 )
 
 PROVIDER_ANTHROPIC = AnthropicProvider(
@@ -243,6 +257,7 @@ class ProviderManager:
         self._add_builtin(PROVIDER_OPENAI)
         self._add_builtin(PROVIDER_AZURE_OPENAI)
         self._add_builtin(PROVIDER_MINIMAX)
+        self._add_builtin(PROVIDER_DEEPSEEK)
         self._add_builtin(PROVIDER_ANTHROPIC)
         self._add_builtin(PROVIDER_OLLAMA)
         self._add_builtin(PROVIDER_LMSTUDIO)


### PR DESCRIPTION
## Description

Add DeepSeek as a built-in LLM provider in `provider_manager.py`.

DeepSeek exposes an OpenAI-compatible API, so it is registered as an `OpenAIProvider` with:
- **Base URL**: `https://api.deepseek.com` (frozen, not editable by users)
- **API key prefix**: `sk-`
- **Models**: `deepseek-chat` (DeepSeek Chat) and `deepseek-reasoner` (DeepSeek Reasoner)

The new provider is registered in `_init_builtins()` so it is automatically available in both the Web Console (Settings → Models) and the CLI (`copaw init`, `copaw models config`, `copaw models list`).

**Security Considerations:** N/A — no new secrets handling; API key is stored the same way as all other providers (persisted to the secrets directory).


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Run `copaw app` and open Console → Settings → Models — DeepSeek should appear with `deepseek-chat` and `deepseek-reasoner`.
2. Run `copaw models list` — DeepSeek (deepseek) should be listed with both models.
3. Run `copaw init` or `copaw models config` — DeepSeek should appear in the provider selection list.
4. Configure a valid DeepSeek API key and set the active model — should work without errors.

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

pytest
collected 64 items                                                                                                                                                                          

tests/integrated/test_app_startup.py .                                                                                                                                                [  1%]
tests/integrated/test_version.py ...                                                                                                                                                  [  6%]
tests/test_cli_version.py .                                                                                                                                                           [  7%]
tests/unit/providers/test_anthropic_provider.py .......                                                                                                                               [ 18%]
tests/unit/providers/test_default_provider.py ..                                                                                                                                      [ 21%]
tests/unit/providers/test_minimax_provider.py .......                                                                                                                                 [ 32%]
tests/unit/providers/test_ollama_manager_timeout.py .                                                                                                                                 [ 34%]
tests/unit/providers/test_ollama_provider.py ..............                                                                                                                           [ 56%]
tests/unit/providers/test_openai_provider.py ...........                                                                                                                              [ 73%]
tests/unit/providers/test_openai_stream_toolcall_compat.py ..                                                                                                                         [ 76%]
tests/unit/providers/test_provider_manager.py ...............                                                                                                                         [100%]

==================================================================================== 64 passed in 9.79s =====================================================================================
```

## Additional Notes

[Optional: any other context]
