### PR TITLE
feat(provider): add separate Kimi CN and international providers

### DIFF
--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -196,7 +196,7 @@ PROVIDER_AZURE_OPENAI = OpenAIProvider(
 
 PROVIDER_MINIMAX = AnthropicProvider(
     id="minimax",
-    name="MiniMax International",
+    name="MiniMax (International)",
     base_url="https://api.minimax.io/anthropic",
     models=MINIMAX_MODELS,
     chat_model="AnthropicChatModel",
@@ -205,7 +205,7 @@ PROVIDER_MINIMAX = AnthropicProvider(
 
 PROVIDER_MINIMAX_CN = AnthropicProvider(
     id="minimax-cn",
-    name="MiniMax China",
+    name="MiniMax (China)",
     base_url="https://api.minimaxi.com/anthropic",
     models=MINIMAX_MODELS,
     chat_model="AnthropicChatModel",
@@ -216,7 +216,7 @@ PROVIDER_MINIMAX_CN = AnthropicProvider(
 
 PROVIDER_KIMI_CN = OpenAIProvider(
     id="kimi-cn",
-    name="Kimi (CN)",
+    name="Kimi (China)",
     base_url="https://api.moonshot.cn/v1",
     api_key_prefix="",
     models=KIMI_MODELS,

--- a/tests/unit/providers/test_kimi_provider.py
+++ b/tests/unit/providers/test_kimi_provider.py
@@ -26,7 +26,7 @@ def test_kimi_providers_are_openai_compatible() -> None:
 def test_kimi_provider_configs() -> None:
     """Verify Kimi provider configuration defaults."""
     assert PROVIDER_KIMI_CN.id == "kimi-cn"
-    assert PROVIDER_KIMI_CN.name == "Kimi (CN)"
+    assert PROVIDER_KIMI_CN.name == "Kimi (China)"
     assert PROVIDER_KIMI_CN.base_url == "https://api.moonshot.cn/v1"
     assert PROVIDER_KIMI_CN.freeze_url is True
 
@@ -74,7 +74,7 @@ async def test_kimi_check_connection_success(monkeypatch) -> None:
     """Kimi check_connection should delegate to OpenAI client."""
     provider = OpenAIProvider(
         id="kimi-cn",
-        name="Kimi (CN)",
+        name="Kimi (China)",
         base_url="https://api.moonshot.cn/v1",
         api_key="test-key",
     )

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -412,7 +412,7 @@ def test_init_from_storage_migrates_with_different_provider(
     # url / name / chatmodel should be updated
     assert provider.base_url == "https://api.minimax.io/anthropic"
     assert provider.chat_model == "AnthropicChatModel"
-    assert provider.name == "MiniMax International"
+    assert provider.name == "MiniMax (International)"
     # api key should be preserved
     assert provider.api_key == "sk-legacy-minimax"
 


### PR DESCRIPTION
## Summary
- add built-in `kimi-cn` and `kimi-intl` providers with fixed Moonshot base URLs
- add shared Kimi model definitions for domestic and international platforms
- add unit tests covering provider config, registration, and activation

## Test Plan
- [x] `uv run --extra dev pytest tests/unit/providers/test_kimi_provider.py tests/unit/providers/test_provider_manager.py -q`