### PR TITLE
fix(web): provider card's mixed column width in models list page

### DIFF
--- a/console/src/pages/Settings/Models/index.module.less
+++ b/console/src/pages/Settings/Models/index.module.less
@@ -68,7 +68,7 @@
 }
 
 .providerCard {
-  flex: 0 1 calc(33.333% - 16px);
+  flex: 0 1 calc((100% - 32px) / 3);
   min-width: 432px;
   border-radius: 16px;
   transition: all 0.2s ease-in-out;


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

- incorrect max width for 2 columns in the last row

- before:
<img width="1636" height="965" alt="image" src="https://github.com/user-attachments/assets/21bafa7e-dead-45e7-9079-8dbe8cb70e5b" />

- after:
<img width="1610" height="943" alt="image" src="https://github.com/user-attachments/assets/28f00237-c1d3-479c-898d-06779c232e77" />

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
