### PR TITLE
fix(desktop): fail fast when WebView2 is unavailable on Windows

### DIFF
--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -344,11 +344,12 @@ def desktop_cmd(
                             "'QwenPaw Desktop (Debug)' and attach the terminal "
                             "output.",
                         )
-                    _abort_desktop_launch(
-                        "Failed to start the embedded desktop window. "
-                        "Run with '--log-level debug' and inspect the "
-                        "terminal output for details.",
-                    )
+                    else:
+                        _abort_desktop_launch(
+                            "Failed to start the embedded desktop window. "
+                            "Run with '--log-level debug' and inspect the "
+                            "terminal output for details.",
+                        )
             else:
                 logger.error("Server did not become ready in time.")
                 click.echo(

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -341,8 +341,8 @@ def desktop_cmd(
                             "WebView2 Runtime and try again.\n\n"
                             f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
                             "If the issue persists, run "
-                            "'QwenPaw Desktop (Debug)' and attach the terminal "
-                            "output.",
+                            "'QwenPaw Desktop (Debug)' and "
+                            "attach the terminal output.",
                         )
                     else:
                         _abort_desktop_launch(

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -28,6 +28,13 @@ logger = logging.getLogger(__name__)
 WEBVIEW2_RUNTIME_DOWNLOAD_URL = (
     "https://developer.microsoft.com/en-us/microsoft-edge/webview2/"
 )
+_WEBVIEW2_TROUBLESHOOT_SUFFIX = (
+    "Install or repair WebView2 Runtime and try again.\n\n"
+    f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
+    "If the issue persists, run "
+    "'QwenPaw Desktop (Debug)' and "
+    "attach the terminal output."
+)
 WEBVIEW2_RUNTIME_GUID = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 WINDOWS_WEBVIEW2_REGISTRY_LOCATIONS = (
     (
@@ -156,12 +163,9 @@ def _ensure_desktop_webview_available() -> None:
 
     _abort_desktop_launch(
         "Microsoft Edge WebView2 Runtime was not detected. "
-        "QwenPaw Desktop requires WebView2 on Windows and may otherwise "
-        "fall back to an unsupported legacy renderer that shows a blank "
-        "window. Install or repair WebView2 Runtime and try again.\n\n"
-        f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
-        "If the issue persists, run 'QwenPaw Desktop (Debug)' and attach "
-        "the terminal output.",
+        "QwenPaw Desktop requires WebView2 on Windows and "
+        "may otherwise fall back to an unsupported legacy "
+        "renderer that shows a blank window. " + _WEBVIEW2_TROUBLESHOOT_SUFFIX,
     )
 
 
@@ -335,14 +339,11 @@ def desktop_cmd(
                     logger.exception("Failed to start embedded desktop window")
                     if sys.platform == "win32":
                         _abort_desktop_launch(
-                            "Failed to start the embedded desktop window.\n\n"
-                            "On Windows this usually means the WebView2 "
-                            "Runtime is missing or damaged. Install or repair "
-                            "WebView2 Runtime and try again.\n\n"
-                            f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
-                            "If the issue persists, run "
-                            "'QwenPaw Desktop (Debug)' and "
-                            "attach the terminal output.",
+                            "Failed to start the embedded "
+                            "desktop window.\n\n"
+                            "On Windows this usually means "
+                            "the WebView2 Runtime is missing "
+                            "or damaged. " + _WEBVIEW2_TROUBLESHOOT_SUFFIX,
                         )
                     else:
                         _abort_desktop_launch(

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -25,6 +25,28 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+WEBVIEW2_RUNTIME_DOWNLOAD_URL = (
+    "https://developer.microsoft.com/en-us/microsoft-edge/webview2/"
+)
+WEBVIEW2_RUNTIME_GUID = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+WINDOWS_WEBVIEW2_REGISTRY_LOCATIONS = (
+    (
+        "HKEY_LOCAL_MACHINE",
+        (
+            "SOFTWARE\\WOW6432Node\\Microsoft\\EdgeUpdate\\Clients\\"
+            f"{WEBVIEW2_RUNTIME_GUID}"
+        ),
+    ),
+    (
+        "HKEY_LOCAL_MACHINE",
+        f"SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{WEBVIEW2_RUNTIME_GUID}",
+    ),
+    (
+        "HKEY_CURRENT_USER",
+        f"Software\\Microsoft\\EdgeUpdate\\Clients\\{WEBVIEW2_RUNTIME_GUID}",
+    ),
+)
+
 
 class WebViewAPI:
     """API exposed to the webview for handling external links."""
@@ -34,6 +56,113 @@ class WebViewAPI:
         if not url.startswith(("http://", "https://")):
             return
         webbrowser.open(url)
+
+
+def _parse_version_string(version: str | None) -> tuple[int, ...] | None:
+    """Parse dotted numeric version strings like 123.0.2420.65."""
+    if not version:
+        return None
+    parts = version.strip().split(".")
+    if not parts or any(not part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
+
+
+def _read_windows_registry_value(
+    root_name: str,
+    sub_key: str,
+    value_name: str,
+) -> str | None:
+    """Read a string value from the Windows registry."""
+    if sys.platform != "win32":
+        return None
+
+    try:
+        import winreg
+    except ImportError:
+        return None
+
+    try:
+        root = getattr(winreg, root_name)
+        with winreg.OpenKey(root, sub_key) as key:
+            value, reg_type = winreg.QueryValueEx(key, value_name)
+    except (AttributeError, OSError):
+        return None
+
+    if reg_type != winreg.REG_SZ or not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    return value or None
+
+
+def _detect_windows_webview2_runtime_version() -> str | None:
+    """Return the installed WebView2 Runtime version on Windows."""
+    if sys.platform != "win32":
+        return None
+
+    for root_name, sub_key in WINDOWS_WEBVIEW2_REGISTRY_LOCATIONS:
+        version = _read_windows_registry_value(root_name, sub_key, "pv")
+        parsed = _parse_version_string(version)
+        if parsed and any(parsed):
+            return version
+
+    return None
+
+
+def _show_windows_message_box(title: str, message: str) -> None:
+    """Display a native Windows error dialog when launched silently."""
+    if sys.platform != "win32":
+        return
+
+    try:
+        import ctypes
+
+        mb_iconerror = 0x00000010
+        mb_setforeground = 0x00010000
+        ctypes.windll.user32.MessageBoxW(
+            None,
+            message,
+            title,
+            mb_iconerror | mb_setforeground,
+        )
+    except Exception:
+        pass
+
+
+def _abort_desktop_launch(message: str) -> None:
+    """Exit the desktop launcher with a visible, actionable error."""
+    logger.error(message)
+    click.echo(f"Error: {message}", err=True)
+    _show_windows_message_box("QwenPaw Desktop", message)
+    raise SystemExit(1)
+
+
+def _ensure_desktop_webview_available() -> None:
+    """Fail fast if the desktop webview backend is unavailable."""
+    if webview is None:
+        _abort_desktop_launch(
+            "pywebview is not available in this QwenPaw Desktop environment. "
+            "Please reinstall QwenPaw Desktop.",
+        )
+
+    if sys.platform != "win32":
+        return
+
+    runtime_version = _detect_windows_webview2_runtime_version()
+    if runtime_version:
+        logger.info(f"Detected WebView2 Runtime {runtime_version}")
+        return
+
+    _abort_desktop_launch(
+        "Microsoft Edge WebView2 Runtime was not detected. "
+        "QwenPaw Desktop requires WebView2 on Windows and may otherwise "
+        "fall back to an unsupported legacy renderer that shows a blank "
+        "window. Install or repair WebView2 Runtime and try again.\n\n"
+        f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
+        "If the issue persists, run 'QwenPaw Desktop (Debug)' and attach "
+        "the terminal output.",
+    )
 
 
 def _find_free_port(host: str = "127.0.0.1") -> int:
@@ -79,6 +208,30 @@ def _stream_reader(in_stream, out_stream) -> None:
             pass
 
 
+def _start_desktop_window(url: str) -> None:
+    """Create and start the embedded desktop window."""
+    if webview is None:
+        raise RuntimeError("pywebview is not available")
+
+    api = WebViewAPI()
+    webview.create_window(
+        "QwenPaw Desktop",
+        url,
+        width=1280,
+        height=800,
+        text_select=True,
+        js_api=api,
+    )
+
+    start_kwargs = {"private_mode": False}
+    if sys.platform == "win32":
+        # Force WebView2 so we fail fast instead of silently falling back
+        # to MSHTML / IE, which cannot render the Vite-built frontend.
+        start_kwargs["gui"] = "edgechromium"
+
+    webview.start(**start_kwargs)
+
+
 @click.command("desktop")
 @click.option(
     "--host",
@@ -108,6 +261,7 @@ def desktop_cmd(
     """
     # Setup logger for desktop command (separate from backend subprocess)
     setup_logger(log_level)
+    _ensure_desktop_webview_available()
 
     port = _find_free_port(host)
     url = f"http://{host}:{port}"
@@ -171,22 +325,30 @@ def desktop_cmd(
             logger.info("Waiting for HTTP ready...")
             if _wait_for_http(host, port):
                 logger.info("HTTP ready, creating webview window...")
-                api = WebViewAPI()
-                webview.create_window(
-                    "QwenPaw Desktop",
-                    url,
-                    width=1280,
-                    height=800,
-                    text_select=True,
-                    js_api=api,
-                )
-                logger.info(
-                    "Calling webview.start() (blocks until closed)...",
-                )
-                webview.start(
-                    private_mode=False,
-                )  # blocks until user closes the window
-                logger.info("webview.start() returned (window closed).")
+                try:
+                    logger.info(
+                        "Calling webview.start() (blocks until closed)...",
+                    )
+                    _start_desktop_window(url)
+                    logger.info("webview.start() returned (window closed).")
+                except Exception:
+                    logger.exception("Failed to start embedded desktop window")
+                    if sys.platform == "win32":
+                        _abort_desktop_launch(
+                            "Failed to start the embedded desktop window.\n\n"
+                            "On Windows this usually means the WebView2 "
+                            "Runtime is missing or damaged. Install or repair "
+                            "WebView2 Runtime and try again.\n\n"
+                            f"Download: {WEBVIEW2_RUNTIME_DOWNLOAD_URL}\n\n"
+                            "If the issue persists, run "
+                            "'QwenPaw Desktop (Debug)' and attach the terminal "
+                            "output.",
+                        )
+                    _abort_desktop_launch(
+                        "Failed to start the embedded desktop window. "
+                        "Run with '--log-level debug' and inspect the "
+                        "terminal output for details.",
+                    )
             else:
                 logger.error("Server did not become ready in time.")
                 click.echo(

--- a/tests/unit/cli/test_cli_desktop.py
+++ b/tests/unit/cli/test_cli_desktop.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.cli import desktop_cmd as desktop_cmd_module
+
+
+def test_detect_windows_webview2_runtime_version_returns_first_valid(
+    monkeypatch,
+) -> None:
+    values = iter(
+        [
+            "0.0.0.0",
+            None,
+            "136.0.3240.8",
+        ],
+    )
+
+    monkeypatch.setattr(desktop_cmd_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        desktop_cmd_module,
+        "_read_windows_registry_value",
+        lambda *_args: next(values),
+    )
+
+    assert (
+        desktop_cmd_module._detect_windows_webview2_runtime_version()
+        == "136.0.3240.8"
+    )
+
+
+def test_detect_windows_webview2_runtime_version_returns_none(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(desktop_cmd_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        desktop_cmd_module,
+        "_read_windows_registry_value",
+        lambda *_args: "",
+    )
+
+    assert desktop_cmd_module._detect_windows_webview2_runtime_version() is None
+
+
+def test_ensure_desktop_webview_available_requires_webview2_runtime(
+    monkeypatch,
+) -> None:
+    dialogs: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(desktop_cmd_module.sys, "platform", "win32")
+    monkeypatch.setattr(desktop_cmd_module, "webview", object())
+    monkeypatch.setattr(
+        desktop_cmd_module,
+        "_detect_windows_webview2_runtime_version",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        desktop_cmd_module,
+        "_show_windows_message_box",
+        lambda title, message: dialogs.append((title, message)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        desktop_cmd_module._ensure_desktop_webview_available()
+
+    assert exc_info.value.code == 1
+    assert dialogs
+    assert "WebView2 Runtime was not detected" in dialogs[0][1]
+
+
+def test_start_desktop_window_forces_edgechromium_on_windows(
+    monkeypatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    class _FakeWebview:
+        def create_window(self, *args, **kwargs) -> None:
+            calls["create"] = (args, kwargs)
+
+        def start(self, **kwargs) -> None:
+            calls["start"] = kwargs
+
+    monkeypatch.setattr(desktop_cmd_module.sys, "platform", "win32")
+    monkeypatch.setattr(desktop_cmd_module, "webview", _FakeWebview())
+
+    desktop_cmd_module._start_desktop_window("http://127.0.0.1:8088")
+
+    assert "create" in calls
+    assert calls["start"] == {
+        "private_mode": False,
+        "gui": "edgechromium",
+    }

--- a/tests/unit/cli/test_cli_desktop.py
+++ b/tests/unit/cli/test_cli_desktop.py
@@ -26,7 +26,8 @@ def test_detect_windows_webview2_runtime_version_returns_first_valid(
     )
 
     assert (
-        desktop_cmd_module._detect_windows_webview2_runtime_version() == "136.0.3240.8"
+        desktop_cmd_module._detect_windows_webview2_runtime_version()
+        == "136.0.3240.8"
     )
 
 
@@ -40,7 +41,9 @@ def test_detect_windows_webview2_runtime_version_returns_none(
         lambda *_args: "",
     )
 
-    assert desktop_cmd_module._detect_windows_webview2_runtime_version() is None
+    assert (
+        desktop_cmd_module._detect_windows_webview2_runtime_version() is None
+    )
 
 
 def test_ensure_desktop_webview_available_requires_webview2_runtime(

--- a/tests/unit/cli/test_cli_desktop.py
+++ b/tests/unit/cli/test_cli_desktop.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from __future__ import annotations
 
 import pytest
@@ -25,8 +26,7 @@ def test_detect_windows_webview2_runtime_version_returns_first_valid(
     )
 
     assert (
-        desktop_cmd_module._detect_windows_webview2_runtime_version()
-        == "136.0.3240.8"
+        desktop_cmd_module._detect_windows_webview2_runtime_version() == "136.0.3240.8"
     )
 
 

--- a/website/public/docs/desktop.en.md
+++ b/website/public/docs/desktop.en.md
@@ -73,10 +73,10 @@ After installation, you'll see **two launch shortcuts**:
 ### Common Issues
 
 **Q: The app window is blank/white screen and cannot display properly?**
-A: This is usually because the system is missing the **Microsoft WebView2** runtime (some Windows 10 systems do not have it pre-installed).
-Download and install it from the Microsoft website:
+A: This is usually because the system is missing or has a damaged **Microsoft WebView2** runtime (a small number of Windows 10 devices don't have it pre-installed, and some devices need a repair/reinstall).
+Download and install or repair it from the Microsoft website:
 [Microsoft WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
-Restart the application after installation.
+Restart the application afterwards. If the problem persists, launch "QwenPaw Desktop (Debug)" and inspect the terminal output.
 
 **Q: Application doesn't respond after launch?**
 A: Use "QwenPaw Desktop (Debug)" mode to view terminal output for error messages

--- a/website/public/docs/desktop.zh.md
+++ b/website/public/docs/desktop.zh.md
@@ -73,10 +73,10 @@
 ### 常见问题
 
 **Q: 应用启动后窗口白屏，无法正常显示？**
-A: 这通常是因为系统缺少 **Microsoft WebView2** 运行时（部分 Windows 10 系统未预装）。
-请前往微软官网下载并安装：
+A: 这通常是因为系统缺少或损坏了 **Microsoft WebView2** 运行时（少数 Windows 10 设备未预装，个别设备也可能需要修复/重装）。
+请前往微软官网下载并安装或修复：
 [Microsoft WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
-安装完成后重启应用即可。
+安装完成后重启应用即可；如果仍有问题，请先运行 "QwenPaw Desktop (Debug)" 查看终端输出。
 
 **Q: 应用启动后没有反应？**
 A: 使用 "QwenPaw Desktop (Debug)" 模式启动，查看终端输出的错误信息


### PR DESCRIPTION
## Description

On a small number of Windows machines, launching CoPaw Desktop shows a blank white window with no error feedback. The root cause is a missing or damaged **Microsoft Edge WebView2 Runtime** — without it, pywebview silently falls back to the legacy MSHTML/IE renderer which cannot render the Vite-built frontend.

This PR turns that silent white-screen into a **fail-fast with an actionable error message**:

- Detects WebView2 Runtime presence via Windows registry before launching
- If missing: shows a native `MessageBox` error dialog + stderr message with a download link
- Forces `gui="edgechromium"` in `webview.start()` to prevent silent MSHTML fallback
- Wraps `webview.start()` exceptions with a clear WebView2-specific error on Windows
- Updates troubleshooting docs (EN + ZH) to cover damaged/repair scenarios

Verified on Alibaba Cloud Wuying (无影云电脑) where WebView2 was initially missing — after this change the error dialog appeared immediately with the download link, and after installing WebView2 the app launched normally.

**Related Issue:** N/A (discovered during user testing on cloud desktops)

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **Unit tests** — 4 new tests in `tests/unit/cli/test_cli_desktop.py`:
   - `test_detect_windows_webview2_runtime_version_returns_first_valid` — skips `0.0.0.0`, returns first real version
   - `test_detect_windows_webview2_runtime_version_returns_none` — returns `None` when no valid version found
   - `test_ensure_desktop_webview_available_requires_webview2_runtime` — exits with code 1 and shows MessageBox when WebView2 missing
   - `test_start_desktop_window_forces_edgechromium_on_windows` — verifies `gui="edgechromium"` is passed on Windows

2. **Manual verification** — Tested on Alibaba Cloud Wuying (无影云电脑), a Windows environment without WebView2 pre-installed:
   - Before fix: blank white window, no error
   - After fix: native error dialog with download link appears immediately
   - After installing WebView2: app launches normally

## Local Verification Evidence

```
pytest tests/unit/cli/test_cli_desktop.py -v
# 4 passed

pre-commit run --all-files
# Passed
```

## Additional Notes

- The WebView2 Runtime GUID `{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}` is the official Evergreen Runtime identifier from Microsoft
- Registry detection covers all three standard locations: HKLM WOW6432Node, HKLM native, and HKCU
- Version `0.0.0.0` is filtered out as it indicates an uninstalled/placeholder state
- A follow-up PR may add WebView2 auto-install to the NSIS installer for an even smoother first-run experience