### PR TITLE
fix(skills): preserve directory contents when renaming skills

### DIFF
--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -165,23 +165,24 @@ def get_pool_skill_manifest_path() -> Path:
     return get_skill_pool_dir() / "skill.json"
 
 
-def _timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+def _get_skill_mtime(skill_dir: Path) -> str:
+    """Return the latest mtime across the skill directory as ISO string.
 
-
-def _get_skill_mtime(skill_dir: Path) -> float:
-    """Return max of SKILL.md mtime and skill_dir mtime.
-
-    Uses two cheap ``stat()`` calls — no file content I/O.
-    Returns ``0.0`` on any filesystem error.
+    Scans SKILL.md and the directory itself.  Returns an empty string
+    on any filesystem error.
     """
     try:
         dir_mtime = skill_dir.stat().st_mtime
         skill_md = skill_dir / "SKILL.md"
         md_mtime = skill_md.stat().st_mtime if skill_md.exists() else 0.0
-        return max(dir_mtime, md_mtime)
+        mtime = max(dir_mtime, md_mtime)
+        return (
+            datetime.fromtimestamp(mtime, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
     except OSError:
-        return 0.0
+        return ""
 
 
 def _directory_tree(directory: Path) -> dict[str, Any]:
@@ -425,7 +426,8 @@ def _classify_pool_skill_source(
     if not _is_builtin_skill(skill_name, builtin_names):
         return "customized", False
 
-    if skill_name not in _get_builtin_signatures():
+    builtin_sigs = _get_builtin_signatures()
+    if skill_name not in builtin_sigs:
         return "customized", False
 
     if existing:
@@ -434,20 +436,14 @@ def _classify_pool_skill_source(
         return "customized", False
 
     pool_signature = _build_signature(skill_dir)
-    builtin_signature = _get_builtin_signatures().get(skill_name, "")
+    builtin_signature = builtin_sigs.get(skill_name, "")
     if pool_signature == builtin_signature:
         return "builtin", False
     return "customized", False
 
 
 def _is_hidden(name: str) -> bool:
-    return name in {
-        "__pycache__",
-        "__MACOSX",
-        ".DS_Store",
-        "Thumbs.db",
-        "desktop.ini",
-    }
+    return name in _IGNORED_SKILL_ARTIFACTS
 
 
 def _extract_and_validate_zip(data: bytes, tmp_dir: Path) -> None:
@@ -663,7 +659,7 @@ def apply_skill_config_env_overrides(
     as environment variables.  The full config is always available as
     ``COPAW_SKILL_CONFIG_<SKILL_NAME>`` (JSON string).
     """
-    manifest = reconcile_workspace_manifest(workspace_dir)
+    manifest = read_skill_manifest(workspace_dir)
     entries = manifest.get("skills", {})
     active_keys: list[str] = []
 
