### PR TITLE
fix: add HTTP 529 to retryable status codes for Anthropic overloaded errors

### DIFF
--- a/src/copaw/providers/retry_chat_model.py
+++ b/src/copaw/providers/retry_chat_model.py
@@ -23,7 +23,7 @@ from ..constant import LLM_BACKOFF_BASE, LLM_BACKOFF_CAP, LLM_MAX_RETRIES
 
 logger = logging.getLogger(__name__)
 
-RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}
 
 _openai_retryable: tuple[type[Exception], ...] | None = None
 _anthropic_retryable: tuple[type[Exception], ...] | None = None


### PR DESCRIPTION
## Problem

Anthropic API returns HTTP 529 (`overloaded_error`) when the service is temporarily overloaded. This is a transient condition that typically resolves within seconds.

However, `RETRYABLE_STATUS_CODES` in `retry_chat_model.py` only includes `{429, 500, 502, 503, 504}`, so 529 is treated as a non-retryable failure. The retry wrapper immediately propagates the error instead of retrying.

This causes agent tasks to fail and stop when Anthropic is briefly overloaded, even though a simple retry would succeed.

## Fix

Add `529` to `RETRYABLE_STATUS_CODES`:

```python
# Before
RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}

# After
RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}
```

## Impact

- One-line change in `src/copaw/providers/retry_chat_model.py`
- No behavior change for other status codes
- 529 errors will now be retried with the same exponential back-off as other transient errors

## Reference

- [Anthropic API errors documentation](https://docs.anthropic.com/en/api/errors): 529 = `overloaded_error`
