### PR TITLE
fix(console): fix batch delete API request format (#2327)

### DIFF
--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -129,7 +129,7 @@ export const sessionApi = {
       "/chats/batch-delete",
       {
         method: "POST",
-        body: JSON.stringify(sessionIds),
+        body: JSON.stringify({ chat_ids: sessionIds }),
       },
     ),
 };


### PR DESCRIPTION
Fixes #2327 - Batch delete API mismatch between frontend and backend. Changed batchDeleteSessions to send { chat_ids: sessionIds } instead of raw array.