### PR TITLE
feat(discord): Add option to filter bot messages

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -18,6 +18,7 @@ export interface DiscordConfig extends BaseChannelConfig {
   bot_token: string;
   http_proxy: string;
   http_proxy_auth: string;
+  accept_bot_messages?: boolean;
 }
 
 export interface DingTalkConfig extends BaseChannelConfig {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -337,6 +337,8 @@
     "pleaseInputDbPath": "Please input DB path",
     "pleaseInputPollInterval": "Please input poll interval",
     "discordBotToken": "Discord bot token",
+    "acceptBotMessages": "Accept Bot Messages",
+    "acceptBotMessagesTooltip": "When enabled, messages from other bots will be accepted",
     "httpProxyPlaceholder": "http://127.0.0.1:18118",
     "httpProxyAuthPlaceholder": "user:password",
     "dbPathPlaceholder": "~/Library/Messages/chat.db",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -293,6 +293,8 @@
     "pleaseInputDbPath": "DBパスを入力してください",
     "pleaseInputPollInterval": "ポーリング間隔を入力してください",
     "discordBotToken": "Discord Botトークン",
+    "acceptBotMessages": "Botメッセージを受信",
+    "acceptBotMessagesTooltip": "有効にすると、他のBotからのメッセージを受信します",
     "httpProxyPlaceholder": "http://127.0.0.1:18118",
     "httpProxyAuthPlaceholder": "ユーザー:パスワード",
     "dbPathPlaceholder": "~/Library/Messages/chat.db",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -298,6 +298,8 @@
     "pleaseInputDbPath": "Пожалуйста, введите путь к БД",
     "pleaseInputPollInterval": "Пожалуйста, введите интервал опроса",
     "discordBotToken": "Токен Discord-бота",
+    "acceptBotMessages": "Принимать сообщения от ботов",
+    "acceptBotMessagesTooltip": "При включении будут приниматься сообщения от других ботов",
     "httpProxyPlaceholder": "http://127.0.0.1:18118",
     "httpProxyAuthPlaceholder": "user:password",
     "dbPathPlaceholder": "~/Library/Messages/chat.db",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -303,6 +303,8 @@
     "pleaseInputDbPath": "请输入数据库路径",
     "pleaseInputPollInterval": "请输入轮询间隔",
     "discordBotToken": "Discord机器人令牌",
+    "acceptBotMessages": "接收机器人消息",
+    "acceptBotMessagesTooltip": "开启后，将接收来自其他机器人的消息",
     "httpProxyPlaceholder": "http://127.0.0.1:18118",
     "httpProxyAuthPlaceholder": "用户名:密码",
     "dbPathPlaceholder": "~/Library/Messages/chat.db",

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -310,6 +310,14 @@ export function ChannelDrawer({
             <Form.Item name="http_proxy_auth" label="HTTP Proxy Auth">
               <Input placeholder="user:password" />
             </Form.Item>
+            <Form.Item
+              name="accept_bot_messages"
+              label={t("channels.acceptBotMessages")}
+              valuePropName="checked"
+              tooltip={t("channels.acceptBotMessagesTooltip")}
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -59,6 +59,7 @@ class DiscordChannel(BaseChannel):
         allow_from: Optional[list] = None,
         deny_message: str = "",
         require_mention: bool = False,
+        accept_bot_messages: bool = False,
     ):
         super().__init__(
             process,
@@ -77,6 +78,7 @@ class DiscordChannel(BaseChannel):
         self.http_proxy = http_proxy
         self.http_proxy_auth = http_proxy_auth
         self.bot_prefix = bot_prefix
+        self.accept_bot_messages = accept_bot_messages
         self._task: Optional[asyncio.Task] = None
         self._client = None
 
@@ -102,7 +104,12 @@ class DiscordChannel(BaseChannel):
 
             @self._client.event
             async def on_message(message):
-                if message.author.bot:
+                # Always ignore messages from the bot itself
+                if message.author == self._client.user:
+                    return
+                # Filter other bot messages unless
+                # accept_bot_messages is enabled
+                if message.author.bot and not self.accept_bot_messages:
                     return
                 text = (message.content or "").strip()
                 attachments = message.attachments
@@ -118,6 +125,25 @@ class DiscordChannel(BaseChannel):
                         "",
                         text,
                     ).strip()
+                # Check role mentions:
+                # if any mentioned role is one the bot has
+                if not is_bot_mentioned and message.guild and bot_user:
+                    bot_member = message.guild.get_member(bot_user.id)
+                    if bot_member:
+                        mentioned_role_ids = {
+                            r.id for r in getattr(message, "role_mentions", [])
+                        }
+                        bot_role_ids = {r.id for r in bot_member.roles}
+                        matched_role_ids = mentioned_role_ids & bot_role_ids
+                        if matched_role_ids:
+                            is_bot_mentioned = True
+                            # Remove role mention tags from text
+                            for role_id in matched_role_ids:
+                                text = re.sub(
+                                    rf"<@&{role_id}>",
+                                    "",
+                                    text,
+                                ).strip()
 
                 content_parts = []
                 if text:
@@ -254,6 +280,11 @@ class DiscordChannel(BaseChannel):
             allow_from=allow_from,
             deny_message=os.getenv("DISCORD_DENY_MESSAGE", ""),
             require_mention=os.getenv("DISCORD_REQUIRE_MENTION", "0") == "1",
+            accept_bot_messages=os.getenv(
+                "DISCORD_ACCEPT_BOT_MESSAGES",
+                "0",
+            )
+            == "1",
         )
 
     @classmethod
@@ -282,6 +313,7 @@ class DiscordChannel(BaseChannel):
             allow_from=config.allow_from or [],
             deny_message=config.deny_message or "",
             require_mention=config.require_mention,
+            accept_bot_messages=config.accept_bot_messages,
         )
 
     async def _resolve_target(self, to_handle, _meta):

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -52,6 +52,7 @@ class DiscordConfig(BaseChannelConfig):
     bot_token: str = ""
     http_proxy: str = ""
     http_proxy_auth: str = ""
+    accept_bot_messages: bool = False
 
 
 class DingTalkConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

- Add processing logic for @role_id
- Add a switch to filter bot messages.
![image](https://github.com/user-attachments/assets/dbfbbabb-ed8e-4cc5-a10f-f567e0276d83)
<img width="1438" height="782" alt="image" src="https://github.com/user-attachments/assets/8afebde6-3be1-4ee7-86d0-69fb87c9b6ea" />


**Related Issue:** Fixes #2057 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
