### PR TITLE
fix(ollama): enable stream_tool_parsing to fix tool call support

### DIFF
--- a/src/copaw/providers/ollama_provider.py
+++ b/src/copaw/providers/ollama_provider.py
@@ -79,7 +79,7 @@ class OllamaProvider(OpenAIProvider):
             model_name=model_id,
             stream=True,
             api_key=self.api_key,
-            stream_tool_parsing=False,
+            stream_tool_parsing=True,
             client_kwargs={"base_url": self._openai_compatible_base_url()},
             generate_kwargs=self.get_effective_generate_kwargs(model_id),
         )

--- a/tests/unit/providers/test_ollama_provider.py
+++ b/tests/unit/providers/test_ollama_provider.py
@@ -133,7 +133,7 @@ def test_get_chat_model_instance_uses_single_v1_suffix(
     assert captured["model_name"] == "llama3.1"
     assert captured["api_key"] == "EMPTY"
     assert captured["stream"] is True
-    assert captured["stream_tool_parsing"] is False
+    assert captured["stream_tool_parsing"] is True
     assert captured["client_kwargs"] == {
         "base_url": "http://localhost:11434/v1",
     }


### PR DESCRIPTION
Fixes #2988

## Problem

The `OllamaProvider.get_chat_model_instance()` method was setting `stream_tool_parsing=False`, which disabled parsing of tool calls from streamed responses. This caused Ollama models that support function calling (e.g., `gemma4`, `qwen2.5`) to never invoke tools or skills — they would return plain text instead.

## Solution

Changed `stream_tool_parsing=False` to `stream_tool_parsing=True` in `ollama_provider.py`. Ollama models support tool calls natively (verified via the Ollama API), so enabling stream tool parsing allows the streaming response to be correctly parsed for tool invocations.

Also updated the corresponding unit test to assert the correct value.

## Testing

- Updated `tests/unit/providers/test_ollama_provider.py` to assert `stream_tool_parsing is True`
- Manually verified that Ollama models (e.g., `gemma4`, `qwen2.5`) return `tool_calls` in their API responses when tools are provided