### PR TITLE
fix(chat): clear preferredChatId and navigate on agent switch

### DIFF
--- a/console/src/components/AgentSelector/index.tsx
+++ b/console/src/components/AgentSelector/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { getAgentDisplayName } from "../../utils/agentDisplayName";
 import { useNavigate } from "react-router-dom";
 import { useAppMessage } from "../../hooks/useAppMessage";
+import sessionApi from "../../pages/Chat/sessionApi";
 import styles from "./index.module.less";
 
 interface AgentSelectorProps {
@@ -57,6 +58,8 @@ export default function AgentSelector({
     }
 
     setSelectedAgent(value);
+    sessionApi.preferredChatId = null;
+    navigate("/chat", { replace: true });
     message.success(t("agent.switchSuccess"));
   };
 


### PR DESCRIPTION
Fixes #2984

## Problem

When switching agents in the web UI, the `AgentSelector` component only updates `selectedAgent` without resetting the chat URL or clearing `sessionApi.preferredChatId`. This causes a stale session ID from the previous agent to persist in the URL and in `preferredChatId`. When the new agent's session list loads, the stale session ID is not found, causing the fallback to `sessions[0]` — which is often the heartbeat session.

Root cause chain (as documented in the issue):
1. Switch agent → URL unchanged → `chatId` still carries old session ID  
2. `sessionApi.preferredChatId` = old session ID  
3. New agent's session list loads → old ID not found → `idx === -1`  
4. No reordering happens → `sessions[0]` (heartbeat) is selected and displayed

## Solution

In `AgentSelector.handleChange`, after switching the agent:
1. Reset `sessionApi.preferredChatId = null` to prevent the stale session from influencing the new agent's session selection
2. Navigate to `/chat` (without a specific session ID) so the chat page initializes cleanly for the new agent

## Testing

1. Start a conversation with Agent A (session `c8353b8e`)
2. Switch to Agent B — observe Agent B's chat loads cleanly
3. Switch back to Agent A — verify it no longer shows the heartbeat session and instead selects Agent A's first session