### PR TITLE
feat(mcp): improve import templates and preserve description

### DIFF
--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -109,9 +109,7 @@ function normalizeClientData(key: string, rawData: RawMCPClientData) {
   const hasUrl = Boolean(rawData.url || rawData.baseUrl);
   const transport =
     normalizeTransport(rawData.transport ?? rawData.type) ??
-    (hasUrl || !rawData.command
-      ? "streamable_http"
-      : "stdio");
+    (hasUrl || !rawData.command ? "streamable_http" : "stdio");
 
   const command =
     transport === "stdio" ? (rawData.command ?? "").toString() : "";
@@ -381,27 +379,27 @@ function MCPPage() {
                 Fill
               </button>
             </li>
-              <li>
-                streamable_http example:{" "}
-                <code>{`{ "mcpServers": { "key": { "transport": "streamable_http", "url": "..." } } }`}</code>
-                <button
-                  type="button"
-                  onClick={() => handleFillTemplate(STREAMABLE_HTTP_TEMPLATE)}
-                  style={{
-                    marginLeft: 8,
-                    border: "1px solid #d9d9d9",
-                    borderRadius: 4,
-                    background: "#fff",
-                    color: "#555",
-                    fontSize: 12,
-                    lineHeight: "20px",
-                    padding: "0 8px",
-                    cursor: "pointer",
-                  }}
-                >
-                  Fill
-                </button>
-              </li>
+            <li>
+              streamable_http example:{" "}
+              <code>{`{ "mcpServers": { "key": { "transport": "streamable_http", "url": "..." } } }`}</code>
+              <button
+                type="button"
+                onClick={() => handleFillTemplate(STREAMABLE_HTTP_TEMPLATE)}
+                style={{
+                  marginLeft: 8,
+                  border: "1px solid #d9d9d9",
+                  borderRadius: 4,
+                  background: "#fff",
+                  color: "#555",
+                  fontSize: 12,
+                  lineHeight: "20px",
+                  padding: "0 8px",
+                  cursor: "pointer",
+                }}
+              >
+                Fill
+              </button>
+            </li>
           </ul>
         </div>
         <textarea

--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -7,6 +7,82 @@ import { useTranslation } from "react-i18next";
 
 type MCPTransport = "stdio" | "streamable_http" | "sse";
 
+type RawMCPClientData = {
+  name?: unknown;
+  title?: unknown;
+  description?: unknown;
+  desc?: unknown;
+  remark?: unknown;
+  enabled?: unknown;
+  isActive?: unknown;
+  transport?: unknown;
+  type?: unknown;
+  url?: unknown;
+  baseUrl?: unknown;
+  headers?: unknown;
+  command?: unknown;
+  args?: unknown;
+  env?: unknown;
+  cwd?: unknown;
+};
+
+const STANDARD_FORMAT_TEMPLATE = `{
+  "mcpServers": {
+    "example-client": {
+      "name": "Example Client",
+      "description": "Optional client description",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": {
+        "API_KEY": "<YOUR_API_KEY>"
+      },
+      "cwd": ""
+    }
+  }
+}`;
+
+const DIRECT_FORMAT_TEMPLATE = `{
+  "example-client": {
+    "name": "Example Client",
+    "description": "Optional client description",
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["-y", "@example/mcp-server"],
+    "env": {
+      "API_KEY": "<YOUR_API_KEY>"
+    }
+  }
+}`;
+
+const SINGLE_FORMAT_TEMPLATE = `{
+  "key": "example-client",
+  "name": "Example Client",
+  "description": "Optional client description",
+  "transport": "stdio",
+  "command": "npx",
+  "args": ["-y", "@example/mcp-server"],
+  "env": {
+    "API_KEY": "<YOUR_API_KEY>"
+  }
+}`;
+
+const STREAMABLE_HTTP_TEMPLATE = `{
+  "mcpServers": {
+    "example_mcp": {
+      "name": "Example Mcp Server",
+      "description": "Remote MCP endpoint over HTTP",
+      "transport": "streamable_http",
+      "url": "http://127.0.0.1:8585/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_TOKEN>"
+      }
+    }
+  }
+}`;
+
+const DEFAULT_MCP_IMPORT_JSON = STANDARD_FORMAT_TEMPLATE;
+
 function normalizeTransport(raw?: unknown): MCPTransport | undefined {
   if (typeof raw !== "string") return undefined;
   const value = raw.trim().toLowerCase();
@@ -25,10 +101,15 @@ function normalizeTransport(raw?: unknown): MCPTransport | undefined {
   }
 }
 
-function normalizeClientData(key: string, rawData: any) {
+function normalizeClientData(key: string, rawData: RawMCPClientData) {
+  const normalizedName = rawData.name ?? rawData.title ?? key;
+  const normalizedDescription =
+    rawData.description ?? rawData.desc ?? rawData.remark ?? "";
+
+  const hasUrl = Boolean(rawData.url || rawData.baseUrl);
   const transport =
     normalizeTransport(rawData.transport ?? rawData.type) ??
-    (rawData.url || rawData.baseUrl || !rawData.command
+    (hasUrl || !rawData.command
       ? "streamable_http"
       : "stdio");
 
@@ -36,16 +117,22 @@ function normalizeClientData(key: string, rawData: any) {
     transport === "stdio" ? (rawData.command ?? "").toString() : "";
 
   return {
-    name: rawData.name || key,
-    description: rawData.description || "",
-    enabled: rawData.enabled ?? rawData.isActive ?? true,
+    name: String(normalizedName),
+    description: String(normalizedDescription),
+    enabled: Boolean(rawData.enabled ?? rawData.isActive ?? true),
     transport,
-    url: (rawData.url || rawData.baseUrl || "").toString(),
-    headers: rawData.headers || {},
+    url: String(rawData.url ?? rawData.baseUrl ?? ""),
+    headers:
+      rawData.headers && typeof rawData.headers === "object"
+        ? (rawData.headers as Record<string, string>)
+        : {},
     command,
     args: Array.isArray(rawData.args) ? rawData.args : [],
-    env: rawData.env || {},
-    cwd: (rawData.cwd || "").toString(),
+    env:
+      rawData.env && typeof rawData.env === "object"
+        ? (rawData.env as Record<string, string>)
+        : {},
+    cwd: String(rawData.cwd ?? ""),
   };
 }
 
@@ -61,17 +148,11 @@ function MCPPage() {
   } = useMCP();
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [newClientJson, setNewClientJson] = useState(`{
-  "mcpServers": {
-    "example-client": {
-      "command": "npx",
-      "args": ["-y", "@example/mcp-server"],
-      "env": {
-        "API_KEY": "<YOUR_API_KEY>"
-      }
-    }
-  }
-}`);
+  const [newClientJson, setNewClientJson] = useState(DEFAULT_MCP_IMPORT_JSON);
+
+  const handleFillTemplate = (template: string) => {
+    setNewClientJson(template);
+  };
 
   const handleToggleEnabled = async (
     client: MCPClientInfo,
@@ -95,15 +176,18 @@ function MCPPage() {
       // Format 2: { "key": { "command": "...", ... } }
       // Format 3: { "key": "...", "name": "...", "command": "...", ... } (direct)
 
-      const clientsToCreate: Array<{ key: string; data: any }> = [];
+      const clientsToCreate: Array<{
+        key: string;
+        data: ReturnType<typeof normalizeClientData>;
+      }> = [];
 
       if (parsed.mcpServers) {
         // Format 1: nested mcpServers
         Object.entries(parsed.mcpServers).forEach(
-          ([key, data]: [string, any]) => {
+          ([key, data]: [string, unknown]) => {
             clientsToCreate.push({
               key,
-              data: normalizeClientData(key, data),
+              data: normalizeClientData(key, data as RawMCPClientData),
             });
           },
         );
@@ -115,18 +199,22 @@ function MCPPage() {
         const { key, ...clientData } = parsed;
         clientsToCreate.push({
           key,
-          data: normalizeClientData(key, clientData),
+          data: normalizeClientData(key, clientData as RawMCPClientData),
         });
       } else {
         // Format 2: direct client objects with keys
-        Object.entries(parsed).forEach(([key, data]: [string, any]) => {
+        Object.entries(parsed).forEach(([key, data]: [string, unknown]) => {
+          const candidate =
+            data && typeof data === "object"
+              ? (data as RawMCPClientData)
+              : null;
           if (
-            typeof data === "object" &&
-            (data.command || data.url || data.baseUrl)
+            candidate &&
+            (candidate.command || candidate.url || candidate.baseUrl)
           ) {
             clientsToCreate.push({
               key,
-              data: normalizeClientData(key, data),
+              data: normalizeClientData(key, candidate),
             });
           }
         });
@@ -141,19 +229,9 @@ function MCPPage() {
 
       if (allSuccess) {
         setCreateModalOpen(false);
-        setNewClientJson(`{
-  "mcpServers": {
-    "example-client": {
-      "command": "npx",
-      "args": ["-y", "@example/mcp-server"],
-      "env": {
-        "API_KEY": "<YOUR_API_KEY>"
+        setNewClientJson(DEFAULT_MCP_IMPORT_JSON);
       }
-    }
-  }
-}`);
-      }
-    } catch (error) {
+    } catch {
       alert("Invalid JSON format");
     }
   };
@@ -244,14 +322,86 @@ function MCPPage() {
             <li>
               Standard format:{" "}
               <code>{`{ "mcpServers": { "key": {...} } }`}</code>
+              <button
+                type="button"
+                onClick={() => handleFillTemplate(STANDARD_FORMAT_TEMPLATE)}
+                style={{
+                  marginLeft: 8,
+                  border: "1px solid #d9d9d9",
+                  borderRadius: 4,
+                  background: "#fff",
+                  color: "#555",
+                  fontSize: 12,
+                  lineHeight: "20px",
+                  padding: "0 8px",
+                  cursor: "pointer",
+                }}
+              >
+                Fill
+              </button>
             </li>
             <li>
               Direct format: <code>{`{ "key": {...} }`}</code>
+              <button
+                type="button"
+                onClick={() => handleFillTemplate(DIRECT_FORMAT_TEMPLATE)}
+                style={{
+                  marginLeft: 8,
+                  border: "1px solid #d9d9d9",
+                  borderRadius: 4,
+                  background: "#fff",
+                  color: "#555",
+                  fontSize: 12,
+                  lineHeight: "20px",
+                  padding: "0 8px",
+                  cursor: "pointer",
+                }}
+              >
+                Fill
+              </button>
             </li>
             <li>
               Single format:{" "}
               <code>{`{ "key": "...", "name": "...", "command": "..." }`}</code>
+              <button
+                type="button"
+                onClick={() => handleFillTemplate(SINGLE_FORMAT_TEMPLATE)}
+                style={{
+                  marginLeft: 8,
+                  border: "1px solid #d9d9d9",
+                  borderRadius: 4,
+                  background: "#fff",
+                  color: "#555",
+                  fontSize: 12,
+                  lineHeight: "20px",
+                  padding: "0 8px",
+                  cursor: "pointer",
+                }}
+              >
+                Fill
+              </button>
             </li>
+              <li>
+                streamable_http example:{" "}
+                <code>{`{ "mcpServers": { "key": { "transport": "streamable_http", "url": "..." } } }`}</code>
+                <button
+                  type="button"
+                  onClick={() => handleFillTemplate(STREAMABLE_HTTP_TEMPLATE)}
+                  style={{
+                    marginLeft: 8,
+                    border: "1px solid #d9d9d9",
+                    borderRadius: 4,
+                    background: "#fff",
+                    color: "#555",
+                    fontSize: 12,
+                    lineHeight: "20px",
+                    padding: "0 8px",
+                    cursor: "pointer",
+                  }}
+                >
+                  Fill
+                </button>
+              </li>
           </ul>
         </div>
         <textarea

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -522,6 +522,7 @@ class MCPClientConfig(BaseModel):
             normalized = raw_transport.strip().lower()
             transport_alias_map = {
                 "streamablehttp": "streamable_http",
+                "streamable-http": "streamable_http",
                 "http": "streamable_http",
                 "stdio": "stdio",
                 "sse": "sse",

--- a/website/public/docs/mcp.en.md
+++ b/website/public/docs/mcp.en.md
@@ -37,6 +37,9 @@ CoPaw supports three JSON formats for importing MCP clients:
 {
   "mcpServers": {
     "client-name": {
+      "name": "My MCP Client",
+      "description": "Optional client description",
+      "transport": "stdio",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem"],
       "env": {
@@ -52,6 +55,7 @@ CoPaw supports three JSON formats for importing MCP clients:
 ```json
 {
   "client-name": {
+    "description": "Optional client description",
     "command": "npx",
     "args": ["-y", "@modelcontextprotocol/server-filesystem"],
     "env": {
@@ -67,6 +71,7 @@ CoPaw supports three JSON formats for importing MCP clients:
 {
   "key": "client-name",
   "name": "My MCP Client",
+  "description": "Optional client description",
   "command": "npx",
   "args": ["-y", "@modelcontextprotocol/server-filesystem"],
   "env": {
@@ -74,6 +79,21 @@ CoPaw supports three JSON formats for importing MCP clients:
   }
 }
 ```
+
+### Common fields (including description)
+
+- `name`: display name (optional, key is used if omitted)
+- `description`: free-text description (optional, recommended for clarity)
+- `enabled`: whether the client is enabled (optional, default `true`)
+- `transport`: transport type (optional, supports `stdio` / `streamable_http` / `sse`)
+- `command`, `args`, `env`, `cwd`: common fields for local command-based MCP
+- `url`, `headers`: common fields for remote MCP
+
+Transport validation rules:
+
+- `transport=stdio`: requires non-empty `command`
+- `transport=streamable_http` or `sse`: requires non-empty `url`
+- if `transport` is omitted: config with `url` defaults to `streamable_http`; otherwise defaults to `stdio`
 
 ---
 
@@ -95,6 +115,24 @@ CoPaw supports three JSON formats for importing MCP clients:
 ```
 
 > Replace `/Users/username/Documents` with the directory path you want the agent to access.
+
+Remote MCP example (with `description`):
+
+```json
+{
+  "mcpServers": {
+    "example_mcp": {
+      "name": "Example Mcp Server",
+      "description": "Remote MCP endpoint over HTTP",
+      "transport": "streamable_http",
+      "url": "http://127.0.0.1:8585/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
 
 ---
 

--- a/website/public/docs/mcp.zh.md
+++ b/website/public/docs/mcp.zh.md
@@ -37,6 +37,9 @@ CoPaw 支持三种 JSON 格式导入 MCP 客户端：
 {
   "mcpServers": {
     "client-name": {
+      "name": "My MCP Client",
+      "description": "Optional client description",
+      "transport": "stdio",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem"],
       "env": {
@@ -52,6 +55,7 @@ CoPaw 支持三种 JSON 格式导入 MCP 客户端：
 ```json
 {
   "client-name": {
+    "description": "Optional client description",
     "command": "npx",
     "args": ["-y", "@modelcontextprotocol/server-filesystem"],
     "env": {
@@ -67,6 +71,7 @@ CoPaw 支持三种 JSON 格式导入 MCP 客户端：
 {
   "key": "client-name",
   "name": "My MCP Client",
+  "description": "Optional client description",
   "command": "npx",
   "args": ["-y", "@modelcontextprotocol/server-filesystem"],
   "env": {
@@ -74,6 +79,21 @@ CoPaw 支持三种 JSON 格式导入 MCP 客户端：
   }
 }
 ```
+
+### 常用字段说明（含 description）
+
+- `name`：显示名称（可选，不填时通常使用 key）
+- `description`：描述信息（可选，建议填写，便于识别用途）
+- `enabled`：是否启用（可选，默认 `true`）
+- `transport`：传输类型（可选，支持 `stdio` / `streamable_http` / `sse`）
+- `command`、`args`、`env`、`cwd`：本地命令类 MCP 常用字段
+- `url`、`headers`：远程 MCP 常用字段
+
+传输类型校验规则：
+
+- `transport=stdio`：必须提供非空 `command`
+- `transport=streamable_http` 或 `sse`：必须提供非空 `url`
+- 若省略 `transport`：有 `url` 时默认按 `streamable_http` 处理；否则默认按 `stdio` 处理
 
 ---
 
@@ -95,6 +115,24 @@ CoPaw 支持三种 JSON 格式导入 MCP 客户端：
 ```
 
 > 将 `/Users/username/Documents` 替换为你希望智能体访问的目录路径。
+
+远程 MCP 示例（含 `description`）：
+
+```json
+{
+  "mcpServers": {
+    "example_mcp": {
+      "name": "Example Mcp Server",
+      "description": "Remote MCP endpoint over HTTP",
+      "transport": "streamable_http",
+      "url": "http://127.0.0.1:8585/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add click-to-fill templates in MCP create modal for Standard / Direct / Single formats
- add click-to-fill streamable_http remote template
- preserve imported description with robust normalization (supports description/desc/remark)
- accept `streamable-http` transport alias in backend MCP config normalization
- update MCP docs (zh/en) with richer import examples and remote template

## Validation
- npm --prefix console run build
