### PR TITLE
Fix(skills) migrate skills to default workspace

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -137,13 +137,14 @@ class DingTalkChannel(BaseChannel):
         self.card_template_id = card_template_id or ""
         self.card_template_key = card_template_key or "content"
         self.robot_code = robot_code or self.client_id
-        self._active_cards: Dict[str, ActiveAICard] = {}
-        self._active_cards_lock = asyncio.Lock()
-        self._card_store = AICardPendingStore(
-            get_config_path().parent / "dingtalk-active-cards.json",
-        )
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
+        )
+        self._active_cards: Dict[str, ActiveAICard] = {}
+        self._active_cards_lock = asyncio.Lock()
+        cards_dir = self._workspace_dir or get_config_path().parent
+        self._card_store = AICardPendingStore(
+            cards_dir / "dingtalk-active-cards.json",
         )
         # Use workspace-specific media dir if workspace_dir is provided
         if not media_dir and self._workspace_dir:

--- a/src/copaw/app/migration.py
+++ b/src/copaw/app/migration.py
@@ -176,6 +176,21 @@ def migrate_legacy_workspace_to_default_agent() -> bool:
             migrated_items,
         )
 
+    # Migrate skills directories
+    _migrate_workspace_item(
+        old_workspace / "active_skills",
+        default_workspace / "active_skills",
+        "active_skills",
+        migrated_items,
+    )
+
+    _migrate_workspace_item(
+        old_workspace / "customized_skills",
+        default_workspace / "customized_skills",
+        "customized_skills",
+        migrated_items,
+    )
+
     # Migrate channel-specific configuration files
     _migrate_workspace_item(
         old_workspace / "feishu_receive_ids.json",

--- a/src/copaw/constant.py
+++ b/src/copaw/constant.py
@@ -129,12 +129,6 @@ PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"
 # (dev only; keep False in prod).
 DOCS_ENABLED = EnvVarLoader.get_bool("COPAW_OPENAPI_DOCS", False)
 
-# Skills directories
-# Active skills directory (activated skills that agents use)
-ACTIVE_SKILLS_DIR = WORKING_DIR / "active_skills"
-# Customized skills directory (user-created skills)
-CUSTOMIZED_SKILLS_DIR = WORKING_DIR / "customized_skills"
-
 # Memory directory
 MEMORY_DIR = WORKING_DIR / "memory"
 


### PR DESCRIPTION
## Description

Now migrate active skills and customized skills as well.
Remove not used constant and fix dingtalk's skill-related path.

**Related Issue:** Fixes #1718 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review