### PR TITLE
feat(console): restrict model discovery to local model providers only

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -312,7 +312,8 @@ export function RemoteModelManageModal({
     null,
   );
   const [form] = Form.useForm();
-  const canDiscover = provider.support_model_discovery;
+  const isLocalProvider = provider.is_local ?? false;
+  const canDiscover = isLocalProvider && provider.support_model_discovery;
 
   // For custom providers ALL models are deletable.
   // For built-in providers only extra_models are deletable.


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

## Summary
Restricts the “Discover Models” button in the Settings → Models page to **local model providers only** (e.g., `copaw-local`, `ollama`, `lmstudio`). Cloud providers (OpenAI, DashScope, DeepSeek, etc.) will no longer show the discover button, even if they have `support_model_discovery=true`.

## Motivation
Currently, cloud providers that have `support_model_discovery=true` (currently only Gemini) will show the "Discover Models" button. However, model discovery for cloud providers should remain manual—users should explicitly manage their models rather than auto-fetching, as:
- Cloud provider models are typically fixed and well-documented
- Auto-discovery can lead to unexpected model additions
- Local providers are the appropriate target for dynamic discovery since they run on user's machine and may have custom models

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
