### PR TITLE
fix(models): preflight active model and surface provider compute errors

### DIFF
--- a/src/copaw/app/routers/providers.py
+++ b/src/copaw/app/routers/providers.py
@@ -121,6 +121,34 @@ def _validate_model_slot(
         )
 
 
+async def _preflight_model_slot(
+    manager: ProviderManager,
+    provider_id: str,
+    model_id: str,
+) -> None:
+    """Optionally test model availability before activating the slot."""
+    provider = manager.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Provider '{provider_id}' not found.",
+        )
+
+    if not provider.support_connection_check:
+        return
+
+    ok, msg = await provider.check_model_connection(model_id=model_id)
+    if not ok:
+        detail = msg or "model is not available"
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot activate model '{model_id}' on provider "
+                f"'{provider_id}': {detail}"
+            ),
+        )
+
+
 async def _load_agent_model(
     request: Request,
     agent_id: str,
@@ -522,6 +550,12 @@ async def set_active_model(
     """Set active model by scope."""
     if body.scope == "global":
         try:
+            _validate_model_slot(manager, body.provider_id, body.model)
+            await _preflight_model_slot(
+                manager,
+                body.provider_id,
+                body.model,
+            )
             await manager.activate_model(body.provider_id, body.model)
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             message = str(exc)
@@ -538,6 +572,11 @@ async def set_active_model(
         )
 
     _validate_model_slot(manager, body.provider_id, body.model)
+    await _preflight_model_slot(
+        manager,
+        body.provider_id,
+        body.model,
+    )
 
     try:
         workspace = await get_agent_for_request(

--- a/src/copaw/providers/openai_provider.py
+++ b/src/copaw/providers/openai_provider.py
@@ -25,6 +25,26 @@ CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
 
+    @staticmethod
+    def _format_api_error(error: APIError) -> str:
+        """Format OpenAI APIError with status and response body when present."""
+        parts: list[str] = []
+        status = getattr(error, "status_code", None)
+        if status is not None:
+            parts.append(f"status={status}")
+
+        body = getattr(error, "body", None)
+        if body is not None:
+            if isinstance(body, (dict, list)):
+                body_text = json.dumps(body, ensure_ascii=False)
+            else:
+                body_text = str(body)
+            parts.append(f"body={body_text}")
+        else:
+            parts.append(f"message={error}")
+
+        return ", ".join(parts)
+
     def _client(self, timeout: float = 5) -> AsyncOpenAI:
         return AsyncOpenAI(
             base_url=self.base_url,
@@ -62,12 +82,17 @@ class OpenAIProvider(Provider):
         try:
             await client.models.list(timeout=timeout)
             return True, ""
-        except APIError:
-            return False, f"API error when connecting to `{self.base_url}`"
-        except Exception:
+        except APIError as e:
             return (
                 False,
-                f"Unknown exception when connecting to `{self.base_url}`",
+                "API error when connecting to "
+                f"`{self.base_url}` ({self._format_api_error(e)})",
+            )
+        except Exception as e:
+            return (
+                False,
+                "Unknown exception when connecting to "
+                f"`{self.base_url}`: {e}",
             )
 
     async def fetch_models(self, timeout: float = 5) -> List[ModelInfo]:
@@ -115,12 +140,17 @@ class OpenAIProvider(Provider):
             async for _ in res:
                 break
             return True, ""
-        except APIError:
-            return False, f"API error when connecting to model '{model_id}'"
-        except Exception:
+        except APIError as e:
             return (
                 False,
-                f"Unknown exception when connecting to model '{model_id}'",
+                "API error when connecting to model "
+                f"'{model_id}' ({self._format_api_error(e)})",
+            )
+        except Exception as e:
+            return (
+                False,
+                "Unknown exception when connecting to model "
+                f"'{model_id}': {e}",
             )
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:

--- a/src/copaw/providers/openai_provider.py
+++ b/src/copaw/providers/openai_provider.py
@@ -27,7 +27,7 @@ class OpenAIProvider(Provider):
 
     @staticmethod
     def _format_api_error(error: APIError) -> str:
-        """Format OpenAI APIError with status and response body when present."""
+        """Format APIError with status and response body when present."""
         parts: list[str] = []
         status = getattr(error, "status_code", None)
         if status is not None:


### PR DESCRIPTION
## Description

This PR hardens model activation and diagnostics for OpenAI-compatible providers.

Changes included:
- Add a preflight availability check before setting active model (both global scope and agent scope).
- Reject activation when provider reports the model is unavailable, with explicit API response details.
- Improve provider/model connection-test error messages to include structured status/body/message when available.

**Related Issue:** Relates to #N/A

**Security Considerations:** No new auth surface; this change improves failure transparency only and does not relax validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Reproduce unavailable model behavior with LM Studio/OpenAI-compatible endpoint.
2. Verify `POST /api/models/{provider}/models/test` returns actionable error details.
3. Verify `PUT /api/models/active` rejects unavailable model with HTTP 400 and explicit reason.
4. Verify available model can still be activated successfully.

## Local Verification Evidence

```bash
# test unavailable model
curl -X POST /api/models/lmstudio/models/test \
  -d '{"model_id":"qwen/qwen3.5-9b"}'
# => success:false, message contains body={"message":"Compute error."}

# set active model (unavailable)
curl -X PUT /api/models/active \
  -d '{"provider_id":"lmstudio","model":"qwen/qwen3.5-9b","scope":"global"}'
# => HTTP 400, detail starts with
#    Cannot activate model ... API error ... body={"message":"Compute error."}

# set active model (available)
curl -X PUT /api/models/active \
  -d '{"provider_id":"lmstudio","model":"qwen/qwen3.5-9b:2","scope":"agent","agent_id":"default"}'
# => success (active_llm returned)
```

## Additional Notes

- This PR intentionally fails fast during model activation to prevent delayed runtime failures in chat execution.
- Current behavior for providers that do not support connection checks remains unchanged.
