### PR TITLE
fix(install): correct PowerShell cmdlet name

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -400,7 +400,7 @@ if (-not $isAlreadyAdded) {
         $newUserPath = $targetPath
     }
 
-    # 3. 核心修复：使用 SetItemProperty 代替 [Environment]::SetEnvironmentVariable
+    # 3. 核心修复：使用 Set-ItemProperty 代替 [Environment]::SetEnvironmentVariable
     #    这是原生 cmdlet，在 Constrained Language Mode 下通常可用
     try {
         # 确保注册表路径存在 (HKCU:\Environment 通常默认存在，但为了健壮性检查一下)
@@ -410,7 +410,7 @@ if (-not $isAlreadyAdded) {
         }
 
         # 写入注册表
-        SetItemProperty -Path $registryPath -Name $registryName -Value $newUserPath
+        Set-ItemProperty -Path $registryPath -Name $registryName -Value $newUserPath
 
         # 更新当前进程的环境变量，使当前终端立即生效
         $env:Path = "$targetPath;$env:Path"
@@ -418,7 +418,7 @@ if (-not $isAlreadyAdded) {
         Write-Info "Successfully added $targetPath to User PATH (via Registry)"
 
     } catch {
-        # 如果连 SetItemProperty 都失败（例如注册表被组策略完全锁定）
+        # 如果连 Set-ItemProperty 都失败（例如注册表被组策略完全锁定）
         $errorMsg = $_.Exception.Message
 
         Write-Host ""


### PR DESCRIPTION
## Description

Fixes a typo in `install.ps1` that prevented automatic PATH updates on all Windows installations.

**Related Issue:** Fixes #2488

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
