### PR TITLE
fix: load Inter, Lato, and Newsreader fonts via Google Fonts

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/copaw-symbol.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CoPaw Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Lato:wght@400;700&family=Newsreader:ital,wght@0,400;0,500;1,400&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Fixes #2863

## Problem

The console CSS declares `font-family: Inter`, `font-family: Lato`, and `font-family: Newsreader` for several key UI elements (tool names, skill titles, MCP titles, status labels), but none of these fonts are ever loaded. There is no `@font-face` declaration, no Google Fonts `<link>` in `index.html`, and no dynamic font injection in the JS bundle. As a result, browsers fall back to the system generic sans-serif font, making those elements look visually inconsistent with the rest of the UI.

## Solution

Add `<link rel="preconnect">` hints and a Google Fonts stylesheet link to `console/index.html` that loads the three missing typefaces:
- **Inter** (weights 400, 500, 600) — used by tool names, skill titles, MCP titles
- **Lato** (weights 400, 700) — used by status labels
- **Newsreader** (regular + italic, weights 400, 500) — used by the main layout

Using `display=swap` ensures text remains visible with a fallback font during load (good for performance/UX). The `preconnect` hints reduce latency by establishing the connection to Google's font CDN early.

## Testing

- Opened the console in a browser on a system without Inter/Lato installed (Linux + DejaVu fonts only)
- Before: tool names and status labels rendered in DejaVu Sans
- After: fonts load correctly from Google Fonts CDN; elements render in Inter and Lato as designed