### PR TITLE
fix(skill) signature cache & require

### DIFF
--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -514,7 +514,7 @@ def read_skill_requirements(skill_dir: Path) -> SkillRequirements:
         )
 
     if isinstance(requires, list):
-        return SkillRequirements(require_bins=list(requires))
+        return SkillRequirements(require_bins=list(requires), require_envs=[])
 
     if not isinstance(requires, dict):
         return SkillRequirements()


### PR DESCRIPTION
## Description
1. Signature excludes OS/cache artifacts — _build_signature now skips __pycache__, .DS_Store, etc., consistent with _copy_skill_dir. Extracted shared _IGNORED_SKILL_ARTIFACTS constant.                           

2. read_skill_requirements tolerates multiple requires formats:                                                                                                                                                  
- Falls back to top-level frontmatter requires when not nested under metadata                                                                                                                                    
- requires as list → treated as require_bins                                                                                                                                                                     
- requires as non-dict/non-list → returns empty SkillRequirements() instead of crashing

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
