### PR TITLE
fix: add WecomConfig to channel config class map

### DIFF
--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -32,6 +32,7 @@ from ...config.config import (
     SkillScannerWhitelistEntry,
     TelegramConfig,
     VoiceChannelConfig,
+    WecomConfig,
 )
 
 from .schemas_config import HeartbeatBody
@@ -51,6 +52,7 @@ _CHANNEL_CONFIG_CLASS_MAP = {
     "mattermost": MattermostConfig,
     "mqtt": MQTTConfig,
     "matrix": MatrixConfig,
+    "wecom": WecomConfig,
 }
 
 


### PR DESCRIPTION
- Add WecomConfig import in config router
- Register wecom in _CHANNEL_CONFIG_CLASS_MAP
- Fix wecom channel configuration get/update endpoints

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
