### PR TITLE
fix(tool choice): fix the tool choice bug

### DIFF
--- a/src/copaw/agents/tool_guard_mixin.py
+++ b/src/copaw/agents/tool_guard_mixin.py
@@ -343,9 +343,6 @@ class ToolGuardMixin:
             await self.memory.add(msg)
             return msg
 
-        if tool_choice is None and self.toolkit.get_json_schemas():
-            tool_choice = "auto"
-
         return await super()._reasoning(  # type: ignore[misc]
             tool_choice=tool_choice,
         )


### PR DESCRIPTION
## Description

Fixes an incorrect default `tool_choice` override in `ToolGuardMixin`.

Previously, when `tool_choice` was `None` and tools were available, the code forced `tool_choice = "auto"`.
This could override caller/model-level intent and lead to unexpected tool selection behavior.

This PR removes that forced fallback in `ToolGuardMixin._reasoning`, so `tool_choice` is passed through as-is to upstream reasoning logic.

**Related Issue:** Relates to #1449  

**Security Considerations:** No direct security impact. This change only adjusts tool invocation decision flow and does not modify auth/env/config handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review
