### PR TITLE
fix(cron): read heartbeat config from agent.json instead of root config

### DIFF
--- a/src/copaw/app/crons/heartbeat.py
+++ b/src/copaw/app/crons/heartbeat.py
@@ -14,11 +14,10 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from typing import Any, Dict
 
 from ...config import (
-    HeartbeatConfig,
     get_heartbeat_query_path,
     load_config,
+    load_heartbeat_for_agent,
 )
-from ...config.config import load_agent_config
 from ...constant import HEARTBEAT_TARGET_LAST
 
 logger = logging.getLogger(__name__)
@@ -97,15 +96,7 @@ async def run_heartbeat_once(
     optionally dispatch to last channel (target=last).
     """
     config = load_config()
-    try:
-        agent_config = load_agent_config(agent_id)
-        hb = agent_config.heartbeat or HeartbeatConfig()
-    except (ValueError, FileNotFoundError):
-        logger.warning(
-            "Failed to load agent config for %s, using default heartbeat",
-            agent_id,
-        )
-        hb = HeartbeatConfig()
+    hb = load_heartbeat_for_agent(agent_id)
     if not _in_active_hours(hb.active_hours):
         logger.debug("heartbeat skipped: outside active hours")
         return

--- a/src/copaw/app/crons/heartbeat.py
+++ b/src/copaw/app/crons/heartbeat.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 Heartbeat: run agent with HEARTBEAT.md as query at interval.
-Uses config functions (get_heartbeat_config, get_heartbeat_query_path,
-load_config) for paths and settings.
+Uses agent-level config (load_agent_config) for heartbeat settings
+and config functions (get_heartbeat_query_path, load_config) for paths.
 """
 from __future__ import annotations
 
@@ -14,10 +14,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from typing import Any, Dict
 
 from ...config import (
-    get_heartbeat_config,
+    HeartbeatConfig,
     get_heartbeat_query_path,
     load_config,
 )
+from ...config.config import load_agent_config
 from ...constant import HEARTBEAT_TARGET_LAST
 
 logger = logging.getLogger(__name__)
@@ -89,13 +90,22 @@ async def run_heartbeat_once(
     *,
     runner: Any,
     channel_manager: Any,
+    agent_id: str,
 ) -> None:
     """
     Run one heartbeat: read HEARTBEAT.md via config path, run agent,
     optionally dispatch to last channel (target=last).
     """
     config = load_config()
-    hb = get_heartbeat_config()
+    try:
+        agent_config = load_agent_config(agent_id)
+        hb = agent_config.heartbeat or HeartbeatConfig()
+    except (ValueError, FileNotFoundError):
+        logger.warning(
+            "Failed to load agent config for %s, using default heartbeat",
+            agent_id,
+        )
+        hb = HeartbeatConfig()
     if not _in_active_hours(hb.active_hours):
         logger.debug("heartbeat skipped: outside active hours")
         return

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -11,7 +11,8 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from ...config import get_heartbeat_config
+from ...config import HeartbeatConfig
+from ...config.config import load_agent_config
 
 from ..console_push_store import append as push_store_append
 from .executor import CronExecutor
@@ -36,11 +37,13 @@ class CronManager:
         repo: BaseJobRepository,
         runner: Any,
         channel_manager: Any,
+        agent_id: str,
         timezone: str = "UTC",  # pylint: disable=redefined-outer-name
     ):
         self._repo = repo
         self._runner = runner
         self._channel_manager = channel_manager
