### PR TITLE
fix(qq): reset reconnect state when websocket session resumes

### DIFF
--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -1254,6 +1254,9 @@ class QQChannel(BaseChannel):
                 state.last_connect_time = time.time()
                 logger.info("qq ready session_id=%s", state.session_id)
             elif t == "RESUMED":
+                state.identify_fail_count = 0
+                state.reconnect_attempts = 0
+                state.last_connect_time = time.time()
                 logger.info("qq session resumed")
             elif t in _MESSAGE_EVENT_SPECS:
                 self._handle_msg_event(t, d or {})

--- a/tests/unit/channels/test_qq_channel.py
+++ b/tests/unit/channels/test_qq_channel.py
@@ -365,6 +365,26 @@ class TestHandleWsPayload:
         assert state.session_id == "new_sess"
         assert state.last_seq == 1
 
+    def test_dispatch_resumed_resets_reconnect_state(self):
+        ch, ws, state, hb = self._make_deps()
+        state.identify_fail_count = 2
+        state.reconnect_attempts = 5
+        state.last_connect_time = 1.0
+        payload = {
+            "op": OP_DISPATCH,
+            "d": {},
+            "s": 7,
+            "t": "RESUMED",
+        }
+        before = time.time()
+        result = ch._handle_ws_payload(payload, ws, "tok", state, hb)
+        after = time.time()
+        assert result is None
+        assert state.identify_fail_count == 0
+        assert state.reconnect_attempts == 0
+        assert before <= state.last_connect_time <= after
+        assert state.last_seq == 7
+
     def test_dispatch_message_calls_handle_msg_event(self):
         ch, ws, state, hb = self._make_deps()
         ch._handle_msg_event = MagicMock()


### PR DESCRIPTION
## Summary
- reset `identify_fail_count` and `reconnect_attempts` when the QQ gateway emits `RESUMED`
- refresh `last_connect_time` after a successful session resume
- add a regression test covering the `RESUMED` dispatch path

## Testing
- `uv run --extra dev pytest tests/unit/channels/test_qq_channel.py`

Closes #2796.
