### PR TITLE
feat(channels): add streaming typewriter card for Feishu

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -12,6 +12,7 @@ deduplication.
 
 from __future__ import annotations
 
+import os
 import base64
 import asyncio
 import json
@@ -23,6 +24,7 @@ import time
 from email.utils import parsedate_to_datetime
 import types
 from collections import OrderedDict
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -147,11 +149,19 @@ finally:
             delattr(_pkg_resources_module, "declare_namespace")
 
 if TYPE_CHECKING:
-    from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
+    from agentscope_runtime.engine.schemas.agent_schemas import (
+        AgentRequest,
+        RunStatus,
+    )
 
 logger = logging.getLogger(__name__)
 
 # Serialise multi-instance WebSocket start-up: lark_oapi.ws.client.loop is a
+
+# Streaming card constants
+_STREAMING_ELEMENT_ID = "content"
+_STREAMING_UPDATE_INTERVAL_SEC = 0.06
+_STREAMING_ENV_KEY = "FEISHU_STREAMING_ENABLED"
 # module-level variable that concurrent start() calls would overwrite.
 _WS_START_LOCK: threading.Lock = threading.Lock()
 
@@ -248,8 +258,6 @@ class FeishuChannel(BaseChannel):
         process: ProcessHandler,
         on_reply_sent: OnReplySent = None,
     ) -> "FeishuChannel":
