### PR TITLE
fix(console): BASE_URL

### DIFF
--- a/console/src/api/config.ts
+++ b/console/src/api/config.ts
@@ -1,4 +1,4 @@
-declare const BASE_URL: string;
+declare const VITE_API_BASE_URL: string;
 declare const TOKEN: string;
 
 const AUTH_TOKEN_KEY = "copaw_auth_token";
@@ -9,7 +9,7 @@ const AUTH_TOKEN_KEY = "copaw_auth_token";
  * @returns Full API URL (e.g., "http://localhost:8088/api/models" or "/api/models")
  */
 export function getApiUrl(path: string): string {
-  const base = BASE_URL || "";
+  const base = VITE_API_BASE_URL || "";
   const apiPrefix = "/api";
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return `${base}${apiPrefix}${normalizedPath}`;

--- a/console/src/api/modules/skill.ts
+++ b/console/src/api/modules/skill.ts
@@ -3,12 +3,12 @@ import { getApiUrl } from "../config";
 import { buildAuthHeaders } from "../authHeaders";
 import type { HubSkillSpec, SkillSpec } from "../types";
 
-// Declare BASE_URL as global (injected by Vite)
-declare const BASE_URL: string;
+// Declare VITE_API_BASE_URL as global (injected by Vite)
+declare const VITE_API_BASE_URL: string;
 
 // Get the API base URL for streaming requests
 function getStreamApiUrl(): string {
-  const base = typeof BASE_URL === "string" ? BASE_URL : "";
+  const base = typeof VITE_API_BASE_URL === "string" ? VITE_API_BASE_URL : "";
   return `${base}/api`;
 }
 

--- a/console/src/pages/Settings/Models/useProviders.ts
+++ b/console/src/pages/Settings/Models/useProviders.ts
@@ -24,7 +24,7 @@ export function useProviders() {
       ]);
       if (!Array.isArray(provData)) {
         throw new Error(
-          "Unexpected API response. Is BASE_URL configured correctly?",
+          "Unexpected API response. Is VITE_API_BASE_URL configured correctly?",
         );
       }
       setProviders(provData);

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     define: {
-      BASE_URL: JSON.stringify(apiBaseUrl),
+      VITE_API_BASE_URL: JSON.stringify(apiBaseUrl),
       TOKEN: JSON.stringify(env.TOKEN || ""),
       MOBILE: false,
     },


### PR DESCRIPTION
✅ Prevents the BASE_URL environment variable in the shell from polluting the front-end build.

✅ Only explicitly setting VITE_API_BASE_URL will override the default same-origin API behavior.

✅ Retains import.meta.env.BASE_URL for static resource paths (this is a built-in Vite variable; use it correctly).

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
