### PR TITLE
fix(Workspace): handle path separators correctly in workspace path ex…

### DIFF
--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -41,10 +41,10 @@ export const useAgentsData = () => {
       // Set workspace path
       if (fileList.length > 0) {
         const path = fileList[0].path;
-        const workspace = path.substring(
-          0,
-          path.lastIndexOf("/") || path.lastIndexOf("\\"),
-        );
+        const lastSlashIndex = path.lastIndexOf("/");
+        const lastBackslashIndex = path.lastIndexOf("\\");
+        const separatorIndex = Math.max(lastSlashIndex, lastBackslashIndex);
+        const workspace = separatorIndex > 0 ? path.substring(0, separatorIndex) : path;
         setWorkspacePath(workspace);
       }
 


### PR DESCRIPTION
## Description

Fix workspace path showing "loading..." indefinitely. The original code had a flaw in path separator detection logic when extracting the workspace path, causing incorrect path extraction on some systems (especially Windows).

**Related Issue:** Fixes #workspace-path-always-loading

**Security Considerations:** N/A - Only fixes path string handling logic, no security impact

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open Agent Workspace page
2. Verify workspace path displays correctly (no longer shows "loading...")
3. Confirm both Windows paths (e.g., `C:\Users\...\workspace`) and Unix paths (e.g., `/home/.../workspace`) display correctly

## Local Verification Evidence

```bash
# Frontend code fix, run frontend type check and build
cd console
pnpm typecheck
# No type errors

pnpm build
# Build successful
```

## Additional Notes

**Root Cause:**
The original code used `path.lastIndexOf("/") || path.lastIndexOf("\\")` to detect path separators. When `lastIndexOf("/")` returns `-1` (falsy), the `||` operator would short-circuit, but `substring(0, -1)` returns an empty string, causing the workspace path to fail to display correctly.

**Fix:**
Use `Math.max(lastSlashIndex, lastBackslashIndex)` to correctly get the position of the last separator, and handle the case where no separator is found.