### PR TITLE
fix(wecom): ensure stdio streams in wecom WS thread on Windows daemon

### DIFF
--- a/src/copaw/app/channels/wecom/channel.py
+++ b/src/copaw/app/channels/wecom/channel.py
@@ -947,7 +947,12 @@ class WecomChannel(BaseChannel):
                 try:
                     stream.write("")
                     stream.flush()
-                except OSError:
+                except (
+                    OSError,
+                    ValueError,
+                    AttributeError,
+                    TypeError,
+                ):
                     needs_fix = True
             if needs_fix:
                 setattr(


### PR DESCRIPTION
## Description

Add _ensure_stdio() to redirect invalid stdout/stderr to os.devnull before aibot SDK connect(), preventing OSError crash in daemon mode.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
