### PR TITLE
fix(weixin): add file, image and video sending support

### DIFF
--- a/src/copaw/app/channels/weixin/channel.py
+++ b/src/copaw/app/channels/weixin/channel.py
@@ -4,8 +4,12 @@
 """WeChat (iLink Bot) Channel.
 
 Uses the official WeChat iLink Bot HTTP API to receive and send messages.
-Incoming messages are fetched via long-polling (getupdates); replies are sent
-via sendmessage. Supports text, image, voice (ASR text), and file messages.
+Incoming messages are fetched via long-polling (getupdates); replies are
+sent via sendmessage. Supports text, image, voice (ASR text), file, and
+video messages.
+
+For sending media (image/video/file), files are uploaded to WeChat CDN via
+getuploadurl API, encrypted with AES-128-ECB before upload.
 
 Authentication:
   - If bot_token is configured, it is used directly.
@@ -36,7 +40,7 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
     VideoContent,
 )
 
-from ....constant import DEFAULT_MEDIA_DIR
+from ....constant import DEFAULT_MEDIA_DIR, WORKING_DIR
 from ..base import (
     BaseChannel,
     ContentType,
@@ -44,7 +48,7 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import split_text
+from ..utils import file_url_to_local_path, split_text
 from .client import ILinkClient, _DEFAULT_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -52,8 +56,8 @@ logger = logging.getLogger(__name__)
 # Max dedup set size
 _WEIXIN_PROCESSED_IDS_MAX = 2000
 
-# Default token file path
-_DEFAULT_TOKEN_FILE = Path("~/.copaw/weixin_bot_token").expanduser()
+# Default token file path (under WORKING_DIR to respect COPAW_WORKING_DIR)
+_DEFAULT_TOKEN_FILE = WORKING_DIR / "weixin_bot_token"
 
 
 class WeixinChannel(BaseChannel):
@@ -751,7 +755,11 @@ class WeixinChannel(BaseChannel):
         parts: List[OutgoingContentPart],
         meta: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Send agent response content back to the WeChat user."""
+        """Send agent response content back to the WeChat user.
+
+        Supports TEXT, IMAGE, VIDEO, FILE, and REFUSAL content types.
+        Media files are uploaded to WeChat CDN via getuploadurl API.
+        """
         if not self.enabled:
             return
         m = meta or {}
@@ -768,6 +776,10 @@ class WeixinChannel(BaseChannel):
             logger.warning("weixin send_content_parts: no to_user_id")
             return
 
+        if not self._client:
+            logger.warning("weixin send_content_parts: client not initialized")
+            return
+
         prefix = m.get("bot_prefix", "") or self.bot_prefix or ""
         text_parts: List[str] = []
 
@@ -781,21 +793,164 @@ class WeixinChannel(BaseChannel):
             refusal_val = getattr(p, "refusal", None) or (
                 p.get("refusal") if isinstance(p, dict) else None
             )
+
             if t == ContentType.TEXT and text_val:
                 text_parts.append(text_val)
             elif t == ContentType.REFUSAL and refusal_val:
                 text_parts.append(refusal_val)
-            # Media send not yet implemented for iLink (no upload API)
+            elif t == ContentType.IMAGE:
+                await self._send_image_part(to_user_id, context_token, p)
+            elif t == ContentType.VIDEO:
+                await self._send_video_part(to_user_id, context_token, p)
+            elif t == ContentType.FILE:
+                await self._send_file_part(to_user_id, context_token, p)
 
         body = "\n".join(text_parts).strip()
         if prefix and body:
             body = prefix + "  " + body
 
-        if not body:
-            return
+        if body:
+            for chunk in split_text(body):
+                await self._send_text_direct(to_user_id, chunk, context_token)
 
