### PR TITLE
fix(shell): Fix shell command hang and process cleanup

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -6,8 +6,10 @@
 import asyncio
 import locale
 import os
+import signal
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -35,6 +37,29 @@ def _kill_process_tree_win32(pid: int) -> None:
         pass
 
 
+def _sanitize_win_cmd(cmd: str) -> str:
+    """Fix common LLM escaping artefacts for Windows ``cmd.exe``.
+
+    LLMs sometimes produce commands with backslash-escaped double quotes
+    (``\\"``) — valid in bash/JSON but meaningless to ``cmd.exe``.  When
+    *every* double-quote in the command is preceded by a backslash, it is
+    almost certainly a double-escape artefact, so we strip them.
+    """
+    if '\\"' in cmd and '"' not in cmd.replace('\\"', ""):
+        return cmd.replace('\\"', '"')
+    return cmd
+
+
+def _read_temp_file(path: str) -> str:
+    """Read a temporary output file and return its decoded content."""
+    try:
+        with open(path, "rb") as f:
+            return smart_decode(f.read())
+    except OSError:
+        return ""
+
+
+# pylint: disable=too-many-branches, too-many-statements
 def _execute_subprocess_sync(
     cmd: str,
     cwd: str,
@@ -46,10 +71,13 @@ def _execute_subprocess_sync(
     This function runs in a separate thread to avoid Windows asyncio
     subprocess limitations.
 
-    Uses ``Popen`` directly instead of ``subprocess.run`` because the
-    latter's internal cleanup after a timeout calls ``communicate()``
-    **without** a timeout, which hangs when descendant processes still
-    hold the pipe handles open (e.g. ``notepad.exe``, ``cmd /k pause``).
+    stdout/stderr are redirected to temporary files instead of pipes.
+    On Windows, child processes inherit pipe handles and keep them open
+    even after the parent exits, which causes ``communicate()`` to block
+    until *all* holders close (e.g. a Chrome process launched via
+    ``Start-Process``).  With temp-file redirection, ``proc.wait()``
+    only waits for the direct child (``cmd.exe``) to exit, so commands
+    that spawn background processes return immediately.
 
     Args:
         cmd (`str`):
@@ -67,59 +95,84 @@ def _execute_subprocess_sync(
             standard error of the executed command. If timeout occurs, the
             return code will be -1 and stderr will contain timeout information.
     """
+    stdout_path: str | None = None
+    stderr_path: str | None = None
+    stdout_file = None
+    stderr_file = None
+
     try:
+        cmd = _sanitize_win_cmd(cmd)
         wrapped = f'cmd /D /S /C "{cmd}"'
-        with subprocess.Popen(
+
+        stdout_fd, stdout_path = tempfile.mkstemp(prefix="copaw_out_")
+        stderr_fd, stderr_path = tempfile.mkstemp(prefix="copaw_err_")
+        stdout_file = os.fdopen(stdout_fd, "wb")
+        stderr_file = os.fdopen(stderr_fd, "wb")
+
+        proc = subprocess.Popen(  # pylint: disable=consider-using-with
             wrapped,
             shell=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=stdout_file,
+            stderr=stderr_file,
             text=False,
             cwd=cwd,
             env=env,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-        ) as proc:
+        )
+
+        # Parent copies are no longer needed — the child inherited its own
+        # handles via CreateProcess.  Closing here avoids holding the files
+        # open longer than necessary.
+        stdout_file.close()
+        stdout_file = None
+        stderr_file.close()
+        stderr_file = None
+
+        timed_out = False
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill_process_tree_win32(proc.pid)
             try:
-                stdout, stderr = proc.communicate(timeout=timeout)
-                return (
-                    proc.returncode,
-                    smart_decode(stdout),
-                    smart_decode(stderr),
-                )
+                proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                _kill_process_tree_win32(proc.pid)
-
-                # Try to drain remaining output after the tree has been killed.
-                # The second communicate() should return quickly now that all
-                # writers are dead.  Guard with a timeout just in case.
                 try:
-                    stdout, stderr = proc.communicate(timeout=5)
-                    stdout_str = smart_decode(stdout)
-                    stderr_str = smart_decode(stderr)
-                except (subprocess.TimeoutExpired, OSError, ValueError):
-                    stdout_str, stderr_str = "", ""
-                    # Force-close pipes to unblock any lingering reader threads
-                    # spawned by the first communicate() call.
-                    for pipe in (proc.stdout, proc.stderr, proc.stdin):
-                        if pipe:
-                            try:
-                                pipe.close()
-                            except OSError:
-                                pass
-                    try:
-                        proc.wait(timeout=3)
-                    except subprocess.TimeoutExpired:
-                        pass
+                    proc.kill()
+                except OSError:
+                    pass
 
-                timeout_msg = f"Command execution exceeded the timeout of {timeout} seconds."
-                if stderr_str:
-                    stderr_str = f"{stderr_str}\n{timeout_msg}"
-                else:
-                    stderr_str = timeout_msg
-                return -1, stdout_str, stderr_str
+        stdout_str = _read_temp_file(stdout_path)
+        stderr_str = _read_temp_file(stderr_path)
+
+        if timed_out:
+            timeout_msg = (
+                f"Command execution exceeded the timeout of {timeout} seconds."
+            )
+            if stderr_str:
+                stderr_str = f"{stderr_str}\n{timeout_msg}"
+            else:
+                stderr_str = timeout_msg
+            return -1, stdout_str, stderr_str
+
+        returncode = proc.returncode if proc.returncode is not None else -1
+        return returncode, stdout_str, stderr_str
 
     except Exception as e:
         return -1, "", str(e)
+    finally:
+        for f in (stdout_file, stderr_file):
+            if f is not None:
+                try:
+                    f.close()
+                except OSError:
+                    pass
+        for path in (stdout_path, stderr_path):
+            if path is not None:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
 
 # pylint: disable=too-many-branches, too-many-statements
@@ -153,7 +206,6 @@ async def execute_shell_command(
 
     cmd = (command or "").strip()
 
-    # Set working directory
     # Use current workspace_dir from context, fallback to WORKING_DIR
     if cwd is not None:
         working_dir = cwd
@@ -187,6 +239,7 @@ async def execute_shell_command(
                 bufsize=0,
                 cwd=str(working_dir),
                 env=env,
+                start_new_session=True,
             )
 
             try:
@@ -201,7 +254,6 @@ async def execute_shell_command(
                 returncode = proc.returncode
 
             except asyncio.TimeoutError:
-                # Handle timeout
                 stderr_suffix = (
                     f"⚠️ TimeoutError: The command execution exceeded "
                     f"the timeout of {timeout} seconds. "
@@ -210,16 +262,17 @@ async def execute_shell_command(
                 )
                 returncode = -1
                 try:
-                    proc.terminate()
-                    # Wait a bit for graceful termination
+                    # Kill the entire process group so that child processes
+                    # spawned by the shell are also terminated.
+                    pgid = os.getpgid(proc.pid)
+                    os.killpg(pgid, signal.SIGTERM)
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=1)
+                        await asyncio.wait_for(proc.wait(), timeout=2)
                     except asyncio.TimeoutError:
-                        # Force kill if graceful termination fails
-                        proc.kill()
-                        await proc.wait()
+                        os.killpg(pgid, signal.SIGKILL)
+                        await asyncio.wait_for(proc.wait(), timeout=2)
 
-                    # Avoid hanging forever while draining pipes after timeout.
+                    # Drain remaining output.
                     try:
                         stdout, stderr = await asyncio.wait_for(
                             proc.communicate(),
@@ -233,23 +286,23 @@ async def execute_shell_command(
                         stderr_str += f"\n{stderr_suffix}"
                     else:
                         stderr_str = stderr_suffix
-                except ProcessLookupError:
+                except (ProcessLookupError, OSError):
+                    # Process already gone or pgid lookup failed — fall back
+                    # to direct kill on the process itself.
+                    try:
+                        proc.kill()
+                        await proc.wait()
+                    except (ProcessLookupError, OSError):
+                        pass
                     stdout_str = ""
                     stderr_str = stderr_suffix
 
-        # Apply output truncation
-        # stdout_str = truncate_shell_output(stdout_str)
-        # stderr_str = truncate_shell_output(stderr_str)
-
-        # Format the response in a human-friendly way
         if returncode == 0:
-            # Success case: just show the output
             if stdout_str:
                 response_text = stdout_str
             else:
                 response_text = "Command executed successfully (no output)."
         else:
-            # Error case: show detailed information
             response_parts = [f"Command failed with exit code {returncode}."]
             if stdout_str:
                 response_parts.append(f"\n[stdout]\n{stdout_str}")


### PR DESCRIPTION
## Description

Fix: eliminate shell command hang on Windows by replacing PIPE with temp-file redirect, and add Unix process-group cleanup.

- Fixes #2058. Fixes #2060. Fixes #2066. 
- Relates to #2059. Relates to #2068.

More details: 
1. **Windows: replace `stdout/stderr=PIPE` with temp-file redirection** — `proc.wait()` now only waits for `cmd.exe` to exit, so commands that spawn background processes (e.g. `Start-Process`) return immediately instead of blocking for the full timeout.
2. **Windows: remove `with Popen(...)` context manager** — `Popen.__exit__` calls `wait()` without timeout, which can hang indefinitely; replaced with manual lifecycle + `finally` cleanup.
3. **Windows: add `proc.kill()` fallback** after `taskkill /F /T` in timeout path, preventing unkillable-process deadlock.
4. **Unix: add `start_new_session=True`** — creates an isolated process group for the shell command.
5. **Unix: use `os.killpg(os.getpgid(...), SIGTERM/SIGKILL)`** on timeout — kills the entire process tree instead of only the shell process; verified zero orphan processes.
6. **Add `_sanitize_win_cmd`** — auto-fixes LLM double-escaped quotes (`\"` → `"`) when all quotes in the command are escaped.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