+        self._agent_id = agent_id
         self._scheduler = AsyncIOScheduler(timezone=timezone)
         self._executor = CronExecutor(
             runner=runner,
@@ -52,6 +55,18 @@ class CronManager:
         self._rt: Dict[str, _Runtime] = {}
         self._started = False
 
+    def _load_heartbeat_config(self) -> HeartbeatConfig:
+        """Load heartbeat config from agent-level agent.json."""
+        try:
+            agent_config = load_agent_config(self._agent_id)
+            return agent_config.heartbeat or HeartbeatConfig()
+        except (ValueError, FileNotFoundError):
+            logger.warning(
+                "Failed to load agent config for %s, using default heartbeat",
+                self._agent_id,
+            )
+            return HeartbeatConfig()
+
     async def start(self) -> None:
         async with self._lock:
             if self._started:
@@ -62,9 +77,9 @@ class CronManager:
             for job in jobs_file.jobs:
                 await self._register_or_update(job)
 
-            # Heartbeat: one interval job when enabled in config
-            hb = get_heartbeat_config()
-            if getattr(hb, "enabled", True):
+            # Heartbeat: one interval job when enabled in agent config
+            hb = self._load_heartbeat_config()
+            if hb.enabled:
                 interval_seconds = parse_heartbeat_every(hb.every)
                 self._scheduler.add_job(
                     self._heartbeat_callback,
@@ -118,14 +133,14 @@ class CronManager:
             self._scheduler.resume_job(job_id)
 
     async def reschedule_heartbeat(self) -> None:
-        """Reload heartbeat config and update or remove the heartbeat job."""
+        """Reload heartbeat config from agent.json and update the job."""
         async with self._lock:
             if not self._started:
                 return
-            hb = get_heartbeat_config()
+            hb = self._load_heartbeat_config()
             if self._scheduler.get_job(HEARTBEAT_JOB_ID):
                 self._scheduler.remove_job(HEARTBEAT_JOB_ID)
-            if getattr(hb, "enabled", True):
+            if hb.enabled:
                 interval_seconds = parse_heartbeat_every(hb.every)
                 self._scheduler.add_job(
                     self._heartbeat_callback,
@@ -261,6 +276,7 @@ class CronManager:
             await run_heartbeat_once(
                 runner=self._runner,
                 channel_manager=self._channel_manager,
+                agent_id=self._agent_id,
             )
         except Exception:  # pylint: disable=broad-except
             logger.exception("heartbeat run failed")

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -11,8 +11,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from ...config import HeartbeatConfig
-from ...config.config import load_agent_config
+from ...config import HeartbeatConfig, load_heartbeat_for_agent
 
 from ..console_push_store import append as push_store_append
 from .executor import CronExecutor
@@ -57,15 +56,7 @@ class CronManager:
 
     def _load_heartbeat_config(self) -> HeartbeatConfig:
         """Load heartbeat config from agent-level agent.json."""
-        try:
-            agent_config = load_agent_config(self._agent_id)
-            return agent_config.heartbeat or HeartbeatConfig()
-        except (ValueError, FileNotFoundError):
-            logger.warning(
-                "Failed to load agent config for %s, using default heartbeat",
-                self._agent_id,
-            )
-            return HeartbeatConfig()
+        return load_heartbeat_for_agent(self._agent_id)
 
     async def start(self) -> None:
         async with self._lock:

--- a/src/copaw/app/workspace.py
+++ b/src/copaw/app/workspace.py
@@ -223,6 +223,7 @@ class Workspace:
                 repo=job_repo,
                 runner=self._runner,
                 channel_manager=self._channel_manager,
+                agent_id=self.agent_id,
                 timezone="UTC",
             )
             # Only start background tasks if heartbeat is enabled

--- a/src/copaw/config/__init__.py
+++ b/src/copaw/config/__init__.py
@@ -18,6 +18,7 @@ from .utils import (
     get_system_default_browser,
     is_running_in_container,
     load_config,
+    load_heartbeat_for_agent,
     save_config,
     update_last_dispatch,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "get_system_default_browser",
     "is_running_in_container",
     "load_config",
+    "load_heartbeat_for_agent",
     "save_config",
     "update_last_dispatch",
 ]

--- a/src/copaw/config/utils.py
+++ b/src/copaw/config/utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import plistlib
 import subprocess
@@ -18,6 +19,8 @@ from ..constant import (
     WORKING_DIR,
 )
 from .config import Config, HeartbeatConfig, LastApiConfig, LastDispatchConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _discover_system_chromium_path() -> Optional[str]:
@@ -363,14 +366,31 @@ def save_config(config: Config, config_path: Optional[Path] = None) -> None:
 def get_heartbeat_config() -> HeartbeatConfig:
     """Return heartbeat config from root config (legacy).
 
-    Deprecated: prefer loading from agent-level config via
-    ``load_agent_config(agent_id).heartbeat`` instead.
+    Deprecated: prefer ``load_heartbeat_for_agent(agent_id)`` instead.
     """
     config = load_config()
     defaults = config.agents.defaults
-    if defaults is None:
+    if defaults and defaults.heartbeat:
+        return defaults.heartbeat
+    return HeartbeatConfig()
+
+
+def load_heartbeat_for_agent(agent_id: str) -> HeartbeatConfig:
+    """Load heartbeat config from agent-level agent.json.
+
+    Falls back to default HeartbeatConfig on any config load failure.
+    """
+    from .config import load_agent_config
+
+    try:
+        agent_config = load_agent_config(agent_id)
+        return agent_config.heartbeat or HeartbeatConfig()
+    except (ValueError, OSError):
+        logger.warning(
+            "Failed to load agent config for %s, using default heartbeat",
+            agent_id,
+        )
         return HeartbeatConfig()
-    return defaults.heartbeat if defaults.heartbeat is not None else HeartbeatConfig()
 
 
 def update_last_dispatch(channel: str, user_id: str, session_id: str) -> None:

--- a/src/copaw/config/utils.py
+++ b/src/copaw/config/utils.py
@@ -389,6 +389,7 @@ def load_heartbeat_for_agent(agent_id: str) -> HeartbeatConfig:
         logger.warning(
             "Failed to load agent config for %s, using default heartbeat",
             agent_id,
+            exc_info=True,
         )
         return HeartbeatConfig()
 

--- a/src/copaw/config/utils.py
+++ b/src/copaw/config/utils.py
@@ -361,10 +361,16 @@ def save_config(config: Config, config_path: Optional[Path] = None) -> None:
 
 
 def get_heartbeat_config() -> HeartbeatConfig:
-    """Return effective heartbeat config (from file or default 30m/main)."""
+    """Return heartbeat config from root config (legacy).
+
+    Deprecated: prefer loading from agent-level config via
+    ``load_agent_config(agent_id).heartbeat`` instead.
+    """
     config = load_config()
-    hb = config.agents.defaults.heartbeat
-    return hb if hb is not None else HeartbeatConfig()
+    defaults = config.agents.defaults
+    if defaults is None:
+        return HeartbeatConfig()
+    return defaults.heartbeat if defaults.heartbeat is not None else HeartbeatConfig()
 
 
 def update_last_dispatch(channel: str, user_id: str, session_id: str) -> None:

--- a/tests/unit/workspace/test_heartbeat_config.py
+++ b/tests/unit/workspace/test_heartbeat_config.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Tests for heartbeat config loading (issue #1597).
+
+Verifies that CronManager and heartbeat functions read heartbeat config
+from agent-level agent.json, not from root config.json, and that
+the legacy get_heartbeat_config() handles null defaults gracefully.
+"""
+from pathlib import Path
+import json
+
+import pytest
+
+from copaw.config.config import (
+    AgentProfileConfig,
+    AgentProfileRef,
+    AgentsConfig,
+    Config,
+    HeartbeatConfig,
+    load_agent_config,
+    save_agent_config,
+)
+from copaw.config.utils import get_config_path, get_heartbeat_config
+
+
+@pytest.fixture
+def workspace_with_heartbeat(tmp_path, monkeypatch):
+    """Create a workspace where agent.json has heartbeat enabled
+    but root config.json has agents.defaults = null.
+    """
+    monkeypatch.setenv(
+        "COPAW_CONFIG_PATH",
+        str(tmp_path / "config.json"),
+    )
+
+    workspace_dir = tmp_path / "workspaces" / "test_agent"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    # Root config: agents.defaults is explicitly null
+    root_config = Config(
+        agents=AgentsConfig(
+            active_agent="test_agent",
+            defaults=None,
+            profiles={
+                "test_agent": AgentProfileRef(
+                    id="test_agent",
+                    workspace_dir=str(workspace_dir),
+                ),
+            },
+        ),
+    )
+    config_path = Path(get_config_path())
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(root_config.model_dump(mode="json", by_alias=True), f)
+
+    # Agent config: heartbeat enabled with custom interval
+    agent_config = AgentProfileConfig(
+        id="test_agent",
+        name="Test Agent",
+        description="Test agent for heartbeat",
+        heartbeat=HeartbeatConfig(
+            enabled=True,
+            every="15m",
+            target="main",
+        ),
+    )
+    save_agent_config("test_agent", agent_config)
+
+    return {
+        "workspace_dir": workspace_dir,
+        "agent_id": "test_agent",
+    }
+
+
+def test_legacy_get_heartbeat_config_null_defaults(
+    workspace_with_heartbeat,
+):  # pylint: disable=redefined-outer-name
+    """Issue #1597: get_heartbeat_config() must not crash when
+    agents.defaults is null in root config.
+    """
+    # This used to raise: AttributeError: 'NoneType' has no attribute 'heartbeat'
+    hb = get_heartbeat_config()
+    assert isinstance(hb, HeartbeatConfig)
+    # Should return default (enabled=False) since root defaults is null
+    assert hb.enabled is False
+
+
+def test_agent_level_heartbeat_config_is_loaded(
+    workspace_with_heartbeat,
+):  # pylint: disable=redefined-outer-name
+    """Heartbeat config should be loaded from agent.json, not root config."""
+    agent_id = workspace_with_heartbeat["agent_id"]
+    agent_config = load_agent_config(agent_id)
+
+    assert agent_config.heartbeat is not None
+    assert agent_config.heartbeat.enabled is True
+    assert agent_config.heartbeat.every == "15m"
+    assert agent_config.heartbeat.target == "main"
+
+
+def test_cron_manager_reads_agent_config(
+    workspace_with_heartbeat,
+):  # pylint: disable=redefined-outer-name
+    """CronManager._load_heartbeat_config should read from agent.json."""
+    from unittest.mock import MagicMock
+
+    from copaw.app.crons.manager import CronManager
+    from copaw.app.crons.repo.base import BaseJobRepository
+
+    mock_repo = MagicMock(spec=BaseJobRepository)
+    agent_id = workspace_with_heartbeat["agent_id"]
+
+    mgr = CronManager(
+        repo=mock_repo,
+        runner=MagicMock(),
+        channel_manager=MagicMock(),
+        agent_id=agent_id,
+    )
+
+    hb = mgr._load_heartbeat_config()
+    assert hb.enabled is True
+    assert hb.every == "15m"
+    assert hb.target == "main"
+
+
+def test_cron_manager_fallback_on_missing_agent(tmp_path, monkeypatch):
+    """CronManager should fall back to defaults if agent config is missing."""
+    from unittest.mock import MagicMock
+
+    from copaw.app.crons.manager import CronManager
+    from copaw.app.crons.repo.base import BaseJobRepository
+
+    monkeypatch.setenv(
+        "COPAW_CONFIG_PATH",
+        str(tmp_path / "config.json"),
+    )
+
+    # Root config with no agents
+    root_config = Config()
+    config_path = Path(get_config_path())
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(root_config.model_dump(mode="json", by_alias=True), f)
+
+    mock_repo = MagicMock(spec=BaseJobRepository)
+    mgr = CronManager(
+        repo=mock_repo,
+        runner=MagicMock(),
+        channel_manager=MagicMock(),
+        agent_id="nonexistent_agent",
+    )
+
+    # Should not crash, should return default config
+    hb = mgr._load_heartbeat_config()
+    assert isinstance(hb, HeartbeatConfig)
+    assert hb.enabled is False
+
+
+def test_heartbeat_config_independence_between_agents(tmp_path, monkeypatch):
+    """Different agents should have independent heartbeat configs."""
+    monkeypatch.setenv(
+        "COPAW_CONFIG_PATH",
+        str(tmp_path / "config.json"),
+    )
+
+    agent1_dir = tmp_path / "workspaces" / "agent1"
+    agent2_dir = tmp_path / "workspaces" / "agent2"
+    agent1_dir.mkdir(parents=True, exist_ok=True)
+    agent2_dir.mkdir(parents=True, exist_ok=True)
+
+    root_config = Config(
+        agents=AgentsConfig(
+            active_agent="agent1",
+            defaults=None,
+            profiles={
+                "agent1": AgentProfileRef(
+                    id="agent1",
+                    workspace_dir=str(agent1_dir),
+                ),
+                "agent2": AgentProfileRef(
+                    id="agent2",
+                    workspace_dir=str(agent2_dir),
+                ),
+            },
+        ),
+    )
+    config_path = Path(get_config_path())
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(root_config.model_dump(mode="json", by_alias=True), f)
+
+    save_agent_config(
+        "agent1",
+        AgentProfileConfig(
+            id="agent1",
+            name="Agent 1",
+            heartbeat=HeartbeatConfig(enabled=True, every="10m"),
+        ),
+    )
+    save_agent_config(
+        "agent2",
+        AgentProfileConfig(
+            id="agent2",
+            name="Agent 2",
+            heartbeat=HeartbeatConfig(enabled=False, every="1h"),
+        ),
+    )
+
+    from unittest.mock import MagicMock
+
+    from copaw.app.crons.manager import CronManager
+    from copaw.app.crons.repo.base import BaseJobRepository
+
+    mock_repo = MagicMock(spec=BaseJobRepository)
+
+    mgr1 = CronManager(
+        repo=mock_repo,
+        runner=MagicMock(),
+        channel_manager=MagicMock(),
+        agent_id="agent1",
+    )
+    mgr2 = CronManager(
+        repo=mock_repo,
+        runner=MagicMock(),
+        channel_manager=MagicMock(),
+        agent_id="agent2",
+    )
+
+    hb1 = mgr1._load_heartbeat_config()
+    hb2 = mgr2._load_heartbeat_config()
+
+    assert hb1.enabled is True
+    assert hb1.every == "10m"
+    assert hb2.enabled is False
+    assert hb2.every == "1h"

--- a/tests/unit/workspace/test_heartbeat_config.py
+++ b/tests/unit/workspace/test_heartbeat_config.py
@@ -19,7 +19,11 @@ from copaw.config.config import (
     load_agent_config,
     save_agent_config,
 )
-from copaw.config.utils import get_config_path, get_heartbeat_config
+from copaw.config.utils import (
+    get_config_path,
+    get_heartbeat_config,
+    load_heartbeat_for_agent,
+)
 
 
 @pytest.fixture
@@ -96,6 +100,34 @@ def test_agent_level_heartbeat_config_is_loaded(
     assert agent_config.heartbeat.enabled is True
     assert agent_config.heartbeat.every == "15m"
     assert agent_config.heartbeat.target == "main"
+
+
+def test_load_heartbeat_for_agent_reads_agent_json(
+    workspace_with_heartbeat,
+):  # pylint: disable=redefined-outer-name
+    """load_heartbeat_for_agent should read from agent.json."""
+    agent_id = workspace_with_heartbeat["agent_id"]
+    hb = load_heartbeat_for_agent(agent_id)
+    assert hb.enabled is True
+    assert hb.every == "15m"
+    assert hb.target == "main"
+
+
+def test_load_heartbeat_for_agent_fallback(tmp_path, monkeypatch):
+    """load_heartbeat_for_agent should return defaults for missing agents."""
+    monkeypatch.setenv(
+        "COPAW_CONFIG_PATH",
+        str(tmp_path / "config.json"),
+    )
+    root_config = Config()
+    config_path = Path(get_config_path())
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(root_config.model_dump(mode="json", by_alias=True), f)
+
+    hb = load_heartbeat_for_agent("nonexistent")
+    assert isinstance(hb, HeartbeatConfig)
+    assert hb.enabled is False
 
 
 def test_cron_manager_reads_agent_config(

--- a/tests/unit/workspace/test_heartbeat_config.py
+++ b/tests/unit/workspace/test_heartbeat_config.py
@@ -77,12 +77,12 @@ def workspace_with_heartbeat(tmp_path, monkeypatch):
 
 
 def test_legacy_get_heartbeat_config_null_defaults(
-    workspace_with_heartbeat,
+    workspace_with_heartbeat,  # pylint: disable=unused-argument
 ):  # pylint: disable=redefined-outer-name
-    """Issue #1597: get_heartbeat_config() must not crash when
-    agents.defaults is null in root config.
+    """Issue #1597: get_heartbeat_config() must not crash
+    when agents.defaults is null in root config.
     """
-    # This used to raise: AttributeError: 'NoneType' has no attribute 'heartbeat'
+    # Previously raised: AttributeError: 'NoneType' ...
     hb = get_heartbeat_config()
     assert isinstance(hb, HeartbeatConfig)
     # Should return default (enabled=False) since root defaults is null
@@ -130,10 +130,10 @@ def test_load_heartbeat_for_agent_fallback(tmp_path, monkeypatch):
     assert hb.enabled is False
 
 
-def test_cron_manager_reads_agent_config(
+def test_cron_manager_accepts_agent_id(
     workspace_with_heartbeat,
 ):  # pylint: disable=redefined-outer-name
-    """CronManager._load_heartbeat_config should read from agent.json."""
+    """CronManager should accept agent_id parameter."""
     from unittest.mock import MagicMock
 
     from copaw.app.crons.manager import CronManager
@@ -148,44 +148,8 @@ def test_cron_manager_reads_agent_config(
         channel_manager=MagicMock(),
         agent_id=agent_id,
     )
-
-    hb = mgr._load_heartbeat_config()
-    assert hb.enabled is True
-    assert hb.every == "15m"
-    assert hb.target == "main"
-
-
-def test_cron_manager_fallback_on_missing_agent(tmp_path, monkeypatch):
-    """CronManager should fall back to defaults if agent config is missing."""
-    from unittest.mock import MagicMock
-
-    from copaw.app.crons.manager import CronManager
-    from copaw.app.crons.repo.base import BaseJobRepository
-
-    monkeypatch.setenv(
-        "COPAW_CONFIG_PATH",
-        str(tmp_path / "config.json"),
-    )
-
-    # Root config with no agents
-    root_config = Config()
-    config_path = Path(get_config_path())
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "w", encoding="utf-8") as f:
-        json.dump(root_config.model_dump(mode="json", by_alias=True), f)
-
-    mock_repo = MagicMock(spec=BaseJobRepository)
-    mgr = CronManager(
-        repo=mock_repo,
-        runner=MagicMock(),
-        channel_manager=MagicMock(),
-        agent_id="nonexistent_agent",
-    )
-
-    # Should not crash, should return default config
-    hb = mgr._load_heartbeat_config()
-    assert isinstance(hb, HeartbeatConfig)
-    assert hb.enabled is False
+    # Verify CronManager was created with agent_id
+    assert mgr._agent_id == agent_id  # pylint: disable=protected-access
 
 
 def test_heartbeat_config_independence_between_agents(tmp_path, monkeypatch):
@@ -238,28 +202,8 @@ def test_heartbeat_config_independence_between_agents(tmp_path, monkeypatch):
         ),
     )
 
-    from unittest.mock import MagicMock
-
-    from copaw.app.crons.manager import CronManager
-    from copaw.app.crons.repo.base import BaseJobRepository
-
-    mock_repo = MagicMock(spec=BaseJobRepository)
-
-    mgr1 = CronManager(
-        repo=mock_repo,
-        runner=MagicMock(),
-        channel_manager=MagicMock(),
-        agent_id="agent1",
-    )
-    mgr2 = CronManager(
-        repo=mock_repo,
-        runner=MagicMock(),
-        channel_manager=MagicMock(),
-        agent_id="agent2",
-    )
-
-    hb1 = mgr1._load_heartbeat_config()
-    hb2 = mgr2._load_heartbeat_config()
+    hb1 = load_heartbeat_for_agent("agent1")
+    hb2 = load_heartbeat_for_agent("agent2")
 
     assert hb1.enabled is True
     assert hb1.every == "10m"


### PR DESCRIPTION
## Summary

- **Root cause**: After multi-agent architecture (PR #1375), `CronManager` still read heartbeat config from the legacy root `config.json` path (`agents.defaults.heartbeat`). When `agents.defaults` is `null`, this caused `AttributeError` and crashed the app on startup.
- **Fix**: Make `CronManager` agent-aware by accepting `agent_id`, reading heartbeat config from agent-level `agent.json` instead of root config. This aligns with the multi-agent architecture where each agent owns its own configuration.
- **Defensive fallback**: Added null-safety to the legacy `get_heartbeat_config()` function so any remaining callers won't crash.

## Design

The core issue was a **config source inconsistency** between two steps in the startup flow:

| Step | Code | Config source |
|------|------|---------------|
| Decide to start CronManager | `workspace.py:229` | `agent_config.heartbeat` (agent.json) ✅ |
| CronManager reads heartbeat config | `manager.py:66` → `utils.py:366` | `config.agents.defaults.heartbeat` (root config.json) ❌ |

This fix unifies both steps to read from `agent.json`, the single source of truth for agent-level config.

### Changes

| File | Change |
|------|--------|
| `app/crons/manager.py` | Added `agent_id` param; `_load_heartbeat_config()` reads from agent.json |
| `app/crons/heartbeat.py` | `run_heartbeat_once()` accepts `agent_id`, reads agent-level config |
| `app/workspace.py` | Passes `agent_id` to `CronManager` constructor |
| `config/utils.py` | `get_heartbeat_config()` null-safety + deprecated docstring |

## Test plan

- [ ] Start app with `agents.defaults: null` in root config and heartbeat enabled in agent.json — should no longer crash
- [ ] Verify heartbeat runs at the interval specified in agent.json (not root config)
- [ ] Verify hot-reload (`reschedule_heartbeat`) picks up changes from agent.json
- [ ] Verify heartbeat disabled in agent.json → no heartbeat job scheduled

Closes #1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)