@@ -718,7 +714,6 @@ def _build_skill_metadata(
     """
     post = _read_frontmatter_safe(skill_dir, skill_name)
     requirements = _extract_requirements(post)
-    now = _timestamp()
     return {
         "name": skill_name,
         "description": str(post.get("description", "") or ""),
@@ -728,7 +723,7 @@ def _build_skill_metadata(
         "source": source,
         "protected": protected,
         "requirements": requirements.model_dump(),
-        "updated_at": now,
+        "updated_at": _get_skill_mtime(skill_dir),
     }
 
 
@@ -787,7 +782,7 @@ def list_builtin_import_candidates() -> list[dict[str, Any]]:
     if not builtin_sigs:
         return []
 
-    manifest = read_skill_pool_manifest(reconcile=False)
+    manifest = read_skill_pool_manifest()
     pool_skills = manifest.get("skills", {})
     candidates: list[dict[str, Any]] = []
 
@@ -1068,7 +1063,7 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
                 "source": source,
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
-                "updated_at": _timestamp(),
+                "updated_at": metadata["updated_at"],
             }
             if "config" in existing:
                 next_entry["config"] = existing.get("config")
@@ -1126,33 +1121,14 @@ def list_workspaces() -> list[dict[str, str]]:
 
 def read_skill_manifest(
     workspace_dir: Path,
-    *,
-    reconcile: bool = True,
 ) -> dict[str, Any]:
-    """Return the workspace skill manifest.
-
-    When *reconcile* is ``True`` (default) the manifest is refreshed
-    from disk first.  Pass ``reconcile=False`` in read-only list paths
-    to skip the reconciliation and just return the cached JSON.
-    """
-    if reconcile:
-        return reconcile_workspace_manifest(workspace_dir)
+    """Return the cached workspace skill manifest."""
     path = get_workspace_skill_manifest_path(workspace_dir)
     return _read_json_unlocked(path, _default_workspace_manifest())
 
 
-def read_skill_pool_manifest(
-    *,
-    reconcile: bool = True,
-) -> dict[str, Any]:
-    """Return the pool skill manifest.
-
-    When *reconcile* is ``True`` (default) the manifest is refreshed
-    from disk first.  Pass ``reconcile=False`` in read-only list paths
-    to skip the expensive reconciliation.
-    """
-    if reconcile:
-        return reconcile_pool_manifest()
+def read_skill_pool_manifest() -> dict[str, Any]:
+    """Return the cached pool skill manifest."""
     path = get_pool_skill_manifest_path()
     return _read_json_unlocked(path, _default_pool_manifest())
 
@@ -1160,11 +1136,9 @@ def read_skill_pool_manifest(
 def resolve_effective_skills(
     workspace_dir: Path,
     channel_name: str,
-    *,
-    _registry: dict | None = None,
 ) -> list[str]:
     """Resolve enabled workspace skills for one channel."""
-    manifest = reconcile_workspace_manifest(workspace_dir)
+    manifest = read_skill_manifest(workspace_dir)
     resolved = []
     for skill_name, entry in sorted(manifest.get("skills", {}).items()):
         if not entry.get("enabled", False):
@@ -1229,7 +1203,7 @@ def update_single_builtin(skill_name: str) -> dict[str, Any]:
     if skill_name not in builtin_sigs:
         raise ValueError(f"'{skill_name}' is not a builtin skill")
 
-    manifest = read_skill_pool_manifest(reconcile=False)
+    manifest = read_skill_pool_manifest()
     existing = manifest.get("skills", {}).get(skill_name)
     if existing is None or not _is_pool_builtin_entry(existing):
         raise ValueError(
@@ -1353,8 +1327,6 @@ def _write_skill_to_dir(
     extra_files: dict[str, Any] | None = None,
 ) -> None:
     """Write a skill's files into a directory (shared by create flows)."""
-    if skill_dir.exists():
-        shutil.rmtree(skill_dir)
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     _create_files_from_tree(skill_dir, extra_files or {})
@@ -1447,18 +1419,11 @@ class SkillService:
         self.workspace_dir = Path(workspace_dir).expanduser()
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
 
-    def _manifest(self) -> dict[str, Any]:
-        return reconcile_workspace_manifest(self.workspace_dir)
-
     def _read_manifest(self) -> dict[str, Any]:
-        """Read workspace manifest without triggering reconcile."""
-        return read_skill_manifest(
-            self.workspace_dir,
-            reconcile=False,
-        )
+        return read_skill_manifest(self.workspace_dir)
 
     def list_all_skills(self) -> list[SkillInfo]:
-        manifest = self._manifest()
+        manifest = self._read_manifest()
         skill_root = get_workspace_skills_dir(self.workspace_dir)
         skills: list[SkillInfo] = []
         for skill_name, entry in sorted(manifest.get("skills", {}).items()):
@@ -1470,7 +1435,7 @@ class SkillService:
         return skills
 
     def list_available_skills(self) -> list[SkillInfo]:
-        manifest = self._manifest()
+        manifest = self._read_manifest()
         skill_root = get_workspace_skills_dir(self.workspace_dir)
         skills: list[SkillInfo] = []
         for skill_name in resolve_effective_skills(
@@ -1544,7 +1509,7 @@ class SkillService:
                 ),
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
-                "updated_at": _timestamp(),
+                "updated_at": metadata["updated_at"],
             }
 
         _mutate_json(
@@ -1630,7 +1595,7 @@ class SkillService:
                     "config": new_config,
                     "metadata": metadata,
                     "requirements": metadata["requirements"],
-                    "updated_at": _timestamp(),
+                    "updated_at": metadata["updated_at"],
                 }
 
             _mutate_json(
@@ -1694,7 +1659,7 @@ class SkillService:
                 "config": old_config,
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
-                "updated_at": _timestamp(),
+                "updated_at": metadata["updated_at"],
             }
             payload["skills"].pop(skill_name, None)
 
