### PR TITLE
feat(cli): add headless task execution command

### DIFF
--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -318,12 +318,10 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
 
         request_context = getattr(self, "_request_context", {})
         channel_name = request_context.get("channel", "console")
-        skills_dir_override = request_context.get("_headless_skills_dir")
 
         effective_skills = resolve_effective_skills(
             workspace_dir,
             channel_name,
-            skills_dir_override=skills_dir_override,
         )
 
         working_skills_dir = get_workspace_skills_dir(Path(workspace_dir))
@@ -1023,13 +1021,8 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
 
         request_context = getattr(self, "_request_context", {}) or {}
         channel_name = request_context.get("channel", "console")
-        skills_dir_override = request_context.get("_headless_skills_dir")
         workspace_dir = Path(self._workspace_dir or WORKING_DIR)
-        with apply_skill_config_env_overrides(
-            workspace_dir,
-            channel_name,
-            skills_dir_override=skills_dir_override,
-        ):
+        with apply_skill_config_env_overrides(workspace_dir, channel_name):
             return await super().reply(
                 msg=msg,
                 structured_model=structured_model,

--- a/src/copaw/agents/skills_manager.py
+++ b/src/copaw/agents/skills_manager.py
@@ -655,8 +655,6 @@ def _release_skill_env_key(key: str) -> None:
 def apply_skill_config_env_overrides(
     workspace_dir: Path,
     channel_name: str,
-    *,
-    skills_dir_override: str | None = None,
 ) -> Iterator[None]:
     """Inject effective skill config into env for one agent turn.
 
@@ -672,7 +670,6 @@ def apply_skill_config_env_overrides(
         for skill_name in resolve_effective_skills(
             workspace_dir,
             channel_name,
-            skills_dir_override=skills_dir_override,
         ):
             entry = entries.get(skill_name) or {}
             config = entry.get("config") or {}
@@ -1148,19 +1145,8 @@ def read_skill_pool_manifest() -> dict[str, Any]:
 def resolve_effective_skills(
     workspace_dir: Path,
     channel_name: str,
-    *,
-    skills_dir_override: str | None = None,
 ) -> list[str]:
     """Resolve enabled workspace skills for one channel."""
-    if skills_dir_override:
-        skills_path = Path(skills_dir_override)
-        if skills_path.is_dir():
-            return [
-                str(p.resolve())
-                for p in sorted(skills_path.iterdir())
-                if p.is_dir() and (p / "SKILL.md").exists()
-            ]
-
     manifest = read_skill_manifest(workspace_dir)
     resolved = []
     for skill_name, entry in sorted(manifest.get("skills", {}).items()):

--- a/src/copaw/cli/task_cmd.py
+++ b/src/copaw/cli/task_cmd.py
@@ -5,12 +5,75 @@ import asyncio
 import json
 import logging
 import sys
+import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 import click
 
 logger = logging.getLogger(__name__)
+
+
+_SKILL_FS_NAMES = {"skills", "skill", "skill.json", ".skill.json.lock"}
+
+
+@contextmanager
+def _isolated_skills_workspace(
+    skills_dir: str | None,
+    base_workspace: Path | None,
+) -> Iterator[Path | None]:
+    """Create a temporary overlay workspace when *skills_dir* is given.
+
+    The overlay symlinks the external skills directory as ``skills/`` and
+    pre-populates a manifest with every discovered skill enabled.  Non-skill
+    files from *base_workspace* are symlinked so that prompt/bootstrap files
+    remain accessible.  All manifest writes land in the temporary directory,
+    keeping the real workspace untouched.
+    """
+    if not skills_dir:
+        yield base_workspace
+        return
+
+    with tempfile.TemporaryDirectory(prefix="copaw_headless_") as tmp:
+        tmp_path = Path(tmp)
+        resolved = Path(skills_dir).resolve()
+        (tmp_path / "skills").symlink_to(resolved)
+
+        skill_entries: dict = {}
+        if resolved.is_dir():
+            for p in sorted(resolved.iterdir()):
+                if p.is_dir() and (p / "SKILL.md").exists():
+                    skill_entries[p.name] = {
+                        "enabled": True,
+                        "channels": ["all"],
+                        "source": "headless",
+                    }
+        (tmp_path / "skill.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "workspace-skill-manifest.v1",
+                    "version": 1,
+                    "skills": skill_entries,
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        if base_workspace and base_workspace.is_dir():
+            for item in base_workspace.iterdir():
+                if item.name in _SKILL_FS_NAMES or item.name.startswith(
+                    ".skill_",
+                ):
+                    continue
+                target = tmp_path / item.name
+                if not target.exists():
+                    target.symlink_to(item)
+
+        yield tmp_path
 
 
 def _read_instruction(raw: str) -> str:
@@ -28,51 +91,55 @@ async def _run_task(
     max_iters: int,
     timeout: int,
     output_dir: str | None,
+    skills_dir: str | None = None,
 ) -> dict:
     from agentscope.message import Msg
     from ..agents.react_agent import CoPawAgent
 
     agent_config.running.max_iters = max_iters
 
-    workspace_dir: Path | None = None
+    base_workspace: Path | None = None
     if agent_config.workspace_dir:
-        workspace_dir = Path(agent_config.workspace_dir).expanduser()
+        base_workspace = Path(agent_config.workspace_dir).expanduser()
 
-    agent = CoPawAgent(
-        agent_config=agent_config,
-        enable_memory_manager=False,
-        request_context=request_context,
-        workspace_dir=workspace_dir,
-    )
-
-    t0 = time.monotonic()
-    try:
-        response = await asyncio.wait_for(
-            agent.reply([Msg(name="user", role="user", content=instruction)]),
-            timeout=timeout,
+    with _isolated_skills_workspace(skills_dir, base_workspace) as workspace:
+        agent = CoPawAgent(
+            agent_config=agent_config,
+            enable_memory_manager=False,
+            request_context=request_context,
+            workspace_dir=workspace,
         )
-        elapsed = time.monotonic() - t0
-        result: dict = {
-            "status": "success",
-            "elapsed_seconds": round(elapsed, 2),
-            "response": response.get_text_content() if response else "",
-        }
-    except asyncio.TimeoutError:
-        elapsed = time.monotonic() - t0
-        result = {
-            "status": "timeout",
-            "elapsed_seconds": round(elapsed, 2),
-            "timeout_seconds": timeout,
-            "response": "",
-        }
-    except Exception as exc:
-        elapsed = time.monotonic() - t0
-        result = {
-            "status": "error",
-            "elapsed_seconds": round(elapsed, 2),
-            "error": str(exc),
-            "response": "",
-        }
+
+        t0 = time.monotonic()
+        try:
+            response = await asyncio.wait_for(
+                agent.reply(
+                    [Msg(name="user", role="user", content=instruction)],
+                ),
+                timeout=timeout,
+            )
+            elapsed = time.monotonic() - t0
+            result: dict = {
+                "status": "success",
+                "elapsed_seconds": round(elapsed, 2),
+                "response": (response.get_text_content() if response else ""),
+            }
+        except asyncio.TimeoutError:
+            elapsed = time.monotonic() - t0
+            result = {
+                "status": "timeout",
+                "elapsed_seconds": round(elapsed, 2),
+                "timeout_seconds": timeout,
+                "response": "",
+            }
+        except Exception as exc:
+            elapsed = time.monotonic() - t0
+            result = {
+                "status": "error",
+                "elapsed_seconds": round(elapsed, 2),
+                "error": str(exc),
+                "response": "",
+            }
 
     usage: dict = {}
     try:
@@ -204,10 +271,6 @@ def task_cmd(
     }
     if no_guard:
         request_context["_headless_tool_guard"] = "false"
-    if skills_dir:
-        request_context["_headless_skills_dir"] = str(
-            Path(skills_dir).resolve(),
-        )
 
     result = asyncio.run(
         _run_task(
@@ -217,6 +280,7 @@ def task_cmd(
             max_iters=max_iters,
             timeout=timeout,
             output_dir=output_dir,
+            skills_dir=skills_dir,
         ),
     )
 

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -287,14 +287,14 @@ async def test_tool_guard_not_bypassed_without_flag():
 
 
 def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
-    """Full chain: CLI flags → request_context → components.
+    """Full chain: CLI flags → _run_task kwargs.
 
-    Verifies both ``--no-guard`` and ``--skills-dir`` propagate via
-    ``request_context``, resolve correctly at the component level,
-    and do **not** pollute environment variables.
+    Verifies ``--no-guard`` propagates via ``request_context``,
+    ``--skills-dir`` is forwarded as a dedicated ``skills_dir`` kwarg
+    (no longer embedded in ``request_context``), and neither flag
+    pollutes environment variables.
     """
     from copaw.config.config import AgentProfileConfig
-    from copaw.agents.skills_manager import resolve_effective_skills
 
     skills_dir = tmp_path / "my_skills"
     skill_sub = skills_dir / "e2e-skill"
@@ -319,16 +319,11 @@ def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
     async def _spy_run_task(**kwargs):
         ctx = kwargs["request_context"]
         captured["request_context"] = dict(ctx)
+        captured["skills_dir"] = kwargs.get("skills_dir")
         captured["env_tool_guard"] = os.environ.get(
             "COPAW_TOOL_GUARD_ENABLED",
         )
         captured["env_skills_dir"] = os.environ.get("COPAW_SKILLS_DIR")
-        resolved = resolve_effective_skills(
-            tmp_path,
-            ctx.get("channel", "console"),
-            skills_dir_override=ctx.get("_headless_skills_dir"),
-        )
-        captured["resolved_skills"] = [Path(p).name for p in resolved]
         captured["guard_bypassed"] = (
             ctx.get("_headless_tool_guard", "true").lower() == "false"
         )
@@ -359,12 +354,87 @@ def test_e2e_cli_no_guard_and_skills_dir(monkeypatch, tmp_path):
 
     ctx = captured["request_context"]
     assert ctx["_headless_tool_guard"] == "false"
-    assert ctx["_headless_skills_dir"] == str(skills_dir.resolve())
+    assert "_headless_skills_dir" not in ctx
     assert ctx["session_id"] == "headless-task"
     assert ctx["agent_id"] == "e2e"
+    assert captured["skills_dir"] == str(skills_dir)
     assert captured["env_tool_guard"] is None
     assert captured["env_skills_dir"] is None
-    assert captured["resolved_skills"] == ["e2e-skill"]
     assert captured["guard_bypassed"] is True
     data = json.loads(result.output)
     assert data["status"] == "success"
+
+
+# ── _isolated_skills_workspace ───────────────────────────────────────
+
+
+def test_isolated_workspace_creates_overlay(tmp_path):
+    """Overlay workspace symlinks skills and pre-populates manifest."""
+    from copaw.cli.task_cmd import _isolated_skills_workspace
+    from copaw.agents.skills_manager import resolve_effective_skills
+
+    skills_dir = tmp_path / "ext_skills"
+    (skills_dir / "alpha").mkdir(parents=True)
+    (skills_dir / "alpha" / "SKILL.md").write_text("# alpha\n")
+    (skills_dir / "beta").mkdir(parents=True)
+    (skills_dir / "beta" / "SKILL.md").write_text("# beta\n")
+    (skills_dir / "not-a-skill").mkdir(parents=True)
+
+    base_ws = tmp_path / "real_workspace"
+    base_ws.mkdir()
+    (base_ws / "AGENTS.md").write_text("agent prompt")
+
+    with _isolated_skills_workspace(
+        str(skills_dir),
+        base_ws,
+    ) as overlay:
+        assert overlay is not None
+        assert overlay != base_ws
+
+        assert (overlay / "skills").is_symlink()
+        assert (overlay / "skills").resolve() == skills_dir.resolve()
+
+        manifest_path = overlay / "skill.json"
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text())
+        assert "alpha" in manifest["skills"]
+        assert "beta" in manifest["skills"]
+        assert "not-a-skill" not in manifest["skills"]
+        assert manifest["skills"]["alpha"]["enabled"] is True
+
+        assert (overlay / "AGENTS.md").is_symlink()
+        assert (overlay / "AGENTS.md").read_text() == "agent prompt"
+
+        resolved = resolve_effective_skills(overlay, "console")
+        assert sorted(resolved) == ["alpha", "beta"]
+
+    assert not overlay.exists()
+
+
+def test_isolated_workspace_none_without_skills_dir(tmp_path):
+    """Without skills_dir the context manager yields base_workspace as-is."""
+    from copaw.cli.task_cmd import _isolated_skills_workspace
+
+    base_ws = tmp_path / "ws"
+    base_ws.mkdir()
+
+    with _isolated_skills_workspace(None, base_ws) as result:
+        assert result == base_ws
+
+
+def test_isolated_workspace_does_not_pollute_real_workspace(tmp_path):
+    """Real workspace must have zero new files after overlay teardown."""
+    from copaw.cli.task_cmd import _isolated_skills_workspace
+
+    skills_dir = tmp_path / "skills_src"
+    (skills_dir / "s1").mkdir(parents=True)
+    (skills_dir / "s1" / "SKILL.md").write_text("# s1\n")
+
+    real_ws = tmp_path / "workspace"
+    real_ws.mkdir()
+    original_contents = set(real_ws.iterdir())
+
+    with _isolated_skills_workspace(str(skills_dir), real_ws):
+        pass
+
+    assert set(real_ws.iterdir()) == original_contents


### PR DESCRIPTION
## Summary

- Add `copaw task` CLI command for running single task instructions headlessly (no web server required)
- Support `COPAW_SKILLS_DIR` env var to load skills from a custom directory (bypasses manifest)
- Support `COPAW_TOOL_GUARD_ENABLED=false` env var to disable tool guard in automated environments

## Motivation

This enables CoPaw to be used in CI/CD pipelines, automated testing, and integration with agent evaluation frameworks (e.g., Harbor/SkillsBench) where a full web server is unnecessary.

## Usage

```bash
# Basic usage
copaw task -i "Build a sales report from /root/sales.csv" -m "anthropic/claude-sonnet-4-5"

# With instruction file, custom skills, and no security guard
copaw task -i instruction.md -m "openai/gpt-4o" --skills-dir ./my-skills --no-guard --output-dir ./results