### PR TITLE
feat(agent): search and browser tools enabled for QA Agent preset

### DIFF
--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -777,7 +777,9 @@ def build_qa_agent_tools_config() -> ToolsConfig:
     """Tools preset for builtin ``default_qa_agent`` (first workspace init).
 
     Only these are enabled: execute_shell_command, read_file, edit_file,
-    write_file, view_image. All other built-ins are disabled.
+    write_file, grep_search, glob_search, browser_use, view_image.
+
+    All other built-ins are disabled.
     """
     allow = frozenset(
         {
@@ -785,6 +787,9 @@ def build_qa_agent_tools_config() -> ToolsConfig:
             "read_file",
             "write_file",
             "edit_file",
+            "grep_search",
+            "glob_search",
+            "browser_use",
             "view_image",
         },
     )


### PR DESCRIPTION
## Description

QA Agent need to search in files and use browser to get online document. Therefore,  "grep_search", "glob_search" and "browser_use" are added into tools preset of QA Agent.

## Feature

- Add  "grep_search", "glob_search" and "browser_use" into tools preset of QA Agent in config.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

After new initialization using ```copaw init```, "grep_search", "glob_search" and "browser_use" are enabled for QA Agent by default.

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
