### PR TITLE
fix(wecom): support attachment access in server deployment

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -132,7 +132,9 @@ class WecomChannel(BaseChannel):
         self.bot_prefix = bot_prefix
         self.welcome_text = welcome_text
         # Store media_dir config, will be resolved in set_workspace()
-        self._media_dir_config = Path(media_dir).expanduser() if media_dir else None
+        self._media_dir_config = (
+            Path(media_dir).expanduser() if media_dir else None
+        )
         # Default to config or global default until set_workspace is called
         self._media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
         self._max_reconnect_attempts = max_reconnect_attempts
@@ -1234,33 +1236,54 @@ class WecomChannel(BaseChannel):
 
     def set_workspace(self, workspace, command_registry=None) -> None:
         """Set workspace and resolve media directory.
-        
+
         This is called by ChannelManager when the channel is registered.
-        We resolve media_dir to one of:
-        1. {workspace_dir}/media (e.g. ./workspaces/default/media)
-        2. Global default (e.g. ~/.copaw/media)
+        Priority order:
+        1. User-provided config (WECOM_MEDIA_DIR / media_dir param)
+        2. {workspace_dir}/media (e.g. ./workspaces/default/media)
+        3. Global default (e.g. ~/.copaw/media)
         """
-        # Call parent class set_workspace to set _workspace and _command_registry
+        # Call parent set_workspace to set _workspace and _command_registry
         super().set_workspace(workspace, command_registry)
-        
+
+        # User-provided config takes highest priority
+        if self._media_dir_config:
+            self._media_dir = self._media_dir_config
+            logger.info(
+                "wecom media_dir: using user config path=%s",
+                self._media_dir,
+            )
+            return
+
         if workspace:
             workspace_dir = workspace.workspace_dir
-            # Try workspace media dir first
             media_dir = workspace_dir / "media"
             if not media_dir.is_dir():
                 try:
                     media_dir.mkdir(parents=True, exist_ok=True)
-                    logger.info("wecom media_dir: created workspace media path=%s", media_dir)
+                    logger.info(
+                        "wecom media_dir: created workspace path=%s",
+                        media_dir,
+                    )
                 except Exception as e:
-                    logger.warning("wecom media_dir: failed to create workspace media path=%s, error=%s", media_dir, e)
-                    # Fallback to global default
-                    media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
+                    logger.warning(
+                        "wecom media_dir: failed to create path=%s, err=%s",
+                        media_dir,
+                        e,
+                    )
+                    media_dir = DEFAULT_MEDIA_DIR
             self._media_dir = media_dir
-            logger.info("wecom media_dir: using workspace path=%s", self._media_dir)
+            logger.info(
+                "wecom media_dir: using workspace path=%s",
+                self._media_dir,
+            )
         else:
-            # No workspace, use default
-            self._media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
-            logger.info("wecom media_dir: using default path=%s", self._media_dir)
+            # No workspace, use global default
+            self._media_dir = DEFAULT_MEDIA_DIR
+            logger.info(
+                "wecom media_dir: using default path=%s",
+                self._media_dir,
+            )
 
     async def stop(self) -> None:
         if not self.enabled:

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -133,7 +133,8 @@ class WecomChannel(BaseChannel):
         self.welcome_text = welcome_text
         # Store media_dir config, will be resolved in set_workspace()
         self._media_dir_config = Path(media_dir).expanduser() if media_dir else None
-        self._media_dir: Optional[Path] = None  # Will be set in set_workspace()
+        # Default to config or global default until set_workspace is called
+        self._media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
         self._max_reconnect_attempts = max_reconnect_attempts
 
         self._client: Any = None
@@ -1243,22 +1244,22 @@ class WecomChannel(BaseChannel):
         super().set_workspace(workspace, command_registry)
         
         if workspace:
-            workspace_dir = Path(workspace.workspace_dir)
+            workspace_dir = workspace.workspace_dir
             # Try workspace media dir first
             media_dir = workspace_dir / "media"
-            if not media_dir.exists():
+            if not media_dir.is_dir():
                 try:
                     media_dir.mkdir(parents=True, exist_ok=True)
                     logger.info("wecom media_dir: created workspace media path=%s", media_dir)
                 except Exception as e:
                     logger.warning("wecom media_dir: failed to create workspace media path=%s, error=%s", media_dir, e)
                     # Fallback to global default
-                    media_dir = self._media_dir_config or Path(DEFAULT_MEDIA_DIR).expanduser()
+                    media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
             self._media_dir = media_dir
             logger.info("wecom media_dir: using workspace path=%s", self._media_dir)
         else:
             # No workspace, use default