-        import os
-
         allow_from_env = os.getenv("FEISHU_ALLOW_FROM", "")
         allow_from = (
             [s.strip() for s in allow_from_env.split(",") if s.strip()]
@@ -1692,6 +1700,197 @@ class FeishuChannel(BaseChannel):
             meta["_last_sent_message_id"] = last_message_id
         return last_message_id
 
+    # ----- streaming card helpers
+
+    def _is_streaming_enabled(self) -> bool:
+        """Check if streaming card output is enabled via env var."""
+        val = os.environ.get(_STREAMING_ENV_KEY, "").lower()
+        return val in ("1", "true", "yes")
+
+    def _next_stream_seq(self) -> int:
+        """Monotonic sequence counter for streaming card updates."""
+        if not hasattr(self, "_stream_seq"):
+            self._stream_seq = 0
+        self._stream_seq += 1
+        return self._stream_seq
+
+    def _feishu_base_url(self) -> str:
+        """Resolve API base URL from domain."""
+        return (
+            "https://open.larksuite.com"
+            if self.domain == "lark"
+            else "https://open.feishu.cn"
+        )
+
+    def _streaming_auth_headers(self) -> dict:
+        """Build auth headers for streaming card API calls."""
+        from lark_oapi.core.token import TokenManager
+
+        token = TokenManager.get_self_tenant_token(self._client._config)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _card_create(self) -> Optional[str]:
+        """Step 1: create an empty streaming card. Returns card_id or None."""
+        card_json = {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 1},
+                },
+            },
+            "header": {
+                "title": {"tag": "plain_text", "content": ""},
+                "template": "invisible",
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "element_id": _STREAMING_ELEMENT_ID,
+                        "content": "⏳ 思考中...",
+                    },
+                ],
+            },
+        }
+        try:
+            resp = await self._http_client.post(
+                f"{self._feishu_base_url()}/open-apis/cardkit/v1/cards",
+                headers=self._streaming_auth_headers(),
+                json={
+                    "type": "card_json",
+                    "data": json.dumps(card_json, ensure_ascii=False),
+                },
+                timeout=10.0,
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "card create failed: status=%d body=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+                return None
+            data = resp.json()
+            if data.get("code") != 0:
+                logger.warning(
+                    "card create failed: code=%s msg=%s",
+                    data.get("code"),
+                    data.get("msg", ""),
+                )
+                return None
+            return data["data"]["card_id"]
+        except Exception:
+            logger.exception("card create error")
+            return None
+
+    async def _card_send(
+        self,
+        card_id: str,
+        receive_id: str,
+        receive_id_type: str,
+    ) -> Optional[str]:
+        """Step 2: send card as message. Returns message_id or None."""
+        try:
+            resp = await self._http_client.post(
+                f"{self._feishu_base_url()}/open-apis/im/v1/messages"
+                f"?receive_id_type={receive_id_type}",
+                headers=self._streaming_auth_headers(),
+                json={
+                    "receive_id": receive_id,
+                    "msg_type": "interactive",
+                    "content": json.dumps(
+                        {
+                            "type": "card",
+                            "data": {"card_id": card_id},
+                        },
+                    ),
+                },
+                timeout=10.0,
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "card send failed: status=%d body=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+                return None
+            data = resp.json()
+            if data.get("code") != 0:
+                logger.warning(
+                    "card send failed: code=%s msg=%s",
+                    data.get("code"),
+                    data.get("msg", ""),
+                )
+                return None
+            return data["data"]["message_id"]
+        except Exception:
+            logger.exception("card send error")
+            return None
+
+    async def _card_update_text(self, card_id: str, text: str) -> bool:
+        """Step 3: update streaming text element (PUT)."""
+        seq = self._next_stream_seq()
+        try:
+            base = self._feishu_base_url()
+            url = (
+                f"{base}/open-apis/cardkit/v1/cards"
+                f"/{card_id}/elements/{_STREAMING_ELEMENT_ID}/content"
+            )
+            resp = await self._http_client.put(
+                url,
+                headers=self._streaming_auth_headers(),
+                json={
+                    "content": text,
+                    "sequence": seq,
+                    "uuid": f"s_{card_id}_{seq}",
+                },
+                timeout=5.0,
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "card update failed: status=%d body=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+                return False
+            return resp.json().get("code") == 0
+        except Exception:
+            logger.exception("card update error")
+            return False
+
+    async def _card_close(self, card_id: str) -> None:
+        """Step 4: turn off streaming mode (finalize card)."""
+        try:
+            seq = self._next_stream_seq()
+            base = self._feishu_base_url()
+            url = f"{base}/open-apis/cardkit/v1/cards" f"/{card_id}/settings"
+            resp = await self._http_client.patch(
+                url,
+                headers=self._streaming_auth_headers(),
+                json={
+                    "settings": json.dumps(
+                        {
+                            "config": {"streaming_mode": False},
+                        },
+                    ),
+                    "sequence": seq,
+                    "uuid": f"c_{card_id}_{seq}",
+                },
+                timeout=5.0,
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "card close failed: status=%d body=%s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+        except Exception:
+            logger.exception("card close error")
+
     async def _on_process_completed(
         self,
         request: Any,
@@ -1702,6 +1901,254 @@ class FeishuChannel(BaseChannel):
         last_msg_id = send_meta.get("_last_sent_message_id")
         if last_msg_id:
             await self._add_reaction(last_msg_id, "DONE")
+
+    # ----- _stream_with_tracker override (CoPaw post-1.0 architecture)
+
+    async def _stream_with_tracker(
+        self,
+        payload: Any,
+    ) -> AsyncGenerator[str, None]:
+        """Override for CoPaw versions that use _stream_with_tracker.
+
+        In post-1.0 CoPaw the message path changed from
+        _consume_one_request -> _run_process_loop to
+        _consume_with_tracker -> _stream_with_tracker.
+        This override mirrors the streaming card logic from
+        _run_process_loop_streaming but adapted to the new async-generator
+        architecture that yields SSE events.
+
+        Falls back to super() if streaming is disabled.
+        """
+        if not self._is_streaming_enabled():
+            async for chunk in super()._stream_with_tracker(
+                payload,
+            ):  # type: ignore[misc]
+                yield chunk
+            return
+
+        # Build request and meta (mirror BaseChannel._stream_with_tracker)
+        request = self._payload_to_request(payload)
+
+        if isinstance(payload, dict):
+            send_meta = dict(payload.get("meta") or {})
+            if payload.get("session_webhook"):
+                send_meta["session_webhook"] = payload["session_webhook"]
+        else:
+            send_meta = getattr(request, "channel_meta", None) or {}
+
+        bot_prefix = getattr(self, "bot_prefix", None) or getattr(
+            self,
+            "_bot_prefix",
+            "",
+        )
+        if bot_prefix and "bot_prefix" not in send_meta:
+            send_meta = {**send_meta, "bot_prefix": bot_prefix}
+
+        to_handle = self.get_to_handle_from_request(request)
+        await self._before_consume_process(request)
+
+        # --- Streaming card state ---
+        card_id: Optional[str] = None  # None=not attempted, ""=failed
+        text_acc = ""
+        last_msg_id: Optional[str] = None
+        last_response = None
+        _updater_task: Optional[asyncio.Task] = None
+
+        async def _card_updater() -> None:
+            nonlocal card_id, text_acc
+            while card_id and card_id != "":
+                await asyncio.sleep(_STREAMING_UPDATE_INTERVAL_SEC)
+                if not card_id or card_id == "":
+                    break
+                if text_acc:
+                    ok = await self._card_update_text(card_id, text_acc)
+                    if not ok:
+                        card_id = ""
+                        return
+
+        async def _stop_updater() -> None:
+            nonlocal _updater_task
+            if _updater_task and not _updater_task.done():
+                _updater_task.cancel()
+                try:
+                    await _updater_task
+                except asyncio.CancelledError:
+                    pass
+                _updater_task = None
+
+        async def _close_card(final_text: str) -> None:
+            nonlocal card_id, text_acc
+            await _stop_updater()
+            if card_id and card_id != "":
+                if final_text:
+                    await self._card_update_text(card_id, final_text)
+                await self._card_close(card_id)
+            card_id = None
+            text_acc = ""
+
+        async def _send_others(parts: list) -> None:
+            nonlocal last_msg_id
+            try:
+                mid = await self.send_content_parts(
+                    to_handle,
+                    parts,
+                    send_meta,
+                )
+                if mid:
+                    last_msg_id = mid
+            except Exception:
+                pass
+
+        async def _create_card() -> bool:
+            nonlocal card_id, last_msg_id, _updater_task
+            try:
+                recv = await self._get_receive_for_send(to_handle, send_meta)
+                if not recv:
+                    card_id = ""
+                    return False
+                rid_type, rid = recv
+                cid = await self._card_create()
+                if not cid:
+                    card_id = ""
+                    return False
+                mid = await self._card_send(cid, rid, rid_type)
+                if not mid:
+                    card_id = ""
+                    return False
+                card_id = cid
+                last_msg_id = mid
+                _updater_task = asyncio.create_task(_card_updater())
+                return True
+            except Exception:
+                logger.warning(
+                    "streaming card create failed, falling back",
+                    exc_info=True,
+                )
+                card_id = ""
+                return False
+
+        # --- Main event loop ---
+        process_iterator = None
+        try:
+            process_iterator = self._process(request)
+            async for event in process_iterator:
+                # Yield SSE event
+                if hasattr(event, "model_dump_json"):
+                    data = event.model_dump_json()
+                elif hasattr(event, "json"):
+                    data = event.json()
+                else:
+                    data = json.dumps({"text": str(event)})
+                yield f"data: {data}\n\n"
+
+                obj = getattr(event, "object", None)
+                st = getattr(event, "status", None)
+
+                # --- response event ---
+                if obj == "response":
+                    last_response = event
+                    await self.on_event_response(request, event)
+                    continue
+
+                # --- message Completed: finalize ---
+                if obj == "message" and st == RunStatus.Completed:
+                    parts = self._message_to_content_parts(event)
+                    if not parts:
+                        continue
+
+                    texts = [
+                        p
+                        for p in parts
+                        if getattr(p, "type", None) in ("text", "markdown")
+                    ]
+                    others = [
+                        p
+                        for p in parts
+                        if getattr(p, "type", None) not in ("text", "markdown")
+                    ]
+                    new_text = "".join(getattr(t, "text", "") for t in texts)
+
+                    if card_id == "":
+                        # Streaming failed, normal send
+                        await _send_others(parts)
+                        continue
+
+                    if card_id and card_id != "":
+                        final = new_text or text_acc
+                        await _close_card(final)
+                        if others:
+                            await _send_others(others)
+                        continue
+
+                    # No card yet: quick create + close
+                    if new_text:
+                        if await _create_card():
+                            await self._card_update_text(
+                                card_id,  # type: ignore[arg-type]
+                                new_text,
+                            )
+                            await _close_card(new_text)
+                            if others:
+                                await _send_others(others)
+                        else:
+                            await _send_others(parts)
+                    else:
+                        if others:
+                            await _send_others(others)
+                    continue
+
+                # --- InProgress streaming deltas ---
+                if st == RunStatus.InProgress:
+                    text = self._extract_streaming_text(
+                        event,
+                        is_streaming=True,
+                    )
+                    if not text:
+                        continue
+                    text_acc = text
+                    if card_id is None:
+                        await _create_card()
+                    continue
+
+        except asyncio.CancelledError:
+            if process_iterator is not None:
+                await process_iterator.aclose()
+            if card_id and card_id != "":
+                await self._card_close(card_id)
+            raise
+
+        except Exception:
+            logger.exception("streaming _stream_with_tracker error")
+            if card_id and card_id != "":
+                await self._card_close(card_id)
+            return
+
+        # --- Post-processing ---
+        if card_id and card_id != "":
+            await _close_card(text_acc)
+
+        err = self._get_response_error_message(last_response)
+        if err:
+            try:
+                await self._on_consume_error(
+                    request,
+                    to_handle,
+                    f"Error: {err}",
+                )
+            except Exception:
+                pass
+        elif last_msg_id:
+            try:
+                await self._add_reaction(last_msg_id, "DONE")
+            except Exception:
+                pass
+
+        if self._on_reply_sent:
+            try:
+                args = self.get_on_reply_sent_args(request, to_handle)
+                self._on_reply_sent(self.channel, *args)
+            except Exception:
+                pass
 
     async def send(
         self,

--- a/tests/unit/channels/test_feishu_streaming.py
+++ b/tests/unit/channels/test_feishu_streaming.py
@@ -1,0 +1,713 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+"""Unit tests for Feishu channel streaming card output."""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from copaw.app.channels.feishu.channel import (
+    FeishuChannel,
+    _STREAMING_ELEMENT_ID,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_process(_request: Any):
+    yield  # pragma: no cover
+
+
+def _make_channel(**overrides: Any) -> FeishuChannel:
+    """Create a FeishuChannel with dummy process handler."""
+    defaults = {
+        "process": _noop_process,
+        "enabled": True,
+        "app_id": "test_app_id",
+        "app_secret": "test_secret",
+        "bot_prefix": "",
+    }
+    defaults.update(overrides)
+    ch = FeishuChannel(**defaults)
+    ch._http_client = MagicMock()
+    return ch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_http():
+    """Mock httpx.AsyncClient instance."""
+    client = AsyncMock()
+    client.post = AsyncMock()
+    client.put = AsyncMock()
+    client.patch = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def channel(mock_http):
+    """Create a FeishuChannel instance with mocked internals."""
+    ch = _make_channel()
+    ch._http_client = mock_http
+    ch._stream_seq = 0
+    ch.domain = "feishu"
+    return ch
+
+
+def _ok_feishu(data=None):
+    """Build a mock 200 response with feishu success code."""
+    resp = MagicMock()
+    resp.status_code = 200
+    body = {"code": 0}
+    if data:
+        body["data"] = data
+    resp.json.return_value = body
+    return resp
+
+
+def _fail_http(status=400, text="Bad Request"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+def _fail_feishu(code=99999, msg="error"):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"code": code, "msg": msg}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _is_streaming_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsStreamingEnabled:
+    def test_true_values(self, channel, monkeypatch):
+        for val in ("true", "True", "TRUE", "1", "yes"):
+            monkeypatch.setenv("FEISHU_STREAMING_ENABLED", val)
+            assert channel._is_streaming_enabled() is True
+
+    def test_false_values(self, channel, monkeypatch):
+        for val in ("false", "0", "no", "", "random"):
+            monkeypatch.setenv("FEISHU_STREAMING_ENABLED", val)
+            assert channel._is_streaming_enabled() is False
+
+    def test_unset(self, channel, monkeypatch):
+        monkeypatch.delenv("FEISHU_STREAMING_ENABLED", raising=False)
+        assert channel._is_streaming_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# _next_stream_seq
+# ---------------------------------------------------------------------------
+
+
+class TestNextStreamSeq:
+    def test_monotonic(self, channel):
+        assert channel._next_stream_seq() == 1
+        assert channel._next_stream_seq() == 2
+        assert channel._next_stream_seq() == 3
+
+    def test_starts_at_1(self, channel):
+        channel._stream_seq = 0
+        assert channel._next_stream_seq() == 1
+
+
+# ---------------------------------------------------------------------------
+# _feishu_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestFeishuBaseUrl:
+    def test_feishu_domain(self, channel):
+        channel.domain = "feishu"
+        assert channel._feishu_base_url() == "https://open.feishu.cn"
+
+    def test_lark_domain(self, channel):
+        channel.domain = "lark"
+        assert channel._feishu_base_url() == "https://open.larksuite.com"
+
+
+# ---------------------------------------------------------------------------
+# _card_create
+# ---------------------------------------------------------------------------
+
+
+class TestCardCreate:
+    @pytest.mark.asyncio
+    async def test_success(self, channel, mock_http):
+        mock_http.post.return_value = _ok_feishu({"card_id": "card_abc123"})
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_create()
+
+        assert result == "card_abc123"
+        mock_http.post.assert_awaited_once()
+        call_url = mock_http.post.call_args[0][0]
+        assert "cardkit/v1/cards" in call_url
+
+    @pytest.mark.asyncio
+    async def test_http_failure(self, channel, mock_http):
+        mock_http.post.return_value = _fail_http()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_create()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_feishu_error_code(self, channel, mock_http):
+        mock_http.post.return_value = _fail_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_create()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sends_cardkit_schema(self, channel, mock_http):
+        mock_http.post.return_value = _ok_feishu({"card_id": "card_x"})
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_create()
+
+        call_kwargs = mock_http.post.call_args[1]
+        body = call_kwargs["json"]
+        assert body["type"] == "card_json"
+        card = json.loads(body["data"])
+        assert card["schema"] == "2.0"
+        assert card["config"]["streaming_mode"] is True
+        assert (
+            card["config"]["streaming_config"]["print_frequency_ms"]["default"]
+            == 50
+        )
+        content_els = [
+            e
+            for e in card["body"]["elements"]
+            if e["element_id"] == _STREAMING_ELEMENT_ID
+        ]
+        assert len(content_els) == 1
+        assert content_els[0]["tag"] == "markdown"
+
+
+# ---------------------------------------------------------------------------
+# _card_send
+# ---------------------------------------------------------------------------
+
+
+class TestCardSend:
+    @pytest.mark.asyncio
+    async def test_success(self, channel, mock_http):
+        mock_http.post.return_value = _ok_feishu({"message_id": "msg_456"})
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_send("card_123", "ou_test", "open_id")
+
+        assert result == "msg_456"
+
+    @pytest.mark.asyncio
+    async def test_http_failure(self, channel, mock_http):
+        mock_http.post.return_value = _fail_http()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_send("card_123", "ou_test", "open_id")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _card_update_text
+# ---------------------------------------------------------------------------
+
+
+class TestCardUpdateText:
+    @pytest.mark.asyncio
+    async def test_success(self, channel, mock_http):
+        mock_http.put.return_value = _ok_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_update_text("card_123", "Hello world")
+
+        assert result is True
+        mock_http.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_failure(self, channel, mock_http):
+        mock_http.put.return_value = _fail_http()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_update_text("card_123", "Hello")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_feishu_error_code(self, channel, mock_http):
+        mock_http.put.return_value = _fail_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        result = await channel._card_update_text("card_123", "Hello")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_sends_full_text(self, channel, mock_http):
+        mock_http.put.return_value = _ok_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_update_text("card_123", "full text here")
+
+        call_kwargs = mock_http.put.call_args[1]
+        body = call_kwargs["json"]
+        assert body["content"] == "full text here"
+        assert body["sequence"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_url_contains_card_id_and_element(self, channel, mock_http):
+        mock_http.put.return_value = _ok_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_update_text("card_xyz", "text")
+
+        call_url = mock_http.put.call_args[0][0]
+        assert "card_xyz" in call_url
+        assert f"elements/{_STREAMING_ELEMENT_ID}/content" in call_url
+
+
+# ---------------------------------------------------------------------------
+# _card_close
+# ---------------------------------------------------------------------------
+
+
+class TestCardClose:
+    @pytest.mark.asyncio
+    async def test_success(self, channel, mock_http):
+        mock_http.patch.return_value = _ok_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_close("card_123")
+
+        mock_http.patch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sends_streaming_mode_false(self, channel, mock_http):
+        mock_http.patch.return_value = _ok_feishu()
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_close("card_123")
+
+        call_kwargs = mock_http.patch.call_args[1]
+        body = call_kwargs["json"]
+        settings = json.loads(body["settings"])
+        assert settings["config"]["streaming_mode"] is False
+
+    @pytest.mark.asyncio
+    async def test_http_failure_no_raise(self, channel, mock_http):
+        mock_http.patch.return_value = _fail_http(500, "Server Error")
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_close("card_123")
+
+    @pytest.mark.asyncio
+    async def test_exception_no_raise(self, channel, mock_http):
+        mock_http.patch.side_effect = Exception("connection reset")
+        channel._streaming_auth_headers = MagicMock(
+            return_value={"Authorization": "Bearer t"},
+        )
+
+        await channel._card_close("card_123")
+
+
+# ---------------------------------------------------------------------------
+# _extract_streaming_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractStreamingText:
+    def test_message_completed(self, channel):
+        ev = MagicMock()
+        ev.object = "message"
+        channel._message_to_content_parts = MagicMock(
+            return_value=[
+                MagicMock(type="text", text="hello world"),
+            ],
+        )
+
+        result = channel._extract_streaming_text(ev, is_streaming=False)
+        assert result == "hello world"
+
+    def test_delta_attribute(self, channel):
+        ev = MagicMock()
+        ev.object = "response"
+        ev.delta = "partial text"
+        ev.content = None
+        ev.text = None
+        ev.content_part = None
+
+        result = channel._extract_streaming_text(ev, is_streaming=True)
+        assert result == "partial text"
+
+    def test_content_attribute(self, channel):
+        ev = MagicMock()
+        ev.object = "response"
+        ev.delta = None
+        ev.content = "some content"
+        ev.text = None
+        ev.content_part = None
+
+        result = channel._extract_streaming_text(ev, is_streaming=True)
+        assert result == "some content"
+
+    def test_nested_message(self, channel):
+        ev = MagicMock(spec=[])
+        inner = MagicMock()
+        inner.content = "nested text"
+        ev.message = inner
+
+        result = channel._extract_streaming_text(ev, is_streaming=True)
+        assert result == "nested text"
+
+    def test_returns_none_when_empty(self, channel):
+        ev = MagicMock(spec=[])
+        result = channel._extract_streaming_text(ev, is_streaming=False)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _run_process_loop routing
+# ---------------------------------------------------------------------------
+
+
+class TestStreamWithTrackerRouting:
+    """Verify _stream_with_tracker delegates correctly."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_delegates_to_super(self, channel, monkeypatch):
+        """When streaming disabled, should delegate to super."""
+        monkeypatch.delenv("FEISHU_STREAMING_ENABLED", raising=False)
+
+        async def fake_super(payload):
+            yield "data: super_chunk\n\n"
+
+        monkeypatch.setattr(
+            type(channel).__bases__[0],
+            "_stream_with_tracker",
+            fake_super,
+        )
+
+        result = []
+        async for chunk in channel._stream_with_tracker({"meta": {}}):
+            result.append(chunk)
+
+        assert result == ["data: super_chunk\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_enabled_yields_sse_events(self, channel, monkeypatch):
+        """When streaming enabled, should yield SSE events."""
+        monkeypatch.setenv("FEISHU_STREAMING_ENABLED", "true")
+
+        monkeypatch.setattr(
+            channel,
+            "_payload_to_request",
+            lambda p: MagicMock(),
+        )
+        monkeypatch.setattr(
+            channel,
+            "get_to_handle_from_request",
+            lambda r: "test_user",
+        )
+        monkeypatch.setattr(channel, "_before_consume_process", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "_get_receive_for_send",
+            AsyncMock(return_value=("open_id", "ou_123")),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_streaming_auth_headers",
+            lambda: {"Authorization": "Bearer t"},
+        )
+        monkeypatch.setattr(channel, "_next_stream_seq", lambda: 1)
+        monkeypatch.setattr(
+            channel,
+            "_feishu_base_url",
+            lambda: "https://open.feishu.cn",
+        )
+
+        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
+
+        ev1 = MagicMock()
+        ev1.object = "response"
+        ev1.status = None
+        ev1.model_dump_json = lambda: '{"object":"response"}'
+
+        ev2 = MagicMock()
+        ev2.object = "message"
+        ev2.status = RunStatus.Completed
+        ev2.model_dump_json = lambda: '{"object":"message"}'
+
+        async def fake_process(req):
+            yield ev1
+            yield ev2
+
+        monkeypatch.setattr(channel, "_process", fake_process)
+
+        content_part = MagicMock()
+        content_part.type = "text"
+        content_part.text = "Hello"
+        monkeypatch.setattr(
+            channel,
+            "_message_to_content_parts",
+            lambda ev: [content_part],
+        )
+        monkeypatch.setattr(
+            channel,
+            "send_content_parts",
+            AsyncMock(return_value="m1"),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_get_response_error_message",
+            lambda r: None,
+        )
+        monkeypatch.setattr(channel, "_add_reaction", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "get_on_reply_sent_args",
+            lambda r, t: (r, t),
+        )
+        monkeypatch.setattr(channel, "_on_reply_sent", None)
+
+        chunks = []
+        async for chunk in channel._stream_with_tracker({"meta": {}}):
+            chunks.append(chunk)
+
+        assert len(chunks) >= 2
+        assert "data:" in chunks[0]
+
+
+class TestStreamWithTrackerStreaming:
+    """Test streaming card lifecycle via _stream_with_tracker."""
+
+    @pytest.mark.asyncio
+    async def test_card_lifecycle_via_tracker(
+        self,
+        channel,
+        mock_http,
+        monkeypatch,
+    ):
+        """Full lifecycle: create card -> stream -> close via tracker."""
+        monkeypatch.setenv("FEISHU_STREAMING_ENABLED", "true")
+
+        monkeypatch.setattr(
+            channel,
+            "_payload_to_request",
+            lambda p: MagicMock(),
+        )
+        monkeypatch.setattr(
+            channel,
+            "get_to_handle_from_request",
+            lambda r: "test_user",
+        )
+        monkeypatch.setattr(channel, "_before_consume_process", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "_get_receive_for_send",
+            AsyncMock(return_value=("open_id", "ou_123")),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_streaming_auth_headers",
+            lambda: {"Authorization": "Bearer t"},
+        )
+        monkeypatch.setattr(channel, "_next_stream_seq", lambda: 1)
+        monkeypatch.setattr(
+            channel,
+            "_feishu_base_url",
+            lambda: "https://open.feishu.cn",
+        )
+
+        mock_http.post.return_value = _ok_feishu(
+            data={"card_id": "card_test123"},
+        )
+        mock_http.put.return_value = _ok_feishu()
+        mock_http.patch.return_value = _ok_feishu()
+
+        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
+
+        async def fake_process(req):
+            ev1 = MagicMock()
+            ev1.object = "message"
+            ev1.status = RunStatus.InProgress
+            ev1.model_dump_json = lambda: '{"partial":true}'
+            yield ev1
+
+            ev2 = MagicMock()
+            ev2.object = "message"
+            ev2.status = RunStatus.Completed
+            ev2.model_dump_json = lambda: '{"done":true}'
+            yield ev2
+
+        monkeypatch.setattr(channel, "_process", fake_process)
+        monkeypatch.setattr(
+            channel,
+            "_extract_streaming_text",
+            lambda ev, is_streaming=True: "Hello world",
+        )
+
+        content_part = MagicMock()
+        content_part.type = "text"
+        content_part.text = "Hello world"
+        monkeypatch.setattr(
+            channel,
+            "_message_to_content_parts",
+            lambda ev: [content_part],
+        )
+        monkeypatch.setattr(
+            channel,
+            "send_content_parts",
+            AsyncMock(return_value="m1"),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_get_response_error_message",
+            lambda r: None,
+        )
+        monkeypatch.setattr(channel, "_add_reaction", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "get_on_reply_sent_args",
+            lambda r, t: (r, t),
+        )
+        monkeypatch.setattr(channel, "_on_reply_sent", None)
+
+        chunks = []
+        async for chunk in channel._stream_with_tracker({"meta": {}}):
+            chunks.append(chunk)
+
+        assert mock_http.post.await_count >= 1
+        assert mock_http.patch.await_count >= 1
+        assert len(chunks) >= 2
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_card_failure_via_tracker(
+        self,
+        channel,
+        mock_http,
+        monkeypatch,
+    ):
+        """Card creation fails -> fall back to normal send via tracker."""
+        monkeypatch.setenv("FEISHU_STREAMING_ENABLED", "true")
+
+        monkeypatch.setattr(
+            channel,
+            "_payload_to_request",
+            lambda p: MagicMock(),
+        )
+        monkeypatch.setattr(
+            channel,
+            "get_to_handle_from_request",
+            lambda r: "test_user",
+        )
+        monkeypatch.setattr(channel, "_before_consume_process", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "_get_receive_for_send",
+            AsyncMock(return_value=("open_id", "ou_123")),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_streaming_auth_headers",
+            lambda: {"Authorization": "Bearer t"},
+        )
+        monkeypatch.setattr(channel, "_next_stream_seq", lambda: 1)
+        monkeypatch.setattr(
+            channel,
+            "_feishu_base_url",
+            lambda: "https://open.feishu.cn",
+        )
+
+        mock_http.post.return_value = _fail_http(500, "Server Error")
+        mock_http.patch.return_value = _ok_feishu()
+
+        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
+
+        async def fake_process(req):
+            ev = MagicMock()
+            ev.object = "message"
+            ev.status = RunStatus.Completed
+            ev.model_dump_json = lambda: '{"done":true}'
+            yield ev
+
+        monkeypatch.setattr(channel, "_process", fake_process)
+
+        content_part = MagicMock()
+        content_part.type = "text"
+        content_part.text = "Hello"
+        monkeypatch.setattr(
+            channel,
+            "_message_to_content_parts",
+            lambda ev: [content_part],
+        )
+        monkeypatch.setattr(
+            channel,
+            "send_content_parts",
+            AsyncMock(return_value="m_fallback"),
+        )
+        monkeypatch.setattr(
+            channel,
+            "_get_response_error_message",
+            lambda r: None,
+        )
+        monkeypatch.setattr(channel, "_add_reaction", AsyncMock())
+        monkeypatch.setattr(
+            channel,
+            "get_on_reply_sent_args",
+            lambda r, t: (r, t),
+        )
+        monkeypatch.setattr(channel, "_on_reply_sent", None)
+
+        async for _ in channel._stream_with_tracker({"meta": {}}):
+            pass
+
+        channel.send_content_parts.assert_awaited()

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -239,6 +239,18 @@ If your environment uses a SOCKS proxy, also install `python-socks` (for example
 > **Note:** You can also fill in **App ID** and **App Secret** in the Console UI, but you must restart the copaw service before continuing with the long-connection configuration.
 > ![console](https://img.alicdn.com/imgextra/i2/O1CN01ybSbN01luB8jyt9BD_!!6000000004878-2-tps-3822-2064.png)
 
+### Streaming Typewriter Effect (Optional)
+
+The Feishu channel supports a **streaming typewriter card** — AI replies are displayed character by character in real time, instead of being sent all at once after generation completes.
+
+**How to enable:** Set the environment variable `FEISHU_STREAMING_ENABLED=true` and restart CoPaw. When disabled, output automatically falls back to normal messages.
+
+**How it works:** Uses the Feishu Cardkit v1 Streaming Card API. On the first token, a streaming card is created and sent. A background task pushes accumulated text every 60ms; Feishu renders it character by character. When generation completes, streaming mode is closed and the card is finalized.
+
+**Additional permissions:** Add `im:card:write` and `im:card:read` to your app's permission JSON.
+
+**Fallback:** If any streaming API call fails, the channel automatically falls back to normal message output with no visible disruption. Lark (international version) is also supported — set `domain` to `"lark"`.
+
 ### Recommended bot permissions
 
 The JSON in step 6 grants the following permissions (app identity) for messaging and files:

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -236,6 +236,18 @@
 > 注: **App ID** 和 **App Secret** 信息也可以在Console前端填写，但需重启 CoPaw 服务，才能继续配置长链接的操作。
 > ![console](https://img.alicdn.com/imgextra/i1/O1CN019Gfox81MMPXosAHhC_!!6000000001420-2-tps-3822-2064.png)
 
+### 流式打字机效果（可选）
+
+飞书频道支持**流式打字机卡片**——AI 回复时实时逐字显示，而非等全部生成完毕后一次性发送。
+
+**启用方式：** 设置环境变量 `FEISHU_STREAMING_ENABLED=true`，重启 CoPaw 即可生效。关闭后自动回退为普通消息。
+
+**工作原理：** 利用飞书 Cardkit v1 Streaming Card API，收到首个 token 时创建流式卡片并推送，后台每 60ms 更新卡片文本，飞书端逐字打印；生成完毕后关闭流式模式，卡片固化。
+
+**额外权限：** 需在应用权限 JSON 中添加 `im:card:write` 和 `im:card:read`。
+
+**回退机制：** 流式 API 调用失败时自动回退到普通消息，用户端无感知断裂。Lark（国际版）同样支持，`domain` 设为 `"lark"` 即可。
+
 ### 机器人权限建议
 
 第6步中的json文件为应用配备了以下权限（应用身份、已开通），以保证收发消息与文件正常：


### PR DESCRIPTION
## Summary

Add real-time streaming card output for Feishu channel. When `FEISHU_STREAMING_ENABLED=true`, agent responses are displayed as an interactive typewriter card with live text updates.

## Changes

- **channel.py**: Override `_stream_with_tracker` to support streaming card creation, real-time text updates, and card finalization
- **test_feishu_streaming.py**: Unit tests for streaming card logic
- **docs**: Update channel documentation with streaming card info

## Behavior

- **Streaming enabled** (`FEISHU_STREAMING_ENABLED=true`): Creates interactive card, updates text in real-time as agent generates response
- **Streaming disabled** (default): Falls back to normal `super()._stream_with_tracker()` behavior
- **DONE reaction**: Preserved from upstream `_on_process_completed`

## Compatibility

Based on latest upstream main (`1.0.1.beta1`), fully compatible with upstream changes including `_on_process_completed` and `send` methods.
