### PR TITLE
fix: upgrade agentscope-runtime to 1.1.1 and bump version to 0.1.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "agentscope==1.0.17",
-    "agentscope-runtime==1.1.0",
+    "agentscope-runtime==1.1.1",
     "httpx>=0.27.0",
     "packaging>=24.0",
     "discord-py>=2.3",

--- a/src/copaw/__version__.py
+++ b/src/copaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.1.0b1"
+__version__ = "0.1.0b2"


### PR DESCRIPTION
There is a breaking change happens in `a2a-sdk~=1.0.0`, so we need to upgrade now.