### PR TITLE
fix(DingTalk): send media files via Open API instead of plain-text path in fallback

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -478,8 +478,8 @@ class DingTalkChannel(BaseChannel):
                 "clearing webhook for key=%s",
                 webhook_key,
             )
-            cleaned = {k: v for k, v in entry.items() if k != "webhook"}
-            self._session_webhook_store[webhook_key] = cleaned
+            entry["webhook"] = ""
+            self._session_webhook_store[webhook_key] = entry
             self._save_session_webhook_store_to_disk()
 
     async def _load_session_webhook(self, webhook_key: str) -> Optional[str]:


### PR DESCRIPTION
## Description

When sessionWebhook is unavailable (Open API fallback path), media files (images, files, audio, video) were sent as plain-text path strings like [File: /path/to/file] instead of actual files.

### Changes:

- Add _send_media_part_via_open_api: uploads media and sends via Open API with sampleFile / sampleImageMsg msgKey
- Add _send_open_api_message: generic Open API message sender supporting arbitrary msgKey types
- Add _resolve_open_api_params_from_handle: resolves conversation params from handle and meta
- Update send_content_parts fallback path to use Open API media upload instead of degrading to text
- Fix audio filename resolution in Open API path (derive real filename from AudioContent.data URL)

**Related Issue:** Fixes #3034 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
