### PR TITLE
fix: split Feishu post message by paragraphs to preserve newlines

### DIFF
--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -1095,9 +1095,13 @@ class FeishuChannel(BaseChannel):
     ) -> Dict[str, Any]:
         content_rows: List[List[Dict[str, Any]]] = []
         if text:
-            content_rows.append(
-                [{"tag": "md", "text": normalize_feishu_md(text)}],
-            )
+            paragraphs = re.split(r"\n\s*\n", text)
+            for para in paragraphs:
+                para = para.strip()
+                if para:
+                    content_rows.append(
+                        [{"tag": "md", "text": normalize_feishu_md(para)}],
+                    )
         for image_key in image_keys:
             content_rows.append([{"tag": "img", "image_key": image_key}])
         if not content_rows:


### PR DESCRIPTION
Fixes #2923

## Problem
When sending messages via the Feishu channel, double newlines (`\n\n`) used to separate paragraphs were not rendered correctly. All text appeared on a single line because the `_build_post_content` method placed the entire text content into a single `md` tag element.

## Solution
Split the text by double newlines (`\n\n` or `\n\s*\n`) in `_build_post_content` and create a separate content row for each paragraph. This matches the Feishu post message API requirement where each paragraph must be a separate array element in the `content` field.

## Changes
- `src/copaw/app/channels/feishu/channel.py`: Modified `_build_post_content` to split text by blank lines and emit one content row per paragraph.

## Testing
Verified the logic manually:
- Input: `"第一段\n\n第二段\n\n第三段"`
- Before: `[[ {"tag": "md", "text": "第一段\n\n第二段\n\n第三段"} ]]` (all on one line)
- After: `[ [{"tag": "md", "text": "第一段"}], [{"tag": "md", "text": "第二段"}], [{"tag": "md", "text": "第三段"}] ]` (correctly separated)