### PR TITLE
feat(provider): Support integration with OpenCode

### DIFF
--- a/.github/workflows/pr-under-review.yml
+++ b/.github/workflows/pr-under-review.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - name: Add Under Review label

--- a/.github/workflows/pr-under-review.yml
+++ b/.github/workflows/pr-under-review.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
 
     steps:
       - name: Add Under Review label

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -322,6 +322,9 @@ export function ProviderConfigModal({
     if (provider.id === "openai") {
       return t("models.openAIEndpoint");
     }
+    if (provider.id === "opencode") {
+      return t("models.openAICompatibleEndpoint");
+    }
     if (provider.id === "ollama") {
       return t("models.ollamaEndpointHint");
     }
@@ -348,6 +351,9 @@ export function ProviderConfigModal({
     }
     if (provider.id === "openai") {
       return "https://api.openai.com/v1";
+    }
+    if (provider.id === "opencode") {
+      return "https://opencode.ai/zen/v1";
     }
     if (provider.id === "ollama") {
       return "http://localhost:11434";

--- a/src/qwenpaw/providers/capability_baseline.py
+++ b/src/qwenpaw/providers/capability_baseline.py
@@ -583,21 +583,42 @@ class ExpectedCapabilityRegistry:
                     note="MiniMax models are text-only",
                 ),
             )
+        # ---------------------------------------------------------------
+        # 13. OpenCode (OpenCode Zen)
+        #     https://opencode.ai/docs/zen
+        # ---------------------------------------------------------------
+        _oc_doc = "https://opencode.ai/docs/zen"
+        for mid in (
+            "big-pickle",
+            "nemotron-3-super-free",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="opencode",
+                    model_id=mid,
+                    expected_image=False,
+                    expected_video=False,
+                    doc_url=_oc_doc,
+                    note=(
+                        "OpenCode Zen aggregates heterogeneous providers; "
+                        "capability varies by model, probe to determine."
+                    ),
+                ),
+            )
+        # ---------------------------------------------------------------
+        # 14. Ollama — no predefined models (dynamic discovery)
+        # ---------------------------------------------------------------
 
         # ---------------------------------------------------------------
-        # 13. Ollama — no predefined models (dynamic discovery)
+        # 15. LM Studio — no predefined models (dynamic discovery)
         # ---------------------------------------------------------------
 
         # ---------------------------------------------------------------
-        # 14. LM Studio — no predefined models (dynamic discovery)
+        # 16. llama.cpp — models discovered via local scan
         # ---------------------------------------------------------------
 
         # ---------------------------------------------------------------
-        # 15. llama.cpp — models discovered via local scan
-        # ---------------------------------------------------------------
-
-        # ---------------------------------------------------------------
-        # 16. MLX (Apple Silicon) — models discovered via local scan
+        # 17. MLX (Apple Silicon) — models discovered via local scan
         # ---------------------------------------------------------------
 
 

--- a/src/qwenpaw/providers/capability_baseline.py
+++ b/src/qwenpaw/providers/capability_baseline.py
@@ -96,7 +96,7 @@ class ExpectedCapabilityRegistry:
         """Register a single baseline entry."""
         self._data[(cap.provider_id, cap.model_id)] = cap
 
-    def _load_baseline(self) -> None:
+    def _load_baseline(self) -> None:  # pylint: disable=too-many-statements
         """Load baseline data for built-in providers."""
 
         # ---------------------------------------------------------------

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -790,9 +790,9 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
     def _normalize_provider_id(provider_id: str) -> str:
         """Normalize provider ID for backward compatibility.
 
-        Maps legacy 'qwenpaw-local' to 'qwenpaw-local'.
+        Maps legacy 'copaw-local' to 'qwenpaw-local'.
         """
-        if provider_id == "qwenpaw-local":
+        if provider_id == "copaw-local":
             return "qwenpaw-local"
         return provider_id
 
@@ -1289,28 +1289,28 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         except Exception:
             return None
 
-    def _migrate_qwenpaw_config(self) -> None:
-        """Migrate qwenpaw-local provider config to qwenpaw-local."""
+    def _migrate_copaw_config(self) -> None:
+        """Migrate copaw-local provider config to qwenpaw-local."""
         # 1. Migrate active model configuration (only provider_id)
         if (
             self.active_model
-            and self.active_model.provider_id == "qwenpaw-local"
+            and self.active_model.provider_id == "copaw-local"
         ):
             self.active_model.provider_id = "qwenpaw-local"
             self.save_active_model(self.active_model)
             logger.info(
                 "Migrated active model provider from "
-                "'qwenpaw-local' to 'qwenpaw-local'",
+                "'copaw-local' to 'qwenpaw-local'",
             )
 
         # 2. Migrate stored provider config file
-        qwenpaw_config_path = self.builtin_path / "qwenpaw-local.json"
-        if not qwenpaw_config_path.exists():
+        copaw_config_path = self.builtin_path / "copaw-local.json"
+        if not copaw_config_path.exists():
             return
 
         try:
             # Load old config and apply to new provider instance
-            with open(qwenpaw_config_path, "r", encoding="utf-8") as f:
+            with open(copaw_config_path, "r", encoding="utf-8") as f:
                 old_config = json.load(f)
 
             # Get the new built-in provider instance
@@ -1333,13 +1333,13 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             self._save_provider(provider, is_builtin=True)
 
             # Remove old config file
-            qwenpaw_config_path.unlink()
+            copaw_config_path.unlink()
             logger.info(
                 "Migrated provider config from "
-                "'qwenpaw-local.json' to 'qwenpaw-local.json'",
+                "'copaw-local.json' to 'qwenpaw-local.json'",
             )
         except Exception as exc:
-            logger.warning("Failed to migrate qwenpaw-local config: %s", exc)
+            logger.warning("Failed to migrate copaw-local config: %s", exc)
 
     # pylint: disable=too-many-branches
     def _migrate_legacy_providers(self):
@@ -1392,8 +1392,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             # Migrate active model (only provider_id, not model)
             if active_model:
                 try:
-                    # Convert legacy qwenpaw-local provider_id
-                    if active_model.get("provider_id") == "qwenpaw-local":
+                    # Convert legacy copaw-local provider_id
+                    if active_model.get("provider_id") == "copaw-local":
                         active_model["provider_id"] = "qwenpaw-local"
                     self.active_model = ModelSlotConfig.model_validate(
                         active_model,
@@ -1445,8 +1445,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         if active_model:
             self.active_model = active_model
 
-        # Migrate qwenpaw-local to qwenpaw-local for backwards compatibility
-        self._migrate_qwenpaw_config()
+        # Migrate copaw-local to qwenpaw-local for backwards compatibility
+        self._migrate_copaw_config()
 
     def _apply_default_annotations(self):
         """Apply doc-based default annotations for unprobed models.

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -254,6 +254,24 @@ OPENAI_MODELS: List[ModelInfo] = [
     ),
 ]
 
+OPENCODE_MODELS: List[ModelInfo] = [
+    # Free models from OpenCode Zen
+    ModelInfo(
+        id="big-pickle",
+        name="Big Pickle",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="nemotron-3-super-free",
+        name="Nemotron 3 Super Free",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+]
+
 AZURE_OPENAI_MODELS: List[ModelInfo] = [
     ModelInfo(
         id="gpt-5-chat",
@@ -543,6 +561,16 @@ PROVIDER_OPENAI = OpenAIProvider(
     freeze_url=True,
 )
 
+PROVIDER_OPENCODE = OpenAIProvider(
+    id="opencode",
+    name="OpenCode",
+    base_url="https://opencode.ai/zen/v1",
+    api_key_prefix="",
+    models=OPENCODE_MODELS,
+    freeze_url=True,
+    support_model_discovery=True,
+)
+
 PROVIDER_AZURE_OPENAI = OpenAIProvider(
     id="azure-openai",
     name="Azure OpenAI",
@@ -715,6 +743,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         self._add_builtin(PROVIDER_DASHSCOPE)
         self._add_builtin(PROVIDER_ALIYUN_CODINGPLAN)
         self._add_builtin(PROVIDER_OPENAI)
+        self._add_builtin(PROVIDER_OPENCODE)
         self._add_builtin(PROVIDER_AZURE_OPENAI)
         self._add_builtin(PROVIDER_ANTHROPIC)
         self._add_builtin(PROVIDER_GEMINI)
@@ -761,9 +790,9 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
     def _normalize_provider_id(provider_id: str) -> str:
         """Normalize provider ID for backward compatibility.
 
-        Maps legacy 'copaw-local' to 'qwenpaw-local'.
+        Maps legacy 'qwenpaw-local' to 'qwenpaw-local'.
         """
-        if provider_id == "copaw-local":
+        if provider_id == "qwenpaw-local":
             return "qwenpaw-local"
         return provider_id
 
@@ -1260,28 +1289,28 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         except Exception:
             return None
 
-    def _migrate_copaw_config(self) -> None:
-        """Migrate copaw-local provider config to qwenpaw-local."""
+    def _migrate_qwenpaw_config(self) -> None:
+        """Migrate qwenpaw-local provider config to qwenpaw-local."""
         # 1. Migrate active model configuration (only provider_id)
         if (
             self.active_model
-            and self.active_model.provider_id == "copaw-local"
+            and self.active_model.provider_id == "qwenpaw-local"
         ):
             self.active_model.provider_id = "qwenpaw-local"
             self.save_active_model(self.active_model)
             logger.info(
                 "Migrated active model provider from "
-                "'copaw-local' to 'qwenpaw-local'",
+                "'qwenpaw-local' to 'qwenpaw-local'",
             )
 
         # 2. Migrate stored provider config file
-        copaw_config_path = self.builtin_path / "copaw-local.json"
-        if not copaw_config_path.exists():
+        qwenpaw_config_path = self.builtin_path / "qwenpaw-local.json"
+        if not qwenpaw_config_path.exists():
             return
 
         try:
             # Load old config and apply to new provider instance
-            with open(copaw_config_path, "r", encoding="utf-8") as f:
+            with open(qwenpaw_config_path, "r", encoding="utf-8") as f:
                 old_config = json.load(f)
 
             # Get the new built-in provider instance
@@ -1304,13 +1333,13 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             self._save_provider(provider, is_builtin=True)
 
             # Remove old config file
-            copaw_config_path.unlink()
+            qwenpaw_config_path.unlink()
             logger.info(
                 "Migrated provider config from "
-                "'copaw-local.json' to 'qwenpaw-local.json'",
+                "'qwenpaw-local.json' to 'qwenpaw-local.json'",
             )
         except Exception as exc:
-            logger.warning("Failed to migrate copaw-local config: %s", exc)
+            logger.warning("Failed to migrate qwenpaw-local config: %s", exc)
 
     # pylint: disable=too-many-branches
     def _migrate_legacy_providers(self):
@@ -1363,8 +1392,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             # Migrate active model (only provider_id, not model)
             if active_model:
                 try:
-                    # Convert legacy copaw-local provider_id
-                    if active_model.get("provider_id") == "copaw-local":
+                    # Convert legacy qwenpaw-local provider_id
+                    if active_model.get("provider_id") == "qwenpaw-local":
                         active_model["provider_id"] = "qwenpaw-local"
                     self.active_model = ModelSlotConfig.model_validate(
                         active_model,
@@ -1416,8 +1445,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         if active_model:
             self.active_model = active_model
 
-        # Migrate copaw-local to qwenpaw-local for backwards compatibility
-        self._migrate_copaw_config()
+        # Migrate qwenpaw-local to qwenpaw-local for backwards compatibility
+        self._migrate_qwenpaw_config()
 
     def _apply_default_annotations(self):
         """Apply doc-based default annotations for unprobed models.

--- a/tests/unit/providers/test_opencode_provider.py
+++ b/tests/unit/providers/test_opencode_provider.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+"""Tests for the OpenCode built-in provider."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import qwenpaw.providers.provider_manager as provider_manager_module
+from qwenpaw.providers.openai_provider import OpenAIProvider
+from qwenpaw.providers.provider_manager import (
+    PROVIDER_OPENCODE,
+    ProviderManager,
+)
+
+
+def test_opencode_provider_is_openai_compatible() -> None:
+    """OpenCode provider should be an OpenAIProvider instance."""
+    assert isinstance(PROVIDER_OPENCODE, OpenAIProvider)
+
+
+def test_opencode_provider_config() -> None:
+    """Verify OpenCode provider configuration defaults."""
+    assert PROVIDER_OPENCODE.id == "opencode"
+    assert PROVIDER_OPENCODE.name == "OpenCode"
+    assert PROVIDER_OPENCODE.base_url == "https://opencode.ai/zen/v1"
+    assert PROVIDER_OPENCODE.freeze_url is True
+    assert PROVIDER_OPENCODE.support_model_discovery is True
+
+
+@pytest.fixture
+def isolated_secret_dir(monkeypatch, tmp_path):
+    secret_dir = tmp_path / ".qwenpaw.secret"
+    monkeypatch.setattr(provider_manager_module, "SECRET_DIR", secret_dir)
+    return secret_dir
+
+
+def test_opencode_registered_in_provider_manager(isolated_secret_dir) -> None:
+    """OpenCode provider should be registered as built-in provider."""
+    manager = ProviderManager()
+
+    provider = manager.get_provider("opencode")
+    assert provider is not None
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.base_url == "https://opencode.ai/zen/v1"
+
+
+async def test_opencode_check_connection_success(monkeypatch) -> None:
+    """OpenCode check_connection should delegate to OpenAI client."""
+    provider = OpenAIProvider(
+        id="opencode",
+        name="OpenCode",
+        base_url="https://opencode.ai/zen/v1",
+        api_key="test-key",
+    )
+
+    class FakeModels:
+        async def list(self, timeout=None):
+            return SimpleNamespace(data=[])
+
+    fake_client = SimpleNamespace(models=FakeModels())
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, msg = await provider.check_connection(timeout=2)
+
+    assert ok is True
+    assert msg == ""
+
+
+def test_opencode_has_expected_models(isolated_secret_dir) -> None:
+    """Provider manager OpenCode provider should include built-in models."""
+    manager = ProviderManager()
+    provider = manager.get_provider("opencode")
+
+    assert provider is not None
+
+    for model_id in [
+        "big-pickle",
+        "nemotron-3-super-free",
+    ]:
+        assert provider.has_model(model_id)

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -550,6 +550,7 @@ QwenPaw needs an LLM provider to work. You can set it up in three ways:
 | Zhipu Coding Plan (BigModel) | `zhipu-cn-codingplan`   | `https://open.bigmodel.cn/api/coding/paas/v4`       | _(any)_        |
 | Zhipu (Z.AI)                 | `zhipu-intl`            | `https://api.z.ai/api/paas/v4`                      | _(any)_        |
 | Zhipu Coding Plan (Z.AI)     | `zhipu-intl-codingplan` | `https://api.z.ai/api/coding/paas/v4`               | _(any)_        |
+| OpenCode           | `opencode`          | `https://opencode.ai/zen/v1`                        | _(any)_        |
 | Custom                       | `custom`                | _(you set it)_                                      | _(any)_        |
 
 For each provider you need to set:

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -550,7 +550,7 @@ QwenPaw needs an LLM provider to work. You can set it up in three ways:
 | Zhipu Coding Plan (BigModel) | `zhipu-cn-codingplan`   | `https://open.bigmodel.cn/api/coding/paas/v4`       | _(any)_        |
 | Zhipu (Z.AI)                 | `zhipu-intl`            | `https://api.z.ai/api/paas/v4`                      | _(any)_        |
 | Zhipu Coding Plan (Z.AI)     | `zhipu-intl-codingplan` | `https://api.z.ai/api/coding/paas/v4`               | _(any)_        |
-| OpenCode           | `opencode`          | `https://opencode.ai/zen/v1`                        | _(any)_        |
+| OpenCode                     | `opencode`              | `https://opencode.ai/zen/v1`                        | _(any)_        |
 | Custom                       | `custom`                | _(you set it)_                                      | _(any)_        |
 
 For each provider you need to set:

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -488,6 +488,7 @@ QwenPaw 需要 LLM 提供商才能运行。配置存储在 `$QWENPAW_SECRET_DIR/
 | Zhipu Coding Plan（BigModel） | `zhipu-cn-codingplan`   | 智谱国内版 Coding Plan |
 | Zhipu（Z.AI）                 | `zhipu-intl`            | 智谱国际版标准 API     |
 | Zhipu Coding Plan（Z.AI）     | `zhipu-intl-codingplan` | 智谱国际版 Coding Plan |
+| OpenCode               | `opencode`          | OpenCode Zen 模型服务          |
 | 自定义                        | `custom`                | 自定义 OpenAI 兼容服务 |
 
 > **完整配置说明：** 每个提供商的详细配置方式、`providers.json` 字段结构、模型发现等请参见 [模型](./models)。

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -488,7 +488,7 @@ QwenPaw 需要 LLM 提供商才能运行。配置存储在 `$QWENPAW_SECRET_DIR/
 | Zhipu Coding Plan（BigModel） | `zhipu-cn-codingplan`   | 智谱国内版 Coding Plan |
 | Zhipu（Z.AI）                 | `zhipu-intl`            | 智谱国际版标准 API     |
 | Zhipu Coding Plan（Z.AI）     | `zhipu-intl-codingplan` | 智谱国际版 Coding Plan |
-| OpenCode               | `opencode`          | OpenCode Zen 模型服务          |
+| OpenCode                      | `opencode`              | OpenCode Zen 模型服务  |
 | 自定义                        | `custom`                | 自定义 OpenAI 兼容服务 |
 
 > **完整配置说明：** 每个提供商的详细配置方式、`providers.json` 字段结构、模型发现等请参见 [模型](./models)。


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

I’ve taken task 16 in https://github.com/agentscope-ai/CoPaw/discussions/2292 to implement native support for opencode zen (https://opencode.ai/zh/zen), and https://github.com/agentscope-ai/CoPaw/pull/2428 appears to be based on a reverse proxy.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
