### PR TITLE
fix: version

### DIFF
--- a/console/src/layouts/constants.ts
+++ b/console/src/layouts/constants.ts
@@ -79,12 +79,36 @@ export const isStableVersion = (v: string): boolean =>
 
 // Compare two PEP 440 version strings. Returns >0 if a>b, <0 if a<b, 0 if equal.
 // .postN releases sort after their base version (e.g. 1.0.0.post1 > 1.0.0).
+// Pre-release versions (aN, bN, rcN) sort before their base version.
 export const compareVersions = (a: string, b: string): number => {
-  const normalise = (v: string) =>
-    v
-      .replace(/\.post(\d+)/i, ".$1")
-      .split(/[.\-]/)
-      .map((seg) => (isNaN(Number(seg)) ? 0 : Number(seg)));
+  const normalise = (v: string): number[] => {
+    // Handle .postN suffix
+    const postMatch = v.match(/\.post(\d+)$/i);
+    const postNum = postMatch ? Number(postMatch[1]) : 0;
+    const baseVersion = v.replace(/\.post\d+$/i, "");
+
+    // Handle pre-release suffix (e.g., 1.0.1b1 -> base=1.0.1, preType=b, preNum=1)
+    const preMatch = baseVersion.match(/^(.+?)(a|alpha|b|beta|rc|c)(\d*)$/i);
+    let coreVersion = baseVersion;
+    let preType = 0; // 0 = stable, -3 = alpha, -2 = beta, -1 = rc
+    let preNum = 0;
+    if (preMatch) {
+      coreVersion = preMatch[1];
+      const preLabel = preMatch[2].toLowerCase();
+      preType =
+        preLabel === "a" || preLabel === "alpha"
+          ? -3
+          : preLabel === "b" || preLabel === "beta"
+          ? -2
+          : -1; // rc or c
+      preNum = preMatch[3] ? Number(preMatch[3]) : 0;
+    }
+
+    const parts = coreVersion.split(/[.\-]/).map((seg) => Number(seg) || 0);
+    // Append: preType (0 for stable, negative for pre-release), preNum, postNum
+    return [...parts, preType, preNum, postNum];
+  };
+
   const aN = normalise(a);
   const bN = normalise(b);
   const len = Math.max(aN.length, bN.length);


### PR DESCRIPTION
## Description


When processing 1.0.1b1:

"1.0.1b1".split(/[.\-]/) → ["1", "0", "1b1"]

"1b1" is not a number, so it is converted to 0.

Result: 1.0.1b1 is incorrectly parsed as [1, 0, 0]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
