### PR TITLE
perf(ci): optimize test workflow to reduce resource consumption

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,42 +28,23 @@ jobs:
       - name: Approval granted
         run: echo "Approved by maintainer"
 
-  discover-unit-test-dirs:
-    name: Discover Unit Test Directories
+  unit-tests:
+    name: Unit Tests - py${{ matrix.python-version }} - ${{ matrix.os }}
     needs: approval-gate
     if: |
       always() &&
       needs.approval-gate.result == 'success'
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Discover unit test subdirectories
-        id: set-matrix
-        shell: bash
-        run: |
-          cd tests/unit
-          dirs=$(find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-          echo "matrix=$dirs" >> "$GITHUB_OUTPUT"
-          echo "Found unit test directories: $dirs"
-
-  unit-tests:
-    name: Unit Tests - ${{ matrix.subdir }} - py${{ matrix.python-version }} - ${{ matrix.os }}
-    needs: [approval-gate, discover-unit-test-dirs]
-    if: |
-      always() &&
-      needs.approval-gate.result == 'success' &&
-      needs.discover-unit-test-dirs.result == 'success' &&
-      needs.discover-unit-test-dirs.outputs.matrix != '[]'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        subdir: ${{ fromJson(needs.discover-unit-test-dirs.outputs.matrix) }}
         python-version: ["3.10", "3.13"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v4
@@ -106,10 +87,10 @@ jobs:
             pip install -e ".[dev,full]"
           fi
 
-      - name: Run unit tests for ${{ matrix.subdir }}
+      - name: Run all unit tests
         shell: bash
         run: |
-          pytest tests/unit/${{ matrix.subdir }} -v
+          pytest tests/unit -v
 
   integrated-tests:
     name: Integrated Tests - py${{ matrix.python-version }} - ${{ matrix.os }}
@@ -122,7 +103,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.13"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Optimize the CI/CD test workflow to significantly reduce resource consumption and execution time by:
1. Reducing the test matrix combinations - run full Python version tests (3.10, 3.13) only on Linux, while macOS and Windows only test Python 3.10
2. Consolidating unit test execution - run all unit test subdirectories sequentially in a single job instead of creating parallel jobs for each subdirectory

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Changes to CI/CD workflow only - verification will be done through actual CI runs.

## Resource Savings

**Before:**
- Unit tests: 3 OS × 2 Python versions × N subdirectories = 6N parallel jobs
- Integrated tests: 3 OS × 2 Python versions = 6 parallel jobs

**After:**
- Unit tests: 2 (Linux) + 1 (macOS) + 1 (Windows) = 4 jobs (all subdirs run in each job)
- Integrated tests: 2 (Linux) + 1 (macOS) + 1 (Windows) = 4 jobs

**Overall:** ~33% reduction in CI/CD job count per subdirectory, with even greater savings from eliminating per-subdirectory job spawning overhead.

## Additional Notes

This change maintains adequate test coverage while being more cost-effective for CI/CD resources.