### PR TITLE
refactor(configs): mordenize configs in groups and fields using Pydantic settings to replace EnvVarLoader

### DIFF
--- a/src/copaw/agents/memory/reme_light_memory_manager.py
+++ b/src/copaw/agents/memory/reme_light_memory_manager.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-branches
 # mypy: ignore-errors
 """ReMeLight-backed memory manager for CoPaw agents."""
+
 import importlib.metadata
 import json
 import logging
@@ -24,7 +25,7 @@ from copaw.config.context import (
     set_current_workspace_dir,
     set_current_recent_max_bytes,
 )
-from copaw.constant import EnvVarLoader
+from copaw.configs import copaw_config
 
 if TYPE_CHECKING:
     from reme.memory.file_based.reme_in_memory_memory import ReMeInMemoryMemory
@@ -67,7 +68,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             f"agent_id={agent_id}, working_dir={working_dir}",
         )
 
-        backend_env = EnvVarLoader.get_str("MEMORY_STORE_BACKEND", "auto")
+        backend_env = copaw_config.MEMORY_STORE_BACKEND
         if backend_env == "auto":
             if platform.system() == "Windows":
                 memory_backend = "local"
@@ -105,7 +106,7 @@ See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
             f"Embedding config: {log_cfg}, vector_enabled={vector_enabled}",
         )
 
