### PR TITLE
fix(dingtalk): save conversation_id for cron task message delivery

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -1753,29 +1753,6 @@ class DingTalkChannel(BaseChannel):
                 )
                 use_ai_card = False
 
-        # Store sessionWebhook (keyed by conversation).
-        if session_webhook:
-            fallback_sid = f"{self.channel}:{request.user_id}"
-            webhook_key = self.to_handle_from_target(
-                user_id=request.user_id or "",
-                session_id=request.session_id or fallback_sid,
-            )
-            logger.info(
-                "dingtalk _process_one_request: storing webhook "
-                "session_id=%s conversation_id=%s webhook_key=%s",
-                getattr(request, "session_id", None),
-                meta.get("conversation_id"),
-                webhook_key,
-            )
-            await self._save_session_webhook(
-                webhook_key,
-                session_webhook,
-                expired_time=meta.get("session_webhook_expired_time"),
-                conversation_id=meta.get("conversation_id"),
-                conversation_type=meta.get("conversation_type"),
-                sender_staff_id=meta.get("sender_staff_id"),
-            )
-
         async for event in self._process(request):
             event_count += 1
             obj = getattr(event, "object", None)


### PR DESCRIPTION
## Description

- Add `_before_consume_process` to save conversation_id to webhook store
- Fix `build_agent_request_from_native`: use `setattr` to ensure channel_meta is set, filter non-serializable fields
- Fix Open API payload format: use `msgKey: "sampleText"` per DingTalk spec

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
