### PR TITLE
fix(stream): sanitize leaked thinking prefix in visible text

### DIFF
--- a/src/copaw/providers/openai_chat_model_compat.py
+++ b/src/copaw/providers/openai_chat_model_compat.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Type
@@ -16,6 +17,55 @@ from copaw.local_models.tag_parser import (
     parse_tool_calls_from_text,
     text_contains_tool_call_tag,
 )
+
+
+_LEAKED_THINKING_PREFIX_RE = re.compile(
+    r"^\s*(?:Thinking|Reasoning|思考|推理)\s*:?\s*(?:\r?\n)+",
+    re.IGNORECASE,
+)
+
+
+def _strip_leaked_thinking_prefix(text: str) -> str:
+    """Drop leaked reasoning title lines from user-visible text.
+
+    Some models emit an internal heading like "Thinking" into the final text
+    when reasoning delimiters are malformed or truncated. We only strip this
+    prefix when the following line looks like formatted answer content.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    match = _LEAKED_THINKING_PREFIX_RE.match(text)
+    if not match:
+        return text
+
+    remainder = text[match.end() :]
+    if not remainder.strip():
+        return text
+
+    first_line = remainder.lstrip().splitlines()[0].strip()
+    looks_like_answer = bool(
+        re.match(r"^(#{1,6}\s|[-*]\s|\d+\.\s|---|[✅📊📁🎯🚀])", first_line),
+    )
+    if not looks_like_answer:
+        return text
+
+    return remainder.lstrip()
+
+
+def _sanitize_visible_text_blocks(parsed: ChatResponse) -> None:
+    """Normalize user-visible text blocks in-place for common leakage cases."""
+    for block in parsed.content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            raw_text = block.get("text")
+            if isinstance(raw_text, str):
+                block["text"] = _strip_leaked_thinking_prefix(raw_text)
+        elif block.get("type") == "refusal":
+            raw_refusal = block.get("refusal")
+            if isinstance(raw_refusal, str):
+                block["refusal"] = _strip_leaked_thinking_prefix(raw_refusal)
 
 
 def _clone_with_overrides(obj: Any, **overrides: Any) -> Any:
@@ -212,6 +262,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
             response=sanitized_response,
             structured_model=structured_model,
         ):
+            _sanitize_visible_text_blocks(parsed)
+
             # Attach extra_content (Gemini thought_signature) to tool_use
             # blocks.
             if sanitized_response.extra_contents:

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from copaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
+    _strip_leaked_thinking_prefix,
     _sanitize_tool_call,
 )
 
@@ -169,3 +170,24 @@ def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:
     assert sanitized_missing_name_and_arguments is not None
     assert sanitized_missing_name_and_arguments.function.name == ""
     assert sanitized_missing_name_and_arguments.function.arguments == ""
+
+
+def test_strip_leaked_thinking_prefix_for_structured_answer() -> None:
+    leaked = (
+        "Thinking\n"
+        "## ✅ 当前进展确认 - 没有丢失！\n"
+        "根据我刚才的读取验证，所有成果都已保存。"
+    )
+
+    cleaned = _strip_leaked_thinking_prefix(leaked)
+
+    assert cleaned.startswith("## ✅ 当前进展确认 - 没有丢失！")
+    assert "Thinking\n" not in cleaned
+
+
+def test_strip_leaked_thinking_prefix_keeps_normal_text() -> None:
+    normal = "Thinking\nI will compare A and B before deciding."
+
+    cleaned = _strip_leaked_thinking_prefix(normal)
+
+    assert cleaned == normal


### PR DESCRIPTION
## Description

Fixes a streaming UX bug where leaked reasoning headings (for example `Thinking` / `Reasoning`) can appear at the beginning of user-visible assistant text when model reasoning delimiters are malformed or truncated.

This PR adds a conservative sanitizer in the OpenAI stream compatibility layer:
- strip leaked reasoning prefix only for visible `text` / `refusal` blocks
- keep behavior safe by requiring the next line to look like structured final answer content
- add unit tests for both sanitize and non-sanitize paths

**Related Issue:** Relates to #N/A

**Security Considerations:** No auth/config/security surface changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Run:
- `/Users/futuremeng/github/futuremeng/CoPaw/.venv/bin/python -m pytest tests/unit/providers/test_openai_stream_toolcall_compat.py -q`

Expected:
- `4 passed`

## Local Verification Evidence

```bash
/Users/futuremeng/github/futuremeng/CoPaw/.venv/bin/python -m pytest tests/unit/providers/test_openai_stream_toolcall_compat.py -q
.... [100%]
4 passed in 1.52s
```

## Additional Notes

This branch is based on `mirror/upstream-main` (`upstream/main`) and contains only one focused bugfix commit for upstream review.
