### PR TITLE
fix(token_usage): replace threading.Lock with asyncio.Lock in record()

### DIFF
--- a/src/copaw/token_usage/manager.py
+++ b/src/copaw/token_usage/manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Token usage manager"""
 
+import asyncio
 import json
 import logging
 import threading
@@ -67,7 +68,7 @@ class TokenUsageManager:
 
     def __init__(self) -> None:
         self._path: Path = (WORKING_DIR / TOKEN_USAGE_FILE).expanduser()
-        self._file_lock = threading.Lock()
+        self._file_lock = asyncio.Lock()
 
     async def _load_data(self) -> dict:
         """Load full token usage data from disk."""
@@ -129,7 +130,7 @@ class TokenUsageManager:
         date_str = at_date.isoformat()
         composite_key = f"{provider_id}:{model_name}"
 
-        with self._file_lock:
+        async with self._file_lock:
             data = await self._load_data()
             if date_str not in data:
                 data[date_str] = {}


### PR DESCRIPTION
## Summary

`TokenUsageManager.record()` is an `async` method that uses `self._file_lock = threading.Lock()` to serialize file I/O. `threading.Lock` is a blocking primitive - when acquired inside an async method on the event loop thread, it blocks the entire event loop until released. Under concurrent calls this produces the deadlock captured in the py-spy stack dump in #1834.

**Fix:** Replace `threading.Lock()` with `asyncio.Lock()` for `_file_lock` and change `with self._file_lock:` to `async with self._file_lock:`. This is the same pattern already used in `app/runner/manager.py`, `app/crons/manager.py`, and `app/mcp/manager.py`.

The class-level `threading.Lock` in `get_instance()` is kept unchanged since that classmethod is synchronous and never awaits.

## Changes

- `src/copaw/token_usage/manager.py`: Add `import asyncio`, change `_file_lock` from `threading.Lock()` to `asyncio.Lock()`, change `with` to `async with` in `record()`

## Test plan

- [ ] `ruff check` passes
- [ ] Concurrent `record()` calls from multiple coroutines no longer deadlock

Closes #1834

This contribution was developed with AI assistance (Claude Code + Codex).