### PR TITLE
feature(provider): Hide providers with uninstalled dependencies

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -86,7 +86,7 @@ COPY pyproject.toml setup.py README.md ./
 COPY src ./src
 # Inject console dist from build stage (repo does not commit dist).
 COPY --from=console-builder /app/console/dist/ ./src/copaw/console/
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir .[ollama,local]
 
 # Init working dir with default config.json and HEARTBEAT.md (build time).
 RUN copaw init --defaults --accept-security

--- a/src/copaw/providers/ollama_provider.py
+++ b/src/copaw/providers/ollama_provider.py
@@ -6,11 +6,6 @@ from __future__ import annotations
 import os
 from typing import Any, List
 
-try:
-    import ollama
-except ImportError:
-    ollama = None  # type: ignore
-
 from agentscope.model import ChatModelBase
 
 from copaw.providers.provider import ModelInfo, Provider
@@ -30,13 +25,15 @@ class OllamaProvider(Provider):
             self.base_url = self.base_url[:-3]
 
     def _client(self, timeout: float = 5):
-        if ollama is None:
+        try:
+            import ollama
+        except ImportError as e:
             raise ImportError(
                 "The 'ollama' Python package is required. You may have "
                 "installed Ollama via their CLI or desktop app, but you "
                 "also need the Python SDK to manage models from CoPaw. "
                 "Please install it with: pip install 'copaw[ollama]'",
-            )
+            ) from e
         return ollama.AsyncClient(host=self.base_url, timeout=timeout)
 
     @staticmethod

--- a/src/copaw/providers/provider_manager.py
+++ b/src/copaw/providers/provider_manager.py
@@ -4,6 +4,7 @@ It provides a unified interface to manage providers, such as listing available
 providers, adding/removing custom providers, and fetching provider details."""
 
 import asyncio
+from importlib.util import find_spec
 import os
 from typing import Dict, List
 import logging
@@ -28,6 +29,11 @@ from copaw.constant import SECRET_DIR
 from copaw.local_models import create_local_chat_model
 
 logger = logging.getLogger(__name__)
+
+
+def _is_module_available(module_name: str) -> bool:
+    """Return whether an optional dependency can be resolved."""
+    return find_spec(module_name) is not None
 
 
 # -------------------------------------------------------
@@ -331,10 +337,19 @@ class ProviderManager:
         self._add_builtin(PROVIDER_GEMINI)
         self._add_builtin(PROVIDER_MINIMAX_CN)
         self._add_builtin(PROVIDER_MINIMAX)
-        self._add_builtin(PROVIDER_OLLAMA)
         self._add_builtin(PROVIDER_LMSTUDIO)
-        self._add_builtin(PROVIDER_LLAMACPP)
-        self._add_builtin(PROVIDER_MLX)
+        if _is_module_available("ollama"):
+            self._add_builtin(PROVIDER_OLLAMA)
+        else:
+            logger.warning("ollama not found, skipping Ollama provider")
+        if _is_module_available("llama_cpp"):
+            self._add_builtin(PROVIDER_LLAMACPP)
+        else:
+            logger.warning("llama_cpp not found, skipping llama.cpp provider")
+        if _is_module_available("mlx_lm"):
+            self._add_builtin(PROVIDER_MLX)
+        else:
+            logger.warning("mlx-lm not found, skipping MLX provider")
 
     def _add_builtin(self, provider: Provider):
         self.builtin_providers[provider.id] = provider

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import copaw.providers.ollama_provider as ollama_provider_module
 from copaw.providers.ollama_provider import OllamaProvider
 from copaw.providers.provider import ModelInfo
 
@@ -54,7 +53,12 @@ async def test_import_error_on_missing_ollama(monkeypatch) -> None:
         name="Ollama",
         chat_model="OllamaChatModel",
     )
-    monkeypatch.setattr(ollama_provider_module, "ollama", None)
+
+    def _raise_import_error(timeout=5):
+        _ = timeout
+        raise ImportError("missing ollama")
+
+    monkeypatch.setattr(provider, "_client", _raise_import_error)
 
     ok, msg = await provider.check_connection(timeout=1.0)
 
@@ -70,11 +74,6 @@ async def test_check_connection_error_returns_false(monkeypatch) -> None:
             raise RuntimeError("boom")
 
     monkeypatch.setattr(provider, "_client", lambda timeout=5: FakeClient())
-    monkeypatch.setattr(
-        ollama_provider_module.ollama,
-        "ResponseError",
-        Exception,
-    )
 
     ok, msg = await provider.check_connection(timeout=1.0)
 
@@ -112,11 +111,6 @@ async def test_fetch_models_error_returns_empty(monkeypatch) -> None:
             raise RuntimeError("failed")
 
     monkeypatch.setattr(provider, "_client", lambda timeout=5: FakeClient())
-    monkeypatch.setattr(
-        ollama_provider_module.ollama,
-        "ResponseError",
-        Exception,
-    )
 
     models = await provider.fetch_models(timeout=3.0)
 
@@ -162,11 +156,6 @@ async def test_check_model_connection_error_returns_false(monkeypatch) -> None:
             raise RuntimeError("failed")
 
     monkeypatch.setattr(provider, "_client", lambda timeout=5: FakeClient())
-    monkeypatch.setattr(
-        ollama_provider_module.ollama,
-        "ResponseError",
-        Exception,
-    )
 
     ok, msg = await provider.check_model_connection("qwen2:7b", timeout=4.0)
 

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -224,6 +224,48 @@ def test_migrate_legacy_file_and_persist_active_model(
     assert active_model_file.exists()
 
 
+def test_init_builtins_skips_optional_providers_when_modules_missing(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    missing_modules = {"ollama", "llama_cpp", "mlx_lm"}
+    original_find_spec = provider_manager_module.find_spec
+
+    def fake_find_spec(name: str, package=None):
+        if name in missing_modules:
+            return None
+        return original_find_spec(name, package)
+
+    monkeypatch.setattr(provider_manager_module, "find_spec", fake_find_spec)
+
+    manager = ProviderManager()
+
+    assert manager.get_provider("ollama") is None
+    assert manager.get_provider("llamacpp") is None
+    assert manager.get_provider("mlx") is None
+
+
+def test_init_builtins_adds_optional_providers_when_modules_available(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    available_modules = {"ollama", "llama_cpp", "mlx_lm"}
+    original_find_spec = provider_manager_module.find_spec
+
+    def fake_find_spec(name: str, package=None):
+        if name in available_modules:
+            return object()
+        return original_find_spec(name, package)
+
+    monkeypatch.setattr(provider_manager_module, "find_spec", fake_find_spec)
+
+    manager = ProviderManager()
+
+    assert manager.get_provider("ollama") is not None
+    assert manager.get_provider("llamacpp") is not None
+    assert manager.get_provider("mlx") is not None
+
+
 async def test_add_custom_provider_conflict_resolution_loops_until_unique(
     isolated_secret_dir,
 ) -> None:


### PR DESCRIPTION
## Description

This PR hides builtin providers with uninstalled dependencies.

**Related Issue:** Fix #1816

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
