### PR TITLE
fix(token): handle list content in CopawTokenCounter

### DIFF
--- a/src/copaw/agents/utils/copaw_token_counter.py
+++ b/src/copaw/agents/utils/copaw_token_counter.py
@@ -145,6 +145,8 @@ class CopawTokenCounter(HuggingFaceTokenCounter):
             estimated minimum.
         """
         if text is not None:
+            if text == "":
+                return 0
             if self._tokenizer_available:
                 try:
                     token_ids = self.tokenizer.encode(text)

--- a/tests/unit/memory/test_copaw_token_counter.py
+++ b/tests/unit/memory/test_copaw_token_counter.py
@@ -403,15 +403,13 @@ def test_count_messages_with_str_content() -> None:
     print(f"  PASSED: str content messages counted ({token_count} tokens)")
 
 
-def test_count_empty_text_not_fallback_to_messages() -> None:
-    """Empty text should still follow text path, not message path fallback."""
-    print("Testing: empty text follows text path")
+def test_count_empty_text_returns_zero() -> None:
+    """Empty text should return zero explicitly."""
+    print("Testing: empty text returns zero")
     counter = CopawTokenCounter(
         token_count_model="default",
         token_count_use_mirror=True,
     )
-    # With explicit empty text, should return estimate("") == 0,
-    # instead of falling back to messages counting.
     token_count = asyncio.run(
         counter.count(
             messages=[{"role": "user", "content": "hello"}],
@@ -419,7 +417,7 @@ def test_count_empty_text_not_fallback_to_messages() -> None:
         ),
     )
     assert token_count == 0
-    print("  PASSED: empty text does not fallback to messages")
+    print("  PASSED: empty text returns zero")
 
 
 def test_count_none_text_fallback_to_messages() -> None:
@@ -484,7 +482,7 @@ def run_all_tests() -> None:
     test_tokenizer_different_models()
     test_count_messages_with_list_content()
     test_count_messages_with_str_content()
-    test_count_empty_text_not_fallback_to_messages()
+    test_count_empty_text_returns_zero()
     test_count_none_text_fallback_to_messages()
     test_normalize_messages_mixed()
 


### PR DESCRIPTION
## Problem

When LLM providers (e.g. Anthropic) return `Msg.content` as a list of content blocks instead of a plain string, `HuggingFaceTokenCounter.apply_chat_template` raises `TypeError: can only concatenate str (not "list") to str`.

This causes `MemoryCompactionHook` to fail silently on every reasoning cycle, preventing memory compression from ever triggering — even when the context window is well over the configured threshold.

## Root Cause

`CopawTokenCounter.count()` passes messages directly to the parent `HuggingFaceTokenCounter.count()`, which calls `tokenizer.apply_chat_template()`. This method expects `content` to be a `str`, but multi-block messages have `content` as `list[dict]`:

```python
# Example: Anthropic-style message
{"role": "assistant", "content": [
    {"type": "text", "text": "Hello"},
    {"type": "tool_use", "id": "t1", "name": "read_file", ...}
]}
```

## Fix

- Add `_normalize_messages()` static method to convert list content blocks to plain strings before tokenization
- Add `_extract_text_from_blocks()` helper to extract text from various block formats (dict with `text` key, objects with `.text` attribute, plain strings)
- Add fallback to `estimate_tokens()` if tokenizer still fails for any reason
- Add test cases covering list content normalization

## Changes

- `src/copaw/agents/utils/copaw_token_counter.py` — normalize messages before tokenization
- `tests/unit/memory/test_copaw_token_counter.py` — add tests for list content handling