### PR TITLE
fix(discord): reserve space for code fence closer in _chunk_text

### DIFF
--- a/src/copaw/app/channels/discord_/channel.py
+++ b/src/copaw/app/channels/discord_/channel.py
@@ -371,7 +371,7 @@ class DiscordChannel(BaseChannel):
 
         # Reserve space for a closing fence suffix ("\n```") that _flush()
         # may append when a code block spans chunk boundaries.
-        _FENCE_CLOSE_LEN = len("\n```")
+        fence_close_len = len("\n```")
 
         chunks: list[str] = []
         current: list[str] = []
@@ -400,8 +400,11 @@ class DiscordChannel(BaseChannel):
             # Flush if adding this line would exceed the limit.
             # When inside a code fence, reserve space for the closing
             # suffix that _flush() appends.
-            reserved = _FENCE_CLOSE_LEN if fence_open else 0
-            if current and current_len + len(line_with_nl) + reserved > max_len:
+            reserved = fence_close_len if fence_open else 0
+            if (
+                current
+                and current_len + len(line_with_nl) + reserved > max_len
+            ):
                 saved_fence = fence_open
                 _flush()
                 current_len = 0


### PR DESCRIPTION
## Problem

`_chunk_text()` can produce chunks that exceed Discord's 2000-character limit when a code fence spans a chunk boundary.

When flushing, `_flush()` appends `"\n```"` (4 chars) to close a dangling fence. But the flush threshold check (`current_len + len(line_with_nl) > max_len`) does not account for this suffix. A chunk at 1998 chars + the fence closer = 2002 chars, which Discord rejects with:

```
400 Bad Request (error code: 50035): Invalid Form Body
In content: Must be 2000 or fewer in length.
```

The user sees "Internal error" instead of the agent's response.

## Fix

Reserve space for the fence closing suffix when inside an open code fence:

```python
reserved = _FENCE_CLOSE_LEN if fence_open else 0
if current and current_len + len(line_with_nl) + reserved > max_len:
```

This ensures the flushed chunk (including the appended `"\n```"`) never exceeds `max_len`.

## Testing

Verified with edge cases:
- Code fence block near the 2000-char limit → chunks stay within limit
- Plain text (no fences) → unchanged behavior
- Short text under limit → returned as-is