### PR TITLE
fix(agents): delete workspace directory when deleting agent

### DIFF
--- a/src/copaw/app/routers/agents.py
+++ b/src/copaw/app/routers/agents.py
@@ -375,9 +375,15 @@ async def delete_agent(
     manager = _get_multi_agent_manager(request)
     await manager.stop_agent(agentId)
 
+    workspace_dir = config.agents.profiles[agentId].workspace_dir
     del config.agents.profiles[agentId]
     config.agents.agent_order = _normalized_agent_order(config)
     save_config(config)
+
+    if workspace_dir:
+        workspace_path = Path(workspace_dir)
+        if workspace_path.exists() and workspace_path.is_dir():
+            shutil.rmtree(workspace_path, ignore_errors=True)
 
     return {"success": True, "agent_id": agentId}
 


### PR DESCRIPTION
Fixes #3036

## Problem

The `DELETE /agents/{agentId}` endpoint only removes the agent profile from `config.json` but leaves the workspace directory (`~/.copaw/workspaces/{agentId}/`) on disk, despite the API description stating "Delete agent and workspace".

## Solution

Before saving the updated config, capture the workspace directory path from the profile. After saving, check if the directory exists and remove it with `shutil.rmtree` (both `shutil` and `Path` were already imported).

The removal uses `ignore_errors=True` to avoid failing the API call if the directory has already been removed manually or doesn't exist.

## Testing

1. Create a new agent
2. Confirm workspace directory exists: `ls ~/.copaw/workspaces/`
3. Delete the agent via Web UI or `DELETE /agents/{agentId}` API
4. Verify the workspace directory is removed: `ls ~/.copaw/workspaces/`