-            self._media_dir = self._media_dir_config or Path(DEFAULT_MEDIA_DIR).expanduser()
+            self._media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
             logger.info("wecom media_dir: using default path=%s", self._media_dir)
 
     async def stop(self) -> None:

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -131,9 +131,9 @@ class WecomChannel(BaseChannel):
         self.secret = secret
         self.bot_prefix = bot_prefix
         self.welcome_text = welcome_text
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else DEFAULT_MEDIA_DIR
-        )
+        # Store media_dir config, will be resolved in set_workspace()
+        self._media_dir_config = Path(media_dir).expanduser() if media_dir else None
+        self._media_dir: Optional[Path] = None  # Will be set in set_workspace()
         self._max_reconnect_attempts = max_reconnect_attempts
 
         self._client: Any = None
@@ -414,6 +414,7 @@ class WecomChannel(BaseChannel):
                             FileContent(
                                 type=ContentType.FILE,
                                 file_url=path,
+                                filename=filename,
                             ),
                         )
                     else:
@@ -471,6 +472,29 @@ class WecomChannel(BaseChannel):
                                 )
                             else:
                                 text_parts.append("[image: download failed]")
+                    elif itype == "file":
+                        file_info = item.get("file") or {}
+                        url = file_info.get("url") or ""
+                        aes_key = file_info.get("aeskey") or ""
+                        filename = file_info.get("filename") or "file.bin"
+                        if url:
+                            path = await self._download_media(
+                                url,
+                                aes_key=aes_key,
+                                filename_hint=filename,
+                            )
+                            if path:
+                                content_parts.append(
+                                    FileContent(
+                                        type=ContentType.FILE,
+                                        file_url=path,
+                                        filename=filename,
+                                    ),
+                                )
+                            else:
+                                text_parts.append("[file: download failed]")
+                        else:
+                            text_parts.append("[file: no url]")
             else:
                 text_parts.append(f"[{msgtype}]")
 
@@ -1206,6 +1230,36 @@ class WecomChannel(BaseChannel):
             "wecom channel started (bot_id=%s)",
             (self.bot_id or "")[:12],
         )
+
+    def set_workspace(self, workspace, command_registry=None) -> None:
+        """Set workspace and resolve media directory.
+        
+        This is called by ChannelManager when the channel is registered.
+        We resolve media_dir to one of:
+        1. {workspace_dir}/media (e.g. ./workspaces/default/media)
+        2. Global default (e.g. ~/.copaw/media)
+        """
+        # Call parent class set_workspace to set _workspace and _command_registry
+        super().set_workspace(workspace, command_registry)
+        
+        if workspace:
+            workspace_dir = Path(workspace.workspace_dir)
+            # Try workspace media dir first
+            media_dir = workspace_dir / "media"
+            if not media_dir.exists():
+                try:
+                    media_dir.mkdir(parents=True, exist_ok=True)
+                    logger.info("wecom media_dir: created workspace media path=%s", media_dir)
+                except Exception as e:
+                    logger.warning("wecom media_dir: failed to create workspace media path=%s, error=%s", media_dir, e)
+                    # Fallback to global default
+                    media_dir = self._media_dir_config or Path(DEFAULT_MEDIA_DIR).expanduser()
+            self._media_dir = media_dir
+            logger.info("wecom media_dir: using workspace path=%s", self._media_dir)
+        else:
+            # No workspace, use default
+            self._media_dir = self._media_dir_config or Path(DEFAULT_MEDIA_DIR).expanduser()
+            logger.info("wecom media_dir: using default path=%s", self._media_dir)
 
     async def stop(self) -> None:
         if not self.enabled:


### PR DESCRIPTION
## Description
Fix WeCom attachment access issue in server deployment scenario.

## Changes
- Add `set_workspace()` to properly resolve media directory
  - Resolves media_dir to workspace/media or global default
  - Supports server deployment scenario
- Add filename field to FileContent for better file handling
- Support file type in mixed messages
  - Handle file attachments in mixed message types
- Fix: Call parent `set_workspace()` to set `_command_registry`

## Related Issue
Related to: #3020 (attachment issue only)

**Note**: The quoted message issue (#3020) has been fixed by #3024, 
so this PR only addresses the attachment/file access problem.

## Testing
- [x] Tested in local deployment
- [x] File messages work correctly
- [x] Mixed messages with files work correctly
- [x] Media directory properly resolved
- [x] No AttributeError in channel manager

## Code Changes
- `src/copaw/app/channels/wecom/channel.py`: +57 lines, -3 lines
  - Added `set_workspace()` method
  - Modified `__init__` to delay media_dir resolution
  - Added filename field to FileContent
  - Added file type support in mixed messages
