### PR TITLE
feat(memory): add pluggable memory manager with adbpg long-term memory

### DIFF
--- a/console/src/api/types/agent.ts
+++ b/console/src/api/types/agent.ts
@@ -64,6 +64,28 @@ export interface AutoTitleConfig {
   timeout_seconds: number;
 }
 
+export interface ADBPGMemoryConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  dbname: string;
+  llm_model: string;
+  llm_api_key: string;
+  llm_base_url: string;
+  embedding_model: string;
+  embedding_api_key: string;
+  embedding_base_url: string;
+  embedding_dims: number;
+  api_mode: string;
+  rest_api_key: string;
+  rest_base_url: string;
+  memory_isolation: boolean;
+  search_timeout: number;
+  pool_minconn: number;
+  pool_maxconn: number;
+}
+
 export interface AgentsRunningConfig {
   max_iters: number;
   auto_continue_on_text_only: boolean;
@@ -82,6 +104,7 @@ export interface AgentsRunningConfig {
   context_manager_backend: string;
   light_context_config: LightContextConfig;
   memory_manager_backend: string;
+  adbpg_memory_config?: ADBPGMemoryConfig | null;
   reme_light_memory_config: ReMeLightMemoryConfig;
   approval_level?: string;
   auto_title_config: AutoTitleConfig;

--- a/console/src/constants/backendMappings.ts
+++ b/console/src/constants/backendMappings.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import { LightContextCard } from "../pages/Agent/Config/components/LightContextCard";
 import { ReMeLightMemoryCard } from "../pages/Agent/Config/components/ReMeLightMemoryCard";
+import { ADBPGConfigCard } from "../pages/Agent/Config/components/ADBPGConfigCard";
 
 interface BackendMapping<T> {
   configField: string;
@@ -30,6 +31,12 @@ export const MEMORY_MANAGER_BACKEND_MAPPINGS: Record<
     component: ReMeLightMemoryCard,
     label: "remelight",
     tabKey: "remeLightMemory",
+  },
+  adbpg: {
+    configField: "adbpg_memory_config",
+    component: ADBPGConfigCard,
+    label: "adbpg",
+    tabKey: "adbpgMemory",
   },
 };
 

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1296,7 +1296,7 @@
     "llmAcquireTimeoutGtPauseJitter": "Slot acquire timeout must be greater than rate limit pause + jitter",
     "contextManagementTitle": "Context Management",
     "memoryManagerBackend": "Memory Manager Backend",
-    "memoryManagerBackendTooltip": "Backend for the memory manager. Currently only remelight is supported.",
+    "memoryManagerBackendTooltip": "Backend for the memory manager. Choose remelight (local files) or adbpg (cloud database).",
     "memoryManagerBackendRestartWarning": "Switching the memory manager backend does not support hot reload. Save and restart QwenPaw for changes to take effect.",
     "maxIters": "Max Iterations",
     "maxItersTooltip": "Maximum number of reasoning-acting iterations for ReAct agent",
@@ -1479,7 +1479,28 @@
     "recursiveFileWatcherTooltip": "Watch the memory directory recursively. Enable to include files in subdirectories like memory/subdirectory/* in vector search indexing.",
     "contextManagerBackend": "Context Manager Backend",
     "contextManagerBackendTooltip": "Backend type for the context manager. Currently only Light is supported.",
-    "backendRestartWarning": "Switching backends does not support hot reload. Save and restart QwenPaw for changes to take effect."
+    "backendRestartWarning": "Switching backends does not support hot reload. Save and restart QwenPaw for changes to take effect.",
+    "adbpgMemoryTitle": "ADBPG Long-term Memory",
+    "adbpgConfig": {
+      "title": "ADBPG Memory Configuration",
+      "apiMode": "API Mode",
+      "host": "Host",
+      "port": "Port",
+      "user": "Username",
+      "password": "Password",
+      "dbname": "Database",
+      "llmModel": "LLM Model",
+      "llmApiKey": "LLM API Key",
+      "llmBaseUrl": "LLM Base URL",
+      "embeddingModel": "Embedding Model",
+      "embeddingApiKey": "Embedding API Key",
+      "embeddingBaseUrl": "Embedding Base URL",
+      "embeddingDims": "Embedding Dimensions",
+      "restBaseUrl": "REST Base URL",
+      "restApiKey": "REST API Key",
+      "memoryIsolation": "Memory Isolation (per-agent)",
+      "searchTimeout": "Search Timeout"
+    }
   },
   "tools": {
     "title": "Built-in Tools",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1089,7 +1089,7 @@
     "llmAcquireTimeoutGtPauseJitter": "スロット取得タイムアウトはレート制限一時停止とジッターの合計より大きい必要があります",
     "contextManagementTitle": "コンテキスト管理",
     "memoryManagerBackend": "メモリマネージャーバックエンド",
-    "memoryManagerBackendTooltip": "メモリマネージャーのバックエンドタイプ。現在は remelight のみサポートされています。",
+    "memoryManagerBackendTooltip": "メモリマネージャーのバックエンドタイプ。remelight（ローカルファイル）または adbpg（クラウドデータベース）から選択できます。",
     "memoryManagerBackendRestartWarning": "メモリマネージャーバックエンドの切り替えはホットリロードに対応していません。変更を反映するには保存後に QwenPaw を再起動してください。",
     "maxIters": "最大反復回数",
     "maxItersTooltip": "ReActエージェントの推論・行動サイクルの最大反復回数",
@@ -1255,7 +1255,28 @@
       "offDesc": "すべてのツール承認を無効化、すべてのツールが自動実行"
     },
     "saveLevelSuccess": "ツール実行セキュリティレベルを保存しました",
-    "saveLevelFailed": "ツール実行セキュリティレベルの保存に失敗しました"
+    "saveLevelFailed": "ツール実行セキュリティレベルの保存に失敗しました",
+    "adbpgMemoryTitle": "ADBPG Long-term Memory",
+    "adbpgConfig": {
+      "title": "ADBPG Memory Configuration",
+      "apiMode": "API Mode",
+      "host": "Host",
+      "port": "Port",
+      "user": "Username",
+      "password": "Password",
+      "dbname": "Database",
+      "llmModel": "LLM Model",
+      "llmApiKey": "LLM API Key",
+      "llmBaseUrl": "LLM Base URL",
+      "embeddingModel": "Embedding Model",
+      "embeddingApiKey": "Embedding API Key",
+      "embeddingBaseUrl": "Embedding Base URL",
+      "embeddingDims": "Embedding Dimensions",
+      "restBaseUrl": "REST Base URL",
+      "restApiKey": "REST API Key",
+      "memoryIsolation": "Memory Isolation (per-agent)",
+      "searchTimeout": "Search Timeout"
+    }
   },
   "tools": {
     "title": "ビルトインツール",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1290,7 +1290,7 @@
     "llmAcquireTimeoutGtPauseJitter": "Slot acquire timeout must be greater than rate limit pause + jitter",
     "contextManagementTitle": "Context Management",
     "memoryManagerBackend": "Memory Manager Backend",
-    "memoryManagerBackendTooltip": "Backend for the memory manager. Currently only remelight is supported.",
+    "memoryManagerBackendTooltip": "Backend para o gerenciador de memória. Escolha remelight (arquivos locais) ou adbpg (banco de dados na nuvem).",
     "memoryManagerBackendRestartWarning": "Switching the memory manager backend does not support hot reload. Save and restart QwenPaw for changes to take effect.",
     "maxIters": "Max Iterations",
     "maxItersTooltip": "Maximum number of reasoning-acting iterations for ReAct agent",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1104,7 +1104,7 @@
     "llmAcquireTimeoutGtPauseJitter": "Таймаут получения слота должен быть больше суммы паузы и джиттера",
     "contextManagementTitle": "Управление контекстом",
     "memoryManagerBackend": "Бэкенд менеджера памяти",
-    "memoryManagerBackendTooltip": "Тип бэкенда менеджера памяти. В настоящее время поддерживается только remelight.",
+    "memoryManagerBackendTooltip": "Тип бэкенда менеджера памяти. Выберите remelight (локальные файлы) или adbpg (облачная база данных).",
     "memoryManagerBackendRestartWarning": "Смена бэкенда менеджера памяти не поддерживает горячую перезагрузку. Сохраните и перезапустите QwenPaw для применения изменений.",
     "maxIters": "Макс. итераций",
     "maxItersTooltip": "Максимальное число итераций рассуждение-действие для агента ReAct",
@@ -1270,7 +1270,28 @@
       "offDesc": "Отключить все одобрения инструментов, все инструменты выполняются автоматически"
     },
     "saveLevelSuccess": "Уровень безопасности выполнения инструментов сохранён",
