### PR TITLE
fix(config): normalize legacy llm routing modes

### DIFF
--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -4,7 +4,13 @@ import json
 from pathlib import Path
 from typing import Optional, Union, Dict, List, Literal
 
-from pydantic import BaseModel, Field, ConfigDict, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+    model_validator,
+    field_validator,
+)
 import shortuuid
 
 from .timezone import detect_system_timezone
@@ -594,6 +600,16 @@ class AgentsLLMRoutingConfig(BaseModel):
             "providers.json active_llm."
         ),
     )
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _normalize_legacy_mode(cls, value):
+        """Accept legacy mode values persisted by older routing flows."""
+        if value == "cloud_only":
+            return "cloud_first"
+        if value == "local_only":
+            return "local_first"
+        return value
 
 
 class AgentProfileRef(BaseModel):

--- a/tests/unit/workspace/test_agent_model.py
+++ b/tests/unit/workspace/test_agent_model.py
@@ -293,3 +293,28 @@ def test_agent_running_config_rejects_backoff_cap_below_base():
             llm_backoff_base=2.0,
             llm_backoff_cap=1.0,
         )
+
+
+def test_load_agent_config_normalizes_legacy_llm_routing_mode(
+    mock_agent_workspace,
+):  # pylint: disable=redefined-outer-name
+    """Legacy cloud_only/local_only routing modes should still load."""
+    import json
+
+    agent_json_path = mock_agent_workspace / "agent.json"
+    with open(agent_json_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    raw_data["llm_routing"] = {
+        "enabled": True,
+        "mode": "cloud_only",
+        "local": {"provider_id": "copaw-local", "model": "copaw-flash"},
+    }
+
+    with open(agent_json_path, "w", encoding="utf-8") as f:
+        json.dump(raw_data, f, ensure_ascii=False, indent=2)
+
+    reloaded = load_agent_config("test_agent")
+
+    assert reloaded.llm_routing.enabled is True
+    assert reloaded.llm_routing.mode == "cloud_first"


### PR DESCRIPTION
## Summary
- normalize legacy `llm_routing.mode` values when loading agent config
- map persisted `cloud_only` -> `cloud_first` and `local_only` -> `local_first`
- add a regression test covering legacy agent.json loading

## Why
After local model deletion, some existing `agent.json` files may still contain historical routing mode values like `cloud_only`. The current config schema only accepts `local_first` and `cloud_first`, which causes workspace startup to fail during config validation.

This change keeps startup backward compatible with already-persisted agent configs and avoids breaking users on old data.

## Testing
- `uv run --extra dev pytest tests/unit/workspace/test_agent_model.py`

Closes #2854.
