### PR TITLE
fix(wecom): Fix event loop issue in file upload and add relative path support for send_file_to_user

### DIFF
--- a/src/qwenpaw/agents/tools/send_file.py
+++ b/src/qwenpaw/agents/tools/send_file.py
@@ -14,6 +14,7 @@ from agentscope.message import (
 )
 
 from ..schema import FileBlock
+from .file_io import _resolve_file_path
 
 
 def _auto_as_type(mt: str) -> str:
@@ -44,6 +45,9 @@ async def send_file_to_user(
     # (e.g. macOS stores filenames as NFD but paths from the LLM arrive as NFC,
     # causing os.path.exists to return False for files that do exist).
     file_path = os.path.expanduser(unicodedata.normalize("NFC", file_path))
+
+    # Resolve relative paths to absolute paths based on workspace directory
+    file_path = _resolve_file_path(file_path)
 
     if not os.path.exists(file_path):
         return ToolResponse(

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -682,12 +682,15 @@ class WecomChannel(BaseChannel):
         # Use the main event loop for the future (response handling)
         main_loop = asyncio.get_running_loop()
         fut: asyncio.Future[Any] = main_loop.create_future()
-        self._upload_ack_futures[req_id] = fut
 
         # WebSocket operations must run in the WS thread's event loop
         ws_loop = self._ws_loop
         if ws_loop is None:
             raise RuntimeError("WebSocket loop not initialized")
+
+        # Register the future after the ws_loop check so it won't leak
+        # if the check raises.
+        self._upload_ack_futures[req_id] = fut
 
         async def _send() -> None:
             await self._client._ws_manager.send(
@@ -696,7 +699,10 @@ class WecomChannel(BaseChannel):
 
         try:
             # Schedule send in WS thread and wait for response
-            asyncio.run_coroutine_threadsafe(_send(), ws_loop)
+            send_future = asyncio.run_coroutine_threadsafe(_send(), ws_loop)
+            send_future.add_done_callback(
+                lambda f: f.result() if not f.cancelled() else None
+            )
             ack = await asyncio.wait_for(
                 asyncio.shield(fut),
                 timeout=_UPLOAD_ACK_TIMEOUT,

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -701,7 +701,7 @@ class WecomChannel(BaseChannel):
             # Schedule send in WS thread and wait for response
             send_future = asyncio.run_coroutine_threadsafe(_send(), ws_loop)
             send_future.add_done_callback(
-                lambda f: f.result() if not f.cancelled() else None
+                lambda f: f.result() if not f.cancelled() else None,
             )
             ack = await asyncio.wait_for(
                 asyncio.shield(fut),
@@ -818,6 +818,7 @@ class WecomChannel(BaseChannel):
                     local[:60],
                     str(e)[:100],
                 )
+
                 return None
 
     async def _send_media_part(

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -679,13 +679,24 @@ class WecomChannel(BaseChannel):
         Returns the ack frame body dict, or raises on timeout / error.
         """
         req_id = generate_req_id(cmd)
-        loop = asyncio.get_event_loop()
-        fut: asyncio.Future[Any] = loop.create_future()
+        # Use the main event loop for the future (response handling)
+        main_loop = asyncio.get_running_loop()
+        fut: asyncio.Future[Any] = main_loop.create_future()
         self._upload_ack_futures[req_id] = fut
-        try:
+
+        # WebSocket operations must run in the WS thread's event loop
+        ws_loop = self._ws_loop
+        if ws_loop is None:
+            raise RuntimeError("WebSocket loop not initialized")
+
+        async def _send() -> None:
             await self._client._ws_manager.send(
                 {"cmd": cmd, "headers": {"req_id": req_id}, "body": body},
             )
+
+        try:
+            # Schedule send in WS thread and wait for response
+            asyncio.run_coroutine_threadsafe(_send(), ws_loop)
             ack = await asyncio.wait_for(
                 asyncio.shield(fut),
                 timeout=_UPLOAD_ACK_TIMEOUT,
@@ -795,10 +806,11 @@ class WecomChannel(BaseChannel):
                     media_type,
                 )
                 return media_id
-            except Exception:
+            except Exception as e:
                 logger.exception(
-                    "wecom _upload_media failed path=%s",
+                    "wecom _upload_media failed path=%s error=%s",
                     local[:60],
+                    str(e)[:100],
                 )
                 return None
 

--- a/tests/unit/channels/test_wecom.py
+++ b/tests/unit/channels/test_wecom.py
@@ -1248,27 +1248,30 @@ class TestWecomChannelMediaUpload:
         """_send_ws_cmd should send command and await ack."""
         wecom_channel._client = mock_ws_client
 
-        # Create future and set result
-        loop = MagicMock()
-        loop.create_future = MagicMock()
-        mock_fut = MagicMock()
-        mock_fut.done.return_value = False
-        mock_fut.result = {"body": {"status": "ok"}, "errcode": 0}
-        loop.create_future.return_value = mock_fut
+        # Set up a fake WS event loop so the None-check passes
+        mock_ws_loop = MagicMock()
+        wecom_channel._ws_loop = mock_ws_loop
 
-        with patch("asyncio.get_event_loop", return_value=loop):
-            # Need to actually create a proper future
-            import asyncio
+        mock_send_future = MagicMock()
 
-            real_fut = asyncio.Future()
-            real_fut.set_result(
-                {
-                    "body": {"result": "success"},
-                    "errcode": 0,
-                },
-            )
-            loop.create_future.return_value = real_fut
+        def fake_run_coroutine_threadsafe(coro, loop):
+            """Simulate scheduling and resolve the ack future."""
+            coro.close()
+            # Find the registered future and set its result
+            for fut in wecom_channel._upload_ack_futures.values():
+                if not fut.done():
+                    fut.set_result(
+                        {
+                            "body": {"result": "success"},
+                            "errcode": 0,
+                        },
+                    )
+            return mock_send_future
 
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=fake_run_coroutine_threadsafe,
+        ):
             result = await wecom_channel._send_ws_cmd(
                 "test_cmd",
                 {"key": "value"},


### PR DESCRIPTION
## Summary
Fixed two issues affecting WeCom file sending and tool usage:
1. Fixed event loop conflict during binary file upload
2. Fixed relative path recognition in [send_file_to_user](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:29:0-125:9) tool

## Problem Description

### Issue 1: WeCom Binary File Upload Failure
**Symptom**: When using [send_file_to_user](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:29:0-125:9) tool to send binary files (e.g., .xlsx, .png), the system shows successful sending but files are not visible in WeCom.

**Error Log**:
```
RuntimeError: Task ... got Future ... attached to a different loop
```

**Root Cause**: WebSocket connection runs in a separate event loop `_ws_loop` in a background thread, but file upload commands execute WebSocket send operations in the main thread's event loop, causing event loop mismatch.

### Issue 2: send_file_to_user Relative Path Not Recognized
**Symptom**: When agent calls [send_file_to_user](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:29:0-125:9) tool with relative paths (e.g., `report.xlsx`), it reports file not found error. Only absolute paths work.

**Root Cause**: [read_file](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/file_io.py:65:0-204:9) tool uses [_resolve_file_path()](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/file_io.py:22:0-38:45) to resolve relative paths to absolute paths based on the workspace directory, but [send_file_to_user](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:29:0-125:9) directly uses `os.path.exists()` to look for files in the current running directory.

## Changes

### File 1: [src/copaw/app/channels/wecom/channel.py](cci:7://file:///research/pipeline_RD/67.CoPaw/src/copaw/app/channels/wecom/channel.py:0:0-0:0)

**Modified [_send_ws_cmd](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/app/channels/wecom/channel.py:670:4-710:36) method**:
- Response Future continues to be created in the main event loop (for receiving WebSocket response callbacks)
- WebSocket send operations are scheduled to execute in the WebSocket thread's event loop using `asyncio.run_coroutine_threadsafe()`
- Keep response waiting in the original calling context

```python
# Execute send in WebSocket thread's event loop
async def _send() -> None:
    await self._client._ws_manager.send(...)

asyncio.run_coroutine_threadsafe(_send(), ws_loop)
```

### File 2: [src/copaw/agents/tools/send_file.py](cci:7://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:0:0-0:0)

**Added relative path resolution**:
- Import [_resolve_file_path](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/file_io.py:22:0-38:45) function (from [file_io.py](cci:7://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/file_io.py:0:0-0:0))
- Before checking file existence, call [_resolve_file_path()](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/file_io.py:22:0-38:45) to convert relative paths to absolute paths

```python
from .file_io import _resolve_file_path

# Resolve relative paths to absolute paths based on workspace directory
file_path = _resolve_file_path(file_path)
```

## Testing

### Test 1: WeCom File Sending
```python
# Test sending different types of files
await send_file_to_user("/path/to/report.xlsx")  # Excel file
await send_file_to_user("/path/to/image.png")    # Image file
await send_file_to_user("/path/to/doc.pdf")      # PDF file
```
Expected result: All files should be visible in WeCom

### Test 2: Relative Path Support
```python
# Create test.txt in working directory, then test
await send_file_to_user("test.txt")              # Relative path
await send_file_to_user("./data/report.xlsx")    # Relative path with subdir
await send_file_to_user("/absolute/path/file")   # Absolute path (should still work)
```
Expected result: All paths should correctly recognize the file

## Impact Scope
- WeCom channel file sending functionality (image, file, audio, video)
- [send_file_to_user](cci:1://file:///research/pipeline_RD/67.CoPaw/src/copaw/agents/tools/send_file.py:29:0-125:9) tool path resolution logic
- Does not affect other channels' media sending logic

## Checklist
- [x] Code follows project coding standards
- [x] Fixed cross-thread event loop issue
- [x] Fixed relative path resolution issue
- [x] Maintained backward compatibility with existing functionality
- [x] Added appropriate logging
```