### PR TITLE
fix: reset reconnect_attempts on QQ RESUMED event

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -1254,6 +1254,8 @@ class QQChannel(BaseChannel):
                 state.last_connect_time = time.time()
                 logger.info("qq ready session_id=%s", state.session_id)
             elif t == "RESUMED":
+                state.identify_fail_count = 0
+                state.reconnect_attempts = 0
                 logger.info("qq session resumed")
             elif t in _MESSAGE_EVENT_SPECS:
                 self._handle_msg_event(t, d or {})

--- a/tests/unit/channels/test_qq_channel.py
+++ b/tests/unit/channels/test_qq_channel.py
@@ -365,6 +365,21 @@ class TestHandleWsPayload:
         assert state.session_id == "new_sess"
         assert state.last_seq == 1
 
+    def test_dispatch_resumed_resets_counters(self):
+        ch, ws, state, hb = self._make_deps()
+        state.reconnect_attempts = 5
+        state.identify_fail_count = 2
+        payload = {
+            "op": OP_DISPATCH,
+            "d": None,
+            "s": 10,
+            "t": "RESUMED",
+        }
+        result = ch._handle_ws_payload(payload, ws, "tok", state, hb)
+        assert result is None
+        assert state.reconnect_attempts == 0
+        assert state.identify_fail_count == 0
+
     def test_dispatch_message_calls_handle_msg_event(self):
         ch, ws, state, hb = self._make_deps()
         ch._handle_msg_event = MagicMock()


### PR DESCRIPTION
Fixes #2796

## Problem

The QQ channel's `RESUMED` event handler was not resetting the `reconnect_attempts` and `identify_fail_count` counters. When the QQ server periodically requests reconnects (OP_RECONNECT) and the client successfully resumes the session, the counters kept accumulating. This eventually caused the bot to hit `max_reconnect_attempts` and permanently disconnect, even though each individual reconnect was successful.

## Solution

Add counter resets in the `RESUMED` event handler to mirror what is already done in the `READY` handler:

```python
elif t == "RESUMED":
    state.identify_fail_count = 0
    state.reconnect_attempts = 0
    logger.info("qq session resumed")
```

A successful `RESUMED` event means the connection is healthy again, so the counters should be zeroed just like after a `READY` event.

## Testing

- Added a unit test `test_dispatch_resumed_resets_counters` that verifies both counters are reset to 0 after a `RESUMED` event, even when they start at non-zero values.