### PR TITLE
【WIP】feat: persist UI language to server-side config

### DIFF
--- a/console/src/api/index.ts
+++ b/console/src/api/index.ts
@@ -22,6 +22,7 @@ import { tokenUsageApi } from "./modules/tokenUsage";
 import { toolsApi } from "./modules/tools";
 import { securityApi } from "./modules/security";
 import { userTimezoneApi } from "./modules/userTimezone";
+import { userLanguageApi } from "./modules/userLanguage";
 
 export const api = {
   // Root
@@ -76,6 +77,9 @@ export const api = {
 
   // User Timezone
   ...userTimezoneApi,
+
+  // User Language
+  ...userLanguageApi,
 };
 
 export default api;

--- a/console/src/api/modules/userLanguage.ts
+++ b/console/src/api/modules/userLanguage.ts
@@ -1,0 +1,11 @@
+import { request } from "../request";
+
+export const userLanguageApi = {
+  getUserLanguage: () => request<{ language: string }>("/config/user-language"),
+
+  updateUserLanguage: (language: string) =>
+    request<{ language: string }>("/config/user-language", {
+      method: "PUT",
+      body: JSON.stringify({ language }),
+    }),
+};

--- a/console/src/components/LanguageSwitcher.tsx
+++ b/console/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { Dropdown, Button } from "@agentscope-ai/design";
 import { GlobalOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { MenuProps } from "antd";
+import api from "../api";
 
 export default function LanguageSwitcher() {
   const { i18n } = useTranslation();
@@ -11,6 +12,9 @@ export default function LanguageSwitcher() {
   const changeLanguage = (lang: string) => {
     i18n.changeLanguage(lang);
     localStorage.setItem("language", lang);
+    api.updateUserLanguage(lang).catch((error) => {
+      console.error("Failed to save user language to server:", error);
+    });
   };
 
   const items: MenuProps["items"] = [

--- a/console/src/i18n.ts
+++ b/console/src/i18n.ts
@@ -4,6 +4,8 @@ import en from "./locales/en.json";
 import ru from "./locales/ru.json";
 import zh from "./locales/zh.json";
 import ja from "./locales/ja.json";
+import { request } from "./api/request";
+
 const resources = {
   en: {
     translation: en,
@@ -27,5 +29,20 @@ i18n.use(initReactI18next).init({
     escapeValue: false,
   },
 });
+
+// Fetch server-saved language before first render; exported for main.tsx to await
+export const languageReady = request<{ language: string }>(
+  "/config/user-language",
+)
+  .then(({ language }) => {
+    if (language && language !== i18n.language) {
+      i18n.changeLanguage(language);
+      localStorage.setItem("language", language);
+    }
+  })
+  .catch((error) => {
+    console.error("Failed to fetch user language from server:", error);
+    /* server unavailable, keep localStorage value */
+  });
 
 export default i18n;

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./i18n";
+import { languageReady } from "./i18n";
 
 if (typeof window !== "undefined") {
   const originalError = console.error;
@@ -27,4 +28,6 @@ if (typeof window !== "undefined") {
   };
 }
 
-createRoot(document.getElementById("root")!).render(<App />);
+languageReady.then(() => {
+  createRoot(document.getElementById("root")!).render(<App />);
+});

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -14,6 +14,7 @@ from ...config import (
     get_available_channels,
     ToolGuardConfig,
     ToolGuardRuleConfig,
+    UserLanguageConfig,
 )
 from ..channels.registry import BUILTIN_CHANNEL_KEYS
 from ...config.config import (
@@ -377,6 +378,26 @@ async def put_user_timezone(
     config.user_timezone = tz
     save_config(config)
     return {"timezone": tz}
+
+
+# ── User Language ─────────────────────────────────────────────────────
+
+
+@router.get("/user-language", summary="Get user language")
+async def get_user_language() -> dict:
+    config = load_config()
+    return {"language": config.user_language}
+
+
+@router.put("/user-language", summary="Update user language")
+async def put_user_language(body: UserLanguageConfig) -> dict:
+    lang = body.language.strip()
+    if not lang:
+        raise HTTPException(status_code=400, detail="language is required")
+    config = load_config()
+    config.user_language = lang
+    save_config(config)
+    return {"language": lang}
 
 
 # ── Security / Tool Guard ────────────────────────────────────────────

--- a/src/copaw/config/__init__.py
+++ b/src/copaw/config/__init__.py
@@ -9,6 +9,7 @@ from .config import (
     SecurityConfig,
     ToolGuardConfig,
     ToolGuardRuleConfig,
+    UserLanguageConfig,
 )
 from .utils import (
     get_available_channels,
@@ -33,6 +34,7 @@ __all__ = [
     "SecurityConfig",
     "ToolGuardConfig",
     "ToolGuardRuleConfig",
+    "UserLanguageConfig",
     "get_available_channels",
     "get_config_path",
     "get_heartbeat_config",

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -858,6 +858,12 @@ class SecurityConfig(BaseModel):
     )
 
 
+class UserLanguageConfig(BaseModel):
+    """Request body for PUT /config/user-language."""
+
+    language: str
+
+
 class Config(BaseModel):
     """Root config (config.json)."""
 
@@ -873,6 +879,10 @@ class Config(BaseModel):
         default_factory=detect_system_timezone,
         description="User IANA timezone (e.g. Asia/Shanghai). "
         "Defaults to the system timezone.",
+    )
+    user_language: str = Field(
+        default="en",
+        description="UI display language (e.g. en, zh, ja, ru).",
     )
 
 

--- a/tests/unit/workspace/test_user_language.py
+++ b/tests/unit/workspace/test_user_language.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 """Unit tests for GET/PUT /config/user-language endpoints."""
 import json
 import tempfile
@@ -19,13 +20,6 @@ from copaw.config.config import Config, UserLanguageConfig
 SUPPORTED_LANGUAGES = ["en", "zh", "ja", "ru"]
 
 
-def _make_client(tmp_config: Path) -> TestClient:
-    """Return a TestClient wired to a temporary config file."""
-    app = FastAPI()
-    app.include_router(router)  # router already has prefix="/config"
-    return TestClient(app)
-
-
 def _write_config(tmp_dir: Path, language: str = "en") -> Path:
     """Write a minimal config.json to *tmp_dir* and return its path."""
     config_path = tmp_dir / "config.json"
@@ -34,6 +28,21 @@ def _write_config(tmp_dir: Path, language: str = "en") -> Path:
         encoding="utf-8",
     )
     return config_path
+
+
+def _make_test_client(config_path: Path):
+    """Return app and patched load/save functions for the given config file."""
+
+    def _load(_path=None):
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        return Config(**data)
+
+    def _save(cfg, _path=None):
+        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+
+    app = FastAPI()
+    app.include_router(router)  # router already has prefix="/config"
+    return app, _load, _save
 
 
 # ---------------------------------------------------------------------------
@@ -49,23 +58,15 @@ def tmp_config_dir():
 
 
 @pytest.fixture()
-def client(tmp_config_dir):
+def lang_client(tmp_config_dir):  # pylint: disable=redefined-outer-name
     """TestClient with load_config / save_config patched to use tmp dir."""
     config_path = _write_config(tmp_config_dir, language="en")
-
-    def _load(path=None):
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-        return Config(**data)
-
-    def _save(cfg, path=None):
-        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+    app, _load, _save = _make_test_client(config_path)
 
     with (
         patch("copaw.app.routers.config.load_config", side_effect=_load),
         patch("copaw.app.routers.config.save_config", side_effect=_save),
     ):
-        app = FastAPI()
-        app.include_router(router)  # router already has prefix="/config"
         yield TestClient(app), config_path
 
 
@@ -75,30 +76,27 @@ def client(tmp_config_dir):
 
 
 class TestGetUserLanguage:
-    def test_returns_default_language(self, client):
-        tc, _ = client
+    def test_returns_default_language(self, lang_client):
+        """GET returns 'en' when config stores the default language."""
+        tc, _ = lang_client
         resp = tc.get("/config/user-language")
         assert resp.status_code == 200
         assert resp.json() == {"language": "en"}
 
     @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
-    def test_returns_stored_language(self, tmp_config_dir, lang):
+    def test_returns_stored_language(
+        self,
+        tmp_config_dir,
+        lang,
+    ):  # pylint: disable=redefined-outer-name
         """GET returns whatever language is saved in config."""
         config_path = _write_config(tmp_config_dir, language=lang)
-
-        def _load(path=None):
-            data = json.loads(config_path.read_text(encoding="utf-8"))
-            return Config(**data)
-
-        def _save(cfg, path=None):
-            config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+        app, _load, _save = _make_test_client(config_path)
 
         with (
             patch("copaw.app.routers.config.load_config", side_effect=_load),
             patch("copaw.app.routers.config.save_config", side_effect=_save),
         ):
-            app = FastAPI()
-            app.include_router(router)  # router already has prefix="/config"
             tc = TestClient(app)
             resp = tc.get("/config/user-language")
             assert resp.status_code == 200
@@ -112,82 +110,82 @@ class TestGetUserLanguage:
 
 class TestPutUserLanguage:
     @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
-    def test_set_each_supported_language(self, client, lang):
+    def test_set_each_supported_language(self, lang_client, lang):
         """PUT persists and returns the chosen language for all 4 locales."""
-        tc, config_path = client
-        resp = tc.put(
-            "/config/user-language",
-            json={"language": lang},
-        )
+        tc, config_path = lang_client
+        resp = tc.put("/config/user-language", json={"language": lang})
         assert resp.status_code == 200
         assert resp.json() == {"language": lang}
 
-        # Verify persisted value
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == lang
 
-    def test_set_english(self, client):
-        tc, config_path = client
+    def test_set_english(self, lang_client):
+        """PUT with 'en' persists English."""
+        tc, config_path = lang_client
         resp = tc.put("/config/user-language", json={"language": "en"})
         assert resp.status_code == 200
         assert resp.json()["language"] == "en"
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == "en"
 
-    def test_set_chinese(self, client):
-        tc, config_path = client
+    def test_set_chinese(self, lang_client):
+        """PUT with 'zh' persists Chinese."""
+        tc, config_path = lang_client
         resp = tc.put("/config/user-language", json={"language": "zh"})
         assert resp.status_code == 200
         assert resp.json()["language"] == "zh"
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == "zh"
 
-    def test_set_japanese(self, client):
-        tc, config_path = client
+    def test_set_japanese(self, lang_client):
+        """PUT with 'ja' persists Japanese."""
+        tc, config_path = lang_client
         resp = tc.put("/config/user-language", json={"language": "ja"})
         assert resp.status_code == 200
         assert resp.json()["language"] == "ja"
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == "ja"
 
-    def test_set_russian(self, client):
-        tc, config_path = client
+    def test_set_russian(self, lang_client):
+        """PUT with 'ru' persists Russian."""
+        tc, config_path = lang_client
         resp = tc.put("/config/user-language", json={"language": "ru"})
         assert resp.status_code == 200
         assert resp.json()["language"] == "ru"
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == "ru"
 
-    def test_strips_whitespace(self, client):
+    def test_strips_whitespace(self, lang_client):
         """Language values with surrounding whitespace are stripped."""
-        tc, config_path = client
+        tc, config_path = lang_client
         resp = tc.put("/config/user-language", json={"language": "  zh  "})
         assert resp.status_code == 200
         assert resp.json()["language"] == "zh"
         saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
         assert saved.user_language == "zh"
 
-    def test_empty_language_returns_400(self, client):
+    def test_empty_language_returns_400(self, lang_client):
         """Empty language string is rejected with HTTP 400."""
-        tc, _ = client
+        tc, _ = lang_client
         resp = tc.put("/config/user-language", json={"language": ""})
         assert resp.status_code == 400
 
-    def test_whitespace_only_returns_400(self, client):
+    def test_whitespace_only_returns_400(self, lang_client):
         """Whitespace-only language string is rejected with HTTP 400."""
-        tc, _ = client
+        tc, _ = lang_client
         resp = tc.put("/config/user-language", json={"language": "   "})
         assert resp.status_code == 400
 
-    def test_missing_language_field_returns_422(self, client):
+    def test_missing_language_field_returns_422(self, lang_client):
         """Missing required field returns HTTP 422 Unprocessable Entity."""
-        tc, _ = client
+        tc, _ = lang_client
         resp = tc.put("/config/user-language", json={})
         assert resp.status_code == 422
 
-    def test_get_after_put_roundtrip(self, client):
+    def test_get_after_put_roundtrip(self, lang_client):
         """PUT then GET returns the updated language."""
-        tc, _ = client
+        tc, _ = lang_client
         for lang in SUPPORTED_LANGUAGES:
             tc.put("/config/user-language", json={"language": lang})
             resp = tc.get("/config/user-language")
@@ -202,15 +200,18 @@ class TestPutUserLanguage:
 
 class TestUserLanguageConfig:
     def test_valid_language_field(self):
+        """UserLanguageConfig accepts a valid language string."""
         cfg = UserLanguageConfig(language="en")
         assert cfg.language == "en"
 
     @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
     def test_all_supported_languages(self, lang):
+        """UserLanguageConfig accepts each of the 4 supported locales."""
         cfg = UserLanguageConfig(language=lang)
         assert cfg.language == lang
 
     def test_missing_field_raises(self):
+        """UserLanguageConfig raises when the required field is absent."""
         with pytest.raises(Exception):
             UserLanguageConfig()  # type: ignore[call-arg]
 
@@ -228,5 +229,6 @@ class TestConfigUserLanguageDefault:
 
     @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
     def test_can_set_any_supported_language(self, lang):
+        """Config.user_language can be assigned any supported locale."""
         cfg = Config(user_language=lang)
         assert cfg.user_language == lang

--- a/tests/unit/workspace/test_user_language.py
+++ b/tests/unit/workspace/test_user_language.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for GET/PUT /config/user-language endpoints."""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from copaw.app.routers.config import router
+from copaw.config.config import Config, UserLanguageConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SUPPORTED_LANGUAGES = ["en", "zh", "ja", "ru"]
+
+
+def _make_client(tmp_config: Path) -> TestClient:
+    """Return a TestClient wired to a temporary config file."""
+    app = FastAPI()
+    app.include_router(router)  # router already has prefix="/config"
+    return TestClient(app)
+
+
+def _write_config(tmp_dir: Path, language: str = "en") -> Path:
+    """Write a minimal config.json to *tmp_dir* and return its path."""
+    config_path = tmp_dir / "config.json"
+    config_path.write_text(
+        json.dumps({"user_language": language}),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_config_dir():
+    """Provide a temporary directory that acts as the config home."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture()
+def client(tmp_config_dir):
+    """TestClient with load_config / save_config patched to use tmp dir."""
+    config_path = _write_config(tmp_config_dir, language="en")
+
+    def _load(path=None):
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        return Config(**data)
+
+    def _save(cfg, path=None):
+        config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+
+    with (
+        patch("copaw.app.routers.config.load_config", side_effect=_load),
+        patch("copaw.app.routers.config.save_config", side_effect=_save),
+    ):
+        app = FastAPI()
+        app.include_router(router)  # router already has prefix="/config"
+        yield TestClient(app), config_path
+
+
+# ---------------------------------------------------------------------------
+# GET /config/user-language
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserLanguage:
+    def test_returns_default_language(self, client):
+        tc, _ = client
+        resp = tc.get("/config/user-language")
+        assert resp.status_code == 200
+        assert resp.json() == {"language": "en"}
+
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
+    def test_returns_stored_language(self, tmp_config_dir, lang):
+        """GET returns whatever language is saved in config."""
+        config_path = _write_config(tmp_config_dir, language=lang)
+
+        def _load(path=None):
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            return Config(**data)
+
+        def _save(cfg, path=None):
+            config_path.write_text(cfg.model_dump_json(), encoding="utf-8")
+
+        with (
+            patch("copaw.app.routers.config.load_config", side_effect=_load),
+            patch("copaw.app.routers.config.save_config", side_effect=_save),
+        ):
+            app = FastAPI()
+            app.include_router(router)  # router already has prefix="/config"
+            tc = TestClient(app)
+            resp = tc.get("/config/user-language")
+            assert resp.status_code == 200
+            assert resp.json()["language"] == lang
+
+
+# ---------------------------------------------------------------------------
+# PUT /config/user-language
+# ---------------------------------------------------------------------------
+
+
+class TestPutUserLanguage:
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
+    def test_set_each_supported_language(self, client, lang):
+        """PUT persists and returns the chosen language for all 4 locales."""
+        tc, config_path = client
+        resp = tc.put(
+            "/config/user-language",
+            json={"language": lang},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"language": lang}
+
+        # Verify persisted value
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == lang
+
+    def test_set_english(self, client):
+        tc, config_path = client
+        resp = tc.put("/config/user-language", json={"language": "en"})
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "en"
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == "en"
+
+    def test_set_chinese(self, client):
+        tc, config_path = client
+        resp = tc.put("/config/user-language", json={"language": "zh"})
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "zh"
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == "zh"
+
+    def test_set_japanese(self, client):
+        tc, config_path = client
+        resp = tc.put("/config/user-language", json={"language": "ja"})
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "ja"
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == "ja"
+
+    def test_set_russian(self, client):
+        tc, config_path = client
+        resp = tc.put("/config/user-language", json={"language": "ru"})
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "ru"
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == "ru"
+
+    def test_strips_whitespace(self, client):
+        """Language values with surrounding whitespace are stripped."""
+        tc, config_path = client
+        resp = tc.put("/config/user-language", json={"language": "  zh  "})
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "zh"
+        saved = Config(**json.loads(config_path.read_text(encoding="utf-8")))
+        assert saved.user_language == "zh"
+
+    def test_empty_language_returns_400(self, client):
+        """Empty language string is rejected with HTTP 400."""
+        tc, _ = client
+        resp = tc.put("/config/user-language", json={"language": ""})
+        assert resp.status_code == 400
+
+    def test_whitespace_only_returns_400(self, client):
+        """Whitespace-only language string is rejected with HTTP 400."""
+        tc, _ = client
+        resp = tc.put("/config/user-language", json={"language": "   "})
+        assert resp.status_code == 400
+
+    def test_missing_language_field_returns_422(self, client):
+        """Missing required field returns HTTP 422 Unprocessable Entity."""
+        tc, _ = client
+        resp = tc.put("/config/user-language", json={})
+        assert resp.status_code == 422
+
+    def test_get_after_put_roundtrip(self, client):
+        """PUT then GET returns the updated language."""
+        tc, _ = client
+        for lang in SUPPORTED_LANGUAGES:
+            tc.put("/config/user-language", json={"language": lang})
+            resp = tc.get("/config/user-language")
+            assert resp.status_code == 200
+            assert resp.json()["language"] == lang
+
+
+# ---------------------------------------------------------------------------
+# UserLanguageConfig model
+# ---------------------------------------------------------------------------
+
+
+class TestUserLanguageConfig:
+    def test_valid_language_field(self):
+        cfg = UserLanguageConfig(language="en")
+        assert cfg.language == "en"
+
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
+    def test_all_supported_languages(self, lang):
+        cfg = UserLanguageConfig(language=lang)
+        assert cfg.language == lang
+
+    def test_missing_field_raises(self):
+        with pytest.raises(Exception):
+            UserLanguageConfig()  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Config model default
+# ---------------------------------------------------------------------------
+
+
+class TestConfigUserLanguageDefault:
+    def test_default_is_en(self):
+        """Config.user_language defaults to 'en'."""
+        cfg = Config()
+        assert cfg.user_language == "en"
+
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
+    def test_can_set_any_supported_language(self, lang):
+        cfg = Config(user_language=lang)
+        assert cfg.user_language == lang


### PR DESCRIPTION
## Description

Persist the UI language setting to the server-side `config.json` so it survives
browser cache clears and works consistently across different browsers/devices.

Previously the language preference was stored only in browser `localStorage`, so
clearing the cache or switching browsers would reset it to the default.

**Related Issue:** N/A

**Security Considerations:** None. The language setting is a non-sensitive user preference stored in the existing config file.

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start the server: `copaw app`
2. Open `http://127.0.0.1:8088` in a browser
3. Switch language using the globe icon in the top-right header
4. Open DevTools → Console → run `localStorage.clear()`
5. Reload the page — the previously selected language should still be active (fetched from server)
6. Repeat for all 4 supported languages: English, Chinese (zh), Japanese (ja), Russian (ru)

## Local Verification Evidence

```bash
pre-commit run --files src/copaw/app/routers/config.py src/copaw/config/__init__.py src/copaw/config/config.py tests/unit/workspace/test_user_language.py
# check python ast...Passed
# mypy...Passed
# black...Passed
# flake8...Passed
# pylint...Passed

pytest tests/unit/workspace/test_user_language.py -v
# 29 passed in 6.13s

pytest
# 418 passed in 139.09s (0:02:19)
```

## Browser Test Results

All 4 languages tested manually with `localStorage` cleared between each reload:

| Language | Switch | Clear localStorage | Reload — Language Persisted? |
|---|---|---|---|
| English (`en`) | ✅ | ✅ | ✅ **PASS** |
| Chinese / 简体中文 (`zh`) | ✅ | ✅ | ✅ **PASS** |
| Japanese / 日本語 (`ja`) | ✅ | ✅ | ✅ **PASS** |
| Russian / Русский (`ru`) | ✅ | ✅ | ✅ **PASS** |

Screenshots and detailed test steps: https://github.com/agentscope-ai/CoPaw/pull/2338#issuecomment-4133826476

## Additional Notes

**Backend:**
- Added `user_language: str` field (default `"en"`) to the `Config` model in `config/config.py`
- Added `UserLanguageConfig` Pydantic model (in `config/config.py`, exported via `config/__init__.py`)
- Added `GET /config/user-language` and `PUT /config/user-language` endpoints in `app/routers/config.py`

**Frontend:**
- New `console/src/api/modules/userLanguage.ts` API module
- `i18n.ts`: fetches server language on startup and exports `languageReady` Promise
- `main.tsx`: defers `createRoot` render until `languageReady` resolves (prevents language flash on load)
- `LanguageSwitcher.tsx`: saves chosen language to server on every change

**Tests:**
- Added `tests/unit/workspace/test_user_language.py` with 29 unit tests covering all 4 locales, edge cases (whitespace stripping, empty/missing field validation), and GET→PUT roundtrips
