### PR TITLE
docs(faq): add Windows port 8088 conflict troubleshooting guide

### DIFF
--- a/website/public/docs/faq.en.md
+++ b/website/public/docs/faq.en.md
@@ -127,6 +127,71 @@ The default Console URL is `http://127.0.0.1:8088/`. After quick init, you can
 open Console and customize settings. See
 [Quick Start](https://copaw.agentscope.io/docs/quickstart).
 
+### Port 8088 conflict on Windows
+
+On Windows, Hyper-V and WSL2 may reserve certain port ranges, which can conflict
+with CoPaw's default port **8088**. This affects all installation methods
+(pip, script, Docker, desktop app).
+
+**Symptoms:**
+
+- Error: `Address already in use` or `OSError: [Errno 98] Address already in use`
+- Error: `An attempt was made to access a socket in a way forbidden by its access permissions`
+- CoPaw fails to start, or browser cannot connect to `http://127.0.0.1:8088/`
+
+**Check if port 8088 is reserved on Windows:**
+
+Open PowerShell or CMD and run:
+
+```powershell
+netsh interface ipv4 show excludedportrange protocol=tcp
+```
+
+If 8088 appears in the excluded ranges, it's reserved by the system.
+
+**Solution: Use a different port**
+
+**For pip / script installation:**
+
+```bash
+copaw app --port 8090
+```
+
+Then open `http://127.0.0.1:8090/` in your browser.
+
+**For Docker:**
+
+```bash
+docker run -p 127.0.0.1:8090:8088 \
+  -v copaw-data:/app/working \
+  -v copaw-secrets:/app/working.secret \
+  agentscope/copaw:latest
+```
+
+Then open `http://127.0.0.1:8090/` in your browser.
+
+**For Windows Desktop App:**
+
+Currently, the desktop app uses port 8088 by default. If you encounter this
+issue, you can:
+
+1. Run `copaw app --port 8090` from a terminal instead
+2. Or exclude port 8088 from Windows reserved ranges (requires administrator
+   privileges and may affect other services)
+
+**Advanced: Prevent Windows from reserving port 8088**
+
+Run the following in an elevated PowerShell (run as Administrator):
+
+```powershell
+# Exclude port 8088 from the dynamic port range
+netsh int ipv4 set dynamicport tcp start=49152 num=16384
+# Restart Windows for changes to take effect
+```
+
+> ⚠️ **Warning**: This changes system-wide port configuration. Only do this if
+> you understand the implications.
+
 ### Open-source repository
 
 CoPaw is open source. Official repository:

--- a/website/public/docs/faq.zh.md
+++ b/website/public/docs/faq.zh.md
@@ -122,6 +122,66 @@ copaw app
 
 控制台默认地址为 `http://127.0.0.1:8088/`，使用默认配置快速初始化后，可以进入控制台快捷自定义相关内容。详情请见[快速开始](https://copaw.agentscope.io/docs/quickstart)。
 
+### Windows 端口 8088 冲突问题
+
+在 Windows 上，Hyper-V 和 WSL2 可能会保留某些端口范围，这可能与 CoPaw 的默认端口 **8088** 冲突。此问题影响所有安装方式（pip 安装、脚本安装、Docker、桌面应用）。
+
+**症状：**
+
+- 报错：`Address already in use` 或 `OSError: [Errno 98] Address already in use`
+- 报错：`An attempt was made to access a socket in a way forbidden by its access permissions`
+- CoPaw 无法启动，或浏览器无法访问 `http://127.0.0.1:8088/`
+
+**检查端口 8088 是否被 Windows 保留：**
+
+在 PowerShell 或 CMD 中运行：
+
+```powershell
+netsh interface ipv4 show excludedportrange protocol=tcp
+```
+
+如果 8088 出现在排除范围内，说明已被系统保留。
+
+**解决方案：使用其他端口**
+
+**pip 安装 / 脚本安装：**
+
+```bash
+copaw app --port 8090
+```
+
+然后在浏览器中打开 `http://127.0.0.1:8090/`。
+
+**Docker 安装：**
+
+```bash
+docker run -p 127.0.0.1:8090:8088 \
+  -v copaw-data:/app/working \
+  -v copaw-secrets:/app/working.secret \
+  agentscope/copaw:latest
+```
+
+然后在浏览器中打开 `http://127.0.0.1:8090/`。
+
+**Windows 桌面应用：**
+
+目前桌面应用默认使用 8088 端口。如果遇到此问题，可以：
+
+1. 改用终端运行 `copaw app --port 8090`
+2. 或从 Windows 保留端口范围中排除 8088（需要管理员权限，可能影响其他服务）
+
+**进阶：防止 Windows 保留 8088 端口**
+
+在管理员权限的 PowerShell 中运行：
+
+```powershell
+# 从动态端口范围中排除 8088
+netsh int ipv4 set dynamicport tcp start=49152 num=16384
+# 重启 Windows 使更改生效
+```
+
+> ⚠️ **警告**：这会更改系统级端口配置，请确保了解相关影响后再操作。
+
 ### 开源地址
 
 CoPaw 已开源，官方仓库地址：


### PR DESCRIPTION
## Summary

Adds comprehensive troubleshooting documentation for Windows users encountering port 8088 conflicts due to Hyper-V/WSL2 port reservations.

## Changes

- Added new FAQ section "Port 8088 conflict on Windows" (English and Chinese)
- Covers all installation methods:
  - **pip/script**: `copaw app --port 8090`
  - **Docker**: `-p 127.0.0.1:8090:8088`
  - **Desktop app**: workaround suggestions
- Explains symptoms and how to check reserved ports with `netsh`
- Includes advanced solution for preventing Windows from reserving port 8088

## Related

Addresses task #18 in #430 (Help Wanted: Open Tasks)

## Checklist

- [x] Documentation added in both English and Chinese
- [x] Build passed (`npm run build`)