### PR TITLE
fix: auto-build console frontend on app startup when source is stale

### DIFF
--- a/src/copaw/_build_console.py
+++ b/src/copaw/_build_console.py
@@ -66,19 +66,17 @@ def _needs_rebuild() -> bool:
     if not _CONSOLE_DIST.exists() or not index_html.exists():
         return True
 
-    try:
-        dist_mtime = max(
-            f.stat().st_mtime for f in _CONSOLE_DIST.rglob("*") if f.is_file()
-        )
-    except StopIteration:
-        return True
+    # Use index.html mtime as proxy for build time (it's written last by Vite)
+    dist_mtime = (_CONSOLE_DIST / "index.html").stat().st_mtime
 
     # Files/dirs whose modification should trigger a rebuild
-    watch_dirs = [_CONSOLE_SRC] if _CONSOLE_SRC else []
+    watch_dirs = [_CONSOLE_SRC, _CONSOLE_DIR / "public"] if _CONSOLE_SRC else []
     watch_files = [
         _CONSOLE_DIR / "package.json",
+        _CONSOLE_DIR / "package-lock.json",
         _CONSOLE_DIR / "vite.config.ts",
         _CONSOLE_DIR / "tsconfig.json",
+        _CONSOLE_DIR / "index.html",
     ]
     for watch_dir in watch_dirs:
         if not watch_dir.exists():
@@ -109,10 +107,15 @@ def build_console_frontend(*, quiet: bool = False) -> None:
     if not (_CONSOLE_DIR / "package.json").exists():
         return
 
-    # Ensure dest is populated even when dist is already fresh
+    # Ensure dest is populated and in sync even when dist is already fresh
     if not _needs_rebuild():
-        if _CONSOLE_DEST is not None:
-            if not (_CONSOLE_DEST / "index.html").exists():
+        if _CONSOLE_DEST is not None and _CONSOLE_DIST is not None:
+            dest_idx = _CONSOLE_DEST / "index.html"
+            dist_idx = _CONSOLE_DIST / "index.html"
+            if not dest_idx.exists() or (
+                dist_idx.exists()
+                and dest_idx.stat().st_mtime < dist_idx.stat().st_mtime
+            ):
                 _copy_dist()
         return
 

