### PR TITLE
fix(feishu): correct stale message filtering with server clock offset

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -20,6 +20,7 @@ import re
 import sys
 import threading
 import time
+from email.utils import parsedate_to_datetime
 import types
 from collections import OrderedDict
 from pathlib import Path
@@ -450,8 +451,6 @@ class FeishuChannel(BaseChannel):
             date_str = response.headers.get("Date")
             if date_str:
                 try:
-                    from email.utils import parsedate_to_datetime
-
                     server_ms = int(
                         parsedate_to_datetime(date_str).timestamp() * 1000,
                     )


### PR DESCRIPTION
## Description

- _fetch_bot_open_id: reads the Date header from the HTTP response and computes _clock_offset = server_time - local_time (ms). Runs once at channel startup.
- _on_message_sync: applies _clock_offset when computing message age: now_ms = local_ms + clock_offset, making the stale check robust against local clock skew.
- __init__: initializes _clock_offset = 0 (safe default; no correction if _fetch_bot_open_id fails).

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
