### PR TITLE
feat(WeCom): support quoted message parsing in incoming messages

### DIFF
--- a/src/copaw/app/channels/wecom/channel.py
+++ b/src/copaw/app/channels/wecom/channel.py
@@ -65,6 +65,25 @@ _MEDIA_MSGTYPE: Dict[str, str] = {
     "file": "file",
 }
 
+# Mapping for quoted media types: msgtype → (filename_hint, ContentClass,
+# content_kwargs, url_field_name).  Used by _on_message to build content
+# parts from quoted image / file / video items.
+_QUOTE_MEDIA_MAP = {
+    "image": (
+        "image.jpg",
+        ImageContent,
+        {"type": ContentType.IMAGE},
+        "image_url",
+    ),
+    "file": (None, FileContent, {"type": ContentType.FILE}, "file_url"),
+    "video": (
+        "video.mp4",
+        VideoContent,
+        {"type": ContentType.VIDEO},
+        "video_url",
+    ),
+}
+
 
 class WecomChannel(BaseChannel):
     """WeCom AI Bot channel: WebSocket receive and send.
@@ -468,33 +487,6 @@ class WecomChannel(BaseChannel):
                 else:
                     quoted_items = []
 
-                _quote_media_map = {
-                    "image": (
-                        "image.jpg",
-                        ImageContent,
-                        {
-                            "type": ContentType.IMAGE,
-                        },
-                        "image_url",
-                    ),
-                    "file": (
-                        None,
-                        FileContent,
-                        {
-                            "type": ContentType.FILE,
-                        },
-                        "file_url",
-                    ),
-                    "video": (
-                        "video.mp4",
-                        VideoContent,
-                        {
-                            "type": ContentType.VIDEO,
-                        },
-                        "video_url",
-                    ),
-                }
-
                 for q_item in quoted_items:
                     q_type = q_item.get("msgtype") or ""
                     if q_type == "text":
@@ -508,13 +500,13 @@ class WecomChannel(BaseChannel):
                                 0,
                                 f"[quoted message: {quoted_text}]",
                             )
-                    elif q_type in _quote_media_map:
+                    elif q_type in _QUOTE_MEDIA_MAP:
                         (
                             hint_default,
                             content_cls,
                             content_kwargs,
                             url_field,
-                        ) = _quote_media_map[q_type]
+                        ) = _QUOTE_MEDIA_MAP[q_type]
                         q_data = q_item.get(q_type) or {}
                         q_url = q_data.get("url") or ""
                         q_aes_key = q_data.get("aeskey") or ""


### PR DESCRIPTION
## Description

Previously, when a user quoted (replied to) a message in WeCom, the quoted content was silently ignored. This PR adds support for parsing the quote field in incoming messages.

What changed:

- Parse the quote field in _on_message to handle quoted/replied-to messages
- Support all quote types: text, image, file, video, and mixed
- Quoted text is prepended as [quoted message: ...] to the user's message
- Quoted media (image/file/video) is downloaded and appended as the corresponding content type (ImageContent/FileContent/VideoContent)
- Mixed quotes (containing multiple items) are flattened and processed with the same unified logic
- Unsupported quote types fall back to placeholder text; download failures are gracefully handled

**Related Issue:** Fixes #3020 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
