### PR TITLE
[#2960] Stabilize MCP hot-reload cleanup lifecycle

### DIFF
--- a/src/copaw/app/mcp/manager.py
+++ b/src/copaw/app/mcp/manager.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """MCP client manager for hot-reloadable client lifecycle management.
 
 This module provides centralized management of MCP clients with support
@@ -82,7 +82,7 @@ class MCPClientManager:
     ) -> None:
         """Replace or add a client with new configuration.
 
-        Flow: connect new (outside lock) 鈫?swap + close old (inside lock).
+        Flow: connect new (outside lock) → swap + close old (inside lock).
         This ensures minimal lock holding time.
 
         Args:
@@ -185,6 +185,8 @@ class MCPClientManager:
             except BaseException as exc:
                 if not request.future.cancelled():
                     request.future.set_exception(exc)
+                if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                    raise
             else:
                 if not request.future.cancelled():
                     request.future.set_result(result)
@@ -298,13 +300,13 @@ class MCPClientManager:
         ``StatefulClientBase.close()`` refuses to run when
         ``is_connected`` is still ``False`` (which is the case when
         ``connect()`` times out or raises).  We bypass that guard by
-        closing the ``AsyncExitStack`` directly 鈥?this triggers the
+        closing the ``AsyncExitStack`` directly — this triggers the
         ``stdio_client`` finally-block that sends SIGTERM/SIGKILL to
         the child process.
 
         The ``ClientSession`` is registered on the same stack via
         ``enter_async_context``, so ``stack.aclose()`` exits it in
-        LIFO order 鈥?no separate session teardown is needed.
+        LIFO order — no separate session teardown is needed.
         """
         if client is None:
             return

--- a/src/copaw/app/multi_agent_manager.py
+++ b/src/copaw/app/multi_agent_manager.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """MultiAgentManager: Manages multiple agent workspaces with lazy loading.
 
 Provides centralized management for multiple Workspace objects,

--- a/src/copaw/app/workspace/workspace.py
+++ b/src/copaw/app/workspace/workspace.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Workspace: Encapsulates a complete independent agent runtime.
 
 Each Workspace represents a standalone agent workspace with its own:

--- a/tests/unit/app/test_mcp_hot_reload_cleanup.py
+++ b/tests/unit/app/test_mcp_hot_reload_cleanup.py
@@ -1,33 +1,28 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Regression tests for MCP hot-reload cleanup."""
 from __future__ import annotations
 
 import asyncio
-import importlib.util
 import sys
-from pathlib import Path
+import types
 from types import SimpleNamespace
 
 import pytest
 
-_MANAGER_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "src"
-    / "copaw"
-    / "app"
-    / "mcp"
-    / "manager.py"
+google_module = sys.modules.setdefault("google", types.ModuleType("google"))
+google_module.__path__ = []
+genai_module = sys.modules.setdefault(
+    "google.genai",
+    types.ModuleType("google.genai"),
 )
-_MANAGER_SPEC = importlib.util.spec_from_file_location(
-    "copaw_mcp_manager_under_test",
-    _MANAGER_PATH,
-)
-assert _MANAGER_SPEC is not None
-assert _MANAGER_SPEC.loader is not None
-_MANAGER_MODULE = importlib.util.module_from_spec(_MANAGER_SPEC)
-sys.modules[_MANAGER_SPEC.name] = _MANAGER_MODULE
-_MANAGER_SPEC.loader.exec_module(_MANAGER_MODULE)
-MCPClientManager = _MANAGER_MODULE.MCPClientManager
+genai_module.Client = object
+genai_module.errors = types.SimpleNamespace(APIError=Exception)
+genai_module.types = types.SimpleNamespace(HttpOptions=object)
+google_module.genai = genai_module
+sys.modules.setdefault("google.genai.errors", genai_module.errors)
+sys.modules.setdefault("google.genai.types", genai_module.types)
+
+from copaw.app.mcp.manager import MCPClientManager
 
 
 class _TaskBoundClient:


### PR DESCRIPTION
## Summary
- move MCP client connect/replace/remove/close onto a manager-owned lifecycle task
- replace syncio.wait_for() around client connect with syncio.timeout() so connect/close stay on the same task
- stop old config watchers before zero-downtime workspace handoff to avoid redundant reloads on the retiring instance
- add regression tests covering replace/remove/close-all lifecycle behavior

## Why this fix
The cleanup failure came from MCP lifecycle work crossing task boundaries during hot reload. Even with a single manager task, syncio.wait_for() still wrapped connect() in a separate task, so later close() calls could hit the same anyio cancel-scope error reported in the issue. This patch keeps the full lifecycle on one task and pauses old watchers before the new workspace starts, which prevents the retiring instance from reacting to the same config save during handoff.

## Validation
- python -m py_compile src/copaw/app/mcp/manager.py src/copaw/app/workspace/workspace.py src/copaw/app/multi_agent_manager.py tests/unit/app/test_mcp_hot_reload_cleanup.py
- PYTHONPATH=src python -m pytest tests/unit/app/test_mcp_hot_reload_cleanup.py -q

Closes #2960.