### PR TITLE
fix(mcp): Handle None mcp config

### DIFF
--- a/src/copaw/app/mcp/watcher.py
+++ b/src/copaw/app/mcp/watcher.py
@@ -129,14 +129,12 @@ class MCPConfigWatcher:
         config = self._config_loader()
         # Support both Config object with .mcp or direct MCPConfig
         if hasattr(config, "mcp"):
-            return config.mcp if config.mcp is not None else MCPConfig()
-        return config if config is not None else MCPConfig()
+            return config.mcp or MCPConfig()
+        return config or MCPConfig()
 
     @staticmethod
-    def _mcp_hash(mcp_config: Optional[MCPConfig]) -> int:
+    def _mcp_hash(mcp_config: MCPConfig) -> int:
         """Fast hash of MCP config for quick change detection."""
-        if mcp_config is None:
-            return hash(str({}))
         return hash(str(mcp_config.model_dump(mode="json")))
 
     async def _poll_loop(self) -> None:


### PR DESCRIPTION
## Description

Add null checks in `MCPConfigWatcher._load_mcp_config()` and `_mcp_hash()` to handle cases where agent config's mcp field is None

Fixes #2462 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
