### PR TITLE
feat(skills): add version-aware builtin skill sync with bidirectional sync fix

### DIFF
--- a/src/copaw/agents/skills/browser_visible/SKILL.md
+++ b/src/copaw/agents/skills/browser_visible/SKILL.md
@@ -3,6 +3,7 @@ name: browser_visible
 description: "当用户希望打开真实可见的浏览器窗口（而非后台无头模式）时，使用 browser_use 的 headed 参数启动浏览器，随后可正常 open/snapshot/click 等。适用于用户想亲眼看到页面、演示或调试场景。"
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "copaw":
       {
         "emoji": "🖥️",

--- a/src/copaw/agents/skills/cron/SKILL.md
+++ b/src/copaw/agents/skills/cron/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cron
 description: 通过 copaw 命令管理定时任务 - 创建、查询、暂停、恢复、删除任务
-metadata: { "copaw": { "emoji": "⏰" } }
+metadata: { "builtin_skill_version": "1.0", "copaw": { "emoji": "⏰" } }
 ---
 
 # 定时任务管理

--- a/src/copaw/agents/skills/dingtalk_channel/SKILL.md
+++ b/src/copaw/agents/skills/dingtalk_channel/SKILL.md
@@ -3,6 +3,7 @@ name: dingtalk_channel_connect
 description: "使用可视浏览器自动完成 CoPaw 的钉钉频道接入。适用于用户提到钉钉、DingTalk、开发者后台、Client ID、Client Secret、机器人、Stream 模式、绑定或配置 channel 的场景；支持遇到登录页时暂停，等待用户登录后继续。"
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "copaw":
       {
         "emoji": "🤖",

--- a/src/copaw/agents/skills/docx/SKILL.md
+++ b/src/copaw/agents/skills/docx/SKILL.md
@@ -2,6 +2,7 @@
 name: docx
 description: "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of \"Word doc\", \"word document\", \".docx\", or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a \"report\", \"memo\", \"letter\", \"template\", or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation."
 license: Proprietary. LICENSE.txt has complete terms
+metadata: { "builtin_skill_version": "1.0" }
 ---
 
 > **Important:** All `scripts/` paths are relative to this skill directory.

--- a/src/copaw/agents/skills/file_reader/SKILL.md
+++ b/src/copaw/agents/skills/file_reader/SKILL.md
@@ -3,6 +3,7 @@ name: file_reader
 description: "Read and summarize text-based file types only. Prefer read_file for text formats; use execute_shell_command for type detection when needed. PDF/Office/images/archives are handled by other skills."
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "copaw":
       {
         "emoji": "📄",

--- a/src/copaw/agents/skills/guidance/SKILL.md
+++ b/src/copaw/agents/skills/guidance/SKILL.md
@@ -3,6 +3,7 @@ name: guidance
 description: "回答用户关于 CoPaw 安装与配置的问题：优先定位并阅读本地文档，再提炼答案；若本地信息不足，兜底访问官网文档。"
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "copaw":
       {
         "emoji": "🧭",

--- a/src/copaw/agents/skills/himalaya/SKILL.md
+++ b/src/copaw/agents/skills/himalaya/SKILL.md
@@ -4,6 +4,7 @@ description: "CLI to manage emails via IMAP/SMTP. Use `himalaya` to list, read, 
 homepage: https://github.com/pimalaya/himalaya
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "openclaw":
       {
         "emoji": "📧",

--- a/src/copaw/agents/skills/news/SKILL.md
+++ b/src/copaw/agents/skills/news/SKILL.md
@@ -3,6 +3,7 @@ name: news
 description: "Look up the latest news for the user from specified news sites. Provides authoritative URLs for politics, finance, society, world, tech, sports, and entertainment. Use browser_use to open each URL and snapshot to get content, then summarize for the user."
 metadata:
   {
+    "builtin_skill_version": "1.0",
     "copaw":
       {
         "emoji": "📰",

--- a/src/copaw/agents/skills/pdf/SKILL.md
+++ b/src/copaw/agents/skills/pdf/SKILL.md
@@ -2,6 +2,7 @@
 name: pdf
 description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
 license: Proprietary. LICENSE.txt has complete terms
+metadata: { "builtin_skill_version": "1.0" }
 ---
 
 > **Important:** All `scripts/` paths are relative to this skill directory.

--- a/src/copaw/agents/skills/pptx/SKILL.md
+++ b/src/copaw/agents/skills/pptx/SKILL.md
@@ -2,6 +2,7 @@
 name: pptx
 description: "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill."
 license: Proprietary. LICENSE.txt has complete terms
+metadata: { "builtin_skill_version": "1.0" }
 ---
 
 > **Important:** All `scripts/` paths are relative to this skill directory.

--- a/src/copaw/agents/skills/xlsx/SKILL.md
+++ b/src/copaw/agents/skills/xlsx/SKILL.md
@@ -2,6 +2,7 @@
 name: xlsx
 description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
 license: Proprietary. LICENSE.txt has complete terms
+metadata: { "builtin_skill_version": "1.0" }
 ---
 
 > **Important:** All `scripts/` paths are relative to this skill directory.

--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -1,97 +1,16 @@
 # -*- coding: utf-8 -*-
 """Skills management: sync skills from code to working_dir."""
 
-import filecmp
 import logging
 import shutil
-from collections.abc import Iterable
-from itertools import zip_longest
 from pathlib import Path
 from typing import Any
 from pydantic import BaseModel
 import frontmatter
+from packaging.version import Version
 
 
 logger = logging.getLogger(__name__)
-
-
-IGNORED_RUNTIME_ARTIFACT_NAMES = {
-    "__pycache__",
-    ".DS_Store",
-    "Thumbs.db",
-    ".pytest_cache",
-}
-IGNORED_RUNTIME_ARTIFACT_SUFFIXES = {
-    ".pyc",
-    ".pyo",
-}
-
-
-def _should_ignore_runtime_artifact(path: Path) -> bool:
-    """Return True for generated runtime files that should not sync."""
-    if path.name in IGNORED_RUNTIME_ARTIFACT_NAMES:
-        return True
-    if path.is_file() and path.suffix in IGNORED_RUNTIME_ARTIFACT_SUFFIXES:
-        return True
-    return False
-
-
-def _iter_relevant_directory_entries(
-    directory: Path,
-) -> Iterable[tuple[Path, Path]]:
-    """Yield relative paths for non-generated files and directories."""
-    if not directory.exists():
-        return
-
-    yield from _iter_relevant_directory_entries_from(
-        root_dir=directory,
-        current_dir=directory,
-    )
-
-
-def _iter_relevant_directory_entries_from(
-    root_dir: Path,
-    current_dir: Path,
-) -> Iterable[tuple[Path, Path]]:
-    """Yield sorted non-generated directory entries without buffering."""
-    for item in sorted(current_dir.iterdir(), key=lambda path: path.name):
-        if _should_ignore_runtime_artifact(item):
-            continue
-
-        yield item.relative_to(root_dir), item
-
-        if item.is_dir():
-            yield from _iter_relevant_directory_entries_from(
-                root_dir=root_dir,
-                current_dir=item,
-            )
-
-
-def _directories_match_ignoring_runtime_artifacts(
-    dir1: Path,
-    dir2: Path,
-) -> bool:
-    """Compare two directories while ignoring generated runtime artifacts."""
-    if not dir1.exists() or not dir2.exists():
-        return False
-
-    for entry1, entry2 in zip_longest(
-        _iter_relevant_directory_entries(dir1),
-        _iter_relevant_directory_entries(dir2),
-    ):
-        if entry1 is None or entry2 is None:
-            return False
-
-        relative_path1, left = entry1
-        relative_path2, right = entry2
-        if relative_path1 != relative_path2:
-            return False
-        if left.is_dir() != right.is_dir():
-            return False
-        if left.is_file() and not filecmp.cmp(left, right, shallow=False):
-            return False
-
-    return True
 
 
 def _dedupe_skills_by_name(skills: list["SkillInfo"]) -> list["SkillInfo"]:
@@ -216,6 +135,47 @@ def _collect_skills_from_dir(directory: Path) -> dict[str, Path]:
     return skills
 
 
+def _get_builtin_skill_version(skill_dir: Path) -> Version | None:
+    """Read ``builtin_skill_version`` from SKILL.md front matter."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return None
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+        post = frontmatter.loads(content)
+        metadata = post.get("metadata") or {}
+        ver = metadata.get("builtin_skill_version")
+        if ver is not None:
+            return Version(str(ver))
+    except Exception as e:
+        logger.warning(
+            "Could not parse version for skill '%s' from '%s': %s",
+            skill_dir.name,
+            skill_md,
+            e,
+        )
+    return None
+
+
+def _replace_skill_dir(source: Path, target: Path) -> None:
+    """Remove *target* (if it exists) and copy *source* in its place."""
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+
+def _skill_md_differs(dir_a: Path, dir_b: Path) -> bool:
+    """Return True when the SKILL.md files in two dirs have different
+    content (or one side is missing)."""
+    md_a = dir_a / "SKILL.md"
+    md_b = dir_b / "SKILL.md"
+    if not md_a.exists() or not md_b.exists():
+        return True
+    return md_a.read_text(encoding="utf-8") != md_b.read_text(
+        encoding="utf-8",
+    )
+
+
 def sync_skills_to_working_dir(
     workspace_dir: Path,
     skill_names: list[str] | None = None,
@@ -265,33 +225,52 @@ def sync_skills_to_working_dir(
     synced_count = 0
     skipped_count = 0
 
-    # Sync each skill
     for skill_name, skill_dir in skills_to_sync.items():
         target_dir = active_skills / skill_name
 
-        # Check if skill already exists
-        if target_dir.exists() and not force:
+        if not target_dir.exists() or force:
+            _replace_skill_dir(skill_dir, target_dir)
             logger.debug(
-                "Skill '%s' already exists in active_skills, skipping. "
-                "Use force=True to overwrite.",
+                "Synced skill '%s' to active_skills.",
                 skill_name,
             )
-            skipped_count += 1
+            synced_count += 1
             continue
 
-        # Copy skill directory
-        try:
-            if target_dir.exists():
-                shutil.rmtree(target_dir)
-            shutil.copytree(skill_dir, target_dir)
-            logger.debug("Synced skill '%s' to active_skills.", skill_name)
-            synced_count += 1
-        except Exception as e:
-            logger.error(
-                "Failed to sync skill '%s': %s",
+        customized_dir = customized_skills / skill_name
+
+        # Builtin version upgrade (only when no customized override)
+        builtin_dir = builtin_skills / skill_name
+        if builtin_dir.exists() and not customized_dir.exists():
+            builtin_ver = _get_builtin_skill_version(builtin_dir)
+            if builtin_ver is not None:
+                active_ver = _get_builtin_skill_version(target_dir)
+                if active_ver is None or builtin_ver > active_ver:
+                    _replace_skill_dir(builtin_dir, target_dir)
+                    logger.debug(
+                        "Builtin skill '%s' updated in "
+                        "active_skills (v%s -> v%s).",
+                        skill_name,
+                        active_ver,
+                        builtin_ver,
+                    )
+                    synced_count += 1
+                    continue
+
+        # Customized override: propagate customized → active
+        if customized_dir.exists() and _skill_md_differs(
+            customized_dir,
+            target_dir,
+        ):
+            _replace_skill_dir(customized_dir, target_dir)
+            logger.debug(
+                "Customized skill '%s' updated in active_skills.",
                 skill_name,
-                e,
             )
+            synced_count += 1
+            continue
+
+        skipped_count += 1
 
     return synced_count, skipped_count
 
@@ -330,23 +309,23 @@ def sync_skills_from_active_to_customized(
         if skill_names is not None and skill_name not in skill_names:
             continue
 
-        if skill_name in builtin_skills_dict:
-            builtin_skill_dir = builtin_skills_dict[skill_name]
-            if _directories_match_ignoring_runtime_artifacts(
-                skill_dir,
-                builtin_skill_dir,
-            ):
-                skipped_count += 1
-                continue
+        # Skip builtin skills (dual check: version field + name match)
+        active_ver = _get_builtin_skill_version(skill_dir)
+        if active_ver is not None and skill_name in builtin_skills_dict:
+            skipped_count += 1
+            continue
 
+        # Only back-sync when customized doesn't already exist
         target_dir = customized_skills / skill_name
+        if target_dir.exists():
+            skipped_count += 1
+            continue
 
         try:
-            if target_dir.exists():
-                shutil.rmtree(target_dir)
             shutil.copytree(skill_dir, target_dir)
             logger.debug(
-                "Synced skill '%s' from active_skills to customized_skills.",
+                "Synced skill '%s' from active_skills to "
+                "customized_skills.",
                 skill_name,
             )
             synced_count += 1
@@ -572,12 +551,27 @@ class SkillService:
             )
             if synced > 0:
                 logger.debug(
-                    "Synced %d skill(s) from active_skills",
+                    "Back-synced %d skill(s) from active_skills",
                     synced,
                 )
         except Exception as e:
             logger.debug(
-                "Failed to sync skills from active_skills: %s",
+                "Failed to back-sync skills: %s",
+                e,
+            )
+
+        try:
+            synced, _ = sync_skills_to_working_dir(
+                self.workspace_dir,
+            )
+            if synced > 0:
+                logger.debug(
+                    "Forward-synced %d skill(s) to active_skills",
+                    synced,
+                )
+        except Exception as e:
+            logger.debug(
+                "Failed to forward-sync skills: %s",
                 e,
             )
 


### PR DESCRIPTION
## Description                                                                                                                                                                                  
                                                                                                                                                                                                  
Add version-aware sync for built-in skills and fix bidirectional sync logic between `active_skills` and `customized_skills`.                                                                    
                                                                                                                                                                                                
### How it works                                                                                                                                                                                
                                                                                                                                                                                                
**Forward sync** (`sync_skills_to_working_dir`):                                                                                                                                                
- New skills (not in active) are copied from builtin/customized.
- Builtin version upgrade: if a built-in skill has a newer `builtin_skill_version`, overwrite active — but only when no user-customized version exists.
- Customized propagation: if a customized skill's SKILL.md differs from the active copy, update active from customized.

**Backward sync** (`sync_skills_from_active_to_customized`):
- Only back-syncs non-builtin skills when customized doesn't already exist (first-time backup).
- Builtin detection uses dual check: `builtin_skill_version` field present AND skill name exists in builtin directory.

**Trigger**: Both syncs run on `list_all_skills()` (backward first, then forward) — triggered by frontend skill list refresh, enable, and disable.

### Builtin skill version: 1.0

### Transition handling for existing users

  Old installs have unversioned copies in `active_skills/`. These are treated as user-customized skills (no version key → backward sync copies them to `customized_skills/`). As a result:
  - Forward sync skips these skills (customized override exists).
  - Once the user cleans up the stale customized copy, the next forward sync pulls in the versioned built-in.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review


