### PR TITLE
fix(telegram): prevent premature timeout

### DIFF
--- a/src/copaw/app/channels/telegram/channel.py
+++ b/src/copaw/app/channels/telegram/channel.py
@@ -352,6 +352,8 @@ class TelegramChannel(BaseChannel):
             return self._http_proxy
 
         builder = Application.builder().token(self._bot_token)
+        builder = builder.get_updates_read_timeout(20)
+        builder = builder.get_updates_connect_timeout(10)
         proxy = proxy_url()
         if proxy:
             builder = builder.proxy(proxy).get_updates_proxy(proxy)


### PR DESCRIPTION
## Description

It seems that the Telegram channel was missing timeout configuration — httpx `read_timeout` (5s default) < Telegram long-poll timeout (10s) caused `getUpdates` to timeout every 5s, triggering `anyio`'s cancel scope busy-loop and immediate retry.

**Related Issue:** Related to #2218 


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
