### PR TITLE
fix: 支持 requires 字段的列表格式

### DIFF
--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -497,6 +497,12 @@ def read_skill_requirements(skill_dir: Path) -> SkillRequirements:
     else:
         requires = metadata.get("requires", {})
 
+    if isinstance(requires, list):
+        return SkillRequirements(
+            require_bins=list(requires),
+            require_envs=[],
+        )
+
     return SkillRequirements(
         require_bins=list(requires.get("bins", [])),
         require_envs=list(requires.get("env", [])),


### PR DESCRIPTION
## 问题
当 skill 的 SKILL.md 中 requires 字段为列表格式时代码会崩溃。

## 解决方案
- 添加 requires 字段的类型检查
- 如果是列表，将其作为 require_bins 处理
- 保持与字典格式的向后兼容

## 测试
使用 requires 列表格式的 skill 测试通过，不再崩溃。