### PR TITLE
fix(shell): include stderr output when command succeeds

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -302,6 +302,8 @@ async def execute_shell_command(
                 response_text = stdout_str
             else:
                 response_text = "Command executed successfully (no output)."
+            if stderr_str:
+                response_text += f"\n[stderr]\n{stderr_str}"
         else:
             response_parts = [f"Command failed with exit code {returncode}."]
             if stdout_str:


### PR DESCRIPTION
## Description

Append [stderr] section to the response when returncode == 0 and stderr is non-empty.

**Related Issue:** Fixes #1131 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