@@ -1841,7 +1806,6 @@ class SkillService:
                 return False
             entry["enabled"] = True
             entry.setdefault("channels", ["all"])
-            entry["updated_at"] = _timestamp()
             return True
 
         updated = _mutate_json(
@@ -1873,7 +1837,6 @@ class SkillService:
             if entry is None:
                 return False
             entry["enabled"] = False
-            entry["updated_at"] = _timestamp()
             return True
 
         updated = _mutate_json(
@@ -1904,7 +1867,6 @@ class SkillService:
             if entry is None:
                 return False
             entry["channels"] = normalized
-            entry["updated_at"] = _timestamp()
             return True
 
         updated = _mutate_json(
@@ -1939,9 +1901,7 @@ class SkillService:
         self,
         skill_name: str,
         file_path: str,
-        source: str,
     ) -> str | None:
-        del source
         normalized = file_path.replace("\\", "/")
         if ".." in normalized or normalized.startswith("/"):
             return None
@@ -1955,13 +1915,9 @@ class SkillService:
         if skill_name not in manifest.get("skills", {}):
             return None
 
-        workspace_base_dir = (
-            get_workspace_skills_dir(self.workspace_dir) / skill_name
-        )
-        if not workspace_base_dir.exists():
+        base_dir = get_workspace_skills_dir(self.workspace_dir) / skill_name
+        if not base_dir.exists():
             return None
-
-        base_dir = workspace_base_dir
 
         full_path = base_dir / normalized
         if not full_path.exists() or not full_path.is_file():
@@ -1995,7 +1951,7 @@ class SkillPoolService:
         ensure_skill_pool_initialized()
 
     def list_all_skills(self) -> list[SkillInfo]:
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         pool_dir = get_skill_pool_dir()
         skills: list[SkillInfo] = []
         for skill_name, entry in sorted(manifest.get("skills", {}).items()):
@@ -2020,7 +1976,7 @@ class SkillPoolService:
         skill_name = _normalize_skill_dir_name(name)
         pool_dir = get_skill_pool_dir()
         skill_dir = pool_dir / skill_name
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         existing = manifest.get("skills", {}).get(skill_name)
         if existing is not None or skill_dir.exists():
             return None
@@ -2080,7 +2036,7 @@ class SkillPoolService:
                 (d, _normalize_skill_dir_name(renames.get(n, n)))
                 for d, n in found
             ]
-            manifest = read_skill_pool_manifest(reconcile=False)
+            manifest = read_skill_pool_manifest()
             existing_pool_names = (
                 set(
                     manifest.get("skills", {}).keys(),
@@ -2165,7 +2121,7 @@ class SkillPoolService:
 
     def delete_skill(self, name: str) -> bool:
         skill_name = str(name or "")
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return False
@@ -2190,7 +2146,7 @@ class SkillPoolService:
         *,
         target_name: str | None = None,
     ) -> dict[str, Any]:
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
@@ -2232,7 +2188,7 @@ class SkillPoolService:
         config: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         _validate_skill_content(content)
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
@@ -2356,7 +2312,7 @@ class SkillPoolService:
 
         final_name = _normalize_skill_dir_name(target_name or skill_name)
         target_dir = get_skill_pool_dir() / final_name
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         existing = manifest.get("skills", {}).get(final_name)
         if existing:
             if _is_pool_builtin_entry(existing):
@@ -2408,6 +2364,50 @@ class SkillPoolService:
 
         return {"success": True, "name": final_name}
 
+    @staticmethod
+    def _check_download_conflict(
+        entry: dict[str, Any],
+        existing: dict[str, Any] | None,
+        final_name: str,
+        workspace_identity: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Return a conflict dict if download should be blocked."""
+        if not existing:
+            return None
+        ws_id = workspace_identity["workspace_id"]
+        ws_name = workspace_identity["workspace_name"]
+        if (
+            entry.get("source") == "builtin"
+            and existing.get("source") == "builtin"
+        ):
+            pool_ver = entry.get("version_text", "")
+            ws_ver = (existing.get("metadata") or {}).get(
+                "version_text",
+                "",
+            )
+            if pool_ver and ws_ver and pool_ver == ws_ver:
+                return {
+                    "success": True,
+                    "mode": "unchanged",
+                    "name": final_name,
+                    "workspace_id": ws_id,
+                    "workspace_name": ws_name,
+                }
+            return {
+                "success": False,
+                "reason": "builtin_upgrade",
+                "workspace_id": ws_id,
+                "workspace_name": ws_name,
+                "skill_name": final_name,
+            }
+        return {
+            "success": False,
+            "reason": "conflict",
+            "workspace_id": ws_id,
+            "workspace_name": ws_name,
+            "suggested_name": suggest_conflict_name(final_name),
+        }
+
     def download_to_workspace(
         self,
         skill_name: str,
@@ -2416,7 +2416,7 @@ class SkillPoolService:
         target_name: str | None = None,
         overwrite: bool = False,
     ) -> dict[str, Any]:
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
@@ -2424,47 +2424,18 @@ class SkillPoolService:
         source_dir = get_skill_pool_dir() / skill_name
         final_name = _normalize_skill_dir_name(target_name or skill_name)
         target_dir = get_workspace_skills_dir(workspace_dir) / final_name
-        workspace_manifest = read_skill_manifest(
-            workspace_dir,
-            reconcile=False,
-        )
+        workspace_manifest = read_skill_manifest(workspace_dir)
         existing = workspace_manifest.get("skills", {}).get(final_name)
         workspace_identity = get_workspace_identity(workspace_dir)
-        if existing and not overwrite:
-            # Both builtin: compare version to decide action.
-            if (
-                entry.get("source") == "builtin"
-                and existing.get("source") == "builtin"
-            ):
-                pool_ver = entry.get("version_text", "")
-                ws_ver = (existing.get("metadata") or {}).get(
-                    "version_text",
-                    "",
-                )
-                if pool_ver and ws_ver and pool_ver == ws_ver:
-                    return {
-                        "success": True,
-                        "mode": "unchanged",
-                        "name": final_name,
-                        "workspace_id": workspace_identity["workspace_id"],
-                        "workspace_name": workspace_identity["workspace_name"],
-                    }
-                return {
-                    "success": False,
-                    "reason": "builtin_upgrade",
-                    "workspace_id": workspace_identity["workspace_id"],
-                    "workspace_name": workspace_identity["workspace_name"],
-                    "skill_name": final_name,
-                }
-            return {
-                "success": False,
-                "reason": "conflict",
-                "workspace_id": workspace_identity["workspace_id"],
-                "workspace_name": workspace_identity["workspace_name"],
-                "suggested_name": suggest_conflict_name(
-                    final_name,
-                ),
-            }
+        if not overwrite:
+            conflict = self._check_download_conflict(
+                entry,
+                existing,
+                final_name,
+                workspace_identity,
+            )
+            if conflict is not None:
+                return conflict
 
         target_dir.parent.mkdir(parents=True, exist_ok=True)
         with _staged_skill_dir(final_name) as staged_dir:
@@ -2491,7 +2462,7 @@ class SkillPoolService:
                 "config": pool_config,
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
-                "updated_at": _timestamp(),
+                "updated_at": metadata["updated_at"],
             }
 
         _mutate_json(
@@ -2514,52 +2485,24 @@ class SkillPoolService:
         target_name: str | None = None,
         overwrite: bool = False,
     ) -> dict[str, Any]:
-        manifest = read_skill_pool_manifest(reconcile=False)
+        manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
 
         final_name = _normalize_skill_dir_name(target_name or skill_name)
-        workspace_manifest = read_skill_manifest(
-            workspace_dir,
-            reconcile=False,
-        )
+        workspace_manifest = read_skill_manifest(workspace_dir)
         existing = workspace_manifest.get("skills", {}).get(final_name)
         workspace_identity = get_workspace_identity(workspace_dir)
-        if existing and not overwrite:
-            if (
-                entry.get("source") == "builtin"
-                and existing.get("source") == "builtin"
-            ):
-                pool_ver = entry.get("version_text", "")
-                ws_ver = (existing.get("metadata") or {}).get(
-                    "version_text",
-                    "",
-                )
-                if pool_ver and ws_ver and pool_ver == ws_ver:
-                    return {
-                        "success": True,
-                        "mode": "unchanged",
-                        "name": final_name,
-                        "workspace_id": workspace_identity["workspace_id"],
-                        "workspace_name": workspace_identity["workspace_name"],
-                    }
-                return {
-                    "success": False,
-                    "reason": "builtin_upgrade",
-                    "workspace_id": workspace_identity["workspace_id"],
-                    "workspace_name": workspace_identity["workspace_name"],
-                    "skill_name": final_name,
-                }
-            return {
-                "success": False,
-                "reason": "conflict",
-                "workspace_id": workspace_identity["workspace_id"],
-                "workspace_name": workspace_identity["workspace_name"],
-                "suggested_name": suggest_conflict_name(
-                    final_name,
-                ),
-            }
+        if not overwrite:
+            conflict = self._check_download_conflict(
+                entry,
+                existing,
+                final_name,
+                workspace_identity,
+            )
+            if conflict is not None:
+                return conflict
         return {
             "success": True,
             "workspace_id": workspace_identity["workspace_id"],

--- a/src/copaw/app/migration.py
+++ b/src/copaw/app/migration.py
@@ -335,12 +335,13 @@ def migrate_legacy_skills_to_skill_pool() -> bool:
 
 def _do_migrate_legacy_skills() -> bool:
     """Internal implementation of legacy skills migration."""
+    from datetime import datetime, timezone
+
     from ..agents.skills_manager import (
         _build_signature,
         _copy_skill_dir,
         _default_workspace_manifest,
         _mutate_json,
-        _timestamp,
         ensure_skill_pool_initialized,
         get_pool_skill_manifest_path,
         get_workspace_skill_manifest_path,
@@ -583,7 +584,11 @@ def _do_migrate_legacy_skills() -> bool:
                     continue
                 if not entry.get("enabled", False):
                     entry["enabled"] = True
-                    entry["updated_at"] = _timestamp()
+                    entry["updated_at"] = (
+                        datetime.now(timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                    )
                     changed += 1
             return changed
 

--- a/src/copaw/app/routers/skills.py
+++ b/src/copaw/app/routers/skills.py
@@ -12,7 +12,6 @@ import tempfile
 import threading
 import time
 import uuid
-from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -181,12 +180,18 @@ class SkillConfigRequest(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
-class SavePoolSkillRequest(CreateSkillRequest):
+class SavePoolSkillRequest(BaseModel):
+    name: str
+    content: str
     source_name: str | None = None
+    config: dict[str, Any] | None = None
 
 
-class SaveSkillRequest(CreateSkillRequest):
+class SaveSkillRequest(BaseModel):
+    name: str
+    content: str
     source_name: str | None = None
+    config: dict[str, Any] | None = None
 
 
 class HubInstallRequest(BaseModel):
@@ -460,19 +465,8 @@ async def _run_hub_install_task(
         await _hub_task_pop_runtime(task_id)
 
 
-def _mtime_to_iso(mtime: float) -> str:
-    """Convert a POSIX mtime float to an ISO-8601 UTC string."""
-    if not mtime:
-        return ""
-    return (
-        datetime.fromtimestamp(mtime, tz=timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
-
-
 def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
-    manifest = read_skill_manifest(workspace_dir, reconcile=False)
+    manifest = read_skill_manifest(workspace_dir)
     entries = manifest.get("skills", {})
     skill_root = get_workspace_skills_dir(workspace_dir)
     specs: list[SkillSpec] = []
@@ -482,21 +476,20 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
         skill = _read_skill_from_dir(skill_dir, source)
         if skill is None:
             continue
-        mtime = _get_skill_mtime(skill_dir)
         specs.append(
             SkillSpec(
                 **skill.model_dump(),
                 enabled=entry.get("enabled", False),
                 channels=entry.get("channels") or ["all"],
                 config=entry.get("config") or {},
-                last_updated=_mtime_to_iso(mtime),
+                last_updated=_get_skill_mtime(skill_dir),
             ),
         )
     return specs
 
 
 def _build_pool_skill_specs() -> list[PoolSkillSpec]:
-    manifest = read_skill_pool_manifest(reconcile=False)
+    manifest = read_skill_pool_manifest()
     entries = manifest.get("skills", {})
     pool_dir = get_skill_pool_dir()
     sync_info = get_pool_builtin_sync_status()
@@ -508,7 +501,6 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
         if skill is None:
             continue
         info = sync_info.get(skill_name, {})
-        mtime = _get_skill_mtime(skill_dir)
         specs.append(
             PoolSkillSpec(
                 **skill.model_dump(exclude={"version_text"}),
@@ -520,7 +512,7 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
                     info.get("latest_version_text", "") or "",
                 ),
                 config=entry.get("config") or {},
-                last_updated=_mtime_to_iso(mtime),
+                last_updated=_get_skill_mtime(skill_dir),
             ),
         )
     return specs
@@ -1241,18 +1233,16 @@ async def delete_skill(
     return {"deleted": True}
 
 
-@router.get("/{skill_name}/files/{source}/{file_path:path}")
+@router.get("/{skill_name}/files/{file_path:path}")
 async def load_skill_file(
     request: Request,
     skill_name: str,
-    source: str,
     file_path: str,
 ) -> dict[str, Any]:
     workspace_dir = await _request_workspace_dir(request)
     content = SkillService(workspace_dir).load_skill_file(
         skill_name=skill_name,
         file_path=file_path,
-        source=source,
     )
     if content is None:
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/copaw/cli/skills_cmd.py
+++ b/src/copaw/cli/skills_cmd.py
@@ -10,6 +10,8 @@ from ..agents.skills_manager import (
     SkillPoolService,
     SkillService,
     read_skill_manifest,
+    reconcile_pool_manifest,
+    reconcile_workspace_manifest,
 )
 from ..constant import WORKING_DIR
 from ..config import load_config
@@ -126,12 +128,14 @@ def configure_skills_interactive(
 
     click.echo(f"Configuring skills for agent: {agent_id}\n")
 
+    reconcile_workspace_manifest(working_dir)
     skill_service = SkillService(working_dir)
     installed_skills = skill_service.list_all_skills()
     installed_by_name = {skill.name: skill for skill in installed_skills}
     pool_candidates = {}
     pool_service = SkillPoolService() if include_pool_candidates else None
     if pool_service is not None:
+        reconcile_pool_manifest()
         pool_candidates = {
             skill.name: skill
             for skill in pool_service.list_all_skills()
@@ -223,6 +227,7 @@ def list_cmd(agent_id: str) -> None:
 
     click.echo(f"Skills for agent: {agent_id}\n")
 
+    reconcile_workspace_manifest(working_dir)
     skill_service = SkillService(working_dir)
     all_skills = skill_service.list_all_skills()
     enabled = {


### PR DESCRIPTION
## Description

Before:
  - save_skill / save_pool_skill called _write_skill_to_dir which wiped the entire skill directory and rebuilt it from scratch using only the parameters passed in.
  - Frontend only sends content (SKILL.md) and config.
  - Result: every save/rename destroyed all files except SKILL.md (references, scripts, and extra files were lost).

After:
  - Save operations copy the existing skill directory first, then overwrite only SKILL.md. All other files (references, scripts, extra files) are preserved.
  - Content change detection uses simple string comparison of SKILL.md instead of full directory hashing.
  - source stays unchanged (e.g. "builtin") when only config is modified; flips to "customized" only when SKILL.md content actually changes.

Besides:
- Optimize reconcile efficiency. Reading now based on manifest, no duplicate reconcile .
- Unify update time -> mtime.

**Related Issue:** Fixes #2770.

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
