### PR TITLE
fear(heartbeat): support cron expressions in heartbeat

### DIFF
--- a/src/copaw/app/crons/heartbeat.py
+++ b/src/copaw/app/crons/heartbeat.py
@@ -20,6 +20,7 @@ from ...config import (
     load_config,
 )
 from ...constant import HEARTBEAT_FILE, HEARTBEAT_TARGET_LAST
+from ..crons.models import _crontab_dow_to_name
 
 logger = logging.getLogger(__name__)
 
@@ -44,11 +45,13 @@ def is_cron_expression(every: str) -> bool:
 
 
 def parse_heartbeat_cron(every: str) -> tuple:
-    """Parse a 5-field cron string.
+    """Parse and normalize a 5-field cron string.
 
     Returns (minute, hour, day, month, dow).
     """
     parts = every.strip().split()
+    if len(parts) == 5:
+        parts[4] = _crontab_dow_to_name(parts[4])
     return tuple(parts)
 
 

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -289,7 +289,10 @@ class CronManager:
             timezone=spec.schedule.timezone,
         )
 
-    def _build_heartbeat_trigger(self, every: str):
+    def _build_heartbeat_trigger(
+        self,
+        every: str,
+    ) -> Union[CronTrigger, IntervalTrigger]:
         """Build a trigger from the heartbeat *every* value.
 
         Returns CronTrigger for cron expressions,


### PR DESCRIPTION
## Description

The heartbeat every field previously only accepted interval strings (e.g. 30m, 1h). Cron expressions like "0 6 * * *" were rejected as invalid and silently fell back to 30 minutes.

Fixes #2207

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
