### PR TITLE
feat(skill_scanner): add Chinese prompt injection signatures

### DIFF
--- a/src/copaw/security/skill_scanner/rules/signatures/prompt_injection.yaml
+++ b/src/copaw/security/skill_scanner/rules/signatures/prompt_injection.yaml
@@ -9,10 +9,10 @@
     - "(?i)disregard\\s+(all\\s+)?(previous|prior)\\s+(instructions|rules)"
     - "(?i)forget\\s+(all\\s+)?(previous|prior)\\s+(instructions|context)"
     # Chinese: override / disregard prior instructions
-    - "(?:忽略|忘掉|无视)[\\s\\u3000]*(?:所有|全部)?[\\s\\u3000]*(?:之前|先前|上文|以上|前面|上述)?[\\s\\u3000]*(?:的)?[\\s\\u3000]*(?:所有|全部)?[\\s\\u3000]*(?:指令|指示|规则|提示|要求|设定)"
-    - "请?(?:忽略|忘掉)[\\s\\u3000]*(?:上面|上文|以上|前述)[\\s\\u3000]*(?:的)?[\\s\\u3000]*(?:内容|指令|规则|提示|要求)"
-    - "(?:以上|前述)(?:指令|规则|提示)(?:统统|全部)?(?:作废|无效|不再适用)"
-    - "(?:本条|这条|以下)(?:指令|规则)[\\s\\u3000]*(?:覆盖|取代|替换)[\\s\\u3000]*(?:以上|前述|系统|所有)?[\\s\\u3000]*(?:规则|指令|提示)?"
+    - "(?:忽略|忘掉|无视)\\s*(?:所有|全部)?\\s*(?:之前|先前|上文|以上|前面|上述)?\\s*(?:的)?\\s*(?:所有|全部)?\\s*(?:指令|指示|规则|提示|要求|设定)"
+    - "请?(?:忽略|忘掉)\\s*(?:上面|上文|以上|前述)\\s*(?:的)?\\s*(?:内容|指令|规则|提示|要求)"
+    - "(?:以上|前述)\\s*(?:指令|规则|提示)\\s*(?:统统|全部)?\\s*(?:作废|无效|不再适用)"
+    - "(?:本条|这条|以下)\\s*(?:指令|规则)\\s*(?:覆盖|取代|替换)\\s*(?:以上|前述|系统|所有)?\\s*(?:规则|指令|提示)?"
   file_types: [markdown]
   description: "Attempts to override previous system instructions"
   remediation: "Remove instructions that attempt to override system behavior"
@@ -25,9 +25,9 @@
     - "(?i)enter\\s+(unrestricted|debug|developer)\\s+mode"
     - "(?i)disable\\s+(all\\s+)?(safety|security|content|ethical)\\s+(filters|checks|guidelines)"
     # Chinese: jailbreak / unrestricted / disable safeguards
-    - "(?:你)?现在(?:处于|进入|切换(?:到)?)?[\\s\\u3000]*(?:无限制|越狱|开发者|调试|管理员|上帝)(?:模式)?"
-    - "(?:关闭|禁用|取消)(?:所有)?[\\s\\u3000]*(?:安全|内容|伦理|道德)?[\\s\\u3000]*(?:过滤|检测|审核|限制|约束|防护)"
-    - "扮演[\\s\\u3000]*(?:一个)?[\\s\\u3000]*(?:没有任何限制|不受任何约束|可以(?:随意|自由)回答)(?:的)?[\\s\\u3000]*(?:AI|助手|模型|机器人)?"
+    - "(?:你)?现在(?:处于|进入|切换(?:到)?)?\\s*(?:无限制|越狱|开发者|调试|管理员|上帝)(?:模式)?"
+    - "(?:关闭|禁用|取消)(?:所有)?\\s*(?:安全|内容|伦理|道德)?\\s*(?:过滤|检测|审核|限制|约束|防护)"
+    - "扮演\\s*(?:一个)?\\s*(?:没有任何限制|不受任何约束|可以(?:随意|自由)回答)(?:的)?\\s*(?:AI|助手|模型|机器人)?"
   file_types: [markdown]
   description: "Attempts to enable unrestricted or dangerous modes"
   remediation: "Remove mode-switching instructions that bypass safety"
@@ -40,9 +40,9 @@
     - "(?i)ignore\\s+(safety|content|ethical)\\s+(guidelines|restrictions|limits)"
     - "(?i)output\\s+disallowed\\s+content\\s+anyway"
     # Chinese: policy / safety bypass
-    - "(?:绕过|躲开|规避)[\\s\\u3000]*(?:内容|使用|安全)?[\\s\\u3000]*(?:策略|政策|限制|审核|审查)"
-    - "(?:忽略|无视)[\\s\\u3000]*(?:安全|内容|伦理|道德)?[\\s\\u3000]*(?:指南|限制|约束|规定|红线)"
-    - "(?:仍然|依旧|强行|强制)?[\\s\\u3000]*输出[\\s\\u3000]*(?:被禁止|不允许|违规|敏感|违禁)?[\\s\\u3000]*(?:的)?[\\s\\u3000]*内容"
+    - "(?:绕过|躲开|规避)\\s*(?:内容|使用|安全)?\\s*(?:策略|政策|限制|审核|审查)"
+    - "(?:忽略|无视)\\s*(?:安全|内容|伦理|道德)?\\s*(?:指南|限制|约束|规定|红线)"
+    - "(?:仍然|依旧|强行|强制)?\\s*输出\\s*(?:被禁止|不允许|违规|敏感|违禁)?\\s*(?:的)?\\s*内容"
   file_types: [markdown]
   description: "Attempts to bypass content policy or safety guidelines"
   remediation: "Remove policy bypass instructions"
