### PR TITLE
[#2955] Flatten llama.cpp archives with metadata dirs

### DIFF
--- a/src/copaw/local_models/llamacpp.py
+++ b/src/copaw/local_models/llamacpp.py
@@ -654,13 +654,29 @@ class LlamaCppBackend:
         staging_dir: Path,
         dest_dir: Path,
     ) -> None:
-        extracted_entries = list(staging_dir.iterdir())
+        extracted_entries = [
+            entry
+            for entry in staging_dir.iterdir()
+            if not LlamaCppBackend._is_ignorable_archive_entry(entry)
+        ]
         source_root = staging_dir
         if len(extracted_entries) == 1 and extracted_entries[0].is_dir():
             source_root = extracted_entries[0]
 
         for item in source_root.iterdir():
+            if LlamaCppBackend._is_ignorable_archive_entry(item):
+                continue
             LlamaCppBackend._merge_path(item, dest_dir / item.name)
+
+    @staticmethod
+    def _is_ignorable_archive_entry(path: Path) -> bool:
+        """Return whether an extracted archive entry is metadata-only."""
+        name = path.name
+        if name == "__MACOSX":
+            return True
+        if name.startswith("._"):
+            return True
+        return False
 
     @staticmethod
     def _merge_path(source: Path, destination: Path) -> None:

--- a/tests/unit/local_models/test_llamacpp_backend.py
+++ b/tests/unit/local_models/test_llamacpp_backend.py
@@ -183,6 +183,21 @@ def _make_zip_payload() -> bytes:
     return buffer.getvalue()
 
 
+def _make_zip_payload_with_macos_metadata_dir() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(
+            "llama-b1234-bin-win-cuda-12.4-x64/llama-server.exe",
+            "zip-binary",
+        )
+        archive.writestr(
+            "llama-b1234-bin-win-cuda-12.4-x64/ggml.dll",
+            "support-dll",
+        )
+        archive.writestr("__MACOSX/._llama-b1234-bin-win-cuda-12.4-x64", "")
+    return buffer.getvalue()
+
+
 def _make_tar_gz_payload() -> bytes:
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
@@ -818,6 +833,52 @@ def test_download_worker_flattens_single_top_level_archive_dir(
 
     assert (staging_dir / "bin" / "server").read_text() == "tar-binary"
     assert not (staging_dir / "llama-b1234").exists()
+    assert isinstance(messages[-1]["payload"], dict)
+    assert messages[-1]["payload"]["status"] == "completed"
+
+
+def test_download_worker_ignores_macos_metadata_dirs_when_flattening(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    downloader = _build_downloader(monkeypatch)
+    monkeypatch.setattr(downloader, "os_name", "windows")
+    monkeypatch.setattr(downloader, "arch", "x64")
+    monkeypatch.setattr(downloader, "cuda_version", "12.4")
+    monkeypatch.setattr(downloader, "backend", "cuda")
+
+    staging_dir = tmp_path / "flattened-windows-install"
+    download_url = (
+        "https://example.com/releases/b1234/"
+        "llama-b1234-bin-win-cuda-12.4-x64.zip"
+    )
+    _patch_httpx_client(
+        monkeypatch,
+        _make_zip_payload_with_macos_metadata_dir(),
+    )
+
+    messages: list[dict[str, object]] = []
+
+    class _Queue:
+        def put(self, item):
+            messages.append(item)
+
+    downloader._download_worker(
+        {
+            "url": download_url,
+            "staging_dir": str(staging_dir),
+            "file_name": "llama-b1234-bin-win-cuda-12.4-x64.zip",
+            "chunk_size": 64,
+            "timeout": 30,
+            "headers": downloader._download_headers,
+        },
+        _Queue(),
+    )
+
+    assert (staging_dir / "llama-server.exe").read_text() == "zip-binary"
+    assert (staging_dir / "ggml.dll").read_text() == "support-dll"
+    assert not (staging_dir / "__MACOSX").exists()
+    assert not (staging_dir / "llama-b1234-bin-win-cuda-12.4-x64").exists()
     assert isinstance(messages[-1]["payload"], dict)
     assert messages[-1]["payload"]["status"] == "completed"
 


### PR DESCRIPTION
## Summary
- ignore metadata-only archive entries like __MACOSX and AppleDouble ._* files when flattening downloaded llama.cpp packages
- flatten the real top-level binary directory even when metadata siblings are present
- add regression coverage for Windows zip packages that include __MACOSX sidecar entries

## Why this fix
The current extraction path only flattens archives when there is exactly one top-level directory. Some Windows users receive packages with both the real versioned directory and a sibling __MACOSX metadata directory. In that shape, CoPaw leaves the binaries nested under the versioned folder, so check_llamacpp_installation() never finds llama-server.exe in ~/.copaw/local_models/bin and the UI keeps showing the install button.

## Validation
- python -m py_compile src/copaw/local_models/llamacpp.py tests/unit/local_models/test_llamacpp_backend.py
- inline pytest run with the same google.genai stub pattern already used in repo tests: 	ests/unit/local_models/test_llamacpp_backend.py ? 24 passed

Closes #2955.