### PR TITLE
fix(skills): add missing channels to cron SKILL.md --channel options

### DIFF
--- a/src/copaw/agents/skills/cron/SKILL.md
+++ b/src/copaw/agents/skills/cron/SKILL.md
@@ -67,7 +67,7 @@ copaw cron create \
 - `--type`：任务类型（text 或 agent）
 - `--name`：任务名称
 - `--cron`：cron 表达式（**UTC 时间**，如用户在 UTC+8 希望每天 9:00 执行，需填 `"0 1 * * *"`）
-- `--channel`：目标频道（imessage / discord / dingtalk / qq / console）
+- `--channel`：目标频道（console / feishu / dingtalk / discord / qq / telegram / imessage / matrix / mattermost 等）。用户未指定时，使用"当前的channel"的值
 - `--target-user`：用户标识
 - `--target-session`：会话标识
 - `--text`：消息内容（text 类型）或提问内容（agent 类型）


### PR DESCRIPTION
The cron skill documentation only listed 5 channels (imessage, discord, dingtalk, qq, console) as valid `--channel` options, causing the agent to fallback to console when users create cron jobs from unlisted channels like feishu, telegram, matrix, etc.

Added all supported channels and guidance to use the current channel as default when user does not specify one.

Fixes #1537

## Description

When creating a cron job via agent conversation in a non-listed channel (e.g. Feishu), the agent reads `SKILL.md` and sees the current channel is not in the valid `--channel` options. It conservatively falls back to `--channel console`, causing the cron job to dispatch reminders to console instead of the user's actual channel.


This PR updates the `--channel` parameter description in `SKILL.md` to:
1. List all supported channels (matching `schema.py:BUILTIN_CHANNEL_TYPES`) with "等" suffix for future extensibility
2. Add default value guidance: use the current channel when user doesn't specify one

**Related Issue:** Fixes #1540

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start CoPaw with Feishu (or any non-console channel) connected
2. In a **new session**, send: "5分钟后提醒我开会"
3. Check `~/.copaw/jobs.json` — `dispatch.channel` should be `"feishu"` (not `"console"`)
4. Wait for cron trigger — reminder should arrive in Feishu

**Note**: Existing sessions may have cached the old `--channel console` pattern in conversation history. Use a new session to verify.

## Local Verification Evidence

```
Before fix — request from Feishu, job dispatched to console:

2026-03-16 00:53:49 | Handle agent query:
  channel: "feishu"
  msgs: "5分钟后提醒我关手机"

~/.copaw/jobs.json:
  name: "关手机提醒"
  dispatch.channel: "console"   ← wrong

Tested 3 cron jobs from Feishu — all resulted in dispatch.channel: "console".

After fix (new session) — job correctly dispatched to feishu. Verified working.
![0dbd9a67fce534091d7c70213826973f](https://github.com/user-attachments/assets/5d5bf190-b4cf-45c9-86a7-ca997e06a93d)


```

