### PR TITLE
fix(console): fix upload file type in console

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -423,12 +423,13 @@ export default function ChatPage() {
   );
 
   const handleFileUpload = useCallback(
-    async (
-      file: File,
-      onSuccess: (body: { url?: string; thumbUrl?: string }) => void,
-      onError?: (e: Error) => void,
-      onProgress?: (e: { percent?: number }) => void,
-    ) => {
+    async (options: {
+      file: File;
+      onSuccess: (body: { url?: string; thumbUrl?: string }) => void;
+      onError?: (e: Error) => void;
+      onProgress?: (e: { percent?: number }) => void;
+    }) => {
+      const { file, onSuccess, onError, onProgress } = options;
       try {
         // Warn when model has no multimodal support
         if (!multimodalCaps.supportsMultimodal) {
@@ -441,16 +442,15 @@ export default function ChatPage() {
           // Warn (not block) when only image is supported
           message.warning(t("chat.attachments.imageOnlyWarning"));
         }
-
         // Check file size limit (10MB)
         const isLt10M = file.size / 1024 / 1024 < 10;
+
         if (!isLt10M) {
           message.error(t("chat.attachments.fileSizeLimit"));
           onError?.(new Error("File size exceeds 10MB"));
           return;
         }
 
-        onProgress?.({ percent: 0 });
         const res = await chatApi.uploadFile(file);
         onProgress?.({ percent: 100 });
         onSuccess({ url: chatApi.fileUrl(res.url) });


### PR DESCRIPTION
修复文件上传问题
![11111](https://github.com/user-attachments/assets/f884530b-63df-4d1b-83ff-a4405599ac66)


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