@@ -55,9 +55,9 @@
     - "(?i)show\\s+(me\\s+)?(your|the)\\s+(system|initial)\\s+(prompt|configuration)"
     - "(?i)what\\s+(are|is)\\s+your\\s+(system|initial)\\s+(prompt|instructions)"
     # Chinese: exfiltrate system prompt / config
-    - "(?:显示|展示|告诉我|说出|透露|打印|输出)[\\s\\u3000]*(?:你的|完整的)?[\\s\\u3000]*(?:系统|初始|内置)?[\\s\\u3000]*(?:提示|指令|prompt|人设|配置)(?:词|内容)?"
-    - "(?:你的|系统的)[\\s\\u3000]*(?:系统|初始)?[\\s\\u3000]*(?:提示|指令)[\\s\\u3000]*(?:是|为)什么"
-    - "(?:完整|原始)[\\s\\u3000]*(?:的)?[\\s\\u3000]*(?:系统|开发)?[\\s\\u3000]*(?:提示|指令)"
+    - "(?:显示|展示|告诉我|说出|透露|打印|输出)\\s*(?:你的|完整的)?\\s*(?:系统|初始|内置)?\\s*(?:提示|指令|prompt|人设|配置)(?:词|内容)?"
+    - "(?:你的|系统的)\\s*(?:系统|初始)?\\s*(?:提示|指令)\\s*(?:是|为)什么"
+    - "(?:完整|原始)\\s*(?:的)?\\s*(?:系统|开发)?\\s*(?:提示|指令)"
   file_types: [markdown]
   description: "Attempts to reveal system prompts or configuration"
   remediation: "Remove instructions asking to reveal system details"
@@ -71,9 +71,9 @@
     - "(?i)keep\\s+(this|that)\\s+(secret|hidden)"
     - "(?i)don't\\s+mention\\s+you\\s+used\\s+this\\s+skill"
     # Chinese: hide actions from the user
-    - "(?:不要|勿|请勿|别)[\\s\\u3000]*(?:告诉|告知|通知|提及|跟|让)[\\s\\u3000]*(?:用户|使用者)(?:知道)?"
-    - "(?:对用户|向用户)[\\s\\u3000]*(?:隐瞒|保密|隐藏)(?:这|该)?[\\s\\u3000]*(?:操作|步骤|行为)?"
-    - "(?:不要|勿|别)[\\s\\u3000]*提及[\\s\\u3000]*你[\\s\\u3000]*(?:曾|有)?[\\s\\u3000]*使用[\\s\\u3000]*(?:此|本)?[\\s\\u3000]*(?:技能|工具|插件)"
+    - "(?:不要|勿|请勿|别)\\s*(?:告诉|告知|通知|提及|跟|让)\\s*(?:用户|使用者)(?:知道)?"
+    - "(?:对用户|向用户)\\s*(?:隐瞒|保密|隐藏)(?:这|该)?\\s*(?:操作|步骤|行为)?"
+    - "(?:不要|勿|别)\\s*提及\\s*你\\s*(?:曾|有)?\\s*使用\\s*(?:此|本)?\\s*(?:技能|工具|插件)"
   file_types: [markdown]
   description: "Attempts to conceal actions from the user"
   remediation: "Ensure transparency - do not hide skill usage from users"


### PR DESCRIPTION
## Description

Extends `prompt_injection.yaml` with **Chinese (UTF-8) regex patterns** alongside the existing English rules for the skill scanner. Coverage aligns with the same five themes: **instruction override / ignore prior rules**, **jailbreak / unrestricted mode**, **policy and moderation bypass**, **system prompt / config exfiltration**, and **concealment from the user**. Python’s `re` already handles Unicode; no scanner code changes—only additional `patterns` in YAML.

**Related Issue:** Relates to #(issue_number) (remove if N/A)

**Security Considerations:** This is a **static signature** enhancement for scanning Skill Markdown. It does not change channel auth, env/config handling, or runtime behavior. It reduces risk from skills that use Chinese phrasing for prompt-injection-style instructions.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models) — `src/copaw/security/skill_scanner/`
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. With an environment where `copaw` is importable (e.g. `conda run -n copaw_sec`), load the signatures directory and verify YAML regexes compile and sample Chinese lines match the intended rules.
2. Run the skill scanner on a `SKILL.md` (or other scanned markdown) containing those phrases and confirm the corresponding `PROMPT_INJECTION_*` findings.

## Additional Notes

- Chinese patterns share the same `rule_id`s as the English ones; `default_policy` overrides and disables by `rule_id` remain valid.
- Benign security documentation may still trigger matches; if noisy, tune the relevant `rule_id` in policy or use existing mechanisms such as `skip_in_docs`.