### PR TITLE
fix: fallback to model-level connection check for minimax-cn

### DIFF
--- a/src/copaw/providers/anthropic_provider.py
+++ b/src/copaw/providers/anthropic_provider.py
@@ -65,6 +65,24 @@ class AnthropicProvider(Provider):
 
     async def check_connection(self, timeout: float = 5) -> tuple[bool, str]:
         """Check if Anthropic provider is reachable."""
+        if not self.support_connection_check:
+            probe_model = next(
+                (
+                    model.id
+                    for model in [*self.models, *self.extra_models]
+                    if getattr(model, "id", "")
+                ),
+                "",
+            )
+            if not probe_model:
+                return (
+                    False,
+                    "Connection check requires at least one configured model",
+                )
+            return await self.check_model_connection(
+                probe_model,
+                timeout=timeout,
+            )
         try:
             client = self._client(timeout=timeout)
             await client.models.list()

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -59,22 +59,28 @@ async def test_check_connection_api_error_returns_false(monkeypatch) -> None:
     assert msg == "Anthropic API error"
 
 
-async def test_check_connection_falls_back_to_model_ping_when_disabled() -> None:
-    provider = _make_provider()
-    provider.support_connection_check = False
-    provider.models = [ModelInfo(id="MiniMax-M2.5", name="MiniMax M2.5")]
-
+async def test_check_connection_falls_back_when_disabled() -> None:
     captured: dict[str, object] = {}
 
-    async def fake_check_model_connection(
-        model_id: str,
-        timeout: float = 5,
-    ) -> tuple[bool, str]:
-        captured["model_id"] = model_id
-        captured["timeout"] = timeout
-        return True, ""
+    class _FallbackProvider(AnthropicProvider):
+        async def check_model_connection(
+            self,
+            model_id: str,
+            timeout: float = 5,
+        ) -> tuple[bool, str]:
+            captured["model_id"] = model_id
+            captured["timeout"] = timeout
+            return True, ""
 
-    provider.check_model_connection = fake_check_model_connection
+    provider = _FallbackProvider(
+        id="anthropic",
+        name="Anthropic",
+        base_url="https://mock-anthropic.local",
+        api_key="ant-test",
+        chat_model="AnthropicChatModel",
+        support_connection_check=False,
+        models=[ModelInfo(id="MiniMax-M2.5", name="MiniMax M2.5")],
+    )
 
     ok, msg = await provider.check_connection(timeout=2.5)
 
@@ -121,7 +127,7 @@ async def test_list_model_normalizes_and_deduplicates(monkeypatch) -> None:
         "Claude Haiku",
         "claude-3-5-sonnet",
     ]
-    assert provider.models == []
+    assert not provider.models
 
 
 async def test_check_model_connection_success(monkeypatch) -> None:

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import copaw.providers.anthropic_provider as anthropic_provider_module
 from copaw.providers.anthropic_provider import AnthropicProvider
+from copaw.providers.provider import ModelInfo
 
 
 def _make_provider(is_custom: bool = False) -> AnthropicProvider:
@@ -56,6 +57,42 @@ async def test_check_connection_api_error_returns_false(monkeypatch) -> None:
 
     assert ok is False
     assert msg == "Anthropic API error"
+
+
+async def test_check_connection_falls_back_to_model_ping_when_disabled() -> None:
+    provider = _make_provider()
+    provider.support_connection_check = False
+    provider.models = [ModelInfo(id="MiniMax-M2.5", name="MiniMax M2.5")]
+
+    captured: dict[str, object] = {}
+
+    async def fake_check_model_connection(
+        model_id: str,
+        timeout: float = 5,
+    ) -> tuple[bool, str]:
+        captured["model_id"] = model_id
+        captured["timeout"] = timeout
+        return True, ""
+
+    provider.check_model_connection = fake_check_model_connection
+
+    ok, msg = await provider.check_connection(timeout=2.5)
+
+    assert ok is True
+    assert msg == ""
+    assert captured == {"model_id": "MiniMax-M2.5", "timeout": 2.5}
+
+
+async def test_check_connection_without_direct_support_needs_model() -> None:
+    provider = _make_provider()
+    provider.support_connection_check = False
+    provider.models = []
+    provider.extra_models = []
+
+    ok, msg = await provider.check_connection(timeout=2.5)
+
+    assert ok is False
+    assert msg == "Connection check requires at least one configured model"
 
 
 async def test_list_model_normalizes_and_deduplicates(monkeypatch) -> None:


### PR DESCRIPTION
## Description

This PR fixes connection testing for Anthropic-compatible providers that do not support provider-level health checks, specifically the built-in `MiniMax (China)` provider (`minimax-cn`) when used with MiniMax Token Plan API keys.

Previously, `AnthropicProvider.check_connection()` always attempted a provider-level `models.list()` request. In the MiniMax Token Plan case, this could fail even though actual model inference through the Anthropic-compatible messages endpoint worked correctly.

This change makes `AnthropicProvider.check_connection()` respect `support_connection_check=False` and fall back to a model-level connectivity check by calling `check_model_connection()` with the first configured model.

Closes #2195

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Component(s) Affected

- [x] Core
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts

## Checklist

- [x] Ran relevant tests for this change
- [x] Added or updated tests where applicable
- [ ] Updated documentation (not needed for this change)
- [x] Ran `pre-commit run --files src/copaw/providers/anthropic_provider.py tests/unit/providers/test_anthropic_provider.py`
- [ ] `pre-commit run --all-files` passes

Note: `pre-commit run --all-files` currently fails due to pre-existing repository-wide `mypy` issues unrelated to this PR, including errors in `src/copaw/cli/shutdown_cmd.py`.

## Root Cause

The built-in `MiniMax (China)` provider is already defined with `support_connection_check=False`, which indicates that provider-level connection checks are not supported.

However, `AnthropicProvider.check_connection()` still called `client.models.list()` unconditionally. For MiniMax Token Plan, this caused a false-negative connection failure even though the model could be used successfully through the Anthropic-compatible messages API.

## Fix

- Honor `support_connection_check=False` in `AnthropicProvider.check_connection()`
- Fallback to `check_model_connection()` using the first configured model
- Return a clear error if no model is configured

## Testing

### Manual verification

I reproduced the issue locally with the built-in `MiniMax (China)` provider and a MiniMax Token Plan API key.

Before this fix:
- the built-in `minimax-cn` provider failed connection validation

After this fix:
- the built-in `minimax-cn` provider worked correctly using model-level validation
- I was able to use the built-in provider without relying on a custom provider workaround

### Local Verification Evidence

`python -m pytest tests/unit/providers/test_anthropic_provider.py -q`
- Passed (`13 passed`)

`python -m pytest tests/unit/providers/test_provider_manager.py -q`
- Passed (`21 passed`)

`pre-commit run --files src/copaw/providers/anthropic_provider.py tests/unit/providers/test_anthropic_provider.py`
- Passed

`pre-commit run --all-files`
- Failed due to pre-existing repository-wide `mypy` issues unrelated to this PR
- Relevant errors were reported in `src/copaw/cli/shutdown_cmd.py`

### Additional verification

Added unit tests for:
- fallback to model-level connectivity check when provider-level checks are disabled
- expected error when no model is configured for fallback validation