-        fts_enabled = EnvVarLoader.get_bool("FTS_ENABLED", True)
+        fts_enabled = copaw_config.FTS_ENABLED
 
         agent_config = load_agent_config(self.agent_id)
         rebuild_on_start = (
@@ -187,12 +188,9 @@ See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
         cfg = load_agent_config(self.agent_id).running.embedding_config
         return {
             "backend": cfg.backend,
-            "api_key": cfg.api_key
-            or EnvVarLoader.get_str("EMBEDDING_API_KEY"),
-            "base_url": cfg.base_url
-            or EnvVarLoader.get_str("EMBEDDING_BASE_URL"),
-            "model_name": cfg.model_name
-            or EnvVarLoader.get_str("EMBEDDING_MODEL_NAME"),
+            "api_key": cfg.api_key or copaw_config.EMBEDDING_API_KEY,
+            "base_url": cfg.base_url or copaw_config.EMBEDDING_BASE_URL,
+            "model_name": cfg.model_name or copaw_config.EMBEDDING_MODEL_NAME,
             "dimensions": cfg.dimensions,
             "enable_cache": cfg.enable_cache,
             "use_dimensions": cfg.use_dimensions,
@@ -233,8 +231,9 @@ See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
             return True
         result = await self._reme.close()
         logger.info(
-            f"ReMeLightMemoryManager closed: "
-            f"agent_id={self.agent_id}, result={result}",
+            "ReMeLight closed: agent_id=%s, result=%s",
+            self.agent_id,
+            result,
         )
         return result
 

--- a/src/copaw/configs/__init__.py
+++ b/src/copaw/configs/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""CoPaw configuration module with Pydantic Settings singleton."""
+
+from .settings import CopawSettings
+
+# Global singleton instance
+copaw_config = CopawSettings()

--- a/src/copaw/configs/app.py
+++ b/src/copaw/configs/app.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class AppSettings(BaseSettings):
+    COPAW_WORKING_DIR: Path = Field(
+        description="Working directory for CoPaw data and configuration files",
+        default=Path("~/.copaw").expanduser().resolve(),
+    )
+
+    COPAW_RUNNING_IN_CONTAINER: bool = Field(
+        description=(
+            "Set to true if running inside Docker "
+            "(Env: COPAW_RUNNING_IN_CONTAINER=1/true/yes)"
+        ),
+        default=False,
+    )
+
+    COPAW_OPENAPI_DOCS: bool = Field(
+        description=(
+            "When true, expose /docs, /redoc, /openapi.json (dev only)"
+        ),
+        default=False,
+    )
+
+    COPAW_MODEL_PROVIDER_CHECK_TIMEOUT: float = Field(
+        description=(
+            "Timeout in seconds for checking if a provider is reachable"
+        ),
+        default=5.0,
+        ge=0,
+    )
+
+    COPAW_TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS: float = Field(
+        description="Tool guard approval timeout in seconds",
+        default=600.0,
+        ge=1.0,
+    )
+
+    COPAW_JOBS_FILE: str = Field(
+        description="Filename for jobs data storage",
+        default="jobs.json",
+    )
+
+    COPAW_CHATS_FILE: str = Field(
+        description="Filename for chats data storage",
+        default="chats.json",
+    )
+
+    COPAW_TOKEN_USAGE_FILE: str = Field(
+        description="Filename for token usage tracking",
+        default="token_usage.json",
+    )
+
+    COPAW_CONFIG_FILE: str = Field(
+        description="Filename for main configuration file",
+        default="config.json",
+    )
+
+    COPAW_HEARTBEAT_FILE: str = Field(
+        description="Filename for heartbeat status file",
+        default="HEARTBEAT.md",
+    )
+
+    COPAW_DEBUG_HISTORY_FILE: str = Field(
+        description=(
+            "Debug history file for /dump_history and /load_history commands"
+        ),
+        default="debug_history.jsonl",
+    )
+
+    COPAW_SECRET_DIR: Path | None = Field(
+        description=(
+            "Secret directory for sensitive data. "
+            "Defaults to WORKING_DIR.parent / '.copaw.secret'"
+        ),
+        default=None,
+    )

--- a/src/copaw/configs/cors.py
+++ b/src/copaw/configs/cors.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class CorsSettings(BaseSettings):
+    COPAW_CORS_ORIGINS: str = Field(
+        description=(
+            "Comma-separated allowed CORS origins "
+            "(Env: COPAW_CORS_ORIGINS='http://localhost:5173')"
+        ),
+        default="",
+    )

--- a/src/copaw/configs/memory.py
+++ b/src/copaw/configs/memory.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class MemorySettings(BaseSettings):
+    COPAW_MEMORY_COMPACT_KEEP_RECENT: int = Field(
+        description="Number of recent memory items to keep during compaction",
+        default=3,
+        ge=0,
+    )
+
+    COPAW_MEMORY_COMPACT_RATIO: float = Field(
+        description="Ratio of memory items to keep during compaction",
+        default=0.7,
+        ge=0,
+    )
+
+    MEMORY_STORE_BACKEND: str = Field(
+        description="Backend storage for memory ('auto', 'sqlite', 'redis')",
+        default="auto",
+    )
+
+    FTS_ENABLED: bool = Field(
+        description="Whether to enable full-text search",
+        default=True,
+    )
+
+    EMBEDDING_API_KEY: str = Field(
+        description="API key for embedding service",
+        default="",
+    )
+
+    EMBEDDING_BASE_URL: str = Field(
+        description="Base URL for embedding service",
+        default="",
+    )
+
+    EMBEDDING_MODEL_NAME: str = Field(
+        description="Model name for embeddings",
+        default="",
+    )

--- a/src/copaw/configs/model.py
+++ b/src/copaw/configs/model.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class ModelSettings(BaseSettings):
+    DASHSCOPE_BASE_URL: str = Field(
+        description="Base URL for DashScope API",
+        default="https://dashscope.aliyuncs.com/compatible-mode/v1",
+    )
+
+    COPAW_LLM_MAX_RETRIES: int = Field(
+        description="Maximum number of retries for LLM API calls",
+        default=3,
+        ge=0,
+    )
+
+    COPAW_LLM_MAX_CONCURRENT: int = Field(
+        description=(
+            "Max concurrent in-flight LLM calls. Excess wait on semaphore"
+        ),
+        default=10,
+        ge=1,
+    )
+
+    COPAW_LLM_MAX_QPM: int = Field(
+        description=(
+            "Max queries per minute. 0=unlimited. E.g. OpenAI Tier-1 ~500 QPM"
+        ),
+        default=600,
+        ge=0,
+    )
+
+    COPAW_LLM_BACKOFF_BASE: float = Field(
+        description="Base in seconds for exponential backoff on retries",
+        default=1.0,
+        ge=0.1,
+    )
+
+    COPAW_LLM_BACKOFF_CAP: float = Field(
+        description="Max backoff time in seconds for LLM retries",
+        default=10.0,
+        ge=0.5,
+    )
+
+    COPAW_LLM_RATE_LIMIT_PAUSE: float = Field(
+        description="Global pause seconds when 429 received.\n"
+        "Override by Retry-After header",
+        default=5.0,
+        ge=1.0,
+    )
+
+    COPAW_LLM_RATE_LIMIT_JITTER: float = Field(
+        description=(
+            "Random jitter seconds to stagger concurrent waiters wake-up"
+        ),
+        default=1.0,
+        ge=0.0,
+    )
+
+    COPAW_LLM_ACQUIRE_TIMEOUT: float = Field(
+        description=(
+            "Max seconds to wait for semaphore slot before RuntimeError"
+        ),
+        default=300.0,
+        ge=10.0,
+    )

--- a/src/copaw/configs/settings.py
+++ b/src/copaw/configs/settings.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+from .app import AppSettings
+from .cors import CorsSettings
+from .memory import MemorySettings
+from .model import ModelSettings
+
+# Repo root: src/copaw/configs/settings.py -> 4 parents -> repo root
+_ENV_PATH = Path(__file__).resolve().parent.parent.parent.parent / ".env"
+
+
+class CopawSettings(  # pylint: disable=too-many-ancestors
+    AppSettings,
+    CorsSettings,
+    MemorySettings,
+    ModelSettings,
+):
+    model_config = SettingsConfigDict(
+        env_file=_ENV_PATH,
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(  # pylint: disable=unused-argument
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+        )

--- a/src/copaw/constant.py
+++ b/src/copaw/constant.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
-import os
 from pathlib import Path
+
 from dotenv import load_dotenv
+
+from copaw.configs import copaw_config
 
 # Load .env file from project root before reading any env vars
 _env_path = Path(__file__).resolve().parent.parent.parent / ".env"
@@ -9,81 +11,8 @@ if _env_path.exists():
     load_dotenv(_env_path)
 
 
-class EnvVarLoader:
-    """Utility to load and parse environment variables with type safety
-    and defaults.
-    """
-
-    @staticmethod
-    def get_bool(env_var: str, default: bool = False) -> bool:
-        """Get a boolean environment variable,
-        interpreting common truthy values."""
-        val = os.environ.get(env_var, str(default)).lower()
-        return val in ("true", "1", "yes")
-
-    @staticmethod
-    def get_float(
-        env_var: str,
-        default: float = 0.0,
-        min_value: float | None = None,
-        max_value: float | None = None,
-        allow_inf: bool = False,
-    ) -> float:
-        """Get a float environment variable with optional bounds
-        and infinity handling."""
-        try:
-            value = float(os.environ.get(env_var, str(default)))
-            if min_value is not None and value < min_value:
-                return min_value
-            if max_value is not None and value > max_value:
-                return max_value
-            if not allow_inf and (
-                value == float("inf") or value == float("-inf")
-            ):
-                return default
-            return value
-        except (TypeError, ValueError):
-            return default
-
-    @staticmethod
-    def get_int(
-        env_var: str,
-        default: int = 0,
-        min_value: int | None = None,
-        max_value: int | None = None,
-    ) -> int:
-        """Get an integer environment variable with optional bounds."""
-        try:
-            value = int(os.environ.get(env_var, str(default)))
-            if min_value is not None and value < min_value:
-                return min_value
-            if max_value is not None and value > max_value:
-                return max_value
-            return value
-        except (TypeError, ValueError):
-            return default
-
-    @staticmethod
-    def get_str(env_var: str, default: str = "") -> str:
-        """Get a string environment variable with a default fallback."""
-        return os.environ.get(env_var, default)
-
-
-WORKING_DIR = (
-    Path(EnvVarLoader.get_str("COPAW_WORKING_DIR", "~/.copaw"))
-    .expanduser()
-    .resolve()
-)
-SECRET_DIR = (
-    Path(
-        EnvVarLoader.get_str(
-            "COPAW_SECRET_DIR",
-            f"{WORKING_DIR}.secret",
-        ),
-    )
-    .expanduser()
-    .resolve()
-)
+WORKING_DIR = copaw_config.COPAW_WORKING_DIR
+SECRET_DIR = copaw_config.COPAW_SECRET_DIR or WORKING_DIR / ".secret"
 
 # Default media directory for channels (cross-platform)
 DEFAULT_MEDIA_DIR = WORKING_DIR / "media"
@@ -91,9 +20,9 @@ DEFAULT_MEDIA_DIR = WORKING_DIR / "media"
 # Default local provider directory
 DEFAULT_LOCAL_PROVIDER_DIR = WORKING_DIR / "local_models"
 
-JOBS_FILE = EnvVarLoader.get_str("COPAW_JOBS_FILE", "jobs.json")
+JOBS_FILE = copaw_config.COPAW_JOBS_FILE
 
-CHATS_FILE = EnvVarLoader.get_str("COPAW_CHATS_FILE", "chats.json")
+CHATS_FILE = copaw_config.COPAW_CHATS_FILE
 
 # Builtin multi-agent profile: CoPaw Q&A helper.
 BUILTIN_QA_AGENT_ID = "CoPaw_QA_Agent_0.1beta1"
@@ -104,48 +33,34 @@ BUILTIN_QA_AGENT_SKILL_NAMES: tuple[str, ...] = (
     "copaw_source_index",
 )
 
-TOKEN_USAGE_FILE = EnvVarLoader.get_str(
-    "COPAW_TOKEN_USAGE_FILE",
-    "token_usage.json",
-)
+TOKEN_USAGE_FILE = copaw_config.COPAW_TOKEN_USAGE_FILE
 
-CONFIG_FILE = EnvVarLoader.get_str("COPAW_CONFIG_FILE", "config.json")
+CONFIG_FILE = copaw_config.COPAW_CONFIG_FILE
 
-HEARTBEAT_FILE = EnvVarLoader.get_str("COPAW_HEARTBEAT_FILE", "HEARTBEAT.md")
+HEARTBEAT_FILE = copaw_config.COPAW_HEARTBEAT_FILE
 HEARTBEAT_DEFAULT_EVERY = "6h"
 HEARTBEAT_DEFAULT_TARGET = "main"
 HEARTBEAT_TARGET_LAST = "last"
 
 # Debug history file for /dump_history and /load_history commands
-DEBUG_HISTORY_FILE = EnvVarLoader.get_str(
-    "COPAW_DEBUG_HISTORY_FILE",
-    "debug_history.jsonl",
-)
+DEBUG_HISTORY_FILE = copaw_config.COPAW_DEBUG_HISTORY_FILE
 MAX_LOAD_HISTORY_COUNT = 10000
 
 # Env key for app log level (used by CLI and app load for reload child).
 LOG_LEVEL_ENV = "COPAW_LOG_LEVEL"
 
 # Env to indicate running inside a container (e.g. Docker). Set to 1/true/yes.
-RUNNING_IN_CONTAINER = EnvVarLoader.get_bool(
-    "COPAW_RUNNING_IN_CONTAINER",
-    False,
-)
+RUNNING_IN_CONTAINER = copaw_config.COPAW_RUNNING_IN_CONTAINER
 
 # Timeout in seconds for checking if a provider is reachable.
-MODEL_PROVIDER_CHECK_TIMEOUT = EnvVarLoader.get_float(
-    "COPAW_MODEL_PROVIDER_CHECK_TIMEOUT",
-    5.0,
-    min_value=0,
-    allow_inf=False,
-)
+MODEL_PROVIDER_CHECK_TIMEOUT = copaw_config.COPAW_MODEL_PROVIDER_CHECK_TIMEOUT
 
 # Playwright: use system Chromium when set (e.g. in Docker).
 PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV = "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"
 
 # When True, expose /docs, /redoc, /openapi.json
 # (dev only; keep False in prod).
-DOCS_ENABLED = EnvVarLoader.get_bool("COPAW_OPENAPI_DOCS", False)
+DOCS_ENABLED = copaw_config.COPAW_OPENAPI_DOCS
 
 # Memory directory
 MEMORY_DIR = WORKING_DIR / "memory"
@@ -157,104 +72,54 @@ CUSTOM_CHANNELS_DIR = WORKING_DIR / "custom_channels"
 # Local models directory
 MODELS_DIR = WORKING_DIR / "models"
 
-MEMORY_COMPACT_KEEP_RECENT = EnvVarLoader.get_int(
-    "COPAW_MEMORY_COMPACT_KEEP_RECENT",
-    3,
-    min_value=0,
-)
+MEMORY_COMPACT_KEEP_RECENT = copaw_config.COPAW_MEMORY_COMPACT_KEEP_RECENT
 
 # Memory compaction configuration
-MEMORY_COMPACT_RATIO = EnvVarLoader.get_float(
-    "COPAW_MEMORY_COMPACT_RATIO",
-    0.7,
-    min_value=0,
-    allow_inf=False,
-)
+MEMORY_COMPACT_RATIO = copaw_config.COPAW_MEMORY_COMPACT_RATIO
 
-DASHSCOPE_BASE_URL = EnvVarLoader.get_str(
-    "DASHSCOPE_BASE_URL",
-    "https://dashscope.aliyuncs.com/compatible-mode/v1",
-)
+DASHSCOPE_BASE_URL = copaw_config.DASHSCOPE_BASE_URL
 
 # CORS configuration — comma-separated list of allowed origins for dev mode.
 # Example: COPAW_CORS_ORIGINS="http://localhost:5173,http://127.0.0.1:5173"
 # When unset, CORS middleware is not applied.
-CORS_ORIGINS = EnvVarLoader.get_str("COPAW_CORS_ORIGINS", "").strip()
+CORS_ORIGINS = copaw_config.COPAW_CORS_ORIGINS
 
 # LLM API retry configuration
-LLM_MAX_RETRIES = EnvVarLoader.get_int(
-    "COPAW_LLM_MAX_RETRIES",
-    3,
-    min_value=0,
-)
+LLM_MAX_RETRIES = copaw_config.COPAW_LLM_MAX_RETRIES
 
-LLM_BACKOFF_BASE = EnvVarLoader.get_float(
-    "COPAW_LLM_BACKOFF_BASE",
-    1.0,
-    min_value=0.1,
-)
+LLM_BACKOFF_BASE = copaw_config.COPAW_LLM_BACKOFF_BASE
 
-LLM_BACKOFF_CAP = EnvVarLoader.get_float(
-    "COPAW_LLM_BACKOFF_CAP",
-    10.0,
-    min_value=0.5,
-)
+LLM_BACKOFF_CAP = copaw_config.COPAW_LLM_BACKOFF_CAP
 
 # LLM concurrency control
 # Maximum number of concurrent in-flight LLM calls; excess requests wait on
 # the semaphore.  Tune to your API quota: start conservatively at 3-5 and
 # increase (e.g. OpenAI Tier 1 ~500 QPM allows ~25 at 3 s/call average).
-LLM_MAX_CONCURRENT = EnvVarLoader.get_int(
-    "COPAW_LLM_MAX_CONCURRENT",
-    10,
-    min_value=1,
-)
+LLM_MAX_CONCURRENT = copaw_config.COPAW_LLM_MAX_CONCURRENT
 
 # Maximum queries per minute (QPM), enforced via a 60-second sliding window.
 # New requests that would exceed this limit will wait before being dispatched
 # to the API — proactively preventing 429s rather than reacting to them.
 # 0 = unlimited (disabled).
 # Examples: Anthropic Tier-1 ≈ 50 QPM; OpenAI Tier-1 ≈ 500 QPM.
-LLM_MAX_QPM = EnvVarLoader.get_int(
-    "COPAW_LLM_MAX_QPM",
-    600,
-    min_value=0,
-)
+LLM_MAX_QPM = copaw_config.COPAW_LLM_MAX_QPM
 
 # Default global pause duration (seconds) applied to all waiters when a 429
 # is received.  Overridden by the API's Retry-After header when present.
-LLM_RATE_LIMIT_PAUSE = EnvVarLoader.get_float(
-    "COPAW_LLM_RATE_LIMIT_PAUSE",
-    5.0,
-    min_value=1.0,
-)
+LLM_RATE_LIMIT_PAUSE = copaw_config.COPAW_LLM_RATE_LIMIT_PAUSE
 
 # Random jitter range (seconds) added on top of the pause remaining time so
 # concurrent waiters stagger their wake-up and avoid a new burst.
-LLM_RATE_LIMIT_JITTER = EnvVarLoader.get_float(
-    "COPAW_LLM_RATE_LIMIT_JITTER",
-    1.0,
-    min_value=0.0,
-)
+LLM_RATE_LIMIT_JITTER = copaw_config.COPAW_LLM_RATE_LIMIT_JITTER
 
 # Maximum time (seconds) a caller will wait for a semaphore slot before
 # giving up with a RuntimeError rather than blocking indefinitely.
-LLM_ACQUIRE_TIMEOUT = EnvVarLoader.get_float(
-    "COPAW_LLM_ACQUIRE_TIMEOUT",
-    300.0,
-    min_value=10.0,
-)
+LLM_ACQUIRE_TIMEOUT = copaw_config.COPAW_LLM_ACQUIRE_TIMEOUT
 
 # Tool guard approval timeout (seconds).
-try:
-    TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS = max(
-        float(
-            os.environ.get("COPAW_TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS", "600"),
-        ),
-        1.0,
-    )
-except (TypeError, ValueError):
-    TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS = 600.0
+TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS = (
+    copaw_config.COPAW_TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS
+)
 
 # Marker prepended to every truncation notice.
 # Format:


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

- Replace `EnvVarLoader` with Pydantic Settings `copaw_config` singleton
- Settings organized by functionality: `AppSettings`, `CorsSettings`, `MemorySettings`, `ModelSettings`
- Env var precedence: system env > .env file > defaults
- Auto string value stripping by default
- Type coercion works automatically (e.g., `Path` fields from string env vars)
- Backward compatible: all existing env var names and defaults preserved


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
