### PR TITLE
fix(channels): Fix _in_progress lock leak in ChannelManager._consume_channel_loop

### DIFF
--- a/src/copaw/app/channels/manager.py
+++ b/src/copaw/app/channels/manager.py
@@ -344,10 +344,10 @@ class ChannelManager:
                     (channel_id, key),
                     asyncio.Lock(),
                 )
-                async with key_lock:
-                    self._in_progress.add((channel_id, key))
-                    batch = _drain_same_key(q, ch, key, payload)
                 try:
+                    async with key_lock:
+                        self._in_progress.add((channel_id, key))
+                        batch = _drain_same_key(q, ch, key, payload)
                     await _process_batch(ch, batch)
                 finally:
                     self._in_progress.discard((channel_id, key))


### PR DESCRIPTION
## Description

Fix a lock/state leak in ChannelManager._consume_channel_loop by wrapping both the key_lock section and _process_batch in a single try/finally so that _in_progress and _pending are always cleaned up even if _drain_same_key raises.

**Related Issue:** Fixes #901 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
