### PR TITLE
feat: 为子进程命令添加代理支持

### DIFF
--- a/src/copaw/agents/tools/shell.py
+++ b/src/copaw/agents/tools/shell.py
@@ -221,6 +221,18 @@ async def execute_shell_command(
     else:
         env["PATH"] = python_bin_dir
 
+    # Add proxy support for network requests
+    proxy_host = os.environ.get("PROXY_HOST", "127.0.0.1")
+    proxy_port = os.environ.get("PROXY_PORT", "7897")
+    if not env.get("http_proxy"):
+        env["http_proxy"] = f"http://{proxy_host}:{proxy_port}"
+    if not env.get("https_proxy"):
+        env["https_proxy"] = f"http://{proxy_host}:{proxy_port}"
+    if not env.get("HTTP_PROXY"):
+        env["HTTP_PROXY"] = f"http://{proxy_host}:{proxy_port}"
+    if not env.get("HTTPS_PROXY"):
+        env["HTTPS_PROXY"] = f"http://{proxy_host}:{proxy_port}"
+
     try:
         if sys.platform == "win32":
             # Windows: use thread pool to avoid asyncio subprocess limitations


### PR DESCRIPTION
## 问题
在 WSL 或企业网络环境中，子进程命令（如 npm、pip、git clone）经常因网络限制而失败。

## 解决方案
为所有子进程命令自动注入代理环境变量。

## 配置方法
设置环境变量：
export PROXY_HOST=127.0.0.1
export PROXY_PORT=7897

## 使用场景
- WSL 用户访问 Windows 宿主机代理
- 企业防火墙后的用户
- 中国大陆使用 VPN/代理的用户

## 注意
仅在未设置代理时才注入，尊重用户已有的配置。