-    "saveLevelFailed": "Не удалось сохранить уровень безопасности выполнения инструментов"
+    "saveLevelFailed": "Не удалось сохранить уровень безопасности выполнения инструментов",
+    "adbpgMemoryTitle": "ADBPG Long-term Memory",
+    "adbpgConfig": {
+      "title": "ADBPG Memory Configuration",
+      "apiMode": "API Mode",
+      "host": "Host",
+      "port": "Port",
+      "user": "Username",
+      "password": "Password",
+      "dbname": "Database",
+      "llmModel": "LLM Model",
+      "llmApiKey": "LLM API Key",
+      "llmBaseUrl": "LLM Base URL",
+      "embeddingModel": "Embedding Model",
+      "embeddingApiKey": "Embedding API Key",
+      "embeddingBaseUrl": "Embedding Base URL",
+      "embeddingDims": "Embedding Dimensions",
+      "restBaseUrl": "REST Base URL",
+      "restApiKey": "REST API Key",
+      "memoryIsolation": "Memory Isolation (per-agent)",
+      "searchTimeout": "Search Timeout"
+    }
   },
   "tools": {
     "title": "Встроенные инструменты",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1159,7 +1159,7 @@
     "llmAcquireTimeoutGtPauseJitter": "槽位获取超时必须大于限流暂停时长与抖动范围之和",
     "contextManagementTitle": "上下文管理",
     "memoryManagerBackend": "记忆管理后端",
-    "memoryManagerBackendTooltip": "记忆管理器的后端类型，目前仅支持 remelight",
+    "memoryManagerBackendTooltip": "记忆管理器的后端类型，可选 remelight（本地文件）或 adbpg（云端数据库）",
     "memoryManagerBackendRestartWarning": "切换记忆管理后端不支持热更新，保存后需要重启 QwenPaw 才能生效",
     "maxIters": "最大迭代次数",
     "maxItersTooltip": "ReAct 智能体的最大推理-行动迭代次数",
@@ -1342,7 +1342,28 @@
     "recursiveFileWatcherTooltip": "是否递归监听记忆目录。开启后将包含 memory/subdirectory/* 等子目录中的文件到向量搜索索引。",
     "contextManagerBackend": "上下文管理后端",
     "contextManagerBackendTooltip": "上下文管理器的后端类型，目前仅支持 Light",
-    "backendRestartWarning": "切换后端不支持热更新，保存后需要重启 QwenPaw 才能生效"
+    "backendRestartWarning": "切换后端不支持热更新，保存后需要重启 QwenPaw 才能生效",
+    "adbpgMemoryTitle": "ADBPG 长期记忆",
+    "adbpgConfig": {
+      "title": "ADBPG 记忆配置",
+      "apiMode": "API 模式",
+      "host": "主机地址",
+      "port": "端口",
+      "user": "用户名",
+      "password": "密码",
+      "dbname": "数据库名",
+      "llmModel": "LLM 模型",
+      "llmApiKey": "LLM API Key",
+      "llmBaseUrl": "LLM Base URL",
+      "embeddingModel": "Embedding 模型",
+      "embeddingApiKey": "Embedding API Key",
+      "embeddingBaseUrl": "Embedding Base URL",
+      "embeddingDims": "Embedding 维度",
+      "restBaseUrl": "REST Base URL",
+      "restApiKey": "REST API Key",
+      "memoryIsolation": "记忆隔离（按 Agent）",
+      "searchTimeout": "搜索超时"
+    }
   },
   "tools": {
     "title": "内置工具",

--- a/console/src/pages/Agent/Config/components/ADBPGConfigCard.tsx
+++ b/console/src/pages/Agent/Config/components/ADBPGConfigCard.tsx
@@ -1,0 +1,151 @@
+import {
+  Card,
+  Form,
+  Select,
+  Input,
+  InputNumber,
+  Switch,
+} from "@agentscope-ai/design";
+import { useTranslation } from "react-i18next";
+
+export function ADBPGConfigCard() {
+  const { t } = useTranslation();
+
+  const apiMode = Form.useWatch(["adbpg_memory_config", "api_mode"]) ?? "rest";
+
+  return (
+    <Card title={t("agentConfig.adbpgConfig.title")}>
+      {/* API Mode */}
+      <Form.Item
+        name={["adbpg_memory_config", "api_mode"]}
+        label={t("agentConfig.adbpgConfig.apiMode")}
+        initialValue="rest"
+      >
+        <Select>
+          <Select.Option value="sql">SQL (Direct)</Select.Option>
+          <Select.Option value="rest">REST API</Select.Option>
+        </Select>
+      </Form.Item>
+
+      {apiMode === "sql" ? (
+        <>
+          {/* Database Connection */}
+          <Form.Item
+            name={["adbpg_memory_config", "host"]}
+            label={t("agentConfig.adbpgConfig.host")}
+          >
+            <Input placeholder="gp-xxx.gpdb.rds.aliyuncs.com" />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "port"]}
+            label={t("agentConfig.adbpgConfig.port")}
+          >
+            <InputNumber min={1} max={65535} style={{ width: "100%" }} />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "user"]}
+            label={t("agentConfig.adbpgConfig.user")}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "password"]}
+            label={t("agentConfig.adbpgConfig.password")}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "dbname"]}
+            label={t("agentConfig.adbpgConfig.dbname")}
+          >
+            <Input />
+          </Form.Item>
+
+          {/* LLM Config */}
+          <Form.Item
+            name={["adbpg_memory_config", "llm_model"]}
+            label={t("agentConfig.adbpgConfig.llmModel")}
+          >
+            <Input placeholder="qwen-plus" />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "llm_api_key"]}
+            label={t("agentConfig.adbpgConfig.llmApiKey")}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "llm_base_url"]}
+            label={t("agentConfig.adbpgConfig.llmBaseUrl")}
+          >
+            <Input placeholder="https://dashscope.aliyuncs.com/compatible-mode/v1" />
+          </Form.Item>
+
+          {/* Embedding Config */}
+          <Form.Item
+            name={["adbpg_memory_config", "embedding_model"]}
+            label={t("agentConfig.adbpgConfig.embeddingModel")}
+          >
+            <Input placeholder="text-embedding-v3" />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "embedding_api_key"]}
+            label={t("agentConfig.adbpgConfig.embeddingApiKey")}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "embedding_base_url"]}
+            label={t("agentConfig.adbpgConfig.embeddingBaseUrl")}
+          >
+            <Input placeholder="https://dashscope.aliyuncs.com/compatible-mode/v1" />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "embedding_dims"]}
+            label={t("agentConfig.adbpgConfig.embeddingDims")}
+          >
+            <InputNumber min={1} max={4096} style={{ width: "100%" }} />
+          </Form.Item>
+        </>
+      ) : (
+        <>
+          {/* REST Mode */}
+          <Form.Item
+            name={["adbpg_memory_config", "rest_base_url"]}
+            label={t("agentConfig.adbpgConfig.restBaseUrl")}
+          >
+            <Input placeholder="https://your-adbpg-api.example.com" />
+          </Form.Item>
+          <Form.Item
+            name={["adbpg_memory_config", "rest_api_key"]}
+            label={t("agentConfig.adbpgConfig.restApiKey")}
+          >
+            <Input.Password />
+          </Form.Item>
+        </>
+      )}
+
+      {/* Behavior */}
+      <Form.Item
+        name={["adbpg_memory_config", "memory_isolation"]}
+        label={t("agentConfig.adbpgConfig.memoryIsolation")}
+        valuePropName="checked"
+        initialValue={true}
+      >
+        <Switch />
+      </Form.Item>
+      <Form.Item
+        name={["adbpg_memory_config", "search_timeout"]}
+        label={t("agentConfig.adbpgConfig.searchTimeout")}
+        initialValue={10}
+      >
+        <InputNumber
+          min={1}
+          max={60}
+          addonAfter="s"
+          style={{ width: "100%" }}
+        />
+      </Form.Item>
+    </Card>
+  );
+}

--- a/console/src/pages/Agent/Config/components/index.ts
+++ b/console/src/pages/Agent/Config/components/index.ts
@@ -5,3 +5,4 @@ export { LlmRateLimiterCard } from "./LlmRateLimiterCard";
 export { LightContextCard } from "./LightContextCard";
 export { ReMeLightMemoryCard } from "./ReMeLightMemoryCard";
 export { ToolExecutionLevelCard } from "./ToolExecutionLevelCard";
+export { ADBPGConfigCard } from "./ADBPGConfigCard";

