### PR TITLE
[#2967] Fix shell file-guard path detection for fallback commands

### DIFF
--- a/src/copaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/copaw/security/tool_guard/guardians/file_guardian.py
@@ -92,7 +92,7 @@ _MIME_PREFIXES = (
     "model/",
 )
 
-_WINDOWS_DRIVE_RE = re.compile(r"^[a-zA-Z]:[\/]")
+_WINDOWS_DRIVE_RE = re.compile(r"^[a-zA-Z]:")
 _SHELL_FILE_COMMANDS = frozenset(
     {
         "cat",
@@ -103,6 +103,14 @@ _SHELL_FILE_COMMANDS = frozenset(
         "less",
         "head",
         "tail",
+        "grep",
+        "ls",
+        "dir",
+        "cp",
+        "mv",
+        "rm",
+        "mkdir",
+        "rmdir",
     },
 )
 
@@ -188,16 +196,27 @@ def _extract_paths_from_shell_command(command: str) -> list[str]:
             i += 1
             continue
 
-        if lowered in _SHELL_FILE_COMMANDS and i + 1 < len(tokens):
-            next_token = _strip_shell_quotes(tokens[i + 1])
-            if (
-                next_token
-                and next_token not in _SHELL_REDIRECT_OPERATORS
-                and not next_token.startswith("-")
-            ):
-                candidates.append(next_token)
+        if lowered in _SHELL_FILE_COMMANDS:
+            i += 1
+            while i < len(tokens):
+                next_token = tokens[i]
+                if next_token in _SHELL_REDIRECT_OPERATORS:
+                    break
+
+                clean_token = _strip_shell_quotes(next_token)
+                if clean_token and not clean_token.startswith("-"):
+                    if _looks_like_path_token(clean_token) or lowered in {
+                        "ls",
+                        "dir",
+                        "cp",
+                        "mv",
+                        "rm",
+                        "mkdir",
+                        "rmdir",
+                    }:
+                        candidates.append(clean_token)
                 i += 1
-                continue
+            continue
 
         if _looks_like_path_token(token):
             candidates.append(_strip_shell_quotes(token))
@@ -342,6 +361,18 @@ class FilePathToolGuardian(BaseToolGuardian):
                 ),
             )
 
+    @staticmethod
+    def _iter_candidate_values(param_value: Any) -> Iterable[str]:
+        """Yield string values from string or simple string collections."""
+        if isinstance(param_value, str):
+            yield param_value
+            return
+
+        if isinstance(param_value, (list, tuple)):
+            for value in param_value:
+                if isinstance(value, str):
+                    yield value
+
     def guard(
         self,
         tool_name: str,
@@ -387,11 +418,10 @@ class FilePathToolGuardian(BaseToolGuardian):
 
         # All other tools: scan every string parameter that looks like a path.
         for param_name, param_value in params.items():
-            if not isinstance(param_value, str) or not param_value.strip():
-                continue
-            if not _looks_like_path_token(param_value):
-                continue
-            self._check_value(tool_name, param_name, param_value, findings)
+            for candidate in self._iter_candidate_values(param_value):
+                if not candidate.strip() or not _looks_like_path_token(candidate):
+                    continue
+                self._check_value(tool_name, param_name, candidate, findings)
 
         return findings
 

--- a/tests/unit/security/tool_guard/test_file_guardian_shell_access.py
+++ b/tests/unit/security/tool_guard/test_file_guardian_shell_access.py
@@ -93,6 +93,23 @@ def test_extract_paths_supports_windows_style_shell_access() -> None:
     )
     assert "C:\\Users\\alice\\.ssh\\note.txt" in redirect_paths
 
+    drive_relative_paths = _extract_paths_from_shell_command("type C:secret.txt")
+    assert "C:secret.txt" in drive_relative_paths
+
+
+def test_extract_paths_scans_flags_and_multiple_shell_file_targets() -> None:
+    flagged_paths = _extract_paths_from_shell_command(
+        "cat -n ./secret.txt ../more.txt",
+    )
+    assert "./secret.txt" in flagged_paths
+    assert "../more.txt" in flagged_paths
+
+    copy_paths = _extract_paths_from_shell_command(
+        "cp ./source.txt ../protected/target.txt",
+    )
+    assert "./source.txt" in copy_paths
+    assert "../protected/target.txt" in copy_paths
+
 
 def test_file_guard_blocks_sensitive_shell_reads(
     workspace_root: Path,
@@ -173,3 +190,24 @@ def test_engine_default_guardians_cover_shell_file_access(
     assert result is not None
     assert result.findings_count == 1
     assert result.findings[0].guardian == "file_path_tool_guardian"
+
+
+def test_file_guard_scans_string_lists_for_unknown_tools(
+    workspace_root: Path,
+) -> None:
+    sensitive_dir = workspace_root / "protected"
+    sensitive_dir.mkdir()
+    guardian = FilePathToolGuardian(sensitive_files=[str(sensitive_dir) + "/"])
+
+    findings = guardian.guard(
+        "custom_batch_tool",
+        {
+            "targets": [
+                str(workspace_root / "notes.txt"),
+                str(sensitive_dir / "secret.txt"),
+            ],
+        },
+    )
+
+    assert len(findings) == 1
+    assert findings[0].matched_value == str(sensitive_dir / "secret.txt")


### PR DESCRIPTION
## Summary
- improves shell file-path extraction so tool guard recognizes Windows-style paths, backslash-relative paths, and redirected output targets
- preserves Unix shell detection while adding support for common shell file-reader commands such as 	ype and Get-Content
- adds focused regression tests for shell fallback access to sensitive files and parity with dedicated file tools

## Why this fix
Issue #2967 reports that execute_shell_command can bypass File Guard when the agent falls back to shell-based file access. The root cause is that shell path extraction missed several common path forms:
- Windows drive paths like C:\...
- backslash-relative paths like .\secret.txt and ..\secret.txt
- redirected output targets and common shell file-read commands

That left sensitive shell-based file access under-detected even though the file guard layer already existed.

## Validation
- python -m py_compile src/copaw/security/tool_guard/guardians/file_guardian.py tests/unit/security/tool_guard/test_file_guardian_shell_access.py
- PYTHONPATH=src python -m pytest tests/unit/security/tool_guard/test_file_guardian_shell_access.py -q
  - result: 6 passed

## AI assistance
This PR was prepared with AI-assisted tooling, with local reproduction, implementation, and validation performed before submission.