### PR TITLE
fix: add --no-sandbox and --disable-gpu args for Windows browser laun…

### DIFF
--- a/src/copaw/agents/tools/browser_control.py
+++ b/src/copaw/agents/tools/browser_control.py
@@ -236,11 +236,14 @@ def _tool_response(text: str) -> ToolResponse:
 def _chromium_launch_args() -> list[str]:
     """Extra args for Chromium when running in container or Windows."""
     args = []
+    if is_running_in_container() or sys.platform == "win32":
+        args.extend(["--no-sandbox"])
+
     if is_running_in_container():
-        args.extend(["--no-sandbox", "--disable-dev-shm-usage"])
-    # Windows always needs --no-sandbox and --disable-gpu to run properly
+        args.extend(["--disable-dev-shm-usage"])
+    # Windows always needs --disable-gpu to run properly
     if sys.platform == "win32":
-        args.extend(["--no-sandbox", "--disable-gpu"])
+        args.extend(["--disable-gpu"])
     return args
 
 


### PR DESCRIPTION
## Fix: Windows Browser Launch Failure

### Problem
On Windows desktop environments, the browser tool fails to launch Chrome with exit code 21:
```
BrowserType.launch_persistent_context: Target page, context or browser has been closed
```

### Root Cause
The `_chromium_launch_args()` function only adds `--no-sandbox` and `--disable-dev-shm-usage` when running in a container. On Windows desktop, these flags are missing, causing Chrome to fail due to sandbox permission issues.

### Solution
Add `--no-sandbox` and `--disable-gpu` flags to Chromium launch arguments when running on Windows (`sys.platform == "win32"`).

### Changes
```python
def _chromium_launch_args() -> list[str]:
    """Extra args for Chromium when running in container or Windows."""
    args = []
    if is_running_in_container():
        args.extend(["--no-sandbox", "--disable-dev-shm-usage"])
    # Windows always needs --no-sandbox and --disable-gpu to run properly
    if sys.platform == "win32":
        args.extend(["--no-sandbox", "--disable-gpu"])
    return args
```

### Testing
- ✅ Verified on Windows 10/11 with Chrome
- ✅ Browser launches successfully with `browser_use` tool
- ✅ Can navigate, login, and interact with web pages
