### PR TITLE
feat(console): add agent mention button @ in chat input to for multi-agent collaberation and agent deletation

### DIFF
--- a/console/src/components/AgentMentionButton/index.module.less
+++ b/console/src/components/AgentMentionButton/index.module.less
@@ -1,0 +1,74 @@
+.agentPopover {
+  :global(.ant-popover-inner) {
+    padding: 0;
+    overflow: hidden;
+    border-radius: 12px;
+  }
+}
+
+.agentPopoverContent {
+  min-width: 240px;
+  max-width: 320px;
+}
+
+.popoverHeader {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--ant-color-split);
+}
+
+.popoverTitle {
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--ant-color-text);
+}
+
+.agentList {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px;
+
+  :global(.ant-list-item) {
+    padding: 0;
+    border-bottom: none;
+  }
+}
+
+.agentListItem {
+  cursor: pointer;
+  padding: 10px 12px;
+  margin: 2px 0;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: linear-gradient(
+      135deg,
+      rgba(240, 126, 38, 0.08) 0%,
+      rgba(240, 126, 38, 0.04) 100%
+    );
+    border-color: rgba(240, 126, 38, 0.2);
+
+    .agentName {
+      color: #f07e26;
+    }
+  }
+}
+
+.agentItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agentName {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ant-color-text);
+  transition: color 0.2s ease;
+}
+
+.agentId {
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
+}