-        for chunk in split_text(body):
-            await self._send_text_direct(to_user_id, chunk, context_token)
+    async def _send_image_part(
+        self,
+        to_user_id: str,
+        context_token: str,
+        part: Any,
+    ) -> None:
+        """Send an image content part."""
+        try:
+            image_url = getattr(part, "image_url", None) or (
+                part.get("image_url") if isinstance(part, dict) else None
+            )
+            if not image_url:
+                logger.warning("weixin: image part missing image_url")
+                return
+
+            # Handle file:// URLs
+            if image_url.startswith("file://"):
+                local_path = file_url_to_local_path(image_url)
+                if not local_path:
+                    logger.warning("weixin: invalid file URL: %s", image_url)
+                    return
+                image_url = local_path
+
+            # Read image data from local file
+            if image_url.startswith("/") or not image_url.startswith("http"):
+                path = Path(image_url)
+                if not path.is_file():
+                    logger.warning(
+                        "weixin: image file not found: %s",
+                        image_url,
+                    )
+                    return
+                data = path.read_bytes()
+            else:
+                # Remote URL - download first
+                logger.warning(
+                    "weixin: remote image URL not supported: %s",
+                    image_url,
+                )
+                return
+
+            await self._client.send_image(to_user_id, data, context_token)
+            logger.debug("weixin: sent image %s", image_url[:50])
+        except Exception:
+            logger.exception("weixin: failed to send image")
+
+    async def _send_video_part(
+        self,
+        to_user_id: str,
+        context_token: str,
+        part: Any,
+    ) -> None:
+        """Send a video content part."""
+        try:
+            video_url = getattr(part, "video_url", None) or (
+                part.get("video_url") if isinstance(part, dict) else None
+            )
+            if not video_url:
+                logger.warning("weixin: video part missing video_url")
+                return
+
+            # Handle file:// URLs
+            if video_url.startswith("file://"):
+                local_path = file_url_to_local_path(video_url)
+                if not local_path:
+                    logger.warning("weixin: invalid file URL: %s", video_url)
+                    return
+                video_url = local_path
+
+            if video_url.startswith("/") or not video_url.startswith("http"):
+                path = Path(video_url)
+                if not path.is_file():
+                    logger.warning(
+                        "weixin: video file not found: %s",
+                        video_url,
+                    )
+                    return
+                data = path.read_bytes()
+            else:
+                logger.warning(
+                    "weixin: remote video URL not supported: %s",
+                    video_url,
+                )
+                return
+
+            await self._client.send_video(to_user_id, data, context_token)
+            logger.debug("weixin: sent video %s", video_url[:50])
+        except Exception:
+            logger.exception("weixin: failed to send video")
+
+    async def _send_file_part(
+        self,
+        to_user_id: str,
+        context_token: str,
+        part: Any,
+    ) -> None:
+        """Send a file content part."""
+        try:
+            file_url = getattr(part, "file_url", None) or (
+                part.get("file_url") if isinstance(part, dict) else None
+            )
+            filename = getattr(part, "filename", None) or (
+                part.get("filename") if isinstance(part, dict) else None
+            )
+            if not file_url:
+                logger.warning("weixin: file part missing file_url")
+                return
+
+            # Handle file:// URLs
+            if file_url.startswith("file://"):
+                local_path = file_url_to_local_path(file_url)
+                if not local_path:
+                    logger.warning("weixin: invalid file URL: %s", file_url)
+                    return
+                file_url = local_path
+
+            if file_url.startswith("/") or not file_url.startswith("http"):
+                path = Path(file_url)
+                if not path.is_file():
+                    logger.warning("weixin: file not found: %s", file_url)
+                    return
+                data = path.read_bytes()
+                filename = filename or path.name
+            else:
+                logger.warning(
+                    "weixin: remote file URL not supported: %s",
+                    file_url,
+                )
+                return
+
+            await self._client.send_file(
+                to_user_id,
+                data,
+                filename,
+                context_token,
+            )
+        except Exception:
+            logger.exception("weixin: failed to send file")
 
     async def send(
         self,

--- a/src/copaw/app/channels/weixin/client.py
+++ b/src/copaw/app/channels/weixin/client.py
@@ -9,11 +9,19 @@ Authentication flow:
 2. Poll GET /ilink/bot/get_qrcode_status?qrcode=<qrcode> until confirmed
 3. Save bot_token + baseurl from the confirmed response
 4. Use bearer token for all subsequent requests
+
+Media upload flow:
+1. Call getuploadurl to get CDN upload URL and AES key
+2. Encrypt media data with AES-128-ECB + PKCS7 padding
+3. Upload encrypted data to CDN
+4. Use returned CDN URL in sendmessage
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
 import logging
 import uuid
 from typing import Any, Dict, Optional, Tuple
@@ -21,7 +29,11 @@ from urllib.parse import quote
 
 import httpx
 
-from .utils import aes_ecb_decrypt, make_headers
+from .utils import (
+    aes_ecb_decrypt,
+    aes_ecb_encrypt,
+    make_headers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +42,16 @@ _CHANNEL_VERSION = "2.0.1"
 # Long-poll hold time is up to 35 seconds (server-controlled)
 _GETUPDATES_TIMEOUT = 45.0
 _DEFAULT_TIMEOUT = 15.0
+
+# CDN base URL for media upload/download
+_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
+
+# Message item types (for item_list in sendmessage)
+MESSAGE_ITEM_TYPE_TEXT = 1
+MESSAGE_ITEM_TYPE_IMAGE = 2
+MESSAGE_ITEM_TYPE_VOICE = 3
+MESSAGE_ITEM_TYPE_FILE = 4
+MESSAGE_ITEM_TYPE_VIDEO = 5
 
 
 class ILinkClient:
@@ -316,3 +338,404 @@ class ILinkClient:
         if aes_key_b64:
             data = aes_ecb_decrypt(data, aes_key_b64)
         return data
+
+    # ------------------------------------------------------------------
+    # Media upload APIs
+    # ------------------------------------------------------------------
+
+    async def getuploadurl(
+        self,
+        file_type: str,
+        raw_size: int,
+        encrypted_size: int,
+        raw_md5: str,
+        aes_key: str,
+        to_user_id: str = "",
+        no_need_thumb: bool = True,
+    ) -> Dict[str, Any]:
+        """Request CDN upload URL and AES key for media upload.
+
+        Args:
+            file_type: One of "image", "file", "voice", "video".
+            raw_size: Size of the raw file in bytes (before encryption).
+            encrypted_size: Size of the encrypted file in bytes.
+            raw_md5: MD5 hash of the raw file.
+            aes_key: 32-character hex string AES-128 key for encryption.
+            to_user_id: Target user ID for the media message.
+            no_need_thumb: Whether to skip thumbnail upload URL.
+
+        Returns:
+            Dict with keys:
+                upload_param: CDN upload encrypted parameters.
+                thumb_upload_param: Thumbnail upload encrypted params (if any).
+        """
+        # Map file_type to media_type: 1=IMAGE, 2=VIDEO, 3=FILE, 4=VOICE
+        media_type_map = {
+            "image": 1,
+            "video": 2,
+            "file": 3,
+            "voice": 4,
+        }
+        media_type = media_type_map.get(file_type, 3)
+
+        # Generate filekey (16 bytes random hex = 32 chars)
+        filekey = uuid.uuid4().hex[:32]
+
+        # Build request body per official iLink API spec
+        body: Dict[str, Any] = {
+            "filekey": filekey,
+            "media_type": media_type,
+            "to_user_id": to_user_id,
+            "rawsize": raw_size,
+            "rawfilemd5": raw_md5,
+            "filesize": encrypted_size,
+            "aeskey": aes_key,
+            "no_need_thumb": no_need_thumb,
+            "base_info": {"channel_version": _CHANNEL_VERSION},
+        }
+
+        result = await self._post("ilink/bot/getuploadurl", body)
+        # Include the filekey in the result so caller can use it for CDN upload
+        result["_filekey"] = filekey
+        return result
+
+    async def upload_media(
+        self,
+        data: bytes,
+        file_type: str,
+        to_user_id: str = "",
+    ) -> Dict[str, Any]:
+        """Upload media to WeChat CDN with AES encryption.
+
+        Flow:
+        1. Generate AES key and encrypt data.
+        2. Get upload URL from getuploadurl.
+        3. Upload encrypted data to CDN.
+        4. Get download param from response header.
+
+        Args:
+            data: Raw media bytes to upload.
+            file_type: One of "image", "file", "voice", "video".
+            to_user_id: Target user ID for the media message.
+
+        Returns:
+            Dict with keys:
+                download_param: Encrypted query param for downloading.
+                aes_key: Hex-encoded AES key used for encryption.
+                filekey: File key used for upload.
+        """
+        assert self._client is not None, "ILinkClient not started"
+
+        # Step 1: Generate AES key (16 bytes = 32 hex chars)
+        aes_key_hex = uuid.uuid4().hex[:32]
+        aes_key_bytes = bytes.fromhex(aes_key_hex)
+        # Convert to base64 for encryption function
+        aes_key_b64_for_encrypt = base64.b64encode(aes_key_bytes).decode()
+
+        # Step 2: Encrypt data
+        encrypted_data = aes_ecb_encrypt(data, aes_key_b64_for_encrypt)
+        encrypted_size = len(encrypted_data)
+
+        # Step 3: Calculate raw file MD5
+        raw_md5 = hashlib.md5(data).hexdigest()
+
+        # Step 4: Get upload URL (getuploadurl generates its own filekey)
+        upload_info = await self.getuploadurl(
+            file_type=file_type,
+            raw_size=len(data),
+            encrypted_size=encrypted_size,
+            raw_md5=raw_md5,
+            aes_key=aes_key_hex,
+            to_user_id=to_user_id,
+            no_need_thumb=True,
+        )
+        # Use the filekey generated by getuploadurl for CDN upload
+        filekey = upload_info.get("_filekey", "")
+        # API v2.1+ returns upload_full_url instead of upload_param
+        upload_param = upload_info.get("upload_param", "")
+        upload_full_url = upload_info.get("upload_full_url", "")
+
+        ret = upload_info.get("ret", 0)
+        if ret != 0:
+            errmsg = upload_info.get("errmsg", "")
+            logger.warning(
+                "weixin getuploadurl failed: ret=%s, errmsg=%s, "
+                "file_type=%s, raw_size=%s, encrypted_size=%s",
+                ret,
+                errmsg,
+                file_type,
+                len(data),
+                encrypted_size,
+            )
+
+        # Build CDN upload URL
+        # Use upload_full_url directly if available (API v2.1+),
+        # otherwise build from upload_param
+        if upload_full_url:
+            full_upload_url = upload_full_url
+        elif upload_param:
+            encoded_param = quote(upload_param, safe="")
+            full_upload_url = (
+                f"{_CDN_BASE_URL}/upload?"
+                f"encrypted_query_param={encoded_param}&"
+                f"filekey={filekey}"
+            )
+        else:
+            raise ValueError(
+                f"getuploadurl did not return upload_url: {upload_info}",
+            )
+
+        # Step 7: Upload to CDN
+        resp = await self._client.post(
+            full_upload_url,
+            content=encrypted_data,
+            headers={"Content-Type": "application/octet-stream"},
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+
+        # Step 8: Get download param from response header
+        # httpx.Headers is case-insensitive, so direct get works
+        download_param = resp.headers.get("x-encrypted-param", "")
+        if not download_param:
+            raise ValueError(
+                "CDN upload response missing x-encrypted-param header",
+            )
+
+        return {
+            "download_param": download_param,
+            "aes_key": aes_key_hex,
+            "filekey": filekey,
+            "encrypted_size": encrypted_size,
+            "raw_size": len(data),
+        }
+
+    # ------------------------------------------------------------------
+    # Send media message helpers
+    # ------------------------------------------------------------------
+
+    async def send_image(
+        self,
+        to_user_id: str,
+        image_data: bytes,
+        context_token: str,
+    ) -> Dict[str, Any]:
+        """Send an image message.
+
+        Args:
+            to_user_id: Recipient user ID.
+            image_data: Raw image bytes.
+            context_token: context_token from the inbound message.
+
+        Returns:
+            API response dict.
+        """
+        upload_result = await self.upload_media(
+            image_data,
+            file_type="image",
+            to_user_id=to_user_id,
+        )
+        # Use download_param as encrypt_query_param (not full URL)
+        download_param = upload_result["download_param"]
+        # aes_key format: base64(hex_string)
+        aes_key_hex = upload_result["aes_key"]
+        aes_key_b64 = base64.b64encode(aes_key_hex.encode("ascii")).decode()
+        # Get encrypted file size for mid_size
+        encrypted_size = upload_result.get("encrypted_size", len(image_data))
+        return await self._send_media_message(
+            to_user_id=to_user_id,
+            context_token=context_token,
+            item_type=MESSAGE_ITEM_TYPE_IMAGE,
+            encrypt_query_param=download_param,
+            aes_key=aes_key_b64,
+            mid_size=encrypted_size,
+        )
+
+    async def send_file(
+        self,
+        to_user_id: str,
+        file_data: bytes,
+        filename: str,
+        context_token: str,
+    ) -> Dict[str, Any]:
+        """Send a file message.
+
+        Args:
+            to_user_id: Recipient user ID.
+            file_data: Raw file bytes.
+            filename: Display filename (used for extension detection).
+            context_token: context_token from the inbound message.
+
+        Returns:
+            API response dict.
+        """
+        upload_result = await self.upload_media(
+            file_data,
+            file_type="file",
+            to_user_id=to_user_id,
+        )
+        # Use download_param as encrypt_query_param (not full URL)
+        download_param = upload_result["download_param"]
+        aes_key_hex = upload_result["aes_key"]
+        aes_key_b64 = base64.b64encode(aes_key_hex.encode("ascii")).decode()
+        # Get raw file size for len field
+        raw_size = upload_result.get("raw_size", len(file_data))
+        return await self._send_media_message(
+            to_user_id=to_user_id,
+            context_token=context_token,
+            item_type=MESSAGE_ITEM_TYPE_FILE,
+            encrypt_query_param=download_param,
+            aes_key=aes_key_b64,
+            filename=filename,
+            file_size=raw_size,
+        )
+
+    async def send_voice(
+        self,
+        to_user_id: str,
+        voice_data: bytes,
+        context_token: str,
+    ) -> Dict[str, Any]:
+        """Send a voice message.
+
+        Args:
+            to_user_id: Recipient user ID.
+            voice_data: Raw voice bytes.
+            context_token: context_token from the inbound message.
+
+        Returns:
+            API response dict.
+        """
+        upload_result = await self.upload_media(
+            voice_data,
+            file_type="voice",
+            to_user_id=to_user_id,
+        )
+        # Use download_param as encrypt_query_param (not full URL)
+        download_param = upload_result["download_param"]
+        # aes_key format: base64(hex_string)
+        aes_key_hex = upload_result["aes_key"]
+        aes_key_b64 = base64.b64encode(aes_key_hex.encode("ascii")).decode()
+        return await self._send_media_message(
+            to_user_id=to_user_id,
+            context_token=context_token,
+            item_type=MESSAGE_ITEM_TYPE_VOICE,
+            encrypt_query_param=download_param,
+            aes_key=aes_key_b64,
+        )
+
+    async def send_video(
+        self,
+        to_user_id: str,
+        video_data: bytes,
+        context_token: str,
+    ) -> Dict[str, Any]:
+        """Send a video message.
+
+        Args:
+            to_user_id: Recipient user ID.
+            video_data: Raw video bytes.
+            context_token: context_token from the inbound message.
+
+        Returns:
+            API response dict.
+        """
+        upload_result = await self.upload_media(
+            video_data,
+            file_type="video",
+            to_user_id=to_user_id,
+        )
+        # Use download_param as encrypt_query_param (not full URL)
+        download_param = upload_result["download_param"]
+        # aes_key format: base64(hex_string)
+        aes_key_hex = upload_result["aes_key"]
+        aes_key_b64 = base64.b64encode(aes_key_hex.encode("ascii")).decode()
+        # Get encrypted file size for video_size
+        encrypted_size = upload_result.get("encrypted_size", len(video_data))
+        return await self._send_media_message(
+            to_user_id=to_user_id,
+            context_token=context_token,
+            item_type=MESSAGE_ITEM_TYPE_VIDEO,
+            encrypt_query_param=download_param,
+            aes_key=aes_key_b64,
+            video_size=encrypted_size,
+        )
+
+    async def _send_media_message(
+        self,
+        to_user_id: str,
+        context_token: str,
+        item_type: int,
+        encrypt_query_param: str,
+        aes_key: str,
+        filename: str = "",
+        mid_size: int = 0,
+        video_size: int = 0,
+        file_size: int = 0,
+    ) -> Dict[str, Any]:
+        """Internal helper to send a media message via sendmessage.
+
+        Args:
+            to_user_id: Recipient user ID.
+            context_token: context_token from inbound message.
+            item_type: Message item type (IMAGE=2, VOICE=3, FILE=4, VIDEO=5).
+            encrypt_query_param: CDN download encrypted query param.
+            aes_key: AES key used for encryption
+                (base64-encoded, sent to recipient).
+            filename: Filename (for file type only).
+            mid_size: Ciphertext file size for images.
+            video_size: Ciphertext file size for videos.
+            file_size: Raw file size for files.
+
+        Returns:
+            API response dict.
+        """
+        item: Dict[str, Any] = {"type": item_type}
+
+        if item_type == MESSAGE_ITEM_TYPE_IMAGE:
+            item["image_item"] = {
+                "media": {
+                    "encrypt_query_param": encrypt_query_param,
+                    "aes_key": aes_key,
+                    "encrypt_type": 1,
+                },
+                "mid_size": mid_size,
+            }
+        elif item_type == MESSAGE_ITEM_TYPE_VOICE:
+            item["voice_item"] = {
+                "media": {
+                    "encrypt_query_param": encrypt_query_param,
+                    "aes_key": aes_key,
+                    "encrypt_type": 1,
+                },
+            }
+        elif item_type == MESSAGE_ITEM_TYPE_FILE:
+            item["file_item"] = {
+                "media": {
+                    "encrypt_query_param": encrypt_query_param,
+                    "aes_key": aes_key,
+                    "encrypt_type": 1,
+                },
+                "file_name": filename,
+                "len": str(file_size),
+            }
+        elif item_type == MESSAGE_ITEM_TYPE_VIDEO:
+            item["video_item"] = {
+                "media": {
+                    "encrypt_query_param": encrypt_query_param,
+                    "aes_key": aes_key,
+                    "encrypt_type": 1,
+                },
+                "video_size": video_size,
+            }
+
+        msg_payload = {
+            "from_user_id": "",
+            "to_user_id": to_user_id,
+            "client_id": str(uuid.uuid4()),
+            "message_type": 2,  # BOT
+            "message_state": 2,  # FINISH
+            "context_token": context_token,
+            "item_list": [item],
+        }
+        return await self.sendmessage(msg_payload)


### PR DESCRIPTION
This PR adds support for sending media messages (image, voice, video, file) via WeChat iLink Bot channel.

## Changes
- Add send_image method for sending image messages
- Add send_voice method for sending voice messages  
- Add send_video method for sending video messages
- Add send_file method for sending file messages
- Add upload_media for uploading files to WeChat CDN
- Add _send_media_message internal helper
- Update ILinkClient with media upload and download methods
- Support AES-128-ECB encryption for media upload

## Related Issue
Fixes #2601

## Testing
- [ ] Test sending image messages
- [ ] Test sending file messages
- [ ] Test sending video messages
- [ ] Test sending voice messages