### PR TITLE
style(console): remove padding from page-content

### DIFF
--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -686,7 +686,6 @@ html.dark-mode [class*="chat-anywhere"] [class*="message"] a {
 .page-content {
   flex: 1 1 auto;
   overflow: auto;
-  padding: 0 24px 24px 24px;
 }
 
 .table-container {


### PR DESCRIPTION
## Change

Remove padding from `.page-content` to align with sidebar properly.

## Before

The page content had padding `0 24px 24px 24px` which caused misalignment with the sidebar.

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/0de8186c-f1ea-4cc7-aa59-f4ee474ccc2a" />
<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/8eb106fe-1a77-4817-a8ab-28b818ad3605" />

## After

Removed the padding to ensure the content area aligns correctly with the sidebar edge.

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/5d826cab-016a-4dec-9683-455cbed65a0f" />
<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/f795ea14-c80e-4b98-ba1f-0edb7824c193" />
