### PR TITLE
fix (channel): remove local file path whitelist

### DIFF
--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -497,17 +497,6 @@ ORDER BY m.ROWID ASC
                 filename=safe_filename,
                 download_dir=str(self._media_dir),
             )
-            # Verify the resolved path is within _media_dir
-            # to prevent path traversal
-            resolved_path = Path(local_path).resolve()
-            media_dir_resolved = self._media_dir.resolve()
-            if not str(resolved_path).startswith(str(media_dir_resolved)):
-                logger.error(
-                    "imessage send_media: attempted path traversal detected, "
-                    f"blocked file creation at {resolved_path}",
-                )
-                return None
-
             logger.info(
                 f"imessage send_media: downloaded {url} to {local_path}",
             )
@@ -577,18 +566,6 @@ ORDER BY m.ROWID ASC
                 safe_basename = self._sanitize_filename(filename_hint)
                 safe_filename = f"{safe_basename}_{url_hash}{ext}"
                 local_path = str(self._media_dir / safe_filename)
-
-                # Verify the resolved path is within _media_dir
-                # to prevent path traversal
-                resolved_path = Path(local_path).resolve()
-                media_dir_resolved = self._media_dir.resolve()
-                if not str(resolved_path).startswith(str(media_dir_resolved)):
-                    logger.error(
-                        "imessage send_media: attempted path traversal "
-                        "detected, "
-                        f"blocked file creation at {resolved_path}",
-                    )
-                    return None
 
                 Path(local_path).write_bytes(file_data)
                 logger.info(

--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -790,19 +790,6 @@ class TelegramChannel(BaseChannel):
                     "Could not resolve media file from URL.",
                 )
             local_path = Path(raw_path).resolve()
-            allowed_root = (
-                (self._workspace_dir / "media").resolve()
-                if self._workspace_dir
-                else (WORKING_DIR / "media").resolve()
-            )
-            if not local_path.is_relative_to(allowed_root):
-                logger.error(
-                    "telegram: blocked media outside allowed directory: %s",
-                    local_path,
-                )
-                raise _MediaFileUnavailableError(
-                    f"Media file outside allowed directory: {local_path.name}",
-                )
             if not local_path.exists():
                 logger.warning(
                     "telegram: media file not found at path: %s",


### PR DESCRIPTION
## Description

Remove local file path whitelist for media in channels telegram and imessage to align with other channels.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [] Documentation updated (if needed)
- [x] Ready for review