### PR TITLE
fix(windows): suppress CMD console window when executing shell commands

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -222,7 +222,8 @@ def _execute_subprocess_sync(
             text=False,
             cwd=cwd,
             env=env,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.CREATE_NO_WINDOW,
         )
 
         # Parent copies are no longer needed — the child inherited its own


### PR DESCRIPTION
Fixes #2933

## Problem

On Windows, every time CoPaw executes a shell command via `execute_shell_command`, a CMD console window pops up on screen. This is disruptive when the user is working in the browser or other applications — the CMD window covers the screen and steals focus repeatedly.

The root cause is that `_execute_subprocess_sync` creates a `cmd.exe` subprocess using `subprocess.Popen` with only the `CREATE_NEW_PROCESS_GROUP` flag, which does not suppress the console window.

## Solution

Add `subprocess.CREATE_NO_WINDOW` (`0x08000000`) alongside the existing `CREATE_NEW_PROCESS_GROUP` flag when spawning the `cmd.exe` subprocess on Windows. This is a standard Windows pattern for running background processes silently.

```python
# Before
creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,

# After
creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
```

## Testing

- Verified that `subprocess.CREATE_NO_WINDOW` is available as a built-in constant in Python's `subprocess` module on Windows
- The fix is a one-line change in `_execute_subprocess_sync` in `src/copaw/agents/tools/shell.py`
- This only affects the Windows code path (the function is only called on Windows)