### PR TITLE
fix(mcp): expand ${VAR} placeholders in MCP client config headers

### DIFF
--- a/src/copaw/app/mcp/manager.py
+++ b/src/copaw/app/mcp/manager.py
@@ -227,15 +227,13 @@ class MCPClientManager:
         return {
             "name": client_config.name,
             "transport": client_config.transport,
-            "url": expand(client_config.url) if client_config.url else "",
+            "url": expand(client_config.url),
             "headers": (
                 {k: expand(v) for k, v in client_config.headers.items()}
                 if client_config.headers
                 else None
             ),
-            "command": (
-                expand(client_config.command) if client_config.command else ""
-            ),
+            "command": expand(client_config.command),
             "args": [expand(a) for a in client_config.args],
             "env": (
                 {k: expand(v) for k, v in client_config.env.items()}

--- a/tests/unit/app/test_mcp_env_expansion.py
+++ b/tests/unit/app/test_mcp_env_expansion.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
 """Tests for MCP config ${VAR} environment variable expansion.
 
 Verifies that MCPClientManager correctly expands ${VAR_NAME} placeholders
@@ -7,7 +8,6 @@ in all config fields before passing them to the underlying MCP clients.
 
 from __future__ import annotations
 
-import os
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -103,7 +103,10 @@ class TestExpandConfigStrings:
         assert resolved["args"] == ["--key", "key123"]
         assert resolved["env"]["MY_KEY"] == "key123"
 
-    def test_original_config_not_mutated(self, monkeypatch: pytest.MonkeyPatch):
+    def test_original_config_not_mutated(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         monkeypatch.setenv("TOKEN", "val")
         cfg = MCPClientConfig(
             name="test",


### PR DESCRIPTION
## Summary

Fixes #1585

MCP HTTP client headers containing `${VAR_NAME}` placeholders (e.g. the default GitHub MCP config `"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"`) were passed as literal strings to the HTTP client, causing:
- Authentication failure (HTTP 400)
- `CancelledError` cascade during MCP initialization
- **Complete application startup failure**

## Root Cause

`MCPClientManager._build_client()` passed all config values (`headers`, `url`, `args`, `env`, `cwd`) directly to the MCP client constructors without any `${VAR}` expansion. Despite `load_envs_into_environ()` correctly injecting env vars into `os.environ` at startup, the config strings were never resolved against them.

## Solution

Add environment variable expansion in `_build_client()` via two new methods:

- **`_expand_env_vars(value)`** — Regex-based `${VAR_NAME}` substitution from `os.environ`. Unresolved variables are kept as-is with a warning log guiding users to set them via `copaw env set` or system env.
- **`_expand_config_strings(client_config)`** — Expands all string fields (`url`, `headers`, `command`, `args`, `env`, `cwd`) without mutating the original config object.

Key design decisions:
- **Expansion at build time, not config load time** — ensures `copaw env set` + hot-reload picks up the latest values
- **Raw templates preserved in `_copaw_rebuild_info`** — config watcher hash-based change detection continues to work correctly
- **All paths covered** — `init_from_config()`, `replace_client()`, and API-triggered hot-reload all flow through `_build_client()`

## Validation

```
$ pre-commit run --all-files
check python ast.........Passed
black....................Passed
flake8...................Passed
pylint...................Passed
mypy.....................Passed
prettier.................Passed

$ pytest tests/unit/ -v
170 passed in 11.41s
```

### New test coverage (20 test cases)

- `TestExpandEnvVars` — single/multiple/partial/unset var expansion, non-placeholder `$` ignored
- `TestExpandConfigStrings` — HTTP headers, URL, stdio fields expanded; original config immutability
- `TestBuildClientExpansion` — HTTP/stdio clients receive expanded values; rebuild_info stores raw templates
- `TestEnvVarRegex` — regex pattern correctness
