### PR TITLE
feat(dingtalk): support AI Card in workspace tracker path & refactor shared core

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -1629,6 +1629,17 @@ class DingTalkChannel(BaseChannel):
         ):
             self._reply_sync(pm, SENT_VIA_WEBHOOK)
 
+    def _resolve_to_handle(self, request: Any) -> str:
+        """Resolve target handle from request using session-aware logic."""
+        user_id = getattr(request, "user_id", "") or ""
+        sid = getattr(request, "session_id", "") or ""
+        if sid:
+            return self.to_handle_from_target(
+                user_id=user_id,
+                session_id=sid,
+            )
+        return user_id
+
     async def _run_process_loop(
         self,
         request: Any,
@@ -1935,19 +1946,10 @@ class DingTalkChannel(BaseChannel):
         if bot_prefix and "bot_prefix" not in send_meta:
             send_meta = {**send_meta, "bot_prefix": bot_prefix}
 
-        # Resolve handle using session-aware logic
-        sender_id = getattr(request, "user_id", "") or ""
-        sid = getattr(request, "session_id", "") or ""
-        to_handle = (
-            self.to_handle_from_target(
-                user_id=sender_id,
-                session_id=sid,
-            )
-            if sid
-            else sender_id
-        )
+        to_handle = self._resolve_to_handle(request)
 
         # Allowlist / mention checks
+        sender_id = getattr(request, "user_id", "") or ""
         is_group = bool(send_meta.get("is_group", False))
         allowed, error_msg = self._check_allowlist(
             sender_id,
@@ -1959,17 +1961,23 @@ class DingTalkChannel(BaseChannel):
                 sender_id,
                 is_group,
             )
+            deny_text = bot_prefix + (error_msg or "")
             sw = self._get_session_webhook(send_meta)
             if sw:
                 await self._send_via_session_webhook(
                     sw,
-                    bot_prefix + (error_msg or ""),
+                    deny_text,
                     bot_prefix="",
                 )
-            self._reply_sync_batch(
-                send_meta,
-                bot_prefix + (error_msg or ""),
-            )
+                self._reply_sync_batch(
+                    send_meta,
+                    SENT_VIA_WEBHOOK,
+                )
+            else:
+                self._reply_sync_batch(
+                    send_meta,
+                    deny_text,
+                )
             return
 
         if not self._check_group_mention(is_group, send_meta):
@@ -2048,16 +2056,7 @@ class DingTalkChannel(BaseChannel):
         """
         meta = getattr(request, "channel_meta", None) or {}
         reply_meta = reply_meta or meta
-
-        sid = getattr(request, "session_id", "") or ""
-        to_handle = (
-            self.to_handle_from_target(
-                user_id=request.user_id or "",
-                session_id=sid,
-            )
-            if sid
-            else (request.user_id or "")
-        )
+        to_handle = self._resolve_to_handle(request)
 
         async for _event in self._process_dingtalk_core(
             request,


### PR DESCRIPTION
## Description

Fix DingTalk AI Card not working when agent has a workspace. The workspace tracker path (_consume_with_tracker → _stream_with_tracker) previously bypassed DingTalk's custom _run_process_loop / _process_one_request, so AI Card creation, streaming updates and finalization were skipped entirely.

### Changes:

Extract _process_dingtalk_core as a shared AsyncGenerator that handles AI Card create/stream/finalize, webhook sends, media delivery, _ack_early/_reply_sync_batch, and accumulated_parts fallback
Override _stream_with_tracker to consume the shared core with SSE serialization, enabling AI Card in the workspace path
Simplify _process_one_request to also consume the shared core, eliminating ~300 lines of duplicated logic
Unify to_handle resolution using to_handle_from_target consistently
Improve error messages in exception handler (use actual exception text instead of hardcoded "Internal error")

**Related Issue:** Fixes #2730 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
