### PR TITLE
fix(QQ): optimize QQ channel reply logic

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -70,7 +70,16 @@ MAX_QUICK_DISCONNECT_COUNT = 3
 
 DEFAULT_API_BASE = "https://api.sgroup.qq.com"
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
-_URL_PATTERN = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+_URL_PATTERN = re.compile(r"https?://[^\s]+|www\.[^\s]+", re.IGNORECASE)
+# More aggressive pattern: also catches bare domains like 12306.cn, google.com
+_BARE_DOMAIN_PATTERN = re.compile(
+    r"https?://[^\s]+|www\.[^\s]+"
+    r"|\b[\w][\w.-]*\."
+    r"(?:com|cn|org|net|edu|gov|io|co|cc|tv|me|info|biz|app|dev|top|xyz"
+    r"|site|vip|shop|tech|club|pro|live|mobi|asia|wiki)"
+    r"(?:\.[a-z]{2,3})?\b(?:/[^\s]*)?",
+    re.IGNORECASE,
+)
 _IMAGE_TAG_PATTERN = re.compile(r"\[Image: (https?://[^\]]+)\]", re.IGNORECASE)
 
 # Rich media paths
@@ -96,6 +105,33 @@ def _sanitize_qq_text(text: str) -> tuple[str, bool]:
         return "", False
     sanitized, count = _URL_PATTERN.subn("[链接已省略]", text)
     return sanitized, count > 0
+
+
+def _aggressive_sanitize_qq_text(text: str) -> tuple[str, bool]:
+    """More aggressive URL stripping – also catches bare domain patterns.
+
+    Used as a second-level fallback when QQ still rejects the message
+    because of URL-like content that ``_sanitize_qq_text`` did not catch.
+    """
+    if not text:
+        return "", False
+    sanitized, count = _BARE_DOMAIN_PATTERN.subn("[链接已省略]", text)
+    return sanitized, count > 0
+
+
+def _is_url_content_error(exc: Exception) -> bool:
+    """Return *True* if QQ rejected the message because it contains a URL."""
+    if not isinstance(exc, QQApiError):
+        return False
+    try:
+        payload_text = json.dumps(exc.data, ensure_ascii=False).lower()
+    except Exception:
+        payload_text = str(exc.data).lower()
+    return (
+        "304003" in payload_text
+        or "40034028" in payload_text
+        or "不允许包含url" in payload_text
+    )
 
 
 def _as_bool(value: Any) -> bool:
@@ -752,7 +788,23 @@ class QQChannel(BaseChannel):
                 text_sent = True
             except Exception as exc:
                 if not use_markdown:
-                    logger.exception("send text failed")
+                    if _is_url_content_error(exc):
+                        logger.warning(
+                            "send text failed due to URL content; "
+                            "trying aggressive URL stripping",
+                        )
+                        aggressive_text, _ = _aggressive_sanitize_qq_text(
+                            clean_text,
+                        )
+                        try:
+                            await _dispatch(aggressive_text, False)
+                            text_sent = True
+                        except Exception:
+                            logger.exception(
+                                "send text aggressive fallback failed",
+                            )
+                    else:
+                        logger.exception("send text failed")
                 elif not _should_plaintext_fallback_from_markdown(exc):
                     logger.exception(
                         "send text failed with markdown; "
@@ -772,8 +824,25 @@ class QQChannel(BaseChannel):
                     try:
                         await _dispatch(fallback_text, False)
                         text_sent = True
-                    except Exception:
-                        logger.exception("send text fallback failed")
+                    except Exception as exc2:
+                        if _is_url_content_error(exc2):
+                            logger.warning(
+                                "send text fallback still rejected "
+                                "due to URL content; trying aggressive "
+                                "URL stripping",
+                            )
+                            aggressive_text, _ = _aggressive_sanitize_qq_text(
+                                clean_text,
+                            )
+                            try:
+                                await _dispatch(aggressive_text, False)
+                                text_sent = True
+                            except Exception:
+                                logger.exception(
+                                    "send text aggressive fallback failed",
+                                )
+                        else:
+                            logger.exception("send text fallback failed")
 
         # Send images if any
         if image_urls and message_type in ("c2c", "group"):


### PR DESCRIPTION
## Description

-enable QQ to reply dm
-a more aggressive approach is used when the text contains a URL that is being blocked

**Related Issue:** Fixes #1641 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
