### PR TITLE
fix(memory): make force_memory_search timeout configurable

### DIFF
--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -1003,7 +1003,7 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
                             max_results=ms.force_max_results,
                             min_score=ms.force_min_score,
                         ),
-                        timeout=1,
+                        timeout=ms.force_memory_search_timeout,
                     )
                     self.memory._long_term_memory = "\n".join(
                         block["text"]

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -419,6 +419,15 @@ class MemorySummaryConfig(BaseModel):
         ),
     )
 
+    force_memory_search_timeout: float = Field(
+        default=10.0,
+        gt=0.0,
+        description=(
+            "Timeout in seconds for force memory search. Increase this value"
+            " when using remote embedding APIs that may have higher latency."
+        ),
+    )
+
     rebuild_memory_index_on_start: bool = Field(
         default=False,
         description=(


### PR DESCRIPTION
Fixes #3043

## Problem

The `force_memory_search` feature uses a hardcoded 1-second timeout for `memory_search()`, which causes frequent timeout failures when vector search is enabled with remote embedding APIs that have higher latency.

## Solution

Added a `force_memory_search_timeout` field (default: `10.0` seconds) to `MemorySummaryConfig` in `config.py`. The `react_agent.py` now uses `ms.force_memory_search_timeout` instead of the hardcoded `1` second.

Users with slow remote embedding APIs can increase this value in their config:
```json
{
  "running": {
    "memory_summary": {
      "force_memory_search": true,
      "force_memory_search_timeout": 30.0
    }
  }
}
```

## Testing

- Existing behavior is preserved for users not using `force_memory_search`
- Users with remote embedding APIs can now configure an appropriate timeout
- The default of 10 seconds is sufficient for most remote API calls