--- a/src/copaw/_build_console.py
+++ b/src/copaw/_build_console.py
@@ -130,7 +130,7 @@ def build_console_frontend(*, quiet: bool = False) -> None:
         out = subprocess.DEVNULL if quiet else sys.stdout
         err = subprocess.DEVNULL if quiet else sys.stderr
         subprocess.check_call(
-            ["npm", "ci"],
+            ["npm", "install"],
             cwd=str(_CONSOLE_DIR),
             stdout=out,
             stderr=err,

--- a/src/copaw/_build_console.py
+++ b/src/copaw/_build_console.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Auto-build the console frontend when assets are missing or stale.
+
+Used by:
+  - ``setup.py`` — during ``pip install .`` (build_py) and legacy editable installs
+  - ``_app.py``  — at application startup as a safety-net for PEP 660 editable installs
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("copaw.build_console")
+
+# Resolve repo root: this file lives at src/copaw/_build_console.py
+_THIS_DIR = Path(__file__).resolve().parent  # src/copaw/
+_REPO_ROOT = _THIS_DIR.parent.parent  # repo root
+
+_CONSOLE_DIR: Path | None = None
+_CONSOLE_DIST: Path | None = None
+_CONSOLE_DEST: Path | None = None
+_CONSOLE_SRC: Path | None = None
+
+# Detect console source directory — works both from source tree and editable install
+_candidates = [
+    _REPO_ROOT / "console",  # running from source tree
+    _THIS_DIR.parent / "console",  # unlikely fallback
+]
+for _cand in _candidates:
+    if (_cand / "package.json").exists():
+        _CONSOLE_DIR = _cand
+        _CONSOLE_DIST = _cand / "dist"
+        _CONSOLE_SRC = _cand / "src"
+        _CONSOLE_DEST = _THIS_DIR / "console"
+        break
+
+
+def _has_npm() -> bool:
+    """Return True if npm is available on PATH."""
+    try:
+        subprocess.run(
+            ["npm", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        return False
+
+
+def _needs_rebuild() -> bool:
+    """Return True when console/dist is missing or source files are newer."""
+    if _CONSOLE_DIST is None:
+        return False
+
+    if not _CONSOLE_DIST.exists() or not (_CONSOLE_DIST / "index.html").exists():
+        return True
+
+    try:
+        dist_mtime = max(
+            f.stat().st_mtime for f in _CONSOLE_DIST.rglob("*") if f.is_file()
+        )
+    except StopIteration:
+        return True
+
+    # Files/dirs whose modification should trigger a rebuild
+    watch_dirs = [_CONSOLE_SRC] if _CONSOLE_SRC else []
+    watch_files = [
+        _CONSOLE_DIR / "package.json",
+        _CONSOLE_DIR / "vite.config.ts",
+        _CONSOLE_DIR / "tsconfig.json",
+    ]
+    for watch_dir in watch_dirs:
+        if not watch_dir.exists():
+            continue
+        for f in watch_dir.rglob("*"):
+            if f.is_file() and f.stat().st_mtime > dist_mtime:
+                return True
+    for f in watch_files:
+        if f.exists() and f.stat().st_mtime > dist_mtime:
+            return True
+
+    return False
+
+
+def build_console_frontend(*, quiet: bool = False) -> None:
+    """Build the console frontend and copy to ``src/copaw/console/``.
+
+    Parameters
+    ----------
+    quiet:
+        When True, suppress stdout/stderr from npm.  Useful at app startup
+        to avoid cluttering the log.
+    """
+    if _CONSOLE_DIR is None:
+        return
+
+    # Skip if no console source (e.g. installed from wheel without it)
+    if not (_CONSOLE_DIR / "package.json").exists():
+        return
+
+    # Ensure dest is populated even when dist is already fresh
+    if not _needs_rebuild():
+        if _CONSOLE_DEST and not (_CONSOLE_DEST / "index.html").exists():
+            _copy_dist()
+        return
+
+    if not _has_npm():
+        logger.warning(
+            "Console frontend is stale but npm not found — "
+            "the web UI may be outdated.  "
+            "Install Node.js and run: cd console && npm ci && npm run build",
+        )
+        return
+
+    logger.info("Building console frontend …")
+    try:
+        out = subprocess.DEVNULL if quiet else sys.stdout
+        err = subprocess.DEVNULL if quiet else sys.stderr
+        subprocess.check_call(
+            ["npm", "ci"],
+            cwd=str(_CONSOLE_DIR),
+            stdout=out,
+            stderr=err,
+        )
+        subprocess.check_call(
+            ["npm", "run", "build"],
+            cwd=str(_CONSOLE_DIR),
+            stdout=out,
+            stderr=err,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Console frontend build failed: %s", exc)
+        return
+
+    _copy_dist()
+    logger.info("Console frontend built successfully.")
+
+
+def _copy_dist() -> None:
+    """Copy console/dist/* into src/copaw/console/."""
+    if _CONSOLE_DEST is None or _CONSOLE_DIST is None:
+        return
+    if _CONSOLE_DEST.exists():
+        shutil.rmtree(_CONSOLE_DEST)
+    shutil.copytree(_CONSOLE_DIST, _CONSOLE_DEST)

--- a/src/copaw/_build_console.py
+++ b/src/copaw/_build_console.py
@@ -2,14 +2,16 @@
 """Auto-build the console frontend when assets are missing or stale.
 
 Used by:
-  - ``setup.py`` — during ``pip install .`` (build_py) and legacy editable installs
-  - ``_app.py``  — at application startup as a safety-net for PEP 660 editable installs
+
+  - ``setup.py`` — during ``pip install .`` (build_py)
+    and legacy editable installs
+  - ``_app.py`` — at application startup as a safety-net
+    for PEP 660 editable installs
 """
 
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import subprocess
 import sys
@@ -26,7 +28,8 @@ _CONSOLE_DIST: Path | None = None
 _CONSOLE_DEST: Path | None = None
 _CONSOLE_SRC: Path | None = None
 
-# Detect console source directory — works both from source tree and editable install
+# Detect console source directory — works from source tree
+# and editable install
 _candidates = [
     _REPO_ROOT / "console",  # running from source tree
     _THIS_DIR.parent / "console",  # unlikely fallback
@@ -59,7 +62,8 @@ def _needs_rebuild() -> bool:
     if _CONSOLE_DIST is None:
         return False
 
-    if not _CONSOLE_DIST.exists() or not (_CONSOLE_DIST / "index.html").exists():
+    index_html = _CONSOLE_DIST / "index.html"
+    if not _CONSOLE_DIST.exists() or not index_html.exists():
         return True
 
     try:
@@ -107,15 +111,17 @@ def build_console_frontend(*, quiet: bool = False) -> None:
 
     # Ensure dest is populated even when dist is already fresh
     if not _needs_rebuild():
-        if _CONSOLE_DEST and not (_CONSOLE_DEST / "index.html").exists():
-            _copy_dist()
+        if _CONSOLE_DEST is not None:
+            if not (_CONSOLE_DEST / "index.html").exists():
+                _copy_dist()
         return
 
     if not _has_npm():
         logger.warning(
             "Console frontend is stale but npm not found — "
             "the web UI may be outdated.  "
-            "Install Node.js and run: cd console && npm ci && npm run build",
+            "Install Node.js and run: "
+            "cd console && npm ci && npm run build",
         )
         return
 

--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -17,6 +17,7 @@ from ..config.utils import get_config_path
 from ..constant import DOCS_ENABLED, LOG_LEVEL_ENV, CORS_ORIGINS, WORKING_DIR
 from ..__version__ import __version__
 from ..utils.logging import setup_logger, add_copaw_file_handler
+from .._build_console import build_console_frontend
 from .auth import AuthMiddleware
 from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
@@ -159,6 +160,9 @@ async def lifespan(
 ):  # pylint: disable=too-many-statements,too-many-branches
     startup_start_time = time.time()
     add_copaw_file_handler(WORKING_DIR / "copaw.log")
+
+    # Auto-build console frontend if source files are newer than dist
+    build_console_frontend(quiet=True)
 
     # Auto-register admin from env vars (for automated deployments)
     from .auth import auto_register_from_env


### PR DESCRIPTION
Add _build_console.py to detect and rebuild the frontend when console source files are newer than the built dist. Called at app startup in _app.py lifespan so git pull + restart automatically updates the UI.

## Description

When developing CoPaw from source, `git pull` updates the backend code but the console frontend (React/Vite) does not rebuild automatically. Users must manually run `cd console && npm ci && npm run build` after every pull, which is easy to forget and leads to a stale/broken web UI.

This PR adds `_build_console.py` which:
- Detects if console source files (`console/src/**`) are newer than the built dist (`console/dist/`)
- Automatically runs `npm ci && npm run build` when stale
- Copies the fresh dist to `src/copaw/console/` (where FastAPI serves static files)
- Called once at app startup in `_app.py` lifespan with `quiet=True`
- Gracefully degrades with a warning if npm is not found (no crash)

**Security Considerations:** Only runs `npm ci` and `npm run build` from the repo's own `console/` directory. No user-controlled input feeds into subprocess calls.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Make a source file change in `console/src/` (or `touch console/src/App.tsx`)
2. Start the app (`copaw serve` or `python -m copaw`)
3. Observe log: `Building console frontend …` → `Console frontend built successfully.`
4. Verify `src/copaw/console/index.html` is updated
5. Without source changes, restart — no rebuild triggered (fast path)

**Verified locally:**
- `_needs_rebuild()` returns `False` when dist is fresh, `True` after `touch` a source file
- `_app.py` imports cleanly with the new import
- npm-not-found case logs a warning without crashing

## Local Verification Evidence

```bash
python -c "from src.copaw._build_console import build_console_frontend, _needs_rebuild; print(_needs_rebuild())"
# True (after touching a source file)

python -c "from src.copaw.app._app import app; print('Import OK')"
# Import OK
```

## Additional Notes

The `outDir` override in `vite.config.ts` is currently commented out. The build outputs to `console/dist/` by default, and `_build_console.py` copies from there to `src/copaw/console/`. This keeps the vite config clean and avoids side-effect builds during development.