### PR TITLE
fix(wecom): trigger reconnect on heartbeat failure to prevent permanent disconnection

### DIFF
--- a/src/copaw/app/channels/wecom/channel.py
+++ b/src/copaw/app/channels/wecom/channel.py
@@ -1019,7 +1019,8 @@ class WecomChannel(BaseChannel):
                         await ws_mgr._ws.close()
                     except Exception as e:
                         ws_mgr._logger.warning(
-                            "Failed to close websocket on heartbeat failure: %s", e
+                            "Failed to close ws on heartbeat failure: %s",
+                            e,
                         )
                 # Fix: trigger reconnect instead of silent return
                 await ws_mgr._schedule_reconnect()


### PR DESCRIPTION
## Description

Fix wecom channel not automatically reconnecting after network disconnection.

### Changes

- Patch SDK's `_send_heartbeat` to trigger reconnection when heartbeat fails
- Add event listeners for reconnect state logging

**Related Issue:** Fixes #2438 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
