### PR TITLE
feat: save tool output files under workspace_dir instead of process cwd

### DIFF
--- a/src/copaw/agents/tools/browser_control.py
+++ b/src/copaw/agents/tools/browser_control.py
@@ -15,6 +15,7 @@ from concurrent import futures
 import json
 import logging
 import os
+from pathlib import Path
 import subprocess
 import sys
 import time
@@ -28,10 +29,22 @@ from ...config import (
     get_system_default_browser,
     is_running_in_container,
 )
+from ...config.context import get_current_workspace_dir
+from ...constant import WORKING_DIR
 
 from .browser_snapshot import build_role_snapshot_from_aria
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_output_path(path: str) -> str:
+    """Resolve relative output paths under workspace_dir/browser/."""
+    if Path(path).is_absolute():
+        return path
+    base_dir = (get_current_workspace_dir() or WORKING_DIR) / "browser"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    return str(base_dir / path)
+
 
 # Hybrid mode detection: Windows + Uvicorn reload mode requires sync Playwright
 # to avoid NotImplementedError with asyncio.create_subprocess_exec.
@@ -1106,6 +1119,7 @@ async def _action_screenshot(
     if not path:
         ext = "jpeg" if screenshot_type == "jpeg" else "png"
         path = f"page-{int(time.time())}.{ext}"
+    path = _resolve_output_path(path)
     page = _get_page(page_id)
     if not page:
         return _tool_response(
@@ -1504,6 +1518,7 @@ async def _action_eval(page_id: str, code: str) -> ToolResponse:
 
 async def _action_pdf(page_id: str, path: str) -> ToolResponse:
     path = (path or "page.pdf").strip() or "page.pdf"
+    path = _resolve_output_path(path)
     page = _get_page(page_id)
     if not page:
         return _tool_response(
@@ -1628,9 +1643,10 @@ async def _action_snapshot(
         if frame_selector and frame_selector.strip():
             out["frame_selector"] = frame_selector.strip()
         if filename and filename.strip():
-            with open(filename.strip(), "w", encoding="utf-8") as f:
+            resolved = _resolve_output_path(filename.strip())
+            with open(resolved, "w", encoding="utf-8") as f:
                 f.write(snapshot)
-            out["filename"] = filename.strip()
+            out["filename"] = resolved
         return _tool_response(json.dumps(out, ensure_ascii=False, indent=2))
     except Exception as e:
         return _tool_response(
@@ -1833,14 +1849,15 @@ async def _action_console_messages(
     lines = [f"[{m['level']}] {m['text']}" for m in filtered]
     text = "\n".join(lines)
     if filename and filename.strip():
-        with open(filename.strip(), "w", encoding="utf-8") as f:
+        resolved = _resolve_output_path(filename.strip())
+        with open(resolved, "w", encoding="utf-8") as f:
             f.write(text)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "message": f"Console messages saved to {filename}",
-                    "filename": filename.strip(),
+                    "message": f"Console messages saved to {resolved}",
+                    "filename": resolved,
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -2199,14 +2216,15 @@ async def _action_network_requests(
     ]
     text = "\n".join(lines)
     if filename and filename.strip():
-        with open(filename.strip(), "w", encoding="utf-8") as f:
+        resolved = _resolve_output_path(filename.strip())
+        with open(resolved, "w", encoding="utf-8") as f:
             f.write(text)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "message": f"Network requests saved to {filename}",
-                    "filename": filename.strip(),
+                    "message": f"Network requests saved to {resolved}",
+                    "filename": resolved,
                 },
                 ensure_ascii=False,
                 indent=2,

--- a/src/copaw/agents/tools/desktop_screenshot.py
+++ b/src/copaw/agents/tools/desktop_screenshot.py
@@ -5,11 +5,13 @@ import json
 import os
 import platform
 import subprocess
-import tempfile
 import time
 
 from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
+
+from ...config.context import get_current_workspace_dir
+from ...constant import WORKING_DIR
 
 
 def _tool_error(msg: str) -> ToolResponse:
@@ -112,8 +114,8 @@ async def desktop_screenshot(
 
     Args:
         path (`str`):
-            Optional path to save the screenshot. If empty, saves to a temp
-            file and returns that path. Should end in .png for PNG output.
+            Optional path to save the screenshot. If empty, saves under
+            the current workspace directory. Should end in .png for PNG output.
         capture_window (`bool`):
             If True on macOS, the user can click a window to capture just
             that window. On Windows/Linux, only full-screen is supported
@@ -126,10 +128,8 @@ async def desktop_screenshot(
     """
     path = (path or "").strip()
     if not path:
-        path = os.path.join(
-            tempfile.gettempdir(),
-            f"desktop_screenshot_{int(time.time())}.png",
-        )
+        base_dir = get_current_workspace_dir() or WORKING_DIR
+        path = str(base_dir / f"desktop_screenshot_{int(time.time())}.png")
     if not path.lower().endswith(".png"):
         path = path.rstrip("/\\") + ".png"
 

--- a/src/copaw/agents/utils/file_handling.py
+++ b/src/copaw/agents/utils/file_handling.py
@@ -17,7 +17,16 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+from ...config.context import get_current_workspace_dir
+from ...constant import WORKING_DIR
+
 logger = logging.getLogger(__name__)
+
+
+def _default_download_dir() -> str:
+    """Return the default download directory under the current workspace."""
+    base_dir = get_current_workspace_dir() or WORKING_DIR
+    return str(base_dir / "downloads")
 
 
 def _resolve_local_path(
@@ -146,7 +155,7 @@ def _guess_suffix_from_file_content(path: Path) -> Optional[str]:
 async def download_file_from_base64(
     base64_data: str,
     filename: Optional[str] = None,
-    download_dir: str = "downloads",
+    download_dir: str = "",
 ) -> str:
     """
     Save base64-encoded file data to local download directory.
@@ -154,7 +163,8 @@ async def download_file_from_base64(
     Args:
         base64_data: Base64-encoded file content.
         filename: The filename to save. If not provided, will generate one.
-        download_dir: The directory to save files. Defaults to "downloads".
+        download_dir: The directory to save files. Defaults to
+            workspace_dir/downloads.
 
     Returns:
         The local file path.
@@ -162,7 +172,9 @@ async def download_file_from_base64(
     try:
         file_content = base64.b64decode(base64_data)
 
-        download_path = Path(download_dir)
+        download_path = Path(
+            download_dir if download_dir else _default_download_dir(),
+        )
         download_path.mkdir(parents=True, exist_ok=True)
 
         if not filename:
@@ -184,7 +196,7 @@ async def download_file_from_base64(
 async def download_file_from_url(
     url: str,
     filename: Optional[str] = None,
-    download_dir: str = "downloads",
+    download_dir: str = "",
 ) -> str:
     """
     Download a file from URL to local download directory using wget or curl.
@@ -196,7 +208,8 @@ async def download_file_from_url(
             The filename to save. If not provided, will extract from URL or
             generate a hash-based name.
         download_dir (`str`):
-            The directory to save files. Defaults to "downloads".
+            The directory to save files. Defaults to
+            workspace_dir/downloads.
 
     Returns:
         `str`:
@@ -208,7 +221,9 @@ async def download_file_from_url(
         if local is not None:
             return local
 
-        download_path = Path(download_dir)
+        download_path = Path(
+            download_dir if download_dir else _default_download_dir(),
+        )
         download_path.mkdir(parents=True, exist_ok=True)
         if not filename:
             url_filename = os.path.basename(parsed.path)


### PR DESCRIPTION
## Description

- Browser tool outputs (screenshots, PDFs, snapshots, console logs, network request logs) now save under `workspace_dir/browser/` instead of the process working directory. 
- Desktop screenshots now save under `workspace_dir/` instead of the system temp directory.
- Message attachment downloads (`download_file_from_base64`, `download_file_from_url`) now default to `workspace_dir/downloads/` instead of `<cwd>/downloads/`.
- All changes fall back to `WORKING_DIR` when no per-agent workspace context is set


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
