### PR TITLE
Fix(Deploy): the issue of socks5 error encountered by httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "agentscope==1.0.17",
     "agentscope-runtime==1.1.1",
-    "httpx>=0.27.0",
-    "httpx[socks]",
+    "httpx[socks]>=0.27.0",
     "packaging>=24.0",
     "discord-py>=2.3",
     "dingtalk-stream>=0.24.3",


### PR DESCRIPTION
## Description
I set `export all_proxy=socks5://127.0.0.1:7891` up in my ubuntu environment. it can't work in copaw, err msg:
<img width="1658" height="394" alt="image" src="https://github.com/user-attachments/assets/a57ef465-5087-4e87-8b9b-37a788205b81" />

I try to fix the issue, and i did it.

**Related Issue:** None

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
