### PR TITLE
fix(console): workspace path display issue

### DIFF
--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -7,6 +7,12 @@ import { workspaceApi } from "../../../../api/modules/workspace";
 import { agentsApi } from "../../../../api/modules/agents";
 import { useAgentStore } from "../../../../stores/agentStore";
 
+// Returns the parent directory of a file path, supporting both '/' and '\' separators.
+const getParentDir = (filePath: string): string => {
+  const match = filePath.match(/^(.*)[/\\]/);
+  return match ? match[1] : filePath;
+};
+
 export const useAgentsData = () => {
   const { t } = useTranslation();
   const { selectedAgent } = useAgentStore();
@@ -17,7 +23,7 @@ export const useAgentsData = () => {
   const [fileContent, setFileContent] = useState("");
   const [originalContent, setOriginalContent] = useState("");
   const [loading, setLoading] = useState(false);
-  const [workspacePath, setWorkspacePath] = useState("");
+  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
   const [enabledFiles, setEnabledFiles] = useState<string[]>([]);
 
   useEffect(() => {
@@ -38,14 +44,11 @@ export const useAgentsData = () => {
       );
       setFiles(sortedFiles);
 
-      // Set workspace path
+      // Set workspace path (handle both Unix '/' and Windows '\' separators)
       if (fileList.length > 0) {
-        const path = fileList[0].path;
-        const workspace = path.substring(
-          0,
-          path.lastIndexOf("/") || path.lastIndexOf("\\"),
-        );
-        setWorkspacePath(workspace);
+        setWorkspacePath(getParentDir(fileList[0].path));
+      } else {
+        setWorkspacePath("");
       }
 
       // Try to re-select the same file in new workspace
@@ -131,13 +134,11 @@ export const useAgentsData = () => {
         enabled,
       );
       setFiles(sortedFiles);
+      // Set workspace path (handle both Unix '/' and Windows '\' separators)
       if (fileList.length > 0) {
-        const path = fileList[0].path;
-        const workspace = path.substring(
-          0,
-          path.lastIndexOf("/") || path.lastIndexOf("\\"),
-        );
-        setWorkspacePath(workspace);
+        setWorkspacePath(getParentDir(fileList[0].path));
+      } else {
+        setWorkspacePath("");
       }
     } catch (error) {
       console.error("Failed to fetch files", error);

--- a/console/src/pages/Agent/Workspace/index.tsx
+++ b/console/src/pages/Agent/Workspace/index.tsx
@@ -109,10 +109,9 @@ export default function WorkspacePage() {
         <div className={styles.workspaceInfo}>
           <p className={styles.workspacePath}>
             {t("workspace.workspacePath")}{" "}
-            {workspacePath ||
-              (files.length === 0
-                ? t("workspace.noFiles")
-                : t("common.loading"))}
+            {workspacePath === null
+              ? t("common.loading")
+              : workspacePath || t("workspace.noFiles")}
           </p>
           <div className={styles.actionButtons}>
             <Tooltip


### PR DESCRIPTION
## Description

workspace path display issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

Fixes #1759 
