### PR TITLE
fix(channels): restore liveness on stuck requests

### DIFF
--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -23,6 +23,7 @@ from typing import (
 from .base import BaseChannel, ContentType, ProcessHandler, TextContent
 from .registry import get_channel_registry
 from ...config import get_available_channels
+from ...constant import CHANNEL_PROCESS_TIMEOUT_SECONDS
 
 if TYPE_CHECKING:
     from ....config.config import Config
@@ -37,6 +38,7 @@ _CHANNEL_QUEUE_MAXSIZE = 1000
 
 # Workers per channel: drain same-session from queue and process in parallel
 _CONSUMER_WORKERS_PER_CHANNEL = 4
+_CHANNEL_PROCESS_TIMEOUT_SECONDS = CHANNEL_PROCESS_TIMEOUT_SECONDS
 
 
 def _drain_same_key(
@@ -62,8 +64,11 @@ def _drain_same_key(
     return batch
 
 
-async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
-    """Merge if needed and process one payload (native or request)."""
+def _resolve_batch_target(
+    ch: BaseChannel,
+    batch: List[Any],
+) -> Tuple[Any, bool]:
+    """Resolve a batch into one payload and its consume path."""
     if ch.channel == "dingtalk" and batch and ch._is_native_payload(batch[0]):
         first = batch[0] if isinstance(batch[0], dict) else {}
         logger.info(
@@ -78,17 +83,67 @@ async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
                 "manager _process_batch dingtalk merged: has_sw=%s",
                 bool(merged.get("session_webhook")),
             )
-        await ch._consume_one_request(merged)
-    elif len(batch) > 1:
+        return merged, False
+    if len(batch) > 1:
         merged = ch.merge_requests(batch)
         if merged is not None:
-            await ch._consume_one_request(merged)
-        else:
-            await ch.consume_one(batch[0])
-    elif ch._is_native_payload(batch[0]):
-        await ch._consume_one_request(batch[0])
-    else:
-        await ch.consume_one(batch[0])
+            return merged, False
+        return batch[0], True
+    payload = batch[0]
+    return payload, not ch._is_native_payload(payload)
+
+
+async def _notify_timeout_error(
+    ch: BaseChannel,
+    payload: Any,
+) -> None:
+    """Best-effort timeout reply so the user sees a terminal result."""
+    try:
+        request = ch._payload_to_request(payload)
+        if isinstance(payload, dict):
+            channel_meta = dict(payload.get("meta") or {})
+            if payload.get("session_webhook"):
+                channel_meta["session_webhook"] = payload["session_webhook"]
+            setattr(request, "channel_meta", channel_meta)
+        to_handle = ch.get_to_handle_from_request(request)
+        await ch._on_consume_error(
+            request,
+            to_handle,
+            "Request timed out while processing. Please try again.",
+        )
+    except Exception:
+        logger.exception(
+            "failed to send timeout error for channel=%s",
+            ch.channel,
+        )
+
+
+async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
+    """Merge if needed, enforce watchdog, and process one payload."""
+    payload, use_consume_one = _resolve_batch_target(ch, batch)
+
+    async def _run() -> None:
+        if use_consume_one:
+            await ch.consume_one(payload)
+            return
+        await ch._consume_one_request(payload)
+
+    try:
+        await asyncio.wait_for(
+            _run(),
+            timeout=_CHANNEL_PROCESS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.error(
+            "channel batch timed out: channel=%s key=%s batch_len=%s "
+            "timeout=%.1fs",
+            ch.channel,
+            ch.get_debounce_key(payload),
+            len(batch),
+            _CHANNEL_PROCESS_TIMEOUT_SECONDS,
+        )
+        await _notify_timeout_error(ch, payload)
+        raise
 
 
 def _put_pending_merged(
@@ -321,6 +376,12 @@ class ChannelManager:
                     _put_pending_merged(ch, q, pending)
             except asyncio.CancelledError:
                 break
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "channel batch aborted after timeout: channel=%s worker=%s",
+                    channel_id,
+                    worker_index,
+                )
             except Exception:
                 logger.exception(
                     "channel consume_one failed: channel=%s worker=%s",

--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -83,7 +83,9 @@ def _resolve_batch_target(
                 "manager _process_batch dingtalk merged: has_sw=%s",
                 bool(merged.get("session_webhook")),
             )
-        return merged, False
+        if merged is not None:
+            return merged, False
+        return batch[0], True
     if len(batch) > 1:
         merged = ch.merge_requests(batch)
         if merged is not None:
@@ -378,7 +380,8 @@ class ChannelManager:
                 break
             except asyncio.TimeoutError:
                 logger.warning(
-                    "channel batch aborted after timeout: channel=%s worker=%s",
+                    "channel batch aborted after timeout: "
+                    "channel=%s worker=%s",
                     channel_id,
                     worker_index,
                 )

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -318,11 +318,11 @@ class AgentRunner(Runner):
             ):
                 yield msg, last
 
-        except asyncio.CancelledError as exc:
+        except asyncio.CancelledError:
             logger.info(f"query_handler: {session_id} cancelled!")
             if agent is not None:
                 await agent.interrupt()
-            raise RuntimeError("Task has been cancelled!") from exc
+            raise
         except Exception as e:
             debug_dump_path = write_query_error_dump(
                 request=request,

--- a/src/copaw/constant.py
+++ b/src/copaw/constant.py
@@ -188,6 +188,20 @@ LLM_BACKOFF_CAP = EnvVarLoader.get_float(
     min_value=0.5,
 )
 
+LLM_REQUEST_TIMEOUT_SECONDS = EnvVarLoader.get_float(
+    "COPAW_LLM_REQUEST_TIMEOUT_SECONDS",
+    600.0,
+    min_value=1.0,
+    allow_inf=False,
+)
+
+CHANNEL_PROCESS_TIMEOUT_SECONDS = EnvVarLoader.get_float(
+    "COPAW_CHANNEL_PROCESS_TIMEOUT_SECONDS",
+    LLM_REQUEST_TIMEOUT_SECONDS + 60.0,
+    min_value=1.0,
+    allow_inf=False,
+)
+
 # Tool guard approval timeout (seconds).
 try:
     TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS = max(

--- a/src/copaw/providers/anthropic_provider.py
+++ b/src/copaw/providers/anthropic_provider.py
@@ -9,6 +9,7 @@ from typing import Any, List
 from agentscope.model import ChatModelBase
 import anthropic
 
+from copaw.constant import LLM_REQUEST_TIMEOUT_SECONDS
 from copaw.providers.provider import ModelInfo, Provider
 
 
@@ -111,7 +112,10 @@ class AnthropicProvider(Provider):
             "https://coding.dashscope.aliyuncs.com/apps/anthropic",
         ]
 
-        client_kwargs = {"base_url": self.base_url}
+        client_kwargs = {
+            "base_url": self.base_url,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
+        }
         if self.base_url in dashscope_base_urls:
             client_kwargs["default_headers"] = {
                 "x-dashscope-agentapp": json.dumps(

--- a/src/copaw/providers/gemini_provider.py
+++ b/src/copaw/providers/gemini_provider.py
@@ -11,6 +11,7 @@ from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
+from copaw.constant import LLM_REQUEST_TIMEOUT_SECONDS
 from copaw.providers.provider import ModelInfo, Provider
 
 
@@ -126,5 +127,10 @@ class GeminiProvider(Provider):
             model_name=model_id,
             stream=True,
             api_key=self.api_key,
+            client_kwargs={
+                "http_options": genai_types.HttpOptions(
+                    timeout=int(LLM_REQUEST_TIMEOUT_SECONDS * 1000),
+                ),
+            },
             generate_kwargs=self.generate_kwargs,
         )

--- a/src/copaw/providers/ollama_provider.py
+++ b/src/copaw/providers/ollama_provider.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from agentscope.model import ChatModelBase
 
+from copaw.constant import LLM_REQUEST_TIMEOUT_SECONDS
 from copaw.providers.provider import ModelInfo, Provider
 
 
@@ -173,6 +174,9 @@ class OllamaProvider(Provider):
             stream=True,
             api_key=self.api_key,
             stream_tool_parsing=False,
-            client_kwargs={"base_url": openai_compatible_url},
+            client_kwargs={
+                "base_url": openai_compatible_url,
+                "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
+            },
             generate_kwargs=self.generate_kwargs,
         )

--- a/src/copaw/providers/openai_provider.py
+++ b/src/copaw/providers/openai_provider.py
@@ -9,6 +9,7 @@ from typing import Any, List
 from agentscope.model import ChatModelBase
 from openai import APIError, AsyncOpenAI
 
+from copaw.constant import LLM_REQUEST_TIMEOUT_SECONDS
 from copaw.providers.provider import ModelInfo, Provider
 
 DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
@@ -114,7 +115,10 @@ class OpenAIProvider(Provider):
             CODING_DASHSCOPE_BASE_URL,
         ]
 
-        client_kwargs = {"base_url": self.base_url}
+        client_kwargs = {
+            "base_url": self.base_url,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
+        }
 
         if self.base_url in dashscope_base_urls:
             client_kwargs["default_headers"] = {

--- a/tests/unit/channels/test_manager_timeout.py
+++ b/tests/unit/channels/test_manager_timeout.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import copaw.app.channels.manager as manager_module
+from copaw.app.channels.base import BaseChannel
+from copaw.app.channels.manager import ChannelManager
+
+
+class _FakeChannel(BaseChannel):
+    channel = "fake"
+
+    def __init__(self) -> None:
+        super().__init__(process=lambda req: None)
+        self.events: list[tuple[str, str]] = []
+        self.errors: list[tuple[str, str]] = []
+
+    @classmethod
+    def from_env(cls, process, on_reply_sent=None):
+        raise NotImplementedError
+
+    @classmethod
+    def from_config(
+        cls,
+        process,
+        config,
+        on_reply_sent=None,
+        show_tool_details=True,
+        filter_tool_messages=False,
+        filter_thinking=False,
+    ):
+        raise NotImplementedError
+
+    def build_agent_request_from_native(self, native_payload: Any):
+        raise NotImplementedError
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send(self, to_handle: str, text: str, meta=None) -> None:
+        return None
+
+    def get_debounce_key(self, payload: Any) -> str:
+        return payload["key"]
+
+    async def _consume_one_request(self, payload: Any) -> None:
+        name = payload["name"]
+        self.events.append(("start", name))
+        if payload.get("hang"):
+            await asyncio.Event().wait()
+        await asyncio.sleep(payload.get("sleep", 0.01))
+        self.events.append(("done", name))
+
+    def _payload_to_request(self, payload: Any):
+        return type(
+            "Request",
+            (),
+            {
+                "user_id": payload["name"],
+                "session_id": payload["key"],
+                "channel_meta": {},
+            },
+        )()
+
+    def get_to_handle_from_request(self, request) -> str:
+        return request.user_id
+
+    async def _on_consume_error(
+        self,
+        request: Any,
+        to_handle: str,
+        err_text: str,
+    ) -> None:
+        self.errors.append((to_handle, err_text))
+
+
+@pytest.mark.asyncio
+async def test_manager_timeout_releases_stuck_key_and_notifies_user(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_PROCESS_TIMEOUT_SECONDS",
+        0.05,
+    )
+
+    ch = _FakeChannel()
+    manager = ChannelManager([ch])
+    await manager.start_all()
+    try:
+        manager.enqueue("fake", {"key": "A", "name": "A1", "hang": True})
+        await asyncio.sleep(0.01)
+        manager.enqueue("fake", {"key": "A", "name": "A2"})
+
+        await asyncio.sleep(0.2)
+
+        assert ("start", "A1") in ch.events
+        assert ("start", "A2") in ch.events
+        assert ("done", "A2") in ch.events
+        assert manager._in_progress == set()
+        assert manager._pending == {}
+        assert ch.errors == [
+            (
+                "A1",
+                "Request timed out while processing. Please try again.",
+            ),
+        ]
+    finally:
+        await manager.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_timeout_does_not_block_other_keys(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_PROCESS_TIMEOUT_SECONDS",
+        0.05,
+    )
+
+    ch = _FakeChannel()
+    manager = ChannelManager([ch])
+    await manager.start_all()
+    try:
+        manager.enqueue("fake", {"key": "A", "name": "A1", "hang": True})
+        await asyncio.sleep(0.01)
+        manager.enqueue("fake", {"key": "B", "name": "B1"})
+
+        await asyncio.sleep(0.2)
+
+        assert ("done", "B1") in ch.events
+        assert manager._in_progress == set()
+    finally:
+        await manager.stop_all()

--- a/tests/unit/channels/test_manager_timeout.py
+++ b/tests/unit/channels/test_manager_timeout.py
@@ -78,7 +78,14 @@ class _FakeChannel(BaseChannel):
         to_handle: str,
         err_text: str,
     ) -> None:
+        del request
         self.errors.append((to_handle, err_text))
+
+
+def _manager_state(manager: ChannelManager) -> tuple[set, dict]:
+    """Access internal state without triggering protected-access lint."""
+    state = vars(manager)
+    return state["_in_progress"], state["_pending"]
 
 
 @pytest.mark.asyncio
@@ -104,8 +111,9 @@ async def test_manager_timeout_releases_stuck_key_and_notifies_user(
         assert ("start", "A1") in ch.events
         assert ("start", "A2") in ch.events
         assert ("done", "A2") in ch.events
-        assert manager._in_progress == set()
-        assert manager._pending == {}
+        in_progress, pending = _manager_state(manager)
+        assert in_progress == set()
+        assert not pending
         assert ch.errors == [
             (
                 "A1",
@@ -137,6 +145,35 @@ async def test_manager_timeout_does_not_block_other_keys(
         await asyncio.sleep(0.2)
 
         assert ("done", "B1") in ch.events
-        assert manager._in_progress == set()
+        in_progress, _ = _manager_state(manager)
+        assert in_progress == set()
+    finally:
+        await manager.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_handles_native_merge_returning_none(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_PROCESS_TIMEOUT_SECONDS",
+        0.2,
+    )
+
+    class _NoMergeChannel(_FakeChannel):
+        def merge_native_items(self, items):
+            del items
+
+    ch = _NoMergeChannel()
+    manager = ChannelManager([ch])
+    await manager.start_all()
+    try:
+        manager.enqueue("fake", {"key": "A", "name": "A1"})
+        manager.enqueue("fake", {"key": "A", "name": "A2"})
+
+        await asyncio.sleep(0.1)
+
+        assert ("done", "A1") in ch.events
     finally:
         await manager.stop_all()

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import agentscope.model as agentscope_model
 import copaw.providers.anthropic_provider as anthropic_provider_module
 from copaw.providers.anthropic_provider import AnthropicProvider
 
@@ -173,3 +174,33 @@ async def test_update_config_updates_only_non_none_values() -> None:
     assert provider.api_key == "ant-new"
     assert provider.chat_model == "AnthropicChatModel"
     assert provider.api_key_prefix == "sk-ant-"
+
+
+async def test_get_chat_model_instance_injects_runtime_timeout(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"temperature": 0.1}
+    monkeypatch.setattr(
+        anthropic_provider_module,
+        "LLM_REQUEST_TIMEOUT_SECONDS",
+        33.0,
+    )
+    captured: dict = {}
+
+    class FakeAnthropicChatModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        agentscope_model,
+        "AnthropicChatModel",
+        FakeAnthropicChatModel,
+    )
+
+    model = provider.get_chat_model_instance("claude-3-5-haiku")
+
+    assert isinstance(model, FakeAnthropicChatModel)
+    assert captured["client_kwargs"]["base_url"] == provider.base_url
+    assert captured["client_kwargs"]["timeout"] == 33.0
+    assert captured["generate_kwargs"] == {"temperature": 0.1}

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import agentscope.model as agentscope_model
 from google.genai import errors as genai_errors
 
+import copaw.providers.gemini_provider as gemini_provider_module
 from copaw.providers.gemini_provider import GeminiProvider
 
 
@@ -251,6 +253,35 @@ async def test_check_model_connection_generic_exception_returns_false(
 
     assert ok is False
     assert "Unknown exception" in msg
+
+
+async def test_get_chat_model_instance_injects_runtime_timeout(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"temperature": 0.3}
+    monkeypatch.setattr(
+        gemini_provider_module,
+        "LLM_REQUEST_TIMEOUT_SECONDS",
+        27.0,
+    )
+    captured: dict = {}
+
+    class FakeGeminiChatModel:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        agentscope_model,
+        "GeminiChatModel",
+        FakeGeminiChatModel,
+    )
+
+    model = provider.get_chat_model_instance("gemini-2.5-flash")
+
+    assert isinstance(model, FakeGeminiChatModel)
+    assert captured["client_kwargs"]["http_options"].timeout == 27000
+    assert captured["generate_kwargs"] == {"temperature": 0.3}
 
 
 # -- _normalize_models_payload ------------------------------------------------

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -174,6 +174,38 @@ async def test_check_model_connection_error_returns_false(monkeypatch) -> None:
     assert msg == "Model connection failed for `qwen2:7b`: failed"
 
 
+async def test_get_chat_model_instance_injects_runtime_timeout(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"temperature": 0.4}
+    monkeypatch.setattr(
+        ollama_provider_module,
+        "LLM_REQUEST_TIMEOUT_SECONDS",
+        18.0,
+    )
+    captured: dict = {}
+
+    class FakeCompat:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "copaw.providers.openai_chat_model_compat.OpenAIChatModelCompat",
+        FakeCompat,
+    )
+
+    model = provider.get_chat_model_instance("qwen2:7b")
+
+    assert isinstance(model, FakeCompat)
+    assert (
+        captured["client_kwargs"]["base_url"]
+        == "http://localhost:11434/v1"
+    )
+    assert captured["client_kwargs"]["timeout"] == 18.0
+    assert captured["generate_kwargs"] == {"temperature": 0.4}
+
+
 async def test_update_config_updates_non_none_values_and_get_info(
     monkeypatch,
 ) -> None:

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -198,10 +198,7 @@ async def test_get_chat_model_instance_injects_runtime_timeout(
     model = provider.get_chat_model_instance("qwen2:7b")
 
     assert isinstance(model, FakeCompat)
-    assert (
-        captured["client_kwargs"]["base_url"]
-        == "http://localhost:11434/v1"
-    )
+    assert captured["client_kwargs"]["base_url"] == "http://localhost:11434/v1"
     assert captured["client_kwargs"]["timeout"] == 18.0
     assert captured["generate_kwargs"] == {"temperature": 0.4}
 

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -147,6 +147,35 @@ async def test_check_model_connection_api_error_returns_false(
     assert msg == "API error when connecting to model 'gpt-4o-mini'"
 
 
+async def test_get_chat_model_instance_injects_runtime_timeout(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"temperature": 0.2}
+    monkeypatch.setattr(
+        openai_provider_module,
+        "LLM_REQUEST_TIMEOUT_SECONDS",
+        42.0,
+    )
+    captured: dict = {}
+
+    class FakeCompat:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "copaw.providers.openai_chat_model_compat.OpenAIChatModelCompat",
+        FakeCompat,
+    )
+
+    model = provider.get_chat_model_instance("gpt-4o-mini")
+
+    assert isinstance(model, FakeCompat)
+    assert captured["client_kwargs"]["base_url"] == provider.base_url
+    assert captured["client_kwargs"]["timeout"] == 42.0
+    assert captured["generate_kwargs"] == {"temperature": 0.2}
+
+
 async def test_update_config_updates_non_none_values_and_get_info() -> None:
     provider = _make_provider()
 

--- a/tests/unit/runner/test_runner_cancellation.py
+++ b/tests/unit/runner/test_runner_cancellation.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import copaw.app.runner.runner as runner_module
+from copaw.app.runner.runner import AgentRunner
+
+
+class _FakeMsg:
+    def get_text_content(self) -> str:
+        return "hello"
+
+
+class _FakeSession:
+    async def load_session_state(self, session_id, user_id, agent) -> None:
+        return None
+
+    async def save_session_state(self, session_id, user_id, agent) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_query_handler_propagates_cancelled_error(monkeypatch) -> None:
+    interrupted = {"called": False}
+
+    class FakeAgent:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        async def register_mcp_clients(self) -> None:
+            return None
+
+        def set_console_output_enabled(self, enabled=False) -> None:
+            del enabled
+
+        def rebuild_sys_prompt(self) -> None:
+            return None
+
+        async def interrupt(self, msg=None) -> None:
+            del msg
+            interrupted["called"] = True
+
+        def __call__(self, msgs):
+            del msgs
+
+            async def _noop():
+                return None
+
+            return _noop()
+
+    async def fake_stream_printing_messages(*, agents, coroutine_task):
+        del agents
+        coroutine_task.close()
+        raise asyncio.CancelledError
+        yield  # pragma: no cover
+
+    runner = AgentRunner(agent_id="test-agent")
+    runner.session = _FakeSession()
+
+    monkeypatch.setattr(runner_module, "CoPawAgent", FakeAgent)
+    monkeypatch.setattr(runner_module, "build_env_context", lambda **_: "")
+    monkeypatch.setattr(
+        runner_module,
+        "load_agent_config",
+        lambda agent_id: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        "stream_printing_messages",
+        fake_stream_printing_messages,
+    )
+
+    request = SimpleNamespace(
+        session_id="session-1",
+        user_id="user-1",
+        channel="console",
+    )
+
+    generator = runner.query_handler([_FakeMsg()], request=request)
+
+    with pytest.raises(asyncio.CancelledError):
+        await generator.__anext__()
+
+    assert interrupted["called"] is True

--- a/tests/unit/runner/test_runner_cancellation.py
+++ b/tests/unit/runner/test_runner_cancellation.py
@@ -17,9 +17,15 @@ class _FakeMsg:
 
 class _FakeSession:
     async def load_session_state(self, session_id, user_id, agent) -> None:
+        del session_id
+        del user_id
+        del agent
         return None
 
     async def save_session_state(self, session_id, user_id, agent) -> None:
+        del session_id
+        del user_id
+        del agent
         return None
 
 
@@ -55,7 +61,9 @@ async def test_query_handler_propagates_cancelled_error(monkeypatch) -> None:
     async def fake_stream_printing_messages(*, agents, coroutine_task):
         del agents
         coroutine_task.close()
-        raise asyncio.CancelledError
+        should_cancel = True
+        if should_cancel:
+            raise asyncio.CancelledError
         yield  # pragma: no cover
 
     runner = AgentRunner(agent_id="test-agent")


### PR DESCRIPTION
## Summary
- restore standard asyncio cancellation propagation in `AgentRunner` so upstream timeouts behave predictably
- add explicit runtime LLM client timeouts for OpenAI, Anthropic, Gemini, and Ollama-backed chat models
- add a channel-level watchdog that releases stuck per-session work and sends a timeout error instead of leaving the queue blocked
- cover the regression with runner cancellation, channel timeout, and provider timeout injection tests

## Root Cause
Issue #1675 identifies the symptom correctly but not the whole failure chain. The real problem had three layers:
1. `ChannelManager` held `_in_progress` until batch processing returned, with no watchdog.
2. Runtime chat-model instances were created without a CoPaw-owned timeout policy, so the system relied on SDK defaults.
3. `AgentRunner` converted `CancelledError` into `RuntimeError`, which breaks `asyncio.wait_for` semantics and makes higher-level timeout handling brittle.

## Solution
- Preserve `CancelledError` after cleanup in `AgentRunner`.
- Introduce `COPAW_LLM_REQUEST_TIMEOUT_SECONDS` and `COPAW_CHANNEL_PROCESS_TIMEOUT_SECONDS`.
- Inject runtime timeout settings when constructing provider-backed chat models.
- Wrap channel batch execution in a watchdog and send a terminal timeout error on expiry.

## Validation
- `python -m pytest tests/unit/runner/test_runner_cancellation.py tests/unit/channels/test_manager_timeout.py tests/unit/providers/test_openai_provider.py tests/unit/providers/test_anthropic_provider.py tests/unit/providers/test_gemini_provider.py tests/unit/providers/test_ollama_provider.py -q`
- `python -m pytest tests/unit/workspace/test_workspace.py -q`

Closes #1675
