### PR TITLE
fix(QQ): fix WebSocket reconnect on disconnect and respect max_reconnect_attempts config

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -64,7 +64,6 @@ INTENT_GUILD_MEMBERS = 1 << 1
 
 RECONNECT_DELAYS = [1, 2, 5, 10, 30, 60]
 RATE_LIMIT_DELAY = 60
-MAX_RECONNECT_ATTEMPTS = 100
 QUICK_DISCONNECT_THRESHOLD = 5
 MAX_QUICK_DISCONNECT_COUNT = 3
 
@@ -521,6 +520,7 @@ class QQChannel(BaseChannel):
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
         media_dir: str = "",
+        max_reconnect_attempts: int = 100,
     ):
         super().__init__(
             process,
@@ -537,6 +537,7 @@ class QQChannel(BaseChannel):
         self._media_dir = (
             Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
         )
+        self._max_reconnect_attempts = max_reconnect_attempts
 
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._ws_thread: Optional[threading.Thread] = None
@@ -657,6 +658,11 @@ class QQChannel(BaseChannel):
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
             media_dir=getattr(config, "media_dir", ""),
+            max_reconnect_attempts=getattr(
+                config,
+                "max_reconnect_attempts",
+                100,
+            ),
         )
 
     def _resolve_send_path(
@@ -1361,7 +1367,8 @@ class QQChannel(BaseChannel):
 
         delay = self._compute_reconnect_delay(state)
         state.reconnect_attempts += 1
-        if state.reconnect_attempts >= MAX_RECONNECT_ATTEMPTS:
+        max_attempts = self._max_reconnect_attempts
+        if max_attempts != -1 and state.reconnect_attempts >= max_attempts:
             logger.error("qq max reconnect attempts reached")
             return False
         logger.info(
@@ -1385,10 +1392,14 @@ class QQChannel(BaseChannel):
             )
             return
         state = _WSState()
-        while self._ws_connect_once(state, websocket):
-            pass
-        self._stop_event.set()
-        logger.info("qq ws thread stopped")
+        try:
+            while self._ws_connect_once(state, websocket):
+                pass
+        except Exception:
+            logger.exception("qq ws thread unexpected error")
+        finally:
+            self._stop_event.set()
+            logger.info("qq ws thread stopped")
 
     async def start(self) -> None:
         if not self.enabled:

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -82,6 +82,7 @@ class QQConfig(BaseChannelConfig):
     app_id: str = ""
     client_secret: str = ""
     markdown_enabled: bool = True
+    max_reconnect_attempts: int = 100
 
 
 class TelegramConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

- Add the max_reconnect_attempts parameter; setting it to -1 enables infinite reconnection.
- Add exception handling

**Related Issue:** Fixes #2132 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
