### PR TITLE
fix(console): correct skill toggle icon

### DIFF
--- a/console/src/pages/Agent/Skills/components/SkillCard.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillCard.tsx
@@ -228,9 +228,7 @@ export const SkillCard = React.memo(function SkillCard({
           <Button
             className={styles.actionButton}
             onClick={handleToggleClick}
-            icon={
-              skill.enabled ? <EyeInvisibleOutlined /> : <EyeOutlined />
-            }
+            icon={skill.enabled ? <EyeInvisibleOutlined /> : <EyeOutlined />}
           >
             {skill.enabled ? t("common.disable") : t("common.enable")}
           </Button>


### PR DESCRIPTION
## Description

  This PR fixes an icon mismatch in the Skills page toggle action within `SkillCard`.

  Previously, the toggle button text changed correctly based on the skill state (`Enable` / `Disable`),
  but the icon was always hardcoded to `EyeInvisibleOutlined`. This made the action misleading,
  especially for disabled skills where the button showed `Enable` while still rendering a hidden/
  disable-style icon.

  This change updates the button icon to match the action semantics:
  - disabled skill -> `Enable` with `EyeOutlined`
  - enabled skill -> `Disable` with `EyeInvisibleOutlined`

  A follow-up formatting commit was included after local Prettier verification.

  **Related Issue:** Fixes #2512

  **Security Considerations:** None

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] Refactoring

  ## Component(s) Affected

  - [ ] Core / Backend (app, agents, config, providers, utils, local_models)
  - [x] Console (frontend web UI)
  - [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
  - [x] Skills
  - [ ] CLI
  - [ ] Documentation (website)
  - [ ] Tests
  - [ ] CI/CD
  - [ ] Scripts / Deploy

  ## Checklist

  - [ ] I ran `pre-commit run --all-files` locally and it passes
  - [x] If pre-commit auto-fixed files, I committed those changes and reran checks
  - [ ] I ran tests locally (`pytest` or as relevant) and they pass
  - [ ] Documentation updated (if needed)
  - [ ] Ready for review

  ## Testing
<img width="379" height="320" alt="截屏2026-03-30 10 57 45" src="https://github.com/user-attachments/assets/0216708f-91cf-42d5-a7f4-0a7ea0cf79cb" />


  1. Open the Console UI and navigate to the Skills page.
  2. Hover over a disabled skill card and confirm the toggle button shows `Enable` with `EyeOutlined`.
  3. Hover over an enabled skill card and confirm the toggle button shows `Disable` with
  `EyeInvisibleOutlined`.
  4. Toggle the skill state and verify the button icon and label update consistently with the new state.

  ## Local Verification Evidence

  ```bash
  npm run format:check
  # failed
  # prettier --check reported existing formatting issues in console/dist/** and console/dist/index.html
  # after formatting console/src/pages/Agent/Skills/components/SkillCard.tsx,
  # the modified source file was no longer reported

  UV_CACHE_DIR=/tmp/uv-cache uv run pre-commit run --all-files
  # passed

  UV_CACHE_DIR=/tmp/uv-cache uv run pytest
  # failed: 89 failed, 237 passed
  # representative failures include:
  # - tests/integrated/test_app_startup.py::test_app_startup_and_console
  #   PermissionError: [Errno 1] Operation not permitted
  # - multiple async tests failing with:
  #   "async def functions are not natively supported"
  # - PytestUnknownMarkWarning for pytest.mark.asyncio

  ## Additional Notes

  This PR is scoped to a small UI fix in console/src/pages/Agent/Skills/components/SkillCard.tsx.

  The branch also includes a formatting-only follow-up commit for the same file after local
  verification.