### PR TITLE
feat(channel): make channel initialization robust against custom channel failures

### DIFF
--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -182,11 +182,15 @@ class ChannelManager:
             ch_cfg = getattr(ch, key, None)
             if ch_cfg is None and key in extra:
                 from types import SimpleNamespace
+                from ...config.config import BaseChannelConfig
 
                 raw = extra[key]
-                ch_cfg = (
-                    SimpleNamespace(**raw) if isinstance(raw, dict) else raw
-                )
+                if isinstance(raw, dict):
+                    defaults = BaseChannelConfig().model_dump()
+                    defaults.update(raw)
+                    ch_cfg = SimpleNamespace(**defaults)
+                else:
+                    ch_cfg = raw
             if ch_cfg is None:
                 continue
 
@@ -206,7 +210,6 @@ class ChannelManager:
                 False,
             )
 
-            # Pass workspace_dir to channel if supported
             from_config_kwargs = {
                 "process": process,
                 "config": ch_cfg,
@@ -214,16 +217,34 @@ class ChannelManager:
                 "show_tool_details": show_tool_details,
                 "filter_tool_messages": filter_tool_messages,
                 "filter_thinking": filter_thinking,
+                "workspace_dir": workspace_dir,
             }
 
-            # Only pass workspace_dir to channels that support it
+            # Only pass kwargs that the channel's from_config accepts
             import inspect
 
             sig = inspect.signature(ch_cls.from_config)
-            if "workspace_dir" in sig.parameters:
-                from_config_kwargs["workspace_dir"] = workspace_dir
+            if any(
+                p.kind == inspect.Parameter.VAR_KEYWORD
+                for p in sig.parameters.values()
+            ):
+                filtered_kwargs = from_config_kwargs
+            else:
+                filtered_kwargs = {
+                    k: v
+                    for k, v in from_config_kwargs.items()
+                    if k in sig.parameters
+                }
 
-            channels.append(ch_cls.from_config(**from_config_kwargs))
+            try:
+                channels.append(ch_cls.from_config(**filtered_kwargs))
+            except Exception as e:
+                logger.warning(
+                    "Failed to initialize channel '%s', skipping: %s",
+                    key,
+                    e,
+                )
+                continue
 
         return cls(channels)
 

--- a/src/copaw/cli/channels_cmd.py
+++ b/src/copaw/cli/channels_cmd.py
@@ -83,12 +83,16 @@ class CustomChannel(BaseChannel):
         bot_prefix="",
         on_reply_sent=None,
         show_tool_details=True,
+        filter_tool_messages=False,
+        filter_thinking=False,
         **kwargs,
     ):
         super().__init__(
             process,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
+            filter_tool_messages=filter_tool_messages,
+            filter_thinking=filter_thinking,
         )
         self.enabled = enabled
         self.bot_prefix = bot_prefix or ""
@@ -100,6 +104,7 @@ class CustomChannel(BaseChannel):
         config,
         on_reply_sent=None,
         show_tool_details=True,
+        **kwargs,
     ):
         return cls(
             process=process,
@@ -107,6 +112,14 @@ class CustomChannel(BaseChannel):
             bot_prefix=getattr(config, "bot_prefix", ""),
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
+            filter_tool_messages=kwargs.get(
+                "filter_tool_messages",
+                getattr(config, "filter_tool_messages", False),
+            ),
+            filter_thinking=kwargs.get(
+                "filter_thinking",
+                getattr(config, "filter_thinking", False),
+            ),
         )
 
     @classmethod


### PR DESCRIPTION
## Description

Custom channels with incomplete `from_config` signatures (e.g. missing `filter_tool_messages`·) would crash the entire agent on startup. This change filters kwargs to match each channel's actual signature, wraps initialization in try-except to skip broken channels gracefully, and backfills BaseChannelConfig defaults for custom channel configs from pydantic extra.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
