### PR TITLE
fix(formatter): add placeholder text for assistant messages with only…

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -141,6 +141,26 @@ def _create_file_block_support_formatter(
             """
             msgs = _sanitize_tool_messages(msgs)
 
+            # Ensure assistant messages with only thinking blocks have a
+            # placeholder text block so the parent formatter won't skip them.
+            # Otherwise in_assistant/out_assistant count mismatch occurs and
+            # reasoning_content injection is skipped, causing slot reset.
+            for msg in msgs:
+                if msg.role != "assistant":
+                    continue
+                if isinstance(msg.content, str):
+                    continue
+                blocks = msg.content or []
+                if not blocks:
+                    continue
+                has_visible = any(
+                    b.get("type")
+                    in ("text", "tool_use", "tool_result", "image", "audio", "video")
+                    for b in blocks
+                )
+                if not has_visible:
+                    blocks.append({"type": "text", "text": " "})
+
             reasoning_contents = {}
             extra_contents: dict[str, Any] = {}
             for msg in msgs:


### PR DESCRIPTION
… thinking blocks

When an assistant message contains only thinking blocks, the parent OpenAIChatFormatter skips it, causing in_assistant/out_assistant count mismatch and skipping reasoning_content injection. This leads to prompt structure changes and slot reset on backends like llama-server.

Add a placeholder text block to such messages so the parent formatter retains them, keeping counts aligned and reasoning_content injected.

Made-with: Cursor

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
