### PR TITLE
fix(Workspace): handle path separators correctly in workspace path ex…

### DIFF
--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -7,6 +7,29 @@ import { workspaceApi } from "../../../../api/modules/workspace";
 import { agentsApi } from "../../../../api/modules/agents";
 import { useAgentStore } from "../../../../stores/agentStore";
 
+/**
+ * Extract workspace directory from a file path.
+ * Handles both Unix (/path/to/file) and Windows (C:\path\to\file) paths.
+ * Returns the directory path including the trailing separator.
+ */
+const extractWorkspacePath = (filePath: string): string => {
+  const lastSlashIndex = filePath.lastIndexOf("/");
+  const lastBackslashIndex = filePath.lastIndexOf("\\");
+  const separatorIndex = Math.max(lastSlashIndex, lastBackslashIndex);
+
+  if (separatorIndex <= 0) {
+    // Root directory case: /file.txt -> /, C:\file.txt -> C:\
+    if (lastBackslashIndex === 2 && filePath[1] === ":") {
+      // Windows root: C:\file.txt -> C:\
+      return filePath.substring(0, 3);
+    }
+    // Unix root: /file.txt -> /
+    return filePath.substring(0, 1);
+  }
+
+  return filePath.substring(0, separatorIndex);
+};
+
 export const useAgentsData = () => {
   const { t } = useTranslation();
   const { selectedAgent } = useAgentStore();
@@ -40,12 +63,7 @@ export const useAgentsData = () => {
 
       // Set workspace path
       if (fileList.length > 0) {
-        const path = fileList[0].path;
-        const workspace = path.substring(
-          0,
-          path.lastIndexOf("/") || path.lastIndexOf("\\"),
-        );
-        setWorkspacePath(workspace);
+        setWorkspacePath(extractWorkspacePath(fileList[0].path));
       }
 
       // Try to re-select the same file in new workspace
@@ -132,12 +150,7 @@ export const useAgentsData = () => {
       );
       setFiles(sortedFiles);
       if (fileList.length > 0) {
-        const path = fileList[0].path;
-        const workspace = path.substring(
-          0,
-          path.lastIndexOf("/") || path.lastIndexOf("\\"),
-        );
-        setWorkspacePath(workspace);
+        setWorkspacePath(extractWorkspacePath(fileList[0].path));
       }
     } catch (error) {
       console.error("Failed to fetch files", error);

--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -13,21 +13,21 @@ import { useAgentStore } from "../../../../stores/agentStore";
  * Returns the directory path including the trailing separator.
  */
 const extractWorkspacePath = (filePath: string): string => {
+  if (!filePath) {
+    return "";
+  }
+
   const lastSlashIndex = filePath.lastIndexOf("/");
   const lastBackslashIndex = filePath.lastIndexOf("\\");
   const separatorIndex = Math.max(lastSlashIndex, lastBackslashIndex);
 
-  if (separatorIndex <= 0) {
-    // Root directory case: /file.txt -> /, C:\file.txt -> C:\
-    if (lastBackslashIndex === 2 && filePath[1] === ":") {
-      // Windows root: C:\file.txt -> C:\
-      return filePath.substring(0, 3);
-    }
-    // Unix root: /file.txt -> /
-    return filePath.substring(0, 1);
+  if (separatorIndex < 0) {
+    return ""; // No separator found
   }
 
-  return filePath.substring(0, separatorIndex);
+
+  // This correctly returns the path including the trailing separator for all cases.
+  return filePath.substring(0, separatorIndex + 1);
 };
 
 export const useAgentsData = () => {


### PR DESCRIPTION
## Description

Fix workspace path showing "loading..." indefinitely. The original code had a flaw in path separator detection logic when extracting the workspace path, causing incorrect path extraction on some systems (especially Windows).

**Related Issue:** Fixes #workspace-path-always-loading

**Security Considerations:** N/A - Only fixes path string handling logic, no security impact

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open Agent Workspace page
2. Verify workspace path displays correctly (no longer shows "loading...")
3. Confirm both Windows paths (e.g., `C:\Users\...\workspace`) and Unix paths (e.g., `/home/.../workspace`) display correctly

## Local Verification Evidence

```bash
# Frontend code fix, run frontend type check and build
cd console
pnpm typecheck
# No type errors

pnpm build
# Build successful
```

## Additional Notes

**Root Cause:**
The original code used `path.lastIndexOf("/") || path.lastIndexOf("\\")` to detect path separators. When `lastIndexOf("/")` returns `-1` (falsy), the `||` operator would short-circuit, but `substring(0, -1)` returns an empty string, causing the workspace path to fail to display correctly.

**Fix:**
Use `Math.max(lastSlashIndex, lastBackslashIndex)` to correctly get the position of the last separator, and handle the case where no separator is found.