### PR TITLE
fix(mcp): degrade connection errors to tool-level failure

### DIFF
--- a/src/copaw/agents/tool_guard_mixin.py
+++ b/src/copaw/agents/tool_guard_mixin.py
@@ -62,14 +62,17 @@ class ToolGuardMixin:
 
     def _is_mcp_connection_error(self, exc: BaseException) -> bool:
         """Return True when exception chain matches MCP connection failures."""
+        mcp_error_markers = (
+            "not connected",
+            "connect() method first",
+            "session terminated",
+            "closed resource",
+            "closedresourceerror",
+        )
         for item in self._iter_exception_chain(exc):
             text = f"{item.__class__.__name__}: {item}".lower()
-            if "mcp" in text and (
-                "not connected" in text
-                or "connect() method first" in text
-                or "session terminated" in text
-                or "closed resource" in text
-                or "closedresourceerror" in text
+            if "mcp" in text and any(
+                marker in text for marker in mcp_error_markers
             ):
                 return True
             if "mcp client is not connected to the server" in text:

--- a/src/copaw/agents/tool_guard_mixin.py
+++ b/src/copaw/agents/tool_guard_mixin.py
@@ -14,7 +14,7 @@ import json as _json
 import logging
 from typing import Any, Literal
 
-from agentscope.message import Msg
+from agentscope.message import Msg, ToolResultBlock
 
 from ..security.tool_guard.models import TOOL_GUARD_DENIED_MARK
 
@@ -45,6 +45,64 @@ class ToolGuardMixin:
     def _ensure_tool_guard(self) -> None:
         if not hasattr(self, "_tool_guard_engine"):
             self._init_tool_guard()
+
+    @staticmethod
+    def _iter_exception_chain(exc: BaseException):
+        """Yield exception and chained causes/contexts exactly once."""
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            yield current
+            current = (
+                current.__cause__
+                if current.__cause__ is not None
+                else current.__context__
+            )
+
+    def _is_mcp_connection_error(self, exc: BaseException) -> bool:
+        """Return True when exception chain matches MCP connection failures."""
+        for item in self._iter_exception_chain(exc):
+            text = f"{item.__class__.__name__}: {item}".lower()
+            if "mcp" in text and (
+                "not connected" in text
+                or "connect() method first" in text
+                or "session terminated" in text
+                or "closed resource" in text
+                or "closedresourceerror" in text
+            ):
+                return True
+            if "mcp client is not connected to the server" in text:
+                return True
+        return False
+
+    async def _emit_tool_failure_result(
+        self,
+        tool_call: dict[str, Any],
+        tool_name: str,
+    ) -> None:
+        """Write a generic tool failure result so ReAct can continue."""
+        fail_text = (
+            "⚠️ Tool execution failed for this step. "
+            "Please continue with another approach.\n"
+            "⚠️ 本次工具调用失败，请尝试其他方式继续。"
+        )
+        tool_res_msg = Msg(
+            "system",
+            [
+                ToolResultBlock(
+                    type="tool_result",
+                    id=tool_call["id"],
+                    name=tool_name,
+                    output=[
+                        {"type": "text", "text": fail_text},
+                    ],
+                ),
+            ],
+            "system",
+        )
+        await self.print(tool_res_msg, True)
+        await self.memory.add(tool_res_msg)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -178,7 +236,24 @@ class ToolGuardMixin:
                 exc_info=True,
             )
 
-        return await super()._acting(tool_call)  # type: ignore[misc]
+        try:
+            return await super()._acting(tool_call)  # type: ignore[misc]
+        except Exception as exc:  # pylint: disable=broad-except
+            if not self._is_mcp_connection_error(exc):
+                raise
+
+            tool_id = str(tool_call.get("id") or "")
+            logger.warning(
+                "Tool execution degraded to non-fatal failure: tool=%s, "
+                "tool_call_id=%s, session_id=%s, reason=%s",
+                tool_name,
+                tool_id,
+                str(self._request_context.get("session_id") or ""),
+                exc,
+                exc_info=True,
+            )
+            await self._emit_tool_failure_result(tool_call, tool_name)
+            return None
 
     # ------------------------------------------------------------------
     # Denied / Approval responses
