### PR TITLE
fix(cli): 修正本地回环地址的持久化处理

### DIFF
--- a/src/copaw/cli/app_cmd.py
+++ b/src/copaw/cli/app_cmd.py
@@ -61,7 +61,10 @@ def app_cmd(
 ) -> None:
     """Run CoPaw FastAPI app."""
     # Persist last used host/port for other terminals
-    write_last_api(host, port)
+    if host == "0.0.0.0":
+        write_last_api("127.0.0.1", port)
+    else:
+        write_last_api(host, port)
     os.environ[LOG_LEVEL_ENV] = log_level
 
     # Signal reload mode to browser_control.py for Windows


### PR DESCRIPTION
当 host 为 "0.0.0.0" 时，将其转换为 "127.0.0.1" 进行持久化存储，避免在其他终端使用时出现连接问题。

当前问题：在 Windows 等终端上使用 0.0.0.0 作为 host 启动服务并关闭后，配置文件中保存的是 0.0.0.0 。其他终端加载这个配置并尝试连接时，可能会因为 0.0.0.0 是监听所有接口而非本机回环地址而导致连接失败。

解决方案：将 0.0.0.0 转换为 127.0.0.1 进行持久化，确保其他终端能够正确连接到本地服务。

Related Issue: 暂无

Security Considerations: N/A

## Type of Change
- Bug fix
- New feature
- Breaking change
- Documentation
- Refactoring
## Component(s) Affected
- Core / Backend (app, agents, config, providers, utils, local_models)
- Console (frontend web UI)
- Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- Skills
- CLI
- Documentation (website)
- Tests
- CI/CD
- Scripts / Deploy
## Checklist
- I ran pre-commit run --all-files locally and it passes
- If pre-commit auto-fixed files, I committed those changes and reran checks
- I ran tests locally ( pytest or as relevant) and they pass
- Documentation updated (if needed)
- Ready for review
## Testing
在本地运行 copaw app 命令，测试修改是否生效：

1. 使用默认 host 启动服务后关闭，检查配置文件中的 host 是否为 127.0.0.1
2. 验证服务能够正常启动和连接
## Local Verification Evidence
```
# 修改仅涉及 CLI 模块，未触发新的测试用例
# 本地验证通过
```
## Additional Notes
无