### PR TITLE
fix(wecom): schedule reconnect in separate task on heartbeat failure

### DIFF
--- a/src/copaw/app/channels/wecom/channel.py
+++ b/src/copaw/app/channels/wecom/channel.py
@@ -1024,6 +1024,10 @@ class WecomChannel(BaseChannel):
                     "triggering reconnect",
                     ws_mgr._missed_pong_count,
                 )
+                # Schedule reconnect BEFORE _stop_heartbeat() because
+                # it cancels the current task; any await after that
+                # would raise CancelledError.
+                asyncio.ensure_future(ws_mgr._schedule_reconnect())
                 ws_mgr._stop_heartbeat()
                 if ws_mgr._ws:
                     try:
@@ -1033,9 +1037,6 @@ class WecomChannel(BaseChannel):
                             "wecom heartbeat: failed to close ws: %s",
                             close_err,
                         )
-                # Schedule reconnect in a separate task so it survives
-                # the heartbeat task cancellation above.
-                asyncio.ensure_future(ws_mgr._schedule_reconnect())
                 return
             # Normal path: delegate to original SDK implementation.
             await _original_send_heartbeat()


### PR DESCRIPTION
## Description

Fix wecom channel not reconnecting after heartbeat failure.

SDK bug: _send_heartbeat stops heartbeat and closes WS when pong is missed, but returns without calling _schedule_reconnect(). On a dead network the receive loop never gets a ConnectionClosed event, so the bot stays permanently offline.

Patch SDK _send_heartbeat to trigger reconnect when _missed_pong_count exceeds _max_missed_pong. Use asyncio.ensure_future to schedule reconnect in a separate task. Add event listeners for disconnect/reconnect/error logging.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
