### PR TITLE
feat(config): add tracing configuration support

### DIFF
--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+import agentscope
 from agentscope_runtime.engine.app import AgentApp
 
 from ..config import load_config  # pylint: disable=no-name-in-module
@@ -134,6 +135,20 @@ class DynamicMultiAgentRunner:
         return None
 
 
+config = load_config(get_config_path())
+
+if config.tracing.enabled:
+    agentscope.init(
+        project="CoPaw",
+        name="Friday",
+        studio_url=config.tracing.url
+        if config.tracing.type == "native"
+        else None,
+        tracing_url=config.tracing.url
+        if config.tracing.type == "third-party"
+        else None,
+    )
+
 # Use dynamic runner for AgentApp
 runner = DynamicMultiAgentRunner()
 
@@ -177,7 +192,6 @@ async def lifespan(
     async def _get_agent_by_id(agent_id: str = None):
         """Get agent instance by ID, or active agent if not specified."""
         if agent_id is None:
-            config = load_config(get_config_path())
             agent_id = config.agents.active_agent or "default"
         return await multi_agent_manager.get_agent(agent_id)
 

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -736,6 +736,12 @@ class SecurityConfig(BaseModel):
     )
 
 
+class TracingConfig(BaseModel):
+    enabled: bool = False
+    type: Literal["native", "third-party"] = "native"
+    url: str = "http://localhost:3000"
+
+
 class Config(BaseModel):
     """Root config (config.json)."""
 
@@ -752,6 +758,7 @@ class Config(BaseModel):
         description="User IANA timezone (e.g. Asia/Shanghai). "
         "Defaults to the system timezone.",
     )
+    tracing: TracingConfig = TracingConfig()
 
 
 ChannelConfigUnion = Union[


### PR DESCRIPTION
## Description

Add tracing configuration support to enable AgentScope tracing functionality. Users can now enable tracing in config.json by setting the `tracing` field.

**Related Issue:** Relates to #1645

**Security Considerations:** N/A - configuration-only changes

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes 
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

To test this change:
1. Add tracing config to config.json:
```json
{
  "tracing": {
    "enabled": true,
    "type": "native",
    "url": "http://localhost:3000"
  }
}
```
2. Start the application and verify tracing is initialized

## Local Verification Evidence



## Additional Notes

This adds support for both native AgentScope tracing and third-party tracing endpoints via configuration.
