### PR TITLE
fix(dingtalk): fallback to Open API when sessionWebhook expires for scheduled tasks

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -494,10 +494,13 @@ class DingTalkChannel(BaseChannel):
                 if self._is_webhook_expired(entry):
                     logger.info(
                         "dingtalk _load_session_webhook_entry: "
-                        "webhook_key=%s is expired, returning None",
+                        "webhook_key=%s is expired, clearing webhook "
+                        "but keeping conversation_id for Open API fallback",
                         webhook_key,
                     )
-                    return None
+                    # Clear webhook but keep conversation_id etc for fallback
+                    entry = {k: v for k, v in entry.items() if k != "webhook"}
+                    return entry
                 return entry
 
             logger.info(
@@ -2518,11 +2521,30 @@ class DingTalkChannel(BaseChannel):
                         session_webhook = webhook_entry.get("webhook")
 
         if not session_webhook:
-            logger.warning(
-                "DingTalkChannel.send: no sessionWebhook for to_handle=%s. "
-                "User must have chatted with the bot first, or pass "
-                "meta['session_webhook']. Skip sending.",
+            # No valid webhook: try Open API fallback directly
+            logger.info(
+                "DingTalkChannel.send: no sessionWebhook for to_handle=%s, "
+                "trying Open API fallback",
                 to_handle,
+            )
+            params = self._resolve_open_api_params(
+                meta,
+                webhook_entry,
+            )
+            if not params["conversation_id"]:
+                logger.warning(
+                    "DingTalkChannel.send: no sessionWebhook and no "
+                    "conversation_id for to_handle=%s. User must have "
+                    "chatted with the bot first. Skip sending.",
+                    to_handle,
+                )
+                return
+            await self._send_via_open_api(
+                text,
+                conversation_id=params["conversation_id"],
+                conversation_type=params["conversation_type"],
+                sender_staff_id=params["sender_staff_id"],
+                bot_prefix="",
             )
             return
 


### PR DESCRIPTION
## Description

When a stored sessionWebhook expires, preserve conversation_id from the entry and use Open API as fallback instead of skipping the message entirely.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
