### PR TITLE
fix(agents): cache MCP client registration to avoid repeated list_too…

### DIFF
--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -65,6 +65,8 @@ logger = logging.getLogger(__name__)
 # Valid namesake strategies for tool registration
 NamesakeStrategy = Literal["override", "skip", "raise", "rename"]
 
+_MCP_REGISTRY_CACHE: dict[int, bool] = {}
+
 
 class CoPawAgent(ToolGuardMixin, ReActAgent):
     """CoPaw Agent with integrated tools, skills, and memory management.
@@ -471,18 +473,27 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
     ) -> None:
         """Register MCP clients on this agent's toolkit after construction.
 
+        Uses a cache to avoid repeated list_tools() calls for the same client.
+        Only registers if the client hasn't been registered yet.
+
         Args:
             namesake_strategy: Strategy to handle namesake tool functions.
                 Options: "override", "skip", "raise", "rename"
                 (default: "skip")
         """
         for i, client in enumerate(self._mcp_clients):
+            client_id = id(client)
+            if _MCP_REGISTRY_CACHE.get(client_id, False):
+                logger.debug(f"MCP client '{getattr(client, 'name', repr(client))}' already registered, skipping")
+                continue
+
             client_name = getattr(client, "name", repr(client))
             try:
                 await self.toolkit.register_mcp_client(
                     client,
                     namesake_strategy=namesake_strategy,
                 )
+                _MCP_REGISTRY_CACHE[client_id] = True
             except (ClosedResourceError, asyncio.CancelledError) as error:
                 if self._should_propagate_cancelled_error(error):
                     raise


### PR DESCRIPTION
## Description

**问题：** 每次发送聊天请求时，`query_handler()` 都会创建新的 `CoPawAgent` 实例并调用 `register_mcp_clients()`。这导致每次请求都要通过 `list_tools()` 重新连接 MCP 服务器获取工具列表。当 MCP 服务器响应较慢时，`list_tools()` 的等待过程容易被外部取消，引发 `CancelledError` 导致任务失败。

**修复：** 在 `CoPawAgent` 类中添加 `_MCP_REGISTRY_CACHE` 缓存机制。同一个 MCP 客户端实例只在第一次调用 `register_mcp_clients()` 时执行 `list_tools()`，后续请求直接从缓存跳过，避免重复连接 MCP 服务器。

**Related Issue:** Relates to MCP client registration timeout issue

**Security Considerations:** None - 仅添加内存缓存，不涉及配置或敏感信息

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Testing

启动应用并测试：
1. 配置 MCP 客户端
2. 发送多次聊天请求
3. 验证不再出现 `CancelledError`

## Local Verification Evidence

```bash
# 首次请求会调用 list_tools()
# 后续请求应跳过并输出日志：
# "MCP client 'xxx' already registered, skipping"
```

