### PR TITLE
fix: calculate compact message token stats

### DIFF
--- a/src/copaw/agents/command_handler.py
+++ b/src/copaw/agents/command_handler.py
@@ -3,6 +3,7 @@
 
 This module handles system commands like /compact, /new, /clear, etc.
 """
+
 import json
 import logging
 from pathlib import Path
@@ -12,6 +13,7 @@ from agentscope.message import Msg, TextBlock
 
 from ..config.config import load_agent_config
 from ..constant import DEBUG_HISTORY_FILE, MAX_LOAD_HISTORY_COUNT
+from .utils import get_copaw_token_counter
 
 if TYPE_CHECKING:
     from .memory import MemoryManager
@@ -110,6 +112,44 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Check if memory manager is available."""
         return self._enable_memory_manager and self.memory_manager is not None
 
+    async def _build_compaction_stats(
+        self,
+        messages: list[Msg],
+        compact_content: str,
+    ) -> str:
+        """Build token-based compaction statistics for the response.
+
+        Args:
+            messages: Messages included in the compaction operation.
+            compact_content: Generated compact summary text.
+
+        Returns:
+            Formatted stats block, or an empty string if calculation fails.
+        """
+        if not messages or not compact_content or not self._has_memory_manager():
+            return ""
+
+        try:
+            agent_config = self._get_agent_config()
+            token_counter = get_copaw_token_counter(agent_config)
+            original_tokens = await token_counter.count(
+                messages=[msg.to_dict() for msg in messages],
+            )
+            compacted_tokens = await token_counter.count(
+                messages=[],
+                text=compact_content,
+            )
+        except Exception as e:
+            logger.warning("Failed to calculate compaction stats: %s", e)
+            return ""
+
+        saved_tokens = max(original_tokens - compacted_tokens, 0)
+        return (
+            f"- Original tokens: {original_tokens}\n"
+            f"- Compressed summary tokens: {compacted_tokens}\n"
+            f"- Tokens saved: {saved_tokens}\n"
+        )
+
     async def _process_compact(
         self,
         messages: list[Msg],
@@ -146,10 +186,15 @@ class CommandHandler(ConversationCommandHandlerMixin):
 
         await self.memory.update_compressed_summary(compact_content)
         updated_count = len(messages)
+        compact_stats = await self._build_compaction_stats(
+            messages=messages,
+            compact_content=compact_content,
+        )
         self.memory.clear_content()
         return await self._make_system_msg(
             f"**Compact Complete!**\n\n"
             f"- Messages compacted: {updated_count}\n"
+            f"{compact_stats}"
             f"**Compressed Summary:**\n{compact_content}\n"
             f"- Summary task started in background\n",
         )
@@ -229,9 +274,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
             half = running_config.history_max_length // 2
             history_str = f"{history_str[:half]}\n...\n{history_str[-half:]}"
 
-        history_str += (
-            "\n\n---\n\n- Use /message <index> to view full message content"
-        )
+        history_str += "\n\n---\n\n- Use /message <index> to view full message content"
 
         # Add compact summary hint if available
         if self.memory.get_compressed_summary():
@@ -255,8 +298,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         task_count = len(self.memory_manager.summary_tasks)
         if task_count == 0:
             return await self._make_system_msg(
-                "**No Summary Tasks**\n\n"
-                "- No pending summary tasks to wait for",
+                "**No Summary Tasks**\n\n" "- No pending summary tasks to wait for",
             )
 
         result = await self.memory_manager.await_summary_tasks()
@@ -428,8 +470,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
                         # Check first message for summary marker
                         if (
                             i == 0
-                            and msg.metadata.get("has_compressed_summary")
-                            == "true"
+                            and msg.metadata.get("has_compressed_summary") == "true"
                         ):
                             has_summary_marker = True
                         if len(loaded_messages) >= MAX_LOAD_HISTORY_COUNT:

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for command handler compaction responses."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TextBlock(dict):
+    """Lightweight text block stub for tests."""
+
+    def __init__(self, type: str, text: str) -> None:
+        super().__init__(type=type, text=text)
+
+
+class Msg:
+    """Lightweight message stub for tests."""
+
+    def __init__(
+        self,
+        name: str,
+        role: str,
+        content: list[TextBlock],
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        self.name = name
+        self.role = role
+        self.content = content
+        self.metadata = metadata or {}
+        self.timestamp = "2026-03-24T00:00:00Z"
+
+    def get_text_content(self) -> str:
+        """Return concatenated text content."""
+        return "".join(
+            block.get("text", "")
+            for block in self.content
+            if block.get("type") == "text"
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the message."""
+        return {
+            "name": self.name,
+            "role": self.role,
+            "content": list(self.content),
+            "metadata": self.metadata,
+        }
+
+
+agentscope_module = types.ModuleType("agentscope")
+message_module = types.ModuleType("agentscope.message")
+model_module = types.ModuleType("agentscope.model")
+config_package = types.ModuleType("copaw.config")
+config_module = types.ModuleType("copaw.config.config")
+utils_module = types.ModuleType("copaw.agents.utils")
+message_module.Msg = Msg
+message_module.TextBlock = TextBlock
+model_module.ChatModelBase = type("ChatModelBase", (), {})
+config_module.load_agent_config = lambda _agent_id: SimpleNamespace()
+utils_module.get_copaw_token_counter = lambda _config: None
+agentscope_module.message = message_module
+agentscope_module.model = model_module
+config_package.config = config_module
+sys.modules.setdefault("agentscope", agentscope_module)
+sys.modules["agentscope.message"] = message_module
+sys.modules["agentscope.model"] = model_module
+sys.modules["copaw.config"] = config_package
+sys.modules["copaw.config.config"] = config_module
+sys.modules["copaw.agents.utils"] = utils_module
+
+from copaw.agents.command_handler import CommandHandler
+
+
+class _FakeMemory:
+    """Minimal memory stub for command handler tests."""
+
+    def __init__(self) -> None:
+        self._summary = "previous summary"
+        self.clear_content = MagicMock()
+        self.update_compressed_summary = AsyncMock()
+
+    def get_compressed_summary(self) -> str:
+        """Return the current compressed summary."""
+        return self._summary
+
+
+class _FakeMemoryManager:
+    """Minimal memory manager stub for command handler tests."""
+
+    def __init__(self, compact_result: str) -> None:
+        self.agent_id = "agent-1"
+        self.compact_memory = AsyncMock(return_value=compact_result)
+        self.add_async_summary_task = MagicMock()
+
+
+def _build_message(text: str, role: str = "user") -> Msg:
+    """Create a simple message for tests."""
+    return Msg(
+        name=role,
+        role=role,
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_compact_includes_calculated_token_stats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compact responses should include message and token calculations."""
+    memory = _FakeMemory()
+    memory_manager = _FakeMemoryManager(compact_result="short summary")
+    handler = CommandHandler(
+        agent_name="Friday",
+        memory=memory,
+        memory_manager=memory_manager,
+        enable_memory_manager=True,
+    )
+    counter = MagicMock()
+    counter.count = AsyncMock(side_effect=[120, 30])
+    agent_config = SimpleNamespace(running=SimpleNamespace())
+
+    monkeypatch.setattr(
+        "copaw.agents.command_handler.load_agent_config",
+        lambda _agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        "copaw.agents.command_handler.get_copaw_token_counter",
+        lambda _config: counter,
+    )
+
+    result = await handler._process_compact(
+        messages=[_build_message("first"), _build_message("second", "assistant")],
+    )
+
+    text = result.get_text_content() or ""
+    assert "- Messages compacted: 2" in text
+    assert "- Original tokens: 120" in text
+    assert "- Compressed summary tokens: 30" in text
+    assert "- Tokens saved: 90" in text
+    memory.update_compressed_summary.assert_awaited_once_with("short summary")
+    memory.clear_content.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_process_compact_skips_stats_when_token_count_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compaction should still succeed when stat calculation fails."""
+    memory = _FakeMemory()
+    memory_manager = _FakeMemoryManager(compact_result="short summary")
+    handler = CommandHandler(
+        agent_name="Friday",
+        memory=memory,
+        memory_manager=memory_manager,
+        enable_memory_manager=True,
+    )
+    counter = MagicMock()
+    counter.count = AsyncMock(side_effect=RuntimeError("boom"))
+    agent_config = SimpleNamespace(running=SimpleNamespace())
+
+    monkeypatch.setattr(
+        "copaw.agents.command_handler.load_agent_config",
+        lambda _agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        "copaw.agents.command_handler.get_copaw_token_counter",
+        lambda _config: counter,
+    )
+
+    result = await handler._process_compact(messages=[_build_message("first")])
+
+    text = result.get_text_content() or ""
+    assert "- Messages compacted: 1" in text
+    assert "- Original tokens:" not in text
+    assert "- Compressed summary tokens:" not in text
+    assert "- Tokens saved:" not in text
+    assert "**Compressed Summary:**\nshort summary" in text


### PR DESCRIPTION
## Description
- calculate token counts for manual `/compact` responses
- show original tokens, compressed summary tokens, and saved tokens alongside compacted message count
- keep compaction fail-safe by omitting stats if token counting raises
- add unit coverage for both the happy path and stat-calculation failure path

**Related Issue:** Fixes #100

**Security Considerations:** No new auth, secrets, or external I/O paths.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist
- [ ] Pre-commit hooks pass (`pre-commit run --all-files` or CI)
- [ ] Tests pass locally (`pytest` or as relevant)
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing
- `PYTHONPATH=src:/tmp/copaw-pkg/local/lib/python3.10/dist-packages python3 -m pytest tests/unit/agents/test_command_handler.py`
- `PYTHONPATH=src:/tmp/copaw-pkg/local/lib/python3.10/dist-packages python3 -m black src/copaw/agents/command_handler.py tests/unit/agents/test_command_handler.py --target-version py310`
- attempted repo-wide `pytest`, `black . --check`, and `mypy .`; they currently fail due pre-existing missing optional dependencies, broad formatting drift, and existing type errors unrelated to this change

## Additional Notes
- `black . --check` currently reports 214 unrelated files that would be reformatted.
- `mypy .` currently reports 469 repo-wide errors, including missing optional dependencies and existing typing issues.
- repo-wide `pytest` currently fails during collection because the workspace lacks several optional runtime dependencies used by other modules/tests.
