### PR TITLE
fix(qq): add LLM-based self-healing for send errors

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -803,11 +803,13 @@ class QQChannel(BaseChannel):
                     error_info = (
                         exc.data if isinstance(exc, QQApiError) else {"error": str(exc)}
                     )
+                    if isinstance(error_info, dict):
+                        err_code = error_info.get("err_code") or error_info.get("code", "unknown")
+                    else:
+                        err_code = str(exc)[:50]
                     logger.warning(
                         "QQ send failed (%s), trying LLM to fix",
-                        error_info.get("err_code") or error_info.get("code", "unknown")
-                        if isinstance(error_info, dict)
-                        else str(exc)[:50],
+                        err_code,
                     )
                     
                     # Try LLM-based fixing


### PR DESCRIPTION
- Simplify LLM prompt: just send error info and let LLM decide how to fix
- Apply LLM fixing to all QQ send errors (not just content violation)
- Token 过期自动刷新重试
- Markdown 问题自动转纯文本
- Remove unused helper functions

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
