### PR TITLE
fix(console): prevent shell BASE_URL from overriding API base

### DIFF
--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -5,7 +5,8 @@ import path from "path";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   // Empty = same-origin; frontend and backend served together, no hardcoded host.
-  const apiBaseUrl = env.BASE_URL ?? "";
+  // Use a dedicated Vite-prefixed key so unrelated shell BASE_URL values don't leak into the build.
+  const apiBaseUrl = env.VITE_API_BASE_URL ?? "";
 
   return {
     define: {


### PR DESCRIPTION
Fixes #2171

`console/vite.config.ts` currently reads `env.BASE_URL` while loading all shell variables. If users export `BASE_URL` for unrelated tooling, the console build bakes that value into frontend API calls.

This switches the config to `VITE_API_BASE_URL`, so only an explicit frontend env key can override the default same-origin API behavior.

Greetings, saschabuehrle