### PR TITLE
feat(dingtalk): add card_auto_layout config for widescreen AI card

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -116,6 +116,7 @@ class DingTalkChannel(BaseChannel):
         deny_message: str = "",
         filter_thinking: bool = False,
         require_mention: bool = False,
+        card_auto_layout: bool = False,
     ):
         super().__init__(
             process,
@@ -137,6 +138,7 @@ class DingTalkChannel(BaseChannel):
         self.card_template_id = card_template_id or ""
         self.card_template_key = card_template_key or "content"
         self.robot_code = robot_code or self.client_id
+        self.card_auto_layout = card_auto_layout
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
         )
@@ -212,6 +214,8 @@ class DingTalkChannel(BaseChannel):
             allow_from=allow_from,
             deny_message=os.getenv("DINGTALK_DENY_MESSAGE", ""),
             require_mention=os.getenv("DINGTALK_REQUIRE_MENTION", "0") == "1",
+            card_auto_layout=os.getenv("DINGTALK_CARD_AUTO_LAYOUT", "0")
+            == "1",
         )
 
     @classmethod
@@ -248,6 +252,7 @@ class DingTalkChannel(BaseChannel):
             deny_message=config.deny_message or "",
             filter_thinking=filter_thinking,
             require_mention=config.require_mention,
+            card_auto_layout=getattr(config, "card_auto_layout", False),
         )
 
     # ---------------------------
@@ -1910,10 +1915,13 @@ class DingTalkChannel(BaseChannel):
             or ""
         )
         is_group = bool(meta.get("is_group"))
+        card_param_map: Dict[str, Any] = {self.card_template_key: ""}
+        if self.card_auto_layout:
+            card_param_map["config"] = json.dumps({"autoLayout": True})
         create_payload: Dict[str, Any] = {
             "cardTemplateId": self.card_template_id,
             "outTrackId": card_instance_id,
-            "cardData": {"cardParamMap": {self.card_template_key: ""}},
+            "cardData": {"cardParamMap": card_param_map},
             "callbackType": "STREAM",
             "imGroupOpenSpaceModel": {"supportForward": True},
             "imRobotOpenSpaceModel": {"supportForward": True},

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -65,6 +65,7 @@ class DingTalkConfig(BaseChannelConfig):
     card_template_key: str = "content"
     robot_code: str = ""
     media_dir: Optional[str] = None
+    card_auto_layout: bool = False
 
 
 class FeishuConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description
Support card autoLayout config for DingTalk AI Card                                                                    

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
  1. Add \`card_auto_layout: true\` to DingTalk channel config in \`agent.json\`
  2. Go to https://open-dev.dingtalk.com/fe/card to configure widescreen card following https://open.dingtalk.com/document/development/configure-widescreen-cards, and get the Card      
  Template ID
  3. Set DingTalk channel Message Type to \`card\` and input the Card Template ID

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

Closes https://github.com/agentscope-ai/CoPaw/issues/2187
