### PR TITLE
Fix(core): Prevent Timestamp Injection in Prompts to Preserve LLM KV Cache

### DIFF
--- a/src/copaw/agents/tools/get_current_time.py
+++ b/src/copaw/agents/tools/get_current_time.py
@@ -14,8 +14,11 @@ logger = logging.getLogger(__name__)
 
 
 async def get_current_time() -> ToolResponse:
-    """Get the current time.
-    Only call this tool when the user explicitly asks for the time.
+    """Get the current time in format `%Y-%m-%d %H:%M:%S TZ (Day)`,
+    e.g. "2026-02-13 19:30:45 Asia/Shanghai (Friday)".
+
+    Call this tool when the user asks for the current time or when
+    the current time is needed for other operations.
 
     Returns:
         `ToolResponse`:

--- a/src/copaw/app/runner/utils.py
+++ b/src/copaw/app/runner/utils.py
@@ -70,7 +70,7 @@ def build_env_context(
     if working_dir is not None:
         parts.append(f"- Working directory: {working_dir}")
     parts.append(
-        f"- Current time: {now.strftime('%Y-%m-%d %H:%M:%S')} "
+        f"- Current date: {now.strftime('%Y-%m-%d')} "
         f"{user_tz} ({now.strftime('%A')})",
     )
 

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -257,7 +257,7 @@ class AgentsRunningConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     max_iters: int = Field(
-        default=50,
+        default=100,
         ge=1,
         description=(
             "Maximum number of reasoning-acting iterations for ReAct agent"


### PR DESCRIPTION
## Description

This PR fixes an issue where timestamps injected into prompts caused the LLM's KV cache to become invalid, resulting in increased first-token latency during multi-turn interactions.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