--- a/console/src/pages/Agent/Config/useAgentConfig.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.tsx
@@ -67,6 +67,7 @@ export function useAgentConfig() {
         light_context_config: config.light_context_config,
         memory_manager_backend: memoryBackend,
         reme_light_memory_config: config.reme_light_memory_config,
+        adbpg_memory_config: config.adbpg_memory_config,
         auto_title_config: config.auto_title_config ?? {
           enabled: true,
           timeout_seconds: 30.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ dev = [
 local = [
     "huggingface_hub>=0.20.0",
 ]
+adbpg = [
+    "psycopg2-binary==2.9.10",
+]
 whisper = [
     "openai-whisper>=20231117",
 ]

--- a/src/qwenpaw/agents/memory/__init__.py
+++ b/src/qwenpaw/agents/memory/__init__.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING
 from .agent_md_manager import AgentMdManager
 from .base_memory_manager import BaseMemoryManager
 from .reme_light_memory_manager import ReMeLightMemoryManager
+from .adbpg_memory_manager import (
+    ADBPGMemoryManager,
+)  # registers "adbpg" backend
 
 # Proactive symbols are lazily re-exported via __getattr__ at runtime to
 # avoid circular imports (proactive -> react_agent -> agents.memory loop).
@@ -28,6 +31,7 @@ __all__ = [
     "AgentMdManager",
     "BaseMemoryManager",
     "ReMeLightMemoryManager",
+    "ADBPGMemoryManager",
     # proactive symbols resolved lazily at runtime via __getattr__
     "ProactiveConfig",
     "ProactiveTask",

--- a/src/qwenpaw/agents/memory/adbpg_client.py
+++ b/src/qwenpaw/agents/memory/adbpg_client.py
@@ -1,0 +1,751 @@
+# -*- coding: utf-8 -*-
+"""ADBPG Memory Client for QwenPaw agents.
+
+Provides configuration and database client for ADBPG
+(AnalyticDB for PostgreSQL) memory storage, including
+LLM and Embedding configuration.
+
+Uses a process-global ``ThreadedConnectionPool`` shared across all
+agents so that the total number of database connections stays bounded
+regardless of how many agents are running.
+"""
+import ast
+import json
+import logging
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+try:
+    import psycopg2
+    import psycopg2.pool
+except ImportError:
+    psycopg2 = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigurationError(Exception):
+    """Raised when required configuration is missing or invalid."""
+
+
+@dataclass
+class ADBPGConfig:
+    """ADBPG connection and LLM/Embedding configuration."""
+
+    # Database connection
+    host: str
+    port: int
+    user: str
+    password: str
+    dbname: str
+    # LLM configuration
+    llm_model: str
+    llm_api_key: str
+    llm_base_url: str
+    # Embedding configuration
+    embedding_model: str
+    embedding_api_key: str
+    embedding_base_url: str
+    embedding_dims: int
+    # Optional configuration
+    search_timeout: float = 10.0
+    # Connection pool tuning
+    pool_minconn: int = 2
+    pool_maxconn: int = 10
+    # Tool result compaction
+    tool_compact_mode: str = "summarize"
+    tool_compact_max_len: int = 500
+    # Memory isolation
+    memory_isolation: bool = False
+    user_isolation: bool = False
+    user_isolation_id: str = ""
+    run_isolation: bool = False
+    # Custom fact extraction prompt (SQL mode only)
+    custom_fact_extraction_prompt: str = ""
+    # REST API mode (alternative to SQL)
+    api_mode: str = "sql"
+    rest_api_key: str = ""
+    rest_base_url: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Process-global shared connection pool
+# ---------------------------------------------------------------------------
+# A single ``ThreadedConnectionPool`` is shared across all
+# ``ADBPGMemoryClient`` instances in the process.  This keeps the
+# total number of database connections bounded regardless of how many
+# agents are running concurrently.
+_global_pool: "psycopg2.pool.ThreadedConnectionPool | None" = None
+_global_pool_lock = threading.Lock()
+# Track which connections have been session-configured (by ``id(conn)``)
+# so that ``adbpg_llm_memory.config()`` is called at most once per
+# physical connection.
+_configured_conns: set[int] = set()
+_configured_conns_lock = threading.Lock()
+
+
+def _get_shared_pool(
+    conn_params: dict,
+    minconn: int = 2,
+    maxconn: int = 10,
+) -> "psycopg2.pool.ThreadedConnectionPool":
+    """Return (or create) the process-global ``ThreadedConnectionPool``.
+
+    Thread-safe: uses a lock so that concurrent ``start()`` calls from
+    multiple agents don't race.
+
+    Args:
+        conn_params: psycopg2 connection keyword arguments.
+        minconn: Minimum connections kept open in the pool.
+        maxconn: Maximum connections the pool will create.
+
+    Returns:
+        The shared ``ThreadedConnectionPool`` instance.
+    """
+    global _global_pool  # noqa: PLW0603
+    if _global_pool is not None and not _global_pool.closed:
+        return _global_pool
+    with _global_pool_lock:
+        # Double-check after acquiring lock
+        if _global_pool is not None and not _global_pool.closed:
+            return _global_pool
+        _global_pool = psycopg2.pool.ThreadedConnectionPool(
+            minconn=minconn,
+            maxconn=maxconn,
+            **conn_params,
+        )
+        logger.info(
+            "Created shared ADBPG ThreadedConnectionPool (min=%d, max=%d).",
+            minconn,
+            maxconn,
+        )
+        return _global_pool
+
+
+def close_shared_pool() -> None:
+    """Close the process-global connection pool.
+
+    Safe to call even if the pool was never created.
+    """
+    global _global_pool  # noqa: PLW0603
+    with _global_pool_lock:
+        if _global_pool is not None and not _global_pool.closed:
+            _global_pool.closeall()
+            logger.info("Shared ADBPG connection pool closed.")
+        _global_pool = None
+    with _configured_conns_lock:
+        _configured_conns.clear()
+
+
+def reset_configured_connections() -> None:
+    """Clear the configured-connections cache.
+
+    Forces all pooled connections to re-run
+    ``adbpg_llm_memory.config()`` on their next use.  Call this
+    after a configuration change (e.g. hot-reload) so that updated
+    settings like ``custom_fact_extraction_prompt`` take effect
+    without restarting the process.
+    """
+    with _configured_conns_lock:
+        _configured_conns.clear()
+    logger.debug("Cleared configured-connections cache.")
+
+
+class ADBPGMemoryClient:
+    """Thread-safe ADBPG database client using a shared connection pool.
+
+    All ``ADBPGMemoryClient`` instances within the same process share a
+    single ``ThreadedConnectionPool``.  Connections are borrowed from
+    the pool for each operation and returned immediately afterwards
+    ("borrow-use-return" pattern), which keeps the pool effective and
+    avoids connection leaks.
+
+    Each borrowed connection is session-configured (via
+    ``adbpg_llm_memory.config()``) at most once; the configured state
+    is tracked by connection ``id()`` so that reconnected / new
+    connections are automatically re-configured.
+    """
+
+    def __init__(self, config: ADBPGConfig):
+        """Initialize the client.
+
+        The underlying connection pool is created lazily on first use
+        and shared across all client instances.
+
+        When ``config.api_mode`` is ``"rest"``, no database connection
+        is needed — all operations go through the ADBPG memory REST API.
+
+        Args:
+            config: ADBPG configuration object.
+
+        Raises:
+            ImportError: If psycopg2 is not installed (SQL mode only).
+        """
+        self._config = config
+        self._is_rest = config.api_mode == "rest"
+
+        if self._is_rest:
+            import httpx  # noqa: F401  # pylint: disable=unused-import
+
+            self._rest_headers = {
+                "Authorization": f"Token {config.rest_api_key}",
+                "Content-Type": "application/json",
+            }
+            self._rest_timeout = config.search_timeout
+            self._conn_params = {}
+            self._pool_minconn = 0
+            self._pool_maxconn = 0
+        else:
+            if psycopg2 is None:
+                raise ImportError(
+                    "psycopg2 is required for ADBPGMemoryClient. "
+                    "Install it with: pip install psycopg2-binary",
+                )
+            self._conn_params = {
+                "host": config.host,
+                "port": config.port,
+                "user": config.user,
+                "password": config.password,
+                "dbname": config.dbname,
+            }
+            self._pool_minconn = config.pool_minconn
+            self._pool_maxconn = config.pool_maxconn
+
+    # -- Logging helpers (unchanged) --
+
+    def _log_sql(self, sql: str, params: tuple) -> None:
+        """Log SQL statement with masked sensitive values."""
+
+        def _mask_param(p):
+            if not isinstance(p, str):
+                return p
+            try:
+                obj = json.loads(p)
+                return json.dumps(
+                    _mask_dict(obj),
+                    ensure_ascii=False,
+                )
+            except (json.JSONDecodeError, TypeError):
+                pass
+            return p
+
+        def _mask_dict(d):
+            if isinstance(d, dict):
+                return {
+                    k: (
+                        _mask_val(v)
+                        if k in ("api_key", "password")
+                        else _mask_dict(v)
+                    )
+                    for k, v in d.items()
+                }
+            if isinstance(d, list):
+                return [_mask_dict(i) for i in d]
+            return d
+
+        def _mask_val(v):
+            s = str(v)
+            return s[:4] + "***" if len(s) > 4 else "***"
+
+        masked = tuple(_mask_param(p) for p in params)
+        logger.debug(f"ADBPG SQL: {sql} | params: {masked}")
+
+    def _log_result(self, label: str, result) -> None:
+        """Log SQL result, truncating if too long."""
+        text = str(result)
+        if len(text) > 1000:
+            text = text[:1000] + "...(truncated)"
+        logger.debug(f"ADBPG {label} result: {text}")
+
+    # -- Pool / connection management --
+
+    def _get_pool(self) -> "psycopg2.pool.ThreadedConnectionPool":
+        """Return the shared connection pool, creating it if needed."""
+        return _get_shared_pool(
+            self._conn_params,
+            minconn=self._pool_minconn,
+            maxconn=self._pool_maxconn,
+        )
+
+    @contextmanager
+    def _borrow_connection(self):
+        """Context manager: borrow a connection, yield it, then return it.
+
+        On success the connection is committed and returned to the pool.
+        On error the connection is rolled back and returned to the pool.
+        If the connection is broken (closed), it is discarded via
+        ``putconn(conn, close=True)`` so the pool can replace it.
+        """
+        pool = self._get_pool()
+        conn = pool.getconn()
+        # Server closed the connection; discard and get a fresh one.
+        if conn.closed:
+            pool.putconn(conn, close=True)
+            with _configured_conns_lock:
+                _configured_conns.discard(id(conn))
+            conn = pool.getconn()
+        try:
+            # Ensure session-level config on this connection
+            self._ensure_configured(conn)
+            yield conn
+            conn.commit()
+        except Exception:
+            try:
+                if conn and not conn.closed:
+                    conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            try:
+                if conn.closed:
+                    pool.putconn(conn, close=True)
+                    with _configured_conns_lock:
+                        _configured_conns.discard(id(conn))
+                else:
+                    pool.putconn(conn)
+            except Exception:
+                pass
+
+    def _ensure_configured(self, conn) -> None:
+        """Run session-level ``adbpg_llm_memory.config()`` if needed."""
+        conn_id = id(conn)
+        with _configured_conns_lock:
+            if conn_id in _configured_conns:
+                return
+
+        self._configure_connection(conn)
+
+        with _configured_conns_lock:
+            _configured_conns.add(conn_id)
+
+    def _query_internal_port(
+        self,
+        conn,
+        *,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> int:
+        """Query the master internal port from gp_segment_configuration.
+
+        Retries up to *max_retries* times on failure.  If all attempts
+        fail, raises ``ConfigurationError`` so the caller can disable
+        long-term memory gracefully.
+        """
+        last_err: Exception | None = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT port FROM gp_segment_configuration "
+                        "WHERE content = -1 AND role = 'p'",
+                    )
+                    row = cur.fetchone()
+                    if row and row[0]:
+                        port = int(row[0])
+                        logger.debug(
+                            "Auto-detected ADBPG internal port: %d",
+                            port,
+                        )
+                        return port
+                raise ConfigurationError(
+                    "gp_segment_configuration returned no master port row.",
+                )
+            except Exception as e:
+                last_err = e
+                logger.warning(
+                    "Failed to query internal port (attempt %d/%d): %s",
+                    attempt,
+                    max_retries,
+                    e,
+                )
+                # No point retrying on a closed connection
+                if conn.closed:
+                    break
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                if attempt < max_retries:
+                    time.sleep(retry_delay)
+
+        raise ConfigurationError(
+            f"Unable to detect ADBPG internal port after "
+            f"{max_retries} attempts: {last_err}",
+        )
+
+    def _configure_connection(self, conn) -> None:
+        """Execute ``adbpg_llm_memory.config()`` on *conn*.
+
+        The ``vector_store`` port is auto-detected by querying
+        ``gp_segment_configuration`` for the master internal port.
+        """
+        vector_port = self._query_internal_port(conn)
+
+        config_json = {
+            "llm": {
+                "provider": "qwen",
+                "config": {
+                    "model": self._config.llm_model,
+                    "qwen_base_url": self._config.llm_base_url,
+                    "api_key": self._config.llm_api_key,
+                },
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": self._config.embedding_model,
+                    "api_key": self._config.embedding_api_key,
+                    "embedding_dims": str(self._config.embedding_dims),
+                    "openai_base_url": self._config.embedding_base_url,
+                },
+            },
+            "vector_store": {
+                "provider": "adbpg",
+                "config": {
+                    "user": self._config.user,
+                    "dbname": self._config.dbname,
+                    "password": self._config.password,
+                    "port": str(vector_port),
+                    "embedding_model_dims": str(self._config.embedding_dims),
+                },
+            },
+        }
+        if self._config.custom_fact_extraction_prompt:
+            config_json[
+                "custom_fact_extraction_prompt"
+            ] = self._config.custom_fact_extraction_prompt
+
+        sql = "SELECT adbpg_llm_memory.config(%s::json)"
+        params = (json.dumps(config_json),)
+        self._log_sql(sql, params)
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+            self._log_result("config", row)
+        conn.commit()
+        logger.debug("ADBPG session configured on connection.")
+
+    # -- Public convenience method (kept for backward compat) --
+
+    def configure(self) -> None:
+        """Eagerly configure one connection (validates connectivity).
+
+        In REST mode this is a no-op — the remote ADBPG memory service
+        is assumed to be configured externally.
+
+        In SQL mode, borrows a connection from the pool and runs
+        ``adbpg_llm_memory.config()`` (auto-configured on first use).
+        """
+        if self._is_rest:
+            logger.debug(
+                "REST mode: skipping configure (handled externally).",
+            )
+            return
+        with self._borrow_connection():
+            pass  # _ensure_configured runs inside the context manager
+
+    # -- Core operations --
+
+    def add_memory(
+        self,
+        messages: list[dict],
+        user_id: str = "",
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> None:
+        """Store memories (synchronous, thread-safe).
+
+        Dispatches to REST or SQL based on ``api_mode``.
+        """
+        if self._is_rest:
+            self._rest_add_memory(
+                messages,
+                user_id,
+                run_id,
+                agent_id,
+                metadata,
+            )
+            return
+        try:
+            with self._borrow_connection() as conn:
+                sql = (
+                    "SELECT adbpg_llm_memory.add("
+                    "%s::json, %s, %s, %s, %s, %s, %s"
+                    ")"
+                )
+                params = (
+                    json.dumps(messages),
+                    user_id or None,
+                    run_id,
+                    agent_id,
+                    json.dumps(metadata) if metadata else None,
+                    None,
+                    None,
+                )
+                self._log_sql(sql, params)
+                with conn.cursor() as cur:
+                    cur.execute(sql, params)
+                    row = cur.fetchone()
+                    self._log_result("add", row)
+                logger.debug("Memory added to ADBPG successfully.")
+        except Exception as e:
+            logger.error(f"Failed to add memory to ADBPG: {e}")
+
+    def search_memory(  # pylint: disable=too-many-return-statements
+        self,
+        query: str,
+        user_id: str = "",
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        limit: int = 5,
+        timeout: float | None = None,
+    ) -> list[dict]:
+        """Search memories (synchronous, thread-safe).
+
+        Dispatches to REST or SQL based on ``api_mode``.
+        """
+        if self._is_rest:
+            return self._rest_search_memory(
+                query,
+                user_id,
+                agent_id,
+                limit,
+                timeout,
+            )
+        if timeout is None:
+            timeout = self._config.search_timeout
+        timeout_ms = int(timeout * 1000)
+
+        try:
+            with self._borrow_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"SET statement_timeout = {timeout_ms}",
+                    )
+                    try:
+                        sql = (
+                            "SELECT adbpg_llm_memory.search"
+                            "(%s, %s, %s, %s, %s)"
+                        )
+                        params = (
+                            query,
+                            user_id or None,
+                            run_id,
+                            agent_id,
+                            None,
+                        )
+                        self._log_sql(sql, params)
+                        cur.execute(sql, params)
+                        result = cur.fetchone()
+                        self._log_result("search", result)
+                        if result and result[0]:
+                            raw = result[0]
+                            if isinstance(raw, str):
+                                try:
+                                    parsed = json.loads(raw)
+                                except json.JSONDecodeError:
+                                    parsed = ast.literal_eval(raw)
+                                if isinstance(parsed, dict):
+                                    return parsed.get("results", [])
+                                return parsed
+                            if isinstance(raw, dict):
+                                return raw.get("results", [])
+                            return raw
+                        return []
+                    finally:
+                        try:
+                            cur.execute("SET statement_timeout = 0")
+                        except Exception:
+                            pass
+        except Exception as e:
+            error_str = str(e).lower()
+            if "timeout" in error_str or "cancel" in error_str:
+                logger.warning(
+                    f"Memory search timed out after {timeout}s "
+                    f"for query: {query!r}",
+                )
+            else:
+                logger.error(f"Memory search failed: {e}")
+            return []
+
+    def close(self) -> None:
+        """No-op for individual clients (pool is shared).
+
+        Call ``close_shared_pool()`` at process shutdown to release
+        all connections.
+        """
+        logger.debug(
+            "ADBPGMemoryClient.close() called — shared pool stays open.",
+        )
+
+    # -----------------------------------------------------------------
+    # REST API helpers (used when api_mode == "rest")
+    # -----------------------------------------------------------------
+
+    def _rest_url(self, path: str) -> str:
+        return f"{self._config.rest_base_url.rstrip('/')}{path}"
+
+    def _log_rest_curl(self, method: str, url: str, body: dict) -> None:
+        """Log an equivalent curl command for debugging REST calls."""
+        header_parts = []
+        for k, v in self._rest_headers.items():
+            if k.lower() == "content-type":
+                continue
+            if k.lower() == "authorization":
+                header_parts.append(f"-H '{k}: {v[:12]}***'")
+            else:
+                header_parts.append(f"-H '{k}: {v}'")
+        logger.debug(
+            "curl -X %s '%s' -H 'Content-Type: application/json' %s -d '%s'",
+            method,
+            url,
+            " ".join(header_parts),
+            json.dumps(body, ensure_ascii=False)[:2000],
+        )
+
+    def _rest_identity(self, agent_id: str, user_id: str) -> dict:
+        """Common identity fields for REST requests."""
+        d: dict = {}
+        if agent_id:
+            d["agent_id"] = agent_id
+        if user_id:
+            d["user_id"] = user_id
+        return d
+
+    def _rest_add_memory(
+        self,
+        messages: list[dict],
+        user_id: str = "",
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> None:
+        """POST /mem/memories to store memories."""
+        import httpx
+
+        body: dict = {
+            "messages": messages,
+            **self._rest_identity(agent_id or "", user_id),
+        }
+        if run_id:
+            body["run_id"] = run_id
+        if metadata:
+            body["metadata"] = metadata
+
+        url = self._rest_url("/v3/memories/add/")
+        self._log_rest_curl("POST", url, body)
+        try:
+            with httpx.Client(
+                timeout=max(self._rest_timeout, 30.0),
+                follow_redirects=True,
+            ) as client:
+                resp = client.post(
+                    url,
+                    headers=self._rest_headers,
+                    json=body,
+                )
+                resp.raise_for_status()
+                logger.debug("REST add_memory result: %s", resp.text[:500])
+        except Exception as e:
+            logger.error("REST add_memory failed: %s", e)
+
+    def _rest_search_memory(
+        self,
+        query: str,
+        user_id: str = "",
+        agent_id: str | None = None,
+        limit: int = 5,
+        timeout: float | None = None,
+    ) -> list[dict]:
+        """POST /mem/search to search memories."""
+        import httpx
+
+        body: dict = {
+            "query": query,
+            "filters": self._rest_identity(agent_id or "", user_id),
+            "top_k": limit,
+        }
+
+        url = self._rest_url("/v3/memories/search/")
+        req_timeout = timeout or self._rest_timeout
+        self._log_rest_curl("POST", url, body)
+        try:
+            with httpx.Client(
+                timeout=req_timeout,
+                follow_redirects=True,
+            ) as client:
+                resp = client.post(
+                    url,
+                    headers=self._rest_headers,
+                    json=body,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if isinstance(data, dict):
+                    return data.get("results", [])
+                if isinstance(data, list):
+                    return data
+                return []
+        except Exception as e:
+            error_str = str(e).lower()
+            if "timeout" in error_str:
+                logger.warning(
+                    "REST memory search timed out for query: %r",
+                    query,
+                )
+            else:
+                logger.error("REST search_memory failed: %s", e)
+            return []
+
+
+def test_adbpg_connection(
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    dbname: str,
+) -> tuple[bool, str]:
+    """Test connectivity to an ADBPG instance (synchronous, blocking).
+
+    Returns:
+        (success, message) tuple.
+    """
+    if psycopg2 is None:
+        return False, "psycopg2 is not installed on the server."
+    conn = None
+    try:
+        conn = psycopg2.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            dbname=dbname,
+            connect_timeout=10,
+        )
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT port FROM gp_segment_configuration "
+                "WHERE content = -1 AND role = 'p'",
+            )
+            row = cur.fetchone()
+            if row and row[0]:
+                return (
+                    True,
+                    f"Connection successful (internal port: {row[0]}).",
+                )
+            return False, (
+                "Connected but gp_segment_configuration"
+                " returned no master row."
+            )
+    except Exception as e:
+        return False, str(e)
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/src/qwenpaw/agents/memory/adbpg_memory_manager.py
+++ b/src/qwenpaw/agents/memory/adbpg_memory_manager.py
@@ -1,0 +1,508 @@
+# -*- coding: utf-8 -*-
+"""ADBPG Memory Manager for QwenPaw agents.
+
+Provides long-term memory backed by AnalyticDB for PostgreSQL (ADBPG).
+Context management (compaction, tool result pruning) is handled by
+LightContextManager — this class only manages long-term memory storage
+and retrieval.
+"""
+import asyncio
+import json
+import logging
+import threading
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+from agentscope.message import Msg, TextBlock, ToolResultBlock, ToolUseBlock
+from agentscope.tool import ToolResponse
+
+from .adbpg_client import (
+    ADBPGConfig,
+    ADBPGMemoryClient,
+    ConfigurationError,
+    reset_configured_connections,
+)
+from .adbpg_prompts import ADBPG_MEMORY_GUIDANCE_EN, ADBPG_MEMORY_GUIDANCE_ZH
+from .base_memory_manager import BaseMemoryManager, memory_registry
+from ...config.config import load_agent_config
+
+logger = logging.getLogger(__name__)
+
+
+@memory_registry.register("adbpg")
+class ADBPGMemoryManager(BaseMemoryManager):
+    """ADBPG-backed long-term memory manager.
+
+    Delegates storage and retrieval to AnalyticDB for PostgreSQL.
+    Context management is handled by LightContextManager.
+    """
+
+    def __init__(self, working_dir: str, agent_id: str) -> None:
+        super().__init__(working_dir=working_dir, agent_id=agent_id)
+        self._adbpg_config = None
+        self._client: ADBPGMemoryClient | None = None
+        self._effective_agent_id: str = "shared"
+        self._effective_user_id: str = "shared"
+        self._effective_run_id: str = "shared"
+        self._auto_retrieved: bool = False
+        self._persisted_msg_ids: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Abstract methods (required)
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Initialize ADBPGMemoryClient from agent config."""
+        agent_config = load_agent_config(self.agent_id)
+        self._adbpg_config = getattr(
+            agent_config.running,
+            "adbpg_memory_config",
+            None,
+        )
+
+        if not self._adbpg_config:
+            logger.warning(
+                "No adbpg_memory_config for agent '%s'. "
+                "Long-term memory DISABLED.",
+                self.agent_id,
+            )
+            self._client = None
+            return
+
+        # Resolve isolation modes
+        cfg = self._adbpg_config
+        self._effective_agent_id = (
+            self.agent_id if cfg.memory_isolation else "shared"
+        )
+
+        try:
+            api_mode = getattr(cfg, "api_mode", "sql")
+            if api_mode == "rest":
+                if not cfg.rest_api_key:
+                    raise ConfigurationError(
+                        "ADBPG REST API key not configured.",
+                    )
+            else:
+                if not cfg.host:
+                    raise ConfigurationError("ADBPG host not configured.")
+
+            config = ADBPGConfig(
+                host=cfg.host,
+                port=cfg.port,
+                user=cfg.user,
+                password=cfg.password,
+                dbname=cfg.dbname,
+                llm_model=cfg.llm_model,
+                llm_api_key=cfg.llm_api_key,
+                llm_base_url=cfg.llm_base_url,
+                embedding_model=cfg.embedding_model,
+                embedding_api_key=cfg.embedding_api_key,
+                embedding_base_url=cfg.embedding_base_url,
+                embedding_dims=cfg.embedding_dims,
+                search_timeout=cfg.search_timeout,
+                pool_minconn=cfg.pool_minconn,
+                pool_maxconn=cfg.pool_maxconn,
+                memory_isolation=cfg.memory_isolation,
+                api_mode=api_mode,
+                rest_api_key=cfg.rest_api_key,
+                rest_base_url=cfg.rest_base_url,
+            )
+        except Exception as e:
+            logger.warning(
+                "ADBPG config incomplete for agent '%s': %s. "
+                "Long-term memory DISABLED.",
+                self.agent_id,
+                e,
+            )
+            self._client = None
+            return
+
+        try:
+            reset_configured_connections()
+            client = ADBPGMemoryClient(config)
+            client.configure()
+            self._client = client
+            logger.info(
+                "ADBPGMemoryManager started for agent '%s'.",
+                self.agent_id,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to connect to ADBPG for agent '%s': %s. "
+                "Long-term memory DISABLED.",
+                self.agent_id,
+                e,
+            )
+            self._client = None
+
+    async def close(self) -> bool:
+        """Clean up resources."""
+        self._client = None
+        return True
+
+    def get_memory_prompt(self, language: str = "zh") -> str:
+        """Return ADBPG memory guidance prompt."""
+        prompts = {
+            "zh": ADBPG_MEMORY_GUIDANCE_ZH,
+            "en": ADBPG_MEMORY_GUIDANCE_EN,
+        }
+        return prompts.get(language, ADBPG_MEMORY_GUIDANCE_EN)
+
+    def list_memory_tools(self) -> list[Callable[..., ToolResponse]]:
+        """Return memory tools exposed to the agent."""
+        return [self.memory_search]
+
+    # ------------------------------------------------------------------
+    # Optional methods (override)
+    # ------------------------------------------------------------------
+
+    async def summarize(self, messages: list[Msg], **_kwargs) -> str:
+        """Persist user messages to ADBPG via fire-and-forget."""
+        if self._client is None:
+            return ""
+        user_messages = self._filter_user_messages(messages)
+        if not user_messages:
+            return ""
+        for single in user_messages:
+            self._fire_and_forget_add([single])
+        return (
+            f"Persisted {len(user_messages)} user message(s) "
+            f"to ADBPG for agent '{self.agent_id}'."
+        )
+
+    async def retrieve(
+        self,
+        messages: list[Msg] | Msg,
+        **_kwargs,
+    ) -> dict | None:
+        """Auto-retrieve relevant memories from ADBPG.
+
+        Returns a dict with injected tool_use/tool_result messages,
+        or None if no relevant memory found.
+        """
+        if self._client is None:
+            return None
+
+        msgs: list[Msg] = (
+            [messages] if isinstance(messages, Msg) else list(messages)
+        )
+
+        # Extract query from latest user message
+        query = ""
+        for msg in reversed(msgs):
+            if msg.role == "user":
+                query = (
+                    msg.get_text_content()
+                    if hasattr(msg, "get_text_content")
+                    else str(msg.content)
+                )
+                break
+
+        if not query or len(query.strip()) < 2:
+            return None
+
+        try:
+            loop = asyncio.get_event_loop()
+            results = await loop.run_in_executor(
+                None,
+                lambda: self._client.search_memory(
+                    query=query,
+                    user_id=self._effective_user_id,
+                    agent_id=self._effective_agent_id,
+                    limit=3,
+                ),
+            )
+            if not results:
+                return None
+
+            parts: list[str] = []
+            for item in results:
+                content = item.get("content", item.get("memory", ""))
+                if content:
+                    parts.append(f"- {content}")
+            if not parts:
+                return None
+
+            text_content = "[Long-term Memory from ADBPG]\n" + "\n".join(parts)
+
+            # Construct tool_use + tool_result message pair
+            _id = uuid.uuid4().hex
+            tool_input = {"query": query, "max_results": 3, "min_score": 0.1}
+            agent_name = _kwargs.get("agent_name", "")
+
+            assistant_msg = Msg(
+                name=agent_name,
+                role="assistant",
+                content=[
+                    TextBlock(
+                        type="text",
+                        text="Searching long-term memory...",
+                    ),
+                    ToolUseBlock(
+                        type="tool_use",
+                        id=_id,
+                        name="memory_search",
+                        input=tool_input,
+                        raw_input=json.dumps(tool_input, ensure_ascii=False),
+                    ),
+                ],
+            )
+
+            tool_result_msg = Msg(
+                name=agent_name,
+                role="system",
+                content=[
+                    ToolResultBlock(
+                        type="tool_result",
+                        id=_id,
+                        name="memory_search",
+                        output=[TextBlock(type="text", text=text_content)],
+                    ),
+                ],
+            )
+
+            return {"msg": msgs + [assistant_msg, tool_result_msg]}
+
+        except Exception as e:
+            logger.warning(f"Auto-retrieve ADBPG memories failed: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Auto-memory lifecycle methods (PR #4204 interface)
+    # ------------------------------------------------------------------
+
+    async def auto_memory_search(
+        self,
+        messages: list[Msg] | Msg,
+        agent_name: str = "",
+        **kwargs,
+    ) -> dict | None:
+        """Auto-search ADBPG memory before replying (pre_reply phase).
+
+        ADBPG backend always performs auto-retrieval when client is available.
+        """
+        if self._client is None:
+            return None
+        return await self.retrieve(messages, agent_name=agent_name)
+
+    async def summarize_when_compact(
+        self,
+        messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Persist compacted messages to ADBPG.
+
+        Always triggers since ADBPG server-side handles fact extraction.
+        """
+        if not messages:
+            return
+        await self.summarize(messages)
+
+    async def auto_memory(
+        self,
+        all_messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Persist new user messages to ADBPG every turn.
+
+        ADBPG server-side handles fact extraction, so we persist on every
+        turn (interval=1) without filtering by interval config.
+        """
+        if self._client is None:
+            return
+
+        # Only persist messages not already sent
+        new_messages = [
+            msg
+            for msg in all_messages
+            if msg.role == "user" and msg.id not in self._persisted_msg_ids
+        ]
+        if not new_messages:
+            return
+
+        user_messages = self._filter_user_messages(new_messages)
+        for single in user_messages:
+            self._fire_and_forget_add([single])
+
+        # Track persisted message IDs
+        for msg in new_messages:
+            self._persisted_msg_ids.add(msg.id)
+
+    # ------------------------------------------------------------------
+    # Tool function
+    # ------------------------------------------------------------------
+
+    async def memory_search(
+        self,
+        query: str,
+        max_results: int = 5,
+        min_score: float = 0.1,
+    ) -> ToolResponse:
+        """Search memories from both ADBPG and local memory files.
+
+        Combines results from two sources:
+        1. ADBPG database (semantic search)
+        2. Local MEMORY.md and memory/*.md files (keyword matching)
+
+        Args:
+            query (`str`):
+                The semantic search query.
+            max_results (`int`, optional):
+                Maximum number of results. Defaults to 5.
+            min_score (`float`, optional):
+                Minimum relevance score. Defaults to 0.1.
+
+        Returns:
+            `ToolResponse`:
+                Search results with source and content.
+        """
+        parts: list[str] = []
+
+        # Source 1: ADBPG semantic search
+        if self._client is not None:
+            try:
+                loop = asyncio.get_event_loop()
+                results = await loop.run_in_executor(
+                    None,
+                    lambda: self._client.search_memory(
+                        query=query,
+                        user_id=self._effective_user_id,
+                        agent_id=self._effective_agent_id,
+                        limit=max_results,
+                    ),
+                )
+                for item in results or []:
+                    content = item.get("content", item.get("memory", ""))
+                    score = item.get("score", 0)
+                    if score < min_score or not content:
+                        continue
+                    idx = len(parts) + 1
+                    parts.append(
+                        f"[{idx}] (adbpg, score: {score:.2f})\n{content}",
+                    )
+            except Exception as e:
+                logger.warning("ADBPG memory search failed: %s", e)
+
+        # Source 2: Local memory files (keyword match)
+        try:
+            local_hits = self._search_local_memory_files(
+                query,
+                max_results=max(max_results - len(parts), 3),
+            )
+            for filepath, snippet in local_hits:
+                idx = len(parts) + 1
+                parts.append(f"[{idx}] (file: {filepath})\n{snippet}")
+        except Exception as e:
+            logger.warning("Local memory file search failed: %s", e)
+
+        if not parts:
+            return ToolResponse(
+                content=[
+                    TextBlock(type="text", text="No relevant memories found."),
+                ],
+            )
+
+        return ToolResponse(
+            content=[
+                TextBlock(type="text", text="\n\n".join(parts[:max_results])),
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # Session reset
+    # ------------------------------------------------------------------
+
+    def reset_turn_state(self) -> None:
+        """Reset per-turn state.
+
+        Call at the start of each conversation turn.
+        """
+        self._auto_retrieved = False
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _filter_user_messages(messages: list[Msg]) -> list[dict]:
+        """Extract role=user messages for ADBPG storage."""
+        return [
+            {
+                "role": "user",
+                "content": (
+                    msg.get_text_content()
+                    if hasattr(msg, "get_text_content")
+                    else str(msg.content)
+                ),
+            }
+            for msg in messages
+            if msg.role == "user"
+        ]
+
+    def _fire_and_forget_add(self, user_messages: list[dict]) -> None:
+        """Store messages to ADBPG in a background daemon thread."""
+        if self._client is None:
+            return
+        agent_id = self._effective_agent_id
+        user_id = self._effective_user_id
+        run_id = self._effective_run_id
+        client = self._client
+
+        def _do_add() -> None:
+            try:
+                client.add_memory(
+                    messages=user_messages,
+                    user_id=user_id,
+                    run_id=run_id,
+                    agent_id=agent_id,
+                )
+            except Exception as e:
+                logger.error(f"Background memory add failed: {e}")
+
+        thread = threading.Thread(target=_do_add, daemon=True)
+        thread.start()
+
+    def _search_local_memory_files(
+        self,
+        query: str,
+        max_results: int = 3,
+    ) -> list[tuple[str, str]]:
+        """Keyword-search MEMORY.md and memory/*.md files."""
+        workspace = Path(self.working_dir).expanduser()
+        candidates: list[Path] = []
+
+        memory_md = workspace / "MEMORY.md"
+        if memory_md.is_file():
+            candidates.append(memory_md)
+
+        memory_dir = workspace / "memory"
+        if memory_dir.is_dir():
+            candidates.extend(sorted(memory_dir.glob("*.md")))
+
+        if not candidates:
+            return []
+
+        tokens = {t for t in query.lower().split() if len(t) >= 2}
+        if not tokens:
+            return []
+
+        scored: list[tuple[float, str, str]] = []
+        for filepath in candidates:
+            try:
+                text = filepath.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+            for para in paragraphs:
+                lower = para.lower()
+                hits = sum(1 for t in tokens if t in lower)
+                if hits == 0:
+                    continue
+                score = hits / len(tokens)
+                rel_path = str(filepath.relative_to(workspace))
+                snippet = para if len(para) <= 500 else para[:500] + "..."
+                scored.append((score, rel_path, snippet))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [(path, snippet) for _, path, snippet in scored[:max_results]]

--- a/src/qwenpaw/agents/memory/adbpg_prompts.py
+++ b/src/qwenpaw/agents/memory/adbpg_prompts.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa: E501
+"""ADBPG memory guidance prompts."""
+
+ADBPG_MEMORY_GUIDANCE_ZH = """\
+## 记忆
+
+每次会话都是全新的。你的长期记忆存储在云端数据库（ADBPG）中，对话中的重要信息会自动提取并保存。
+
+### 🧠 云端长期记忆
+
+- 你的对话内容会**自动保存**到云端长期记忆中
+- 系统会自动从对话中提取事实、偏好、决策等关键信息
+- 无需手动写入文件，记忆提取由服务端 LLM 完成
+- 记忆跨会话持久化 — 即使会话结束，记忆仍然保留
+
+### 🔍 检索记忆
+
+回答关于过往工作、决策、日期、人员、偏好或待办的问题前：
+1. 使用 `memory_search` 工具搜索相关记忆
+2. 搜索结果包含历史对话中提取的事实和信息
+3. 如果不确定是否有相关记忆，**先搜索再回答**
+
+### 🎯 主动检索 - 别凭空猜测！
+
+- 用户问"我之前说过什么"、"上次我们讨论了什么" → 先用 `memory_search` 搜索
+- 用户提到名字、项目、偏好相关的问题 → 先搜索记忆确认
+- 需要引用历史信息时 → 搜索而非猜测
+- **关键原则：** 如果答案可能在记忆中，先搜索再回答。搜索比猜测更可靠。
+
+### 📝 自动记录 - 无需手动操作
+
+- 你说的每句话、用户说的每句话，系统都会自动分析并提取有价值的信息
+- 不需要你主动"记住"或"写入文件" — 系统会自动完成
+- 包括但不限于：用户偏好、重要决策、项目上下文、个人信息、工作习惯
+"""
+
+ADBPG_MEMORY_GUIDANCE_EN = """\
+## Memory
+
+Each session is fresh. Your long-term memory is stored in a cloud database (ADBPG). \
+Important information from conversations is automatically extracted and saved.
+
+### 🧠 Cloud Long-Term Memory
+
+- Your conversation content is **automatically saved** to cloud long-term memory
+- The system automatically extracts facts, preferences, decisions, and other key information
+- No need to manually write files — memory extraction is handled by the server-side LLM
+- Memory persists across sessions — even after a session ends, memories are retained
+
+### 🔍 Retrieve Memory
+
+Before answering questions about past work, decisions, dates, people, preferences, or to-do items:
+1. Use the `memory_search` tool to search relevant memories
+2. Results contain facts and information extracted from historical conversations
+3. If unsure whether relevant memory exists, **search first, answer second**
+
+### 🎯 Proactive Retrieval - Don't Guess!
+
+- User asks "what did I say before", "what did we discuss last time" → use `memory_search` first
+- User mentions names, projects, or preference-related questions → search memory to confirm
+- When you need to reference historical information → search rather than guess
+- **Key principle:** If the answer might be in memory, search first. Searching is more reliable than guessing.
+
+### 📝 Automatic Recording - No Manual Action Needed
+
+- Everything you and the user say is automatically analyzed for valuable information
+- You don't need to actively "remember" or "write to files" — the system handles it
+- Includes but not limited to: user preferences, important decisions, project context, personal info, work habits
+"""

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -561,6 +561,47 @@ class EmbeddingModelConfig(BaseModel):
     )
 
 
+class ADBPGMemoryConfig(BaseModel):
+    """ADBPG (AnalyticDB for PostgreSQL) memory configuration."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    # Database connection
+    host: str = ""
+    port: int = 5432
+    user: str = ""
+    password: str = ""
+    dbname: str = ""
+
+    # LLM for server-side fact extraction
+    llm_model: str = ""
+    llm_api_key: str = ""
+    llm_base_url: str = ""
+
+    # Embedding
+    embedding_model: str = ""
+    embedding_api_key: str = ""
+    embedding_base_url: str = ""
+    embedding_dims: int = 1024
+
+    # API mode
+    api_mode: str = Field(
+        default="rest",
+        description="API mode: 'sql' (direct psycopg2) or 'rest' (HTTP API)",
+    )
+    rest_api_key: str = ""
+    rest_base_url: str = ""
+
+    # Behavior
+    memory_isolation: bool = Field(
+        default=True,
+        description="Per-agent memory isolation (True) or shared (False)",
+    )
+    search_timeout: float = 10.0
+    pool_minconn: int = 1
+    pool_maxconn: int = 5
+
+
 class ReMeLightMemoryConfig(BaseModel):
     """ReMeLight memory manager configuration."""
 
@@ -921,6 +962,12 @@ class AgentsRunningConfig(BaseModel):
     )
 
     memory_manager_backend: str = Field(default="remelight")
+
+    adbpg_memory_config: Optional[ADBPGMemoryConfig] = Field(
+        default=None,
+        description="ADBPG memory configuration (used when "
+        "memory_manager_backend='adbpg')",
+    )
 
     reme_light_memory_config: ReMeLightMemoryConfig = Field(
         default_factory=ReMeLightMemoryConfig,

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -300,6 +300,110 @@ Configure the memory storage backend via the `MEMORY_STORE_BACKEND` environment 
 
 ---
 
+## Other Memory Backends
+
+QwenPaw's memory system uses a pluggable backend architecture. In addition to the default ReMeLight (local file storage), you can switch to other backends via `memory_manager_backend`.
+
+### ADBPG (AnalyticDB for PostgreSQL)
+
+A long-term memory backend backed by a cloud vector database. Suitable for scenarios that need cross-device sharing or large-scale semantic retrieval.
+
+**Key features:**
+
+- **Cross-session persistence** — Memories are stored in a cloud database, retained across restarts, and shareable across devices.
+- **Server-side fact extraction** — Fact extraction is performed by the LLM built into ADBPG, with no extra client-side overhead.
+- **Dual API modes** — Supports both direct SQL connection and REST API access.
+- **Graceful degradation** — When ADBPG is unreachable, the agent keeps running normally; only the long-term memory feature is temporarily disabled.
+
+**How to configure:**
+
+Open the agent's "Running Config" tab in the Console, locate the "Memory Manager Backend" dropdown, choose `adbpg`, and fill in the parameters under `adbpg_memory_config` according to the API mode you select.
+
+![adbpg-backend](https://img.alicdn.com/imgextra/i3/O1CN01bH1Rj41wwQs3v04U6_!!6000000006372-2-tps-2954-1484.png)
+
+> ⚠️ Switching the backend does not support hot reload. After saving, restart QwenPaw for the change to take effect (the page also shows a yellow banner reminder).
+
+#### REST Mode (Recommended)
+
+Connect to the ADBPG memory service over HTTP API — no additional Python dependencies required.
+
+Switch to the "ADBPG Long-term Memory" tab, set "API Mode" to `REST API`, and fill in `REST Base URL` and `REST API Key`:
+
+![adbpg-rest-mode](https://img.alicdn.com/imgextra/i4/O1CN01gTvYJI238hAc4fcvr_!!6000000007211-2-tps-2996-1478.png)
+
+| Field              | Description                                                     | Default  |
+| ------------------ | --------------------------------------------------------------- | -------- |
+| `api_mode`         | API mode, set to `"rest"`                                       | `"rest"` |
+| `rest_base_url`    | REST API URL of the ADBPG memory service                        | `""`     |
+| `rest_api_key`     | Access key for the REST API                                     | `""`     |
+| `memory_isolation` | Memory isolation mode: `true` for per-agent, `false` for shared | `true`   |
+| `search_timeout`   | Memory search timeout (seconds)                                 | `10.0`   |
+
+#### SQL Mode
+
+Connect directly to the ADBPG database via psycopg2. Requires installing an extra dependency: `pip install qwenpaw[adbpg]`.
+
+Switch to the "ADBPG Long-term Memory" tab, set "API Mode" to `SQL (Direct)`, and fill in the database connection info (host / port / user / password / dbname) along with LLM and Embedding parameters:
+
+![adbpg-sql-mode](https://img.alicdn.com/imgextra/i2/O1CN01K8Og0P27WkQvGWHvZ_!!6000000007805-2-tps-2988-1498.png)
+
+| Field                | Description                                    | Default |
+| -------------------- | ---------------------------------------------- | ------- |
+| `api_mode`           | API mode, set to `"sql"`                       | `"sql"` |
+| `host`               | ADBPG database host                            | `""`    |
+| `port`               | Database port                                  | `5432`  |
+| `user`               | Database user                                  | `""`    |
+| `password`           | Database password                              | `""`    |
+| `dbname`             | Database name                                  | `""`    |
+| `llm_model`          | LLM model used for server-side fact extraction | `""`    |
+| `llm_api_key`        | API Key for the LLM service                    | `""`    |
+| `llm_base_url`       | Base URL of the LLM service                    | `""`    |
+| `embedding_model`    | Embedding model name                           | `""`    |
+| `embedding_api_key`  | API Key for the Embedding service              | `""`    |
+| `embedding_base_url` | Base URL of the Embedding service              | `""`    |
+| `embedding_dims`     | Vector dimensions                              | `1024`  |
+| `memory_isolation`   | Memory isolation mode                          | `true`  |
+| `search_timeout`     | Memory search timeout (seconds)                | `10.0`  |
+| `pool_minconn`       | Minimum connections in the pool                | `1`     |
+| `pool_maxconn`       | Maximum connections in the pool                | `5`     |
+
+**Configuration example:**
+
+The full configuration can be written into `running.adbpg_memory_config` of `agent.json`:
+
+```json
+{
+  "running": {
+    "memory_manager_backend": "adbpg",
+    "adbpg_memory_config": {
+      "host": "gp-xxxxxxxxx-master.gpdb.rds.aliyuncs.com",
+      "port": 5432,
+      "user": "your_db_user",
+      "password": "your_db_password",
+      "dbname": "your_db_name",
+      "llm_model": "qwen-plus",
+      "llm_api_key": "sk-xxxxxxxx",
+      "llm_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "embedding_model": "text-embedding-v3",
+      "embedding_api_key": "sk-xxxxxxxx",
+      "embedding_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "embedding_dims": 1024,
+      "api_mode": "sql",
+      "rest_api_key": "",
+      "rest_base_url": "",
+      "memory_isolation": true,
+      "search_timeout": 10.0,
+      "pool_minconn": 1,
+      "pool_maxconn": 5
+    }
+  }
+}
+```
+
+> 💡 When you fill these fields in the Console "Running Config" page, the framework writes them into `agent.json` automatically — no need to edit the file by hand.
+
+---
+
 ## Related Pages
 
 - [Memory-Evolving & Proactive Interaction](./memory-evolving-and-proactive.en.md) — Auto-Memory, Auto-Dream, Auto-Memory-Search, Proactive complete workflow

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -253,6 +253,110 @@ Embedding 配置用于向量语义搜索，位于 `running.reme_light_memory_con
 
 ---
 
+## 其他 Memory Backend
+
+QwenPaw 的记忆系统采用可插拔的 Backend 架构。除了默认的 ReMeLight（本地文件存储）外，还支持通过 `memory_manager_backend` 切换到其他后端。
+
+### ADBPG（AnalyticDB for PostgreSQL）
+
+基于云端向量数据库的长期记忆后端，适合需要跨设备共享、大规模语义检索的场景。
+
+**核心特点：**
+
+- **跨会话持久化** — 记忆存储在云端数据库，重启后不丢失，支持多设备共享
+- **服务端事实抽取** — 由 ADBPG 内置 LLM 完成事实提取，客户端无额外开销
+- **双 API 模式** — 支持 SQL 直连和 REST API 两种接入方式
+- **优雅降级** — ADBPG 不可达时 Agent 正常运行，仅长期记忆功能暂时禁用
+
+**配置方式：**
+
+进入 Agent 配置页面的「运行配置」标签，找到「记忆管理后端」下拉框，选择 `adbpg`，并在下方的 `adbpg_memory_config` 中根据所选 API 模式填写对应参数。
+
+![adbpg-backend](https://img.alicdn.com/imgextra/i3/O1CN01bH1Rj41wwQs3v04U6_!!6000000006372-2-tps-2954-1484.png)
+
+> ⚠️ 切换后端不支持热更新，保存后需要重启 QwenPaw 才能生效（页面也会以黄色横幅提醒）。
+
+#### REST 模式（推荐）
+
+通过 HTTP API 接入 ADBPG 记忆服务，无需额外 Python 依赖。
+
+切换到「ADBPG 长期记忆」Tab，将「API 模式」设为 `REST API`，并填写 `REST Base URL` 与 `REST API Key`：
+
+![adbpg-rest-mode](https://img.alicdn.com/imgextra/i4/O1CN01gTvYJI238hAc4fcvr_!!6000000007211-2-tps-2996-1478.png)
+
+| 配置项             | 说明                                                   | 默认值   |
+| ------------------ | ------------------------------------------------------ | -------- |
+| `api_mode`         | API 模式，设为 `"rest"`                                | `"rest"` |
+| `rest_base_url`    | ADBPG 记忆服务的 REST API 地址                         | `""`     |
+| `rest_api_key`     | REST API 的访问密钥                                    | `""`     |
+| `memory_isolation` | 记忆隔离模式，`true` 为每个 Agent 独立，`false` 为共享 | `true`   |
+| `search_timeout`   | 记忆搜索超时时间（秒）                                 | `10.0`   |
+
+#### SQL 模式
+
+通过 psycopg2 直连 ADBPG 数据库，需额外安装依赖：`pip install qwenpaw[adbpg]`。
+
+切换到「ADBPG 长期记忆」Tab，将「API 模式」设为 `SQL (Direct)`，并填写数据库连接信息（主机地址 / 端口 / 用户名 / 密码 / 数据库名）以及 LLM、Embedding 相关参数：
+
+![adbpg-sql-mode](https://img.alicdn.com/imgextra/i2/O1CN01K8Og0P27WkQvGWHvZ_!!6000000007805-2-tps-2988-1498.png)
+
+| 配置项               | 说明                            | 默认值  |
+| -------------------- | ------------------------------- | ------- |
+| `api_mode`           | API 模式，设为 `"sql"`          | `"sql"` |
+| `host`               | ADBPG 数据库地址                | `""`    |
+| `port`               | 数据库端口                      | `5432`  |
+| `user`               | 数据库用户名                    | `""`    |
+| `password`           | 数据库密码                      | `""`    |
+| `dbname`             | 数据库名称                      | `""`    |
+| `llm_model`          | 服务端事实抽取使用的 LLM 模型名 | `""`    |
+| `llm_api_key`        | LLM 服务的 API Key              | `""`    |
+| `llm_base_url`       | LLM 服务的 Base URL             | `""`    |
+| `embedding_model`    | Embedding 模型名称              | `""`    |
+| `embedding_api_key`  | Embedding 服务的 API Key        | `""`    |
+| `embedding_base_url` | Embedding 服务的 Base URL       | `""`    |
+| `embedding_dims`     | 向量维度                        | `1024`  |
+| `memory_isolation`   | 记忆隔离模式                    | `true`  |
+| `search_timeout`     | 记忆搜索超时时间（秒）          | `10.0`  |
+| `pool_minconn`       | 连接池最小连接数                | `1`     |
+| `pool_maxconn`       | 连接池最大连接数                | `5`     |
+
+**配置示例：**
+
+完整配置可写入 `agent.json` 的 `running.adbpg_memory_config` 字段：
+
+```json
+{
+  "running": {
+    "memory_manager_backend": "adbpg",
+    "adbpg_memory_config": {
+      "host": "gp-xxxxxxxxx-master.gpdb.rds.aliyuncs.com",
+      "port": 5432,
+      "user": "your_db_user",
+      "password": "your_db_password",
+      "dbname": "your_db_name",
+      "llm_model": "qwen-plus",
+      "llm_api_key": "sk-xxxxxxxx",
+      "llm_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "embedding_model": "text-embedding-v3",
+      "embedding_api_key": "sk-xxxxxxxx",
+      "embedding_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "embedding_dims": 1024,
+      "api_mode": "sql",
+      "rest_api_key": "",
+      "rest_base_url": "",
+      "memory_isolation": true,
+      "search_timeout": 10.0,
+      "pool_minconn": 1,
+      "pool_maxconn": 5
+    }
+  }
+}
+```
+
+> 💡 通过 Console 「运行配置」页面填写时，框架会自动将这些字段写入 `agent.json`，无需手动编辑文件。
+
+---
+
 ## 相关页面
 
 - [智能体记忆进化](./memory-evolving-and-proactive.zh.md) — Auto-Memory、Auto-Dream、Auto-Memory-Search、Proactive 完整工作流


### PR DESCRIPTION
## Description

Add an optional memory manager powered by AnalyticDB for PostgreSQL (ADBPG), enabling persistent long-term memory across sessions. `ADBPGMemoryManager` registers via `@memory_registry.register("adbpg")` and implements the upstream `BaseMemoryManager` abstract base class, making it a drop-in peer of `ReMeLightMemoryManager`. Switching backends requires only changing `memory_manager_backend` in `AgentsRunningConfig`.
<img width="2968" height="1474" alt="image" src="https://github.com/user-attachments/assets/97a0bcdc-09dd-4a31-b06c-02e68b3286ad" />


```
BaseMemoryManager (ABC)
├── ReMeLightMemoryManager — local memory (upstream, unchanged)
└── ADBPGMemoryManager — ADBPG cloud memory (this PR)
```

Key capabilities:
* **Memory persistence** — Automatically persists user messages to ADBPG asynchronously on every conversation turn (fire-and-forget, non-blocking). Fact extraction is handled by the ADBPG server-side LLM.
* **Auto-retrieval** — Automatically searches ADBPG for relevant long-term memories before each turn and injects them into context as tool_use/tool_result message pairs.
* **Memory search tool** — Provides `memory_search` combining ADBPG semantic search + local file keyword matching, with graceful fallback when ADBPG is unavailable.
* **Multi-agent memory management** — Supports both memory isolation and memory sharing modes between agents via `memory_isolation` toggle.
* **Dual API mode** — SQL (direct ADBPG via psycopg2) and REST (HTTP API compatible with `/v3/memories/add/` and `/v3/memories/search/` endpoints).
* **Stale connection recovery** — Detects closed pooled connections and automatically obtains fresh ones.

Fault tolerance: The agent starts and runs normally even if ADBPG is unreachable — long-term memory features are gracefully disabled while session memory continues to work.

**Related Issue: #2307**

## Type of Change

- ☐ Bug fix
- ☑ New feature
- ☐ Breaking change
- ☐ Documentation
- ☐ Refactoring

## Component(s) Affected

- ☑ Core / Backend (agents/memory, config, context)
- ☑ Console (frontend web UI)
- ☐ Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- ☐ Skills
- ☐ CLI
- ☐ Documentation (website)
- ☐ Tests
- ☐ CI/CD
- ☐ Scripts / Deploy

## Changes Overview

### New files (ADBPG-specific, self-contained)

| File | Description |
|------|-------------|
| `src/qwenpaw/agents/memory/adbpg_memory_manager.py` | `ADBPGMemoryManager` implementing `BaseMemoryManager` via `@memory_registry.register("adbpg")` |
| `src/qwenpaw/agents/memory/adbpg_client.py` | Thread-safe ADBPG client with shared `ThreadedConnectionPool`, SQL/REST dual mode |
| `src/qwenpaw/agents/memory/adbpg_prompts.py` | Memory guidance prompts (zh/en) for ADBPG backend |
| `console/src/pages/Agent/Config/components/ADBPGConfigCard.tsx` | ADBPG config form component |

### Minimal modifications to upstream files

| File | Lines changed | Description |
|------|---------------|-------------|
| `src/qwenpaw/agents/memory/__init__.py` | +2 | Import and export `ADBPGMemoryManager` |
| `src/qwenpaw/config/config.py` | +47 | Add `ADBPGMemoryConfig` model, extend `AgentsRunningConfig` with `adbpg_memory_config` field |
| `src/qwenpaw/agents/context/light_context_manager.py` | +6 | Bypass `reme_light_memory_config` checks when backend is `"adbpg"` (ensure retrieve/summarize always trigger) |
| `console/src/api/types/agent.ts` | +23 | Add `ADBPGMemoryConfig` TypeScript interface |
| `console/src/constants/backendMappings.ts` | +7 | Register adbpg backend mapping |
| `console/src/pages/Agent/Config/useAgentConfig.tsx` | +1 | Load `adbpg_memory_config` into form |
| `console/src/pages/Agent/Config/components/index.ts` | +1 | Export `ADBPGConfigCard` |
| `console/src/locales/{zh,en,ja,ru}.json` | +23 each | ADBPG-related i18n translations |

### Upstream files NOT modified

- `base_memory_manager.py` — zero changes
- `reme_light_memory_manager.py` — zero changes
- `react_agent.py` — zero changes
- `runner.py` — zero changes
- `command_handler.py` — zero changes

## Configuration
<img width="2976" height="1490" alt="image" src="https://github.com/user-attachments/assets/b2de5f50-515e-441e-bc7e-5c0e863e9939" />

```json
{
  "running": {
    "memory_manager_backend": "adbpg",
    "adbpg_memory_config": {
      "host": "gp-xxx.gpdb.rds.aliyuncs.com",
      "port": 5432,
      "user": "your_user",
      "password": "your_password",
      "dbname": "your_db",
      "llm_model": "qwen-plus",
      "llm_api_key": "sk-xxx",
      "llm_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
      "embedding_model": "text-embedding-v3",
      "embedding_api_key": "sk-xxx",
      "embedding_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
      "embedding_dims": 1024,
      "api_mode": "rest",
      "rest_api_key": "sk-xxx",
      "rest_base_url": "https://api-longmemory.example.com",
      "memory_isolation": true,
      "search_timeout": 10.0
    }
  }
}
```

## Checklist

- ☑ I ran `pre-commit run --all-files` and all checks pass
- ☑ I ran tests locally (`pytest tests/unit` — 1863 passed)
- ☑ Documentation updated (if needed)
- ☑ Ready for review

## Testing

Manual testing performed:
* Configured ADBPG backend via console UI, verified memory persistence
* Verified auto-retrieval injects relevant memories into new sessions
* Verified `memory_search` tool works (ADBPG semantic + local keyword)
* Verified graceful degradation when ADBPG is unreachable (agent runs with session memory only)
* Verified switching between `remelight` and `adbpg` backends via console UI
* Verified REST API mode as alternative to SQL mode
* Verified stale connection recovery after server-side idle timeout

## Additional Notes

* The ADBPG backend requires an accessible AnalyticDB for PostgreSQL instance with the `adbpg_llm_memory` extension installed
* REST API mode is also supported as an alternative to direct SQL connection
* All ADBPG-specific code is isolated in dedicated files, minimizing upstream merge conflicts
* Default backend remains `remelight` — no change for existing users
* `psycopg2` is imported conditionally (try/except) — only needed for SQL mode