### PR TITLE
fix: handle None system_prompt in memory compaction

### DIFF
--- a/src/copaw/agents/hooks/memory_compaction.py
+++ b/src/copaw/agents/hooks/memory_compaction.py
@@ -83,7 +83,7 @@ class MemoryCompactionHook:
             system_prompt = agent.sys_prompt
             compressed_summary = memory.get_compressed_summary()
             str_token_count = safe_count_str_tokens(
-                system_prompt + compressed_summary,
+                (system_prompt or "") + (compressed_summary or ""),
             )
 
             # memory_compact_threshold must be provided


### PR DESCRIPTION
## Problem
When an agent has no system prompt set (`agent.sys_prompt` is `None`), the memory compaction hook crashes with:

```
TypeError: can only concatenate str (not "NoneType") to str
```

This occurs at line 85 where `system_prompt + compressed_summary` is evaluated.

## Solution
Guard both variables with `or ""` to handle either being `None`:

```python
str_token_count = safe_count_str_tokens(
    (system_prompt or "") + (compressed_summary or ""),
)
```

## Testing
- Verified fix handles `None` for either or both values
- Returns empty string concatenation when both are `None`

Fixes the crash reported in issue where CoPaw fails during pre_reasoning hook.