@@ -191,7 +266,6 @@ class ToolGuardMixin:
         guard_result=None,
     ) -> dict | None:
         """Auto-deny a tool call without offering approval."""
-        from agentscope.message import ToolResultBlock
         from copaw.security.tool_guard.approval import (
             format_findings_summary,
         )
@@ -241,7 +315,6 @@ class ToolGuardMixin:
         guard_result,
     ) -> dict | None:
         """Deny the tool call and record a pending approval."""
-        from agentscope.message import ToolResultBlock
         from copaw.security.tool_guard.approval import (
             format_findings_summary,
         )

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -65,19 +65,24 @@ def _iter_exception_chain(exc: BaseException):
 
 def _is_mcp_connection_error(exc: Exception) -> bool:
     """Best-effort check for MCP connectivity/session failures."""
+    mcp_error_markers = (
+        "not connected",
+        "connect() method first",
+        "session terminated",
+        "closed resource",
+        "closedresourceerror",
+    )
     for item in _iter_exception_chain(exc):
         text = f"{item.__class__.__name__}: {item}".lower()
         if "mcp client is not connected to the server" in text:
             return True
-        if "mcp" in text and (
-            "not connected" in text
-            or "connect() method first" in text
-            or "session terminated" in text
-            or "closed resource" in text
-            or "closedresourceerror" in text
+        if "mcp" in text and any(
+            marker in text for marker in mcp_error_markers
         ):
             return True
     return False
+
+
 def _is_approval(text: str) -> bool:
     """Return True when *text* expresses approval intent.
 

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -49,6 +49,35 @@ _DENY_RE = re.compile(
 )
 
 
+def _iter_exception_chain(exc: BaseException):
+    """Yield exception with chained causes/contexts exactly once."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = (
+            current.__cause__
+            if current.__cause__ is not None
+            else current.__context__
+        )
+
+
+def _is_mcp_connection_error(exc: Exception) -> bool:
+    """Best-effort check for MCP connectivity/session failures."""
+    for item in _iter_exception_chain(exc):
+        text = f"{item.__class__.__name__}: {item}".lower()
+        if "mcp client is not connected to the server" in text:
+            return True
+        if "mcp" in text and (
+            "not connected" in text
+            or "connect() method first" in text
+            or "session terminated" in text
+            or "closed resource" in text
+            or "closedresourceerror" in text
+        ):
+            return True
+    return False
 def _is_approval(text: str) -> bool:
     """Return True when *text* expresses approval intent.
 
@@ -354,6 +383,20 @@ class AgentRunner(Runner):
                 f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
             )
             logger.exception(f"Error in query handler: {e}{path_hint}")
+
+            # Last-resort guard: MCP connectivity failures should not surface
+            # as chat-visible "Unknown agent error" payloads.
+            if _is_mcp_connection_error(e):
+                logger.warning(
+                    "Suppressing MCP connectivity error in query output; "
+                    "session_id=%s, user_id=%s, channel=%s, reason=%s",
+                    session_id,
+                    user_id,
+                    channel,
+                    e,
+                )
+                return
+
             if debug_dump_path:
                 setattr(e, "debug_dump_path", debug_dump_path)
                 if hasattr(e, "add_note"):

--- a/tests/unit/app/test_tool_guard_mcp_fallback.py
+++ b/tests/unit/app/test_tool_guard_mcp_fallback.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from copaw.agents.tool_guard_mixin import ToolGuardMixin
+
+
+@dataclass
+class _MemoryStub:
+    added: list = field(default_factory=list)
+
+    async def add(self, msg, marks=None):
+        _ = marks
+        self.added.append(msg)
+
+
+class _BaseRaisesMcp:
+    async def _acting(self, tool_call):
+        _ = tool_call
+        raise RuntimeError(
+            "The MCP client is not connected to the server. "
+            "Use the connect() method first.",
+        )
+
+
+class _BaseRaisesGeneric:
+    async def _acting(self, tool_call):
+        _ = tool_call
+        raise RuntimeError("generic tool failure")
+
+
+class _AgentMcpFallback(ToolGuardMixin, _BaseRaisesMcp):
+    def __init__(self):
+        self._tool_guard_engine = type("Engine", (), {"enabled": False})()
+        self._tool_guard_approval_service = object()
+        self._request_context = {"session_id": "s1"}
+        self.memory = _MemoryStub()
+        self.printed = []
+
+    async def print(self, msg, flush):
+        _ = flush
+        self.printed.append(msg)
+
+
+class _AgentGenericError(ToolGuardMixin, _BaseRaisesGeneric):
+    def __init__(self):
+        self._tool_guard_engine = type("Engine", (), {"enabled": False})()
+        self._tool_guard_approval_service = object()
+        self._request_context = {"session_id": "s1"}
+        self.memory = _MemoryStub()
+
+    async def print(self, msg, flush):
+        _ = msg, flush
+
+
+async def test_mcp_connection_error_degrades_to_tool_result() -> None:
+    agent = _AgentMcpFallback()
+    tool_call = {"id": "call_1", "name": "web_search", "input": {}}
+
+    result = await agent._acting(tool_call)
+
+    assert result is None
+    assert len(agent.printed) == 1
+    assert len(agent.memory.added) == 1
+    text = str(agent.memory.added[0].content)
+    assert "工具调用失败" in text
+    assert "mcp" not in text.lower()
+
+
+async def test_non_mcp_error_still_raises() -> None:
+    agent = _AgentGenericError()
+    tool_call = {"id": "call_2", "name": "web_search", "input": {}}
+
+    raised = False
+    try:
+        await agent._acting(tool_call)
+    except RuntimeError as exc:
+        raised = True
+        assert "generic tool failure" in str(exc)
+
+    assert raised is True

--- a/tests/unit/app/test_tool_guard_mcp_fallback.py
+++ b/tests/unit/app/test_tool_guard_mcp_fallback.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from __future__ import annotations
 
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Description

This PR prevents MCP connectivity failures from surfacing as chat-visible unknown-agent errors.

What changed:
- Degrade MCP connection/session failures in tool execution to a normal tool_result failure so ReAct can continue with alternative paths.
- Add a runner-level last-resort guard to suppress MCP connectivity errors from chat output if they still bubble up.
- Add unit tests for MCP-fallback behavior and non-MCP error pass-through.

**Related Issue:** Relates to #1938

**Security Considerations:** No auth/path expansion changes; this only changes error-surface behavior to avoid leaking internal runtime details into user chat output.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes (not run)
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks (not applicable)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) (not needed)
- [x] Ready for review

## Testing

- Run:
  - `/Users/futuremeng/github/futuremeng/CoPaw/.venv/bin/python -m pytest tests/unit/app/test_tool_guard_mcp_fallback.py -q`
- Verified:
  - MCP connection errors are degraded to tool-level failures.
  - Non-MCP errors still raise.

## Local Verification Evidence

```bash
pre-commit run --all-files
# not run in this change set

/Users/futuremeng/github/futuremeng/CoPaw/.venv/bin/python -m pytest tests/unit/app/test_tool_guard_mcp_fallback.py -q
# ..
# 2 passed in 0.73s
```

## Release-specific Checklist (if this is a release PR)

Release PR only. Non-release PR can skip this section.
仅发布类 PR 需要勾选，非发布 PR 可跳过本节。

- [ ] I followed `RELEASE.md` (and `RELEASE_zh.md` if needed)
- [ ] 我已按 `RELEASE.md`（如需要也参考 `RELEASE_zh.md`）执行发布流程
- [ ] `src/copaw/__version__.py` is updated with the target version
- [ ] 我已将目标版本更新到 `src/copaw/__version__.py`
- [ ] I validated version format (PEP 440)
- [ ] 我已校验版本格式（PEP 440）
- [ ] I completed a release checklist issue using `.github/ISSUE_TEMPLATE/6-release_checklist.md`
- [ ] 我已使用 `.github/ISSUE_TEMPLATE/6-release_checklist.md` 创建并完成发布检查清单 issue
- [ ] I verified the target release type (stable/prerelease/post) and tag naming
- [ ] 我已确认发布类型（stable/prerelease/post）与 tag 命名

## Additional Notes

This branch is created from `mirror/upstream-main` as required by local SOP for upstream contributions (`feat/upstream/*`).