### PR TITLE
fix(console): persist chat sessions across navigation

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1,7 +1,9 @@
 import {
   AgentScopeRuntimeWebUI,
   IAgentScopeRuntimeWebUIOptions,
-  IAgentScopeRuntimeWebUIRef,
+  type IAgentScopeRuntimeWebUIMessage,
+  type IAgentScopeRuntimeWebUIRef,
+  Stream,
 } from "@agentscope-ai/chat";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Modal, Result, message } from "antd";
@@ -19,6 +21,9 @@ import api from "../../api";
 import ModelSelector from "./ModelSelector";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useAgentStore } from "../../stores/agentStore";
+import AgentScopeRuntimeResponseBuilder from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.js";
+import { AgentScopeRuntimeRunStatus } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types.js";
+import { useChatAnywhereInput } from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/Context/ChatAnywhereInputContext.js";
 import "./index.module.less";
 
 type CopyableContent = {
@@ -34,6 +39,28 @@ type CopyableMessage = {
 
 type CopyableResponse = {
   output?: CopyableMessage[];
+};
+
+type RuntimeUiMessage = IAgentScopeRuntimeWebUIMessage & {
+  msgStatus?: string;
+  role?: string;
+  cards?: Array<{
+    code: string;
+    data: unknown;
+  }>;
+  history?: boolean;
+};
+
+type StreamResponseData = {
+  status?: string;
+  output?: Array<{
+    content?: unknown[];
+  }>;
+};
+
+type RuntimeLoadingBridgeApi = {
+  getLoading?: () => boolean | string;
+  setLoading?: (loading: boolean | string) => void;
 };
 
 interface CustomWindow extends Window {
@@ -113,6 +140,101 @@ function buildModelError(): Response {
   );
 }
 
+function cloneRuntimeMessages(
+  messages: RuntimeUiMessage[],
+): RuntimeUiMessage[] {
+  return JSON.parse(JSON.stringify(messages)) as RuntimeUiMessage[];
+}
+
+function cloneValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isFinalResponseStatus(status?: string): boolean {
+  return (
+    status === AgentScopeRuntimeRunStatus.Completed ||
+    status === AgentScopeRuntimeRunStatus.Failed ||
+    status === AgentScopeRuntimeRunStatus.Canceled
+  );
+}
+
+function hasRenderableOutput(response: StreamResponseData): boolean {
+  if (response.status === AgentScopeRuntimeRunStatus.Failed) {
+    return true;
+  }
+
+  return (
+    response.output?.some((message) => (message.content?.length ?? 0) > 0) ??
+    false
+  );
+}
+
+function getResponseCardData(
+  message?: RuntimeUiMessage,
+): StreamResponseData | null {
+  const responseCard = message?.cards?.find(
+    (card) => card.code === "AgentScopeRuntimeResponseCard",
+  );
+
+  if (!responseCard?.data) {
+    return null;
+  }
+
+  return cloneValue(responseCard.data as StreamResponseData);
+}
+
+function getStreamingAssistantMessageId(
+  messages: RuntimeUiMessage[],
+): string | null {
+  return (
+    [...messages]
+      .reverse()
+      .find(
+        (message) =>
+          message.role === "assistant" &&
+          (message.msgStatus === "generating" ||
+            (message.cards?.length ?? 0) === 0),
+      )?.id ||
+    [...messages].reverse().find((message) => message.role === "assistant")
+      ?.id ||
+    null
+  );
+}
+
+function RuntimeLoadingBridge({
+  bridgeRef,
+}: {
+  bridgeRef: { current: RuntimeLoadingBridgeApi | null };
+}) {
+  const { setLoading, getLoading } = useChatAnywhereInput(
+    (value) =>
+      ({
+        setLoading: value.setLoading,
+        getLoading: value.getLoading,
+      }) as RuntimeLoadingBridgeApi,
+  );
+
+  useEffect(() => {
+    if (!setLoading || !getLoading) {
+      bridgeRef.current = null;
+      return;
+    }
+
+    bridgeRef.current = {
+      setLoading,
+      getLoading,
+    };
+
+    return () => {
+      if (bridgeRef.current?.setLoading === setLoading) {
+        bridgeRef.current = null;
+      }
+    };
+  }, [getLoading, setLoading, bridgeRef]);
+
+  return null;
+}
+
 export default function ChatPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -129,6 +251,7 @@ export default function ChatPage() {
   const [, setReconnectStreaming] = useState(false);
   const reconnectTriggeredForRef = useRef<string | null>(null);
   const prevChatIdRef = useRef<string | undefined>(undefined);
+  const runtimeLoadingBridgeRef = useRef<RuntimeLoadingBridgeApi | null>(null);
 
   const isComposingRef = useRef(false);
   const isChatActiveRef = useRef(false);
@@ -293,7 +416,7 @@ export default function ChatPage() {
 
   const createSessionWrapped = useCallback(async (session: any) => {
     const result = await sessionApi.createSession(session);
-    const newSessionId = result[0]?.id;
+    const newSessionId = session?.id || result[0]?.id;
     if (isChatActiveRef.current && newSessionId) {
       lastSessionIdRef.current = newSessionId;
       navigateRef.current(`/chat/${newSessionId}`, { replace: true });
@@ -322,6 +445,137 @@ export default function ChatPage() {
       }
     },
     [t],
+  );
+
+  const persistSessionMessages = useCallback(
+    async (sessionId: string, messages: RuntimeUiMessage[]) => {
+      if (!sessionId) return;
+      await sessionApi.updateSession({
+        id: sessionId,
+        messages: cloneRuntimeMessages(messages),
+      });
+    },
+    [],
+  );
+
+  const releaseStaleLoadingState = useCallback((sessionId: string) => {
+    const activeChatId = chatIdRef.current;
+    const realSessionId = sessionApi.getRealIdForSession(sessionId);
+    const isBackgroundSession =
+      activeChatId !== sessionId && activeChatId !== realSessionId;
+
+    if (!isBackgroundSession) {
+      return;
+    }
+
+    if (sessionApi.hasLiveMessagesForSession(activeChatId)) {
+      return;
+    }
+
+    runtimeLoadingBridgeRef.current?.setLoading?.(false);
+  }, []);
+
+  const persistStreamSession = useCallback(
+    (sessionId: string, readableStream: ReadableStream<Uint8Array>) => {
+      const initialMessages = cloneRuntimeMessages(
+        (chatRef.current?.messages.getMessages() as RuntimeUiMessage[]) || [],
+      );
+      const assistantMessageId =
+        getStreamingAssistantMessageId(initialMessages) ||
+        `stream-${sessionId}`;
+      const responseBuilder = new AgentScopeRuntimeResponseBuilder({
+        id: "",
+        status: AgentScopeRuntimeRunStatus.Created,
+        created_at: 0,
+      });
+
+      void (async () => {
+        let cachedMessages = initialMessages;
+        let hasStreamActivity = false;
+        let didReleaseLoading = false;
+
+        try {
+          for await (const chunk of Stream({ readableStream })) {
+            let chunkData: unknown;
+            try {
+              chunkData = JSON.parse(chunk.data);
+            } catch {
+              continue;
+            }
+
+            hasStreamActivity = true;
+            const responseData = responseBuilder.handle(
+              chunkData as never,
+            ) as StreamResponseData;
+            const isFinalChunk = isFinalResponseStatus(responseData.status);
+            const existingAssistantMessage = cachedMessages.find(
+              (message) => message.id === assistantMessageId,
+            );
+            const previousResponseData = getResponseCardData(
+              existingAssistantMessage,
+            );
+
+            let nextResponseData: StreamResponseData | null = null;
+            if (hasRenderableOutput(responseData)) {
+              nextResponseData = cloneValue(responseData);
+            } else if (isFinalChunk && previousResponseData) {
+              nextResponseData = {
+                ...previousResponseData,
+                status: responseData.status ?? previousResponseData.status,
+              };
+            }
+
+            if (nextResponseData) {
+              const assistantMessage: RuntimeUiMessage = {
+                ...(existingAssistantMessage || {
+                  id: assistantMessageId,
+                  role: "assistant",
+                }),
+                id: assistantMessageId,
+                role: "assistant",
+                cards: [
+                  {
+                    code: "AgentScopeRuntimeResponseCard",
+                    data: nextResponseData,
+                  },
+                ],
+                msgStatus: isFinalChunk ? "finished" : "generating",
+              };
+
+              const assistantIndex = cachedMessages.findIndex(
+                (message) => message.id === assistantMessageId,
+              );
+              cachedMessages =
+                assistantIndex >= 0
+                  ? [
+                      ...cachedMessages.slice(0, assistantIndex),
+                      assistantMessage,
+                      ...cachedMessages.slice(assistantIndex + 1),
+                    ]
+                  : [...cachedMessages, assistantMessage];
+
+              await persistSessionMessages(sessionId, cachedMessages);
+            }
+
+            if (!isFinalChunk) {
+              continue;
+            }
+
+            releaseStaleLoadingState(sessionId);
+            didReleaseLoading = true;
+          }
+        } catch (error) {
+          console.error("Failed to persist background chat stream:", error);
+        } finally {
+          if (!hasStreamActivity || didReleaseLoading) {
+            return;
+          }
+
+          releaseStaleLoadingState(sessionId);
+        }
+      })();
+    },
+    [persistSessionMessages, releaseStaleLoadingState],
   );
 
   const customFetch = useCallback(
@@ -423,14 +677,27 @@ export default function ChatPage() {
         ...biz_params,
       };
 
-      return fetch(getApiUrl("/console/chat"), {
+      const response = await fetch(getApiUrl("/console/chat"), {
         method: "POST",
         headers,
         body: JSON.stringify(requestBody),
         signal: data.signal,
       });
+
+      if (!response.ok || !response.body || !requestBody.session_id) {
+        return response;
+      }
+
+      const [uiStream, cacheStream] = response.body.tee();
+      persistStreamSession(requestBody.session_id, cacheStream);
+
+      return new Response(uiStream, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
     },
-    [setChatStatus, setReconnectStreaming],
+    [persistStreamSession, setChatStatus, setReconnectStreaming],
   );
 
   const options = useMemo(() => {
@@ -449,7 +716,12 @@ export default function ChatPage() {
         leftHeader: {
           ...defaultConfig.theme.leftHeader,
         },
-        rightHeader: <ModelSelector />,
+        rightHeader: (
+          <>
+            <RuntimeLoadingBridge bridgeRef={runtimeLoadingBridgeRef} />
+            <ModelSelector />
+          </>
+        ),
       },
       welcome: {
         ...i18nConfig.welcome,

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -67,6 +67,57 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   status?: "idle" | "running";
 }
 
+interface RuntimeResponseCard {
+  data?: {
+    status?: string;
+  };
+}
+
+const LIVE_MESSAGE_STATUSES = new Set(["generating", "created", "in_progress"]);
+
+const hasLiveMessages = (
+  messages?: IAgentScopeRuntimeWebUIMessage[],
+): boolean => {
+  if (!messages?.length) return false;
+
+  return messages.some((message) => {
+    const msgStatus =
+      typeof (message as { msgStatus?: unknown }).msgStatus === "string"
+        ? ((message as { msgStatus: string }).msgStatus as string)
+        : undefined;
+
+    if (msgStatus && LIVE_MESSAGE_STATUSES.has(msgStatus)) {
+      return true;
+    }
+
+    const cards = (message as { cards?: RuntimeResponseCard[] }).cards;
+    return (
+      cards?.some((card) => {
+        const status = card.data?.status;
+        return !!status && LIVE_MESSAGE_STATUSES.has(status);
+      }) ?? false
+    );
+  });
+};
+
+const hasMessages = (messages?: IAgentScopeRuntimeWebUIMessage[]): boolean =>
+  (messages?.length ?? 0) > 0;
+
+const shouldPreferLocalMessages = (
+  localMessages?: IAgentScopeRuntimeWebUIMessage[],
+  remoteMessages?: IAgentScopeRuntimeWebUIMessage[],
+): boolean => {
+  if (!hasMessages(localMessages)) {
+    return false;
+  }
+
+  if (!hasMessages(remoteMessages)) {
+    return true;
+  }
+
+  return (remoteMessages?.length ?? 0) < (localMessages?.length ?? 0);
+};
+
 // ---------------------------------------------------------------------------
 // Message conversion helpers: backend flat messages → card-based UI format
 // ---------------------------------------------------------------------------
@@ -233,6 +284,45 @@ const resolveRealId = (
 
 class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   private sessionList: IAgentScopeRuntimeWebUISession[] = [];
+  private resolvingSessionIds: Set<string> = new Set();
+
+  private findSessionIndexByAnyId(sessionId?: string | null): number {
+    if (!sessionId) {
+      return -1;
+    }
+
+    return this.sessionList.findIndex((session) => {
+      const extended = session as ExtendedSession;
+      return (
+        extended.id === sessionId ||
+        extended.realId === sessionId ||
+        extended.sessionId === sessionId
+      );
+    });
+  }
+
+  private findSessionByAnyId(
+    sessionId?: string | null,
+  ): ExtendedSession | null {
+    const index = this.findSessionIndexByAnyId(sessionId);
+    return index >= 0 ? (this.sessionList[index] as ExtendedSession) : null;
+  }
+
+  private cacheSession(session: ExtendedSession): void {
+    const index = this.findSessionIndexByAnyId(session.id);
+    if (index >= 0) {
+      const existing = this.sessionList[index] as ExtendedSession;
+      this.sessionList[index] = {
+        ...existing,
+        ...session,
+        id: existing.id,
+        realId: session.realId ?? existing.realId,
+      } as ExtendedSession;
+      return;
+    }
+
+    this.sessionList.unshift(session);
+  }
 
   /**
    * Deduplicates concurrent getSessionList calls so that two parallel
@@ -292,6 +382,25 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     });
   }
 
+  private resolveRealIdInBackground(tempId: string): void {
+    if (this.resolvingSessionIds.has(tempId)) {
+      return;
+    }
+
+    this.resolvingSessionIds.add(tempId);
+    void this.getSessionList()
+      .then(() => {
+        const { list, realId } = resolveRealId(this.sessionList, tempId);
+        this.sessionList = list;
+        if (realId) {
+          this.onSessionIdResolved?.(tempId, realId);
+        }
+      })
+      .finally(() => {
+        this.resolvingSessionIds.delete(tempId);
+      });
+  }
+
   private createEmptySession(sessionId: string): ExtendedSession {
     window.currentSessionId = sessionId;
     window.currentUserId = DEFAULT_USER_ID;
@@ -327,10 +436,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    * a local timestamp). Returns null when not yet resolved or not found.
    */
   getRealIdForSession(sessionId: string): string | null {
-    const s = this.sessionList.find((x) => x.id === sessionId) as
-      | ExtendedSession
-      | undefined;
+    const s = this.findSessionByAnyId(sessionId);
     return s?.realId ?? null;
+  }
+
+  hasLiveMessagesForSession(sessionId?: string | null): boolean {
+    return hasLiveMessages(this.findSessionByAnyId(sessionId)?.messages);
   }
 
   async getSessionList() {
@@ -340,6 +451,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     this.sessionListRequest = (async () => {
       try {
+        const previousSessions = [...this.sessionList] as ExtendedSession[];
         const chats = await api.listChats();
         const newList = chats
           .filter((c) => c.id && c.id !== "undefined" && c.id !== "null")
@@ -347,16 +459,47 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
           .reverse();
 
         // Merge: preserve realId mappings (timestamp → UUID) stored in memory
-        this.sessionList = newList.map((s) => {
-          const existing = this.sessionList.find(
+        const mergedSessions = newList.map((s) => {
+          const existing = previousSessions.find(
             (e) =>
               (e as ExtendedSession).sessionId ===
               (s as ExtendedSession).sessionId,
           ) as ExtendedSession | undefined;
-          return existing?.realId
-            ? { ...s, id: existing.id, realId: existing.realId }
-            : s;
+
+          if (!existing) {
+            return s;
+          }
+
+          return {
+            ...s,
+            id: existing.realId ? existing.id : s.id,
+            name:
+              existing.name && existing.name !== DEFAULT_SESSION_NAME
+                ? existing.name
+                : s.name,
+            messages: hasMessages(existing.messages)
+              ? existing.messages
+              : s.messages,
+            meta:
+              Object.keys(existing.meta || {}).length > 0
+                ? existing.meta
+                : s.meta,
+            realId: existing.realId,
+          } as ExtendedSession;
         });
+
+        const preservedLocalSessions = previousSessions.filter((session) => {
+          if (!isLocalTimestamp(session.id) || session.realId) {
+            return false;
+          }
+
+          return !mergedSessions.some(
+            (merged) =>
+              (merged as ExtendedSession).sessionId === session.sessionId,
+          );
+        });
+
+        this.sessionList = [...preservedLocalSessions, ...mergedSessions];
 
         return [...this.sessionList];
       } finally {
@@ -396,56 +539,33 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         | ExtendedSession
         | undefined;
 
+      if (fromList && hasMessages(fromList.messages)) {
+        this.updateWindowVariables(fromList);
+        return fromList;
+      }
+
       // If realId is already resolved, use it directly to fetch history.
       if (fromList?.realId) {
         const chatHistory = await api.getChat(fromList.realId);
+        const remoteMessages = convertMessages(chatHistory.messages || []);
+
+        if (shouldPreferLocalMessages(fromList.messages, remoteMessages)) {
+          this.updateWindowVariables(fromList);
+          return fromList;
+        }
+
         const session: ExtendedSession = {
           id: sessionId,
           name: fromList.name || DEFAULT_SESSION_NAME,
           sessionId: fromList.sessionId || sessionId,
           userId: fromList.userId || DEFAULT_USER_ID,
           channel: fromList.channel || DEFAULT_CHANNEL,
-          messages: convertMessages(chatHistory.messages || []),
+          messages: remoteMessages,
           meta: fromList.meta || {},
           realId: fromList.realId,
           status: chatHistory.status ?? "idle",
         };
-        this.updateWindowVariables(session);
-        return session;
-      }
-
-      // Pure local session (not yet sent to backend): wait until updateSession
-      // resolves the realId, then fetch history with the real UUID.
-      await new Promise<void>((resolve) => {
-        const check = () => {
-          const s = this.sessionList.find((x) => x.id === sessionId) as
-            | ExtendedSession
-            | undefined;
-          if (s?.realId) {
-            resolve();
-          } else {
-            setTimeout(check, 100);
-          }
-        };
-        setTimeout(check, 100);
-      });
-
-      const refreshed = this.sessionList.find((s) => s.id === sessionId) as
-        | ExtendedSession
-        | undefined;
-      if (refreshed?.realId) {
-        const chatHistory = await api.getChat(refreshed.realId);
-        const session: ExtendedSession = {
-          id: sessionId,
-          name: refreshed.name || DEFAULT_SESSION_NAME,
-          sessionId: refreshed.sessionId || sessionId,
-          userId: refreshed.userId || DEFAULT_USER_ID,
-          channel: refreshed.channel || DEFAULT_CHANNEL,
-          messages: convertMessages(chatHistory.messages || []),
-          meta: refreshed.meta || {},
-          realId: refreshed.realId,
-          status: chatHistory.status ?? "idle",
-        };
+        this.cacheSession(session);
         this.updateWindowVariables(session);
         return session;
       }
@@ -466,51 +586,78 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       | ExtendedSession
       | undefined;
 
+    if (fromList && hasMessages(fromList.messages)) {
+      this.updateWindowVariables(fromList);
+      return fromList;
+    }
+
     const chatHistory = await api.getChat(sessionId);
+    const remoteMessages = convertMessages(chatHistory.messages || []);
+
+    if (
+      fromList &&
+      shouldPreferLocalMessages(fromList.messages, remoteMessages)
+    ) {
+      this.updateWindowVariables(fromList);
+      return fromList;
+    }
+
     const session: ExtendedSession = {
       id: sessionId,
       name: fromList?.name || sessionId,
       sessionId: fromList?.sessionId || sessionId,
       userId: fromList?.userId || DEFAULT_USER_ID,
       channel: fromList?.channel || DEFAULT_CHANNEL,
-      messages: convertMessages(chatHistory.messages || []),
+      messages: remoteMessages,
       meta: fromList?.meta || {},
       status: chatHistory.status ?? "idle",
     };
 
+    this.cacheSession(session);
     this.updateWindowVariables(session);
     return session;
   }
 
   async updateSession(session: Partial<IAgentScopeRuntimeWebUISession>) {
-    session.messages = [];
-    const index = this.sessionList.findIndex((s) => s.id === session.id);
+    if (!session.id) {
+      return [...this.sessionList];
+    }
+
+    const index = this.findSessionIndexByAnyId(session.id);
 
     if (index > -1) {
-      this.sessionList[index] = { ...this.sessionList[index], ...session };
+      const existing = this.sessionList[index] as ExtendedSession;
+      this.sessionList[index] = {
+        ...existing,
+        ...session,
+        id: existing.id,
+        sessionId: existing.sessionId || session.id,
+        userId: existing.userId || window.currentUserId || DEFAULT_USER_ID,
+        channel: existing.channel || window.currentChannel || DEFAULT_CHANNEL,
+        messages: session.messages ?? existing.messages,
+        meta: existing.meta || {},
+      } as ExtendedSession;
 
       // Timestamp session without realId yet — resolve in the background
-      const existing = this.sessionList[index] as ExtendedSession;
       if (isLocalTimestamp(existing.id) && !existing.realId) {
-        const tempId = existing.id;
-        this.getSessionList().then(() => {
-          const { list, realId } = resolveRealId(this.sessionList, tempId);
-          this.sessionList = list;
-          if (realId) {
-            this.onSessionIdResolved?.(tempId, realId);
-          }
-        });
+        this.resolveRealIdInBackground(existing.id);
       }
     } else {
-      // Session not found locally — refresh and resolve via session_id
-      const tempId = session.id!;
-      await this.getSessionList().then(() => {
-        const { list, realId } = resolveRealId(this.sessionList, tempId);
-        this.sessionList = list;
-        if (realId) {
-          this.onSessionIdResolved?.(tempId, realId);
-        }
-      });
+      const nextSession: ExtendedSession = {
+        id: session.id,
+        name: session.name ?? DEFAULT_SESSION_NAME,
+        sessionId: session.id,
+        userId: window.currentUserId || DEFAULT_USER_ID,
+        channel: window.currentChannel || DEFAULT_CHANNEL,
+        messages: session.messages ?? [],
+        meta: {},
+      };
+
+      this.sessionList.unshift(nextSession);
+
+      if (isLocalTimestamp(session.id)) {
+        this.resolveRealIdInBackground(session.id);
+      }
     }
 
     return [...this.sessionList];
@@ -521,13 +668,14 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     const extended: ExtendedSession = {
       ...session,
+      name: session.name || DEFAULT_SESSION_NAME,
+      messages: session.messages ?? [],
       sessionId: session.id,
       userId: DEFAULT_USER_ID,
       channel: DEFAULT_CHANNEL,
     } as ExtendedSession;
 
     this.updateWindowVariables(extended);
-    this.sessionList.unshift(extended);
     return [...this.sessionList];
   }
 


### PR DESCRIPTION
## Description

Fix the console chat state desync that required a manual refresh in issue #1553.

This PR preserves local session/message state while the first reply is streaming and after it completes, so chat content does not disappear when switching sessions. It also avoids creating an empty sidebar session before the first user message is actually sent, and clears stale loading state when a background conversation finishes.

**Related Issue:** Fixes #1553

**Security Considerations:** None. This is a frontend-only state/cache fix and does not change auth, secrets, or backend permission handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open a new chat in Console.
2. Send the first user message.
3. Confirm the session appears in the left sidebar without waiting for the full assistant response.
4. While the assistant reply is still streaming, switch to another session and then switch back.
5. Confirm the in-progress response is still visible and continues updating.
6. Switch away again and wait until the background response finishes.
7. Switch back and confirm the completed Q/A is still visible without refreshing.
8. Confirm the send button returns to normal send state after completion.
