### PR TITLE
fix(token_usage): replace threading.Lock with asyncio.Lock (#1834)

### DIFF
--- a/src/copaw/token_usage/manager.py
+++ b/src/copaw/token_usage/manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Token usage manager"""
 
+import asyncio
 import json
 import logging
 import threading
@@ -67,7 +68,7 @@ class TokenUsageManager:
 
     def __init__(self) -> None:
         self._path: Path = (WORKING_DIR / TOKEN_USAGE_FILE).expanduser()
-        self._file_lock = threading.Lock()
+        self._file_lock = asyncio.Lock()
 
     async def _load_data(self) -> dict:
         """Load full token usage data from disk."""
@@ -129,7 +130,7 @@ class TokenUsageManager:
         date_str = at_date.isoformat()
         composite_key = f"{provider_id}:{model_name}"
 
-        with self._file_lock:
+        async with self._file_lock:
             data = await self._load_data()
             if date_str not in data:
                 data[date_str] = {}


### PR DESCRIPTION
## Summary

Fixes #1834 - TokenUsageManager.record uses threading.Lock in async context, causing event loop lockup / deadlock under load

## Changes

- Replace `threading.Lock` with `asyncio.Lock` in `TokenUsageManager.__init__`
- Change `with self._file_lock:` to `async with self._file_lock:` in the `record()` method
- Add `import asyncio` at the top of the file

## Problem

`TokenUsageManager.record()` is an `async def`, but it used a synchronous `threading.Lock`. When multiple coroutines try to acquire this lock concurrently, it can block the main asyncio event loop, causing the entire CoPaw server to appear frozen / deadlocked.

## Solution

Use `asyncio.Lock()` which is cooperative - other coroutines can continue while one is waiting on the lock.