--- a/console/src/components/AgentMentionButton/index.tsx
+++ b/console/src/components/AgentMentionButton/index.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect } from "react";
+import { Popover, List, Spin, Empty } from "antd";
+import { SparkAtLine } from "@agentscope-ai/icons";
+import { IconButton } from "@agentscope-ai/design";
+import { useTranslation } from "react-i18next";
+import { useAgentStore } from "../../stores/agentStore";
+import { agentsApi } from "../../api/modules/agents";
+import { useAppMessage } from "../../hooks/useAppMessage";
+import { getAgentDisplayName } from "../../utils/agentDisplayName";
+import type { AgentSummary } from "../../api/types/agents";
+import styles from "./index.module.less";
+
+interface AgentMentionButtonProps {
+  disabled?: boolean;
+}
+
+export default function AgentMentionButton({
+  disabled = false,
+}: AgentMentionButtonProps) {
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+  const { agents, setAgents } = useAgentStore();
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (open && agents.length === 0) {
+      setLoading(true);
+      agentsApi
+        .listAgents()
+        .then((data) => {
+          const sortedAgents = [...data.agents].sort(
+            (a, b) => Number(b.enabled) - Number(a.enabled),
+          );
+          setAgents(sortedAgents);
+        })
+        .catch((error) => {
+          console.error("Failed to load agents:", error);
+          message.error(t("agent.loadFailed"));
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+  }, [open, agents.length, setAgents, message, t]);
+
+  const handleSelectAgent = (agent: AgentSummary) => {
+    insertMentionText(agent);
+    setOpen(false);
+  };
+
+  const insertMentionText = (agent: AgentSummary) => {
+    const textarea = document.querySelector(
+      '.copaw-sender textarea, [class*="sender"] textarea, textarea.ant-input',
+    ) as HTMLTextAreaElement;
+
+    if (!textarea) {
+      console.warn("Chat input textarea not found");
+      return;
+    }
+
+    const mentionText = ` @${agent.name}(${agent.id}) `;
+
+    textarea.focus();
+
+    const cursorPosition = textarea.selectionStart ?? textarea.value.length;
+    const currentValue = textarea.value;
+
+    const newValue =
+      currentValue.slice(0, cursorPosition) +
+      mentionText +
+      currentValue.slice(cursorPosition);
+
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+
+    if (nativeInputValueSetter) {
+      nativeInputValueSetter.call(textarea, newValue);
+    } else {
+      textarea.value = newValue;
+    }
+
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const newCursorPosition = cursorPosition + mentionText.length;
+    textarea.setSelectionRange(newCursorPosition, newCursorPosition);
+    textarea.focus();
+  };
+
+  const enabledAgents = agents.filter((agent) => agent.enabled);
+
+  const popoverContent = (
+    <div className={styles.agentPopoverContent}>
+      <div className={styles.popoverHeader}>
+        <span className={styles.popoverTitle}>{t("chat.mentionAgent")}</span>
+      </div>
+      <Spin spinning={loading} size="small">
+        {enabledAgents.length > 0 ? (
+          <List
+            className={styles.agentList}
+            dataSource={enabledAgents}
+            renderItem={(agent) => (
+              <List.Item
+                className={styles.agentListItem}
+                onClick={() => handleSelectAgent(agent)}
+              >
+                <div className={styles.agentItem}>
+                  <span className={styles.agentName}>
+                    {getAgentDisplayName(agent, t)}
+                  </span>
+                  <span className={styles.agentId}>ID: {agent.id}</span>
+                </div>
+              </List.Item>
+            )}
+          />
+        ) : (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={
+              loading ? t("common.loading") : t("chat.noEnabledAgents")
+            }
+          />
+        )}
+      </Spin>
+    </div>
+  );
+
+  return (
+    <Popover
+      content={popoverContent}
+      open={open}
+      onOpenChange={setOpen}
+      trigger="click"
+      placement="topLeft"
+      overlayClassName={styles.agentPopover}
+      arrow={false}
+    >
+      <IconButton
+        disabled={disabled}
+        icon={<SparkAtLine />}
+        bordered={false}
+        title={t("chat.mentionAgent")}
+      />
+    </Popover>
+  );
+}

--- a/console/src/components/AgentSelector/index.module.less
+++ b/console/src/components/AgentSelector/index.module.less
@@ -235,6 +235,13 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  border-radius: 8px;
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+
+  .ant-select-item:hover &,
+  .copaw-select-item:hover & {
+    background: rgba(43, 18, 0, 0.06);
+  }
 }
 
 .agentOptionHeader {
@@ -256,7 +263,8 @@
   color: #f07e26;
   transition: all 0.2s ease;
 
-  .agentOption:hover & {
+  .ant-select-item:hover &,
+  .copaw-select-item:hover & {
     background: linear-gradient(135deg, #ffe9d4 0%, #fff0e5 100%);
     border-color: rgba(240, 126, 38, 0.3);
     color: #f07e26;
@@ -445,7 +453,8 @@
     border-color: rgba(245, 160, 90, 0.2);
     color: #f5a05a;
 
-    .agentOption:hover & {
+    .ant-select-item:hover &,
+    .copaw-select-item:hover & {
       background: linear-gradient(
         135deg,
         rgba(240, 126, 38, 0.3) 0%,

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1164,7 +1164,9 @@
       "resultsCount": "Found {{count}} result(s)",
       "userMessage": "User",
       "assistantMessage": "Assistant"
-    }
+    },
+    "mentionAgent": "Refer to Agent",
+    "noEnabledAgents": "No enabled agents available"
   },
   "security": {
     "parent": "Settings",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1099,7 +1099,9 @@
       "resultsCount": "{{count}} 件の結果が見つかりました",
       "userMessage": "ユーザー",
       "assistantMessage": "アシスタント"
-    }
+    },
+    "mentionAgent": "エージェントを参照",
+    "noEnabledAgents": "有効なエージェントがありません"
   },
   "security": {
     "parent": "設定",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1104,7 +1104,9 @@
       "resultsCount": "Найдено {{count}} результат(ов)",
       "userMessage": "Пользователь",
       "assistantMessage": "Ассистент"
-    }
+    },
+    "mentionAgent": "Ссылаться на агента",
+    "noEnabledAgents": "Нет доступных включённых агентов"
   },
   "security": {
     "parent": "Настройки",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1138,7 +1138,9 @@
       "resultsCount": "找到 {{count}} 个结果",
       "userMessage": "用户",
       "assistantMessage": "助手"
-    }
+    },
+    "mentionAgent": "引用智能体",
+    "noEnabledAgents": "暂无可用的已启用智能体"
   },
   "security": {
     "parent": "设置",

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -26,6 +26,7 @@ import { IconButton } from "@agentscope-ai/design";
 import ChatActionGroup from "./components/ChatActionGroup";
 import ChatHeaderTitle from "./components/ChatHeaderTitle";
 import ChatSessionInitializer from "./components/ChatSessionInitializer";
+import AgentMentionButton from "../../components/AgentMentionButton";
 import {
   toDisplayUrl,
   copyText,
@@ -768,6 +769,7 @@ export default function ChatPage() {
           label: renderSuggestionLabel(item.command, item.description),
           value: item.value,
         })),
+        prefix: <AgentMentionButton />,
       },
       session: {
         multiple: true,


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

## Summary
Add an agent mention button to the chat input box, allowing users to quickly insert @agent references in their messages.
### Changes
- **New component**: `AgentMentionButton` - Popover with scrollable list of enabled agents
- **UI enhancement**: Updated `AgentSelector` hover styles for better selector UX
- **i18n**: Added translations for `mentionAgent` and `noEnabledAgents` keys (en, ja, ru, zh)
- **Integration**: Added `AgentMentionButton` as prefix in chat input toolbar


<img width="925" height="620" alt="image" src="https://github.com/user-attachments/assets/319afe3b-bffe-49d8-bd62-0ead4d7132bf" />

<img width="1246" height="594" alt="image" src="https://github.com/user-attachments/assets/d34c4aad-ba15-44af-bbe1-6d75cd621a6c" />



**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
