### PR TITLE
feat(channel): unify no-text debounce for both workspace tracker and legacy paths

### DIFF
--- a/src/copaw/app/channels/base.py
+++ b/src/copaw/app/channels/base.py
@@ -720,21 +720,16 @@ class BaseChannel(ABC):
     def _debounce_payload(self, payload: Any) -> bool:
         """Apply no-text debounce on payload; return False if buffered."""
         if isinstance(payload, dict):
-            session_id = payload.get("session_id") or self.get_debounce_key(
-                payload,
-            )
             content_parts = payload.get("content_parts") or []
         elif hasattr(payload, "input") and payload.input:
-            session_id = getattr(payload, "session_id", "") or ""
-            content_parts = list(
-                getattr(payload.input[0], "content", None) or [],
-            )
+            content_parts = getattr(payload.input[0], "content", None) or []
         else:
             return True
 
         if not content_parts:
             return True
 
+        session_id = self.get_debounce_key(payload)
         should_process, merged = self._apply_no_text_debounce(
             session_id,
             content_parts,
@@ -743,17 +738,16 @@ class BaseChannel(ABC):
             return False
 
         # Write merged parts back so downstream paths see full content.
-        if merged:
-            if isinstance(payload, dict):
-                payload["content_parts"] = merged
-            elif hasattr(payload, "input") and payload.input:
-                first = payload.input[0]
-                if hasattr(first, "model_copy"):
-                    payload.input[0] = first.model_copy(
-                        update={"content": merged},
-                    )
-                elif hasattr(first, "content"):
-                    first.content = merged
+        if isinstance(payload, dict):
+            payload["content_parts"] = merged
+        elif hasattr(payload, "input") and payload.input:
+            first = payload.input[0]
+            if hasattr(first, "model_copy"):
+                payload.input[0] = first.model_copy(
+                    update={"content": merged},
+                )
+            elif hasattr(first, "content"):
+                first.content = merged
         return True
 
     async def _consume_one_request(self, payload: Any) -> None:


### PR DESCRIPTION
## Description

Extracted _debounce_payload as a shared method and moved the no-text debounce check to the top of _consume_one_request, before the workspace/legacy branch. This ensures media-only messages (e.g. image-only) are buffered until a text message arrives, regardless of whether the workspace tracker path is used. Previously, the workspace tracker path (_consume_with_tracker) bypassed the debounce, causing channels like WeChat to trigger agent responses on image-only messages. 

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
