### PR TITLE
fix(discord): add thread awareness to on_message routing

### DIFF
--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -127,10 +127,7 @@ class DiscordChannel(BaseChannel):
                         msg_id,
                     )
                     return
-                if (
-                    len(self._processed_message_ids)
-                    >= self._MAX_CACHED_MESSAGE_IDS
-                ):
+                if len(self._processed_message_ids) >= self._MAX_CACHED_MESSAGE_IDS:
                     oldest = self._processed_message_id_queue.popleft()
                     self._processed_message_ids.discard(oldest)
                 self._processed_message_ids.add(msg_id)
@@ -236,25 +233,18 @@ class DiscordChannel(BaseChannel):
                 is_group = message.guild is not None
                 _is_thread = isinstance(message.channel, discord.Thread)
                 _thread_started = (
-                    not _is_thread
-                    and getattr(message, "thread", None) is not None
+                    not _is_thread and getattr(message, "thread", None) is not None
                 )
                 # Race-condition: thread created simultaneously
                 # with the first message. on_thread_create may
                 # have cached the thread_id before on_message
                 # fires for the starter message.
                 _race_thread_id = None
-                if (
-                    not _is_thread
-                    and not _thread_started
-                    and is_group
-                ):
+                if not _is_thread and not _thread_started and is_group:
                     flags = getattr(message, "flags", None)
                     if flags and getattr(flags, "has_thread", False):
-                        _race_thread_id = (
-                            self._recent_thread_starts.get(
-                                str(message.id),
-                            )
+                        _race_thread_id = self._recent_thread_starts.get(
+                            str(message.id),
                         )
                 # Determine effective channel_id for session routing
                 if _is_thread:
@@ -269,9 +259,7 @@ class DiscordChannel(BaseChannel):
                 meta = {
                     "user_id": str(message.author.id),
                     "channel_id": _effective_channel_id,
-                    "guild_id": (
-                        str(message.guild.id) if message.guild else None
-                    ),
+                    "guild_id": (str(message.guild.id) if message.guild else None),
                     "message_id": str(message.id),
                     "is_dm": not is_group,
                     "is_group": is_group,
@@ -331,8 +319,7 @@ class DiscordChannel(BaseChannel):
                     key = str(starter.id)
                     self._recent_thread_starts[key] = str(thread.id)
                     logger.info(
-                        "discord thread_create: thread=%s "
-                        "starter_msg=%s parent=%s",
+                        "discord thread_create: thread=%s " "starter_msg=%s parent=%s",
                         thread.id,
                         starter.id,
                         thread.parent_id,
@@ -471,10 +458,7 @@ class DiscordChannel(BaseChannel):
             # When inside a code fence, reserve space for the closing
             # suffix that _flush() appends.
             reserved = fence_close_len if fence_open else 0
-            if (
-                current
-                and current_len + len(line_with_nl) + reserved > max_len
-            ):
+            if current and current_len + len(line_with_nl) + reserved > max_len:
                 saved_fence = fence_open
                 _flush()
                 current_len = 0
@@ -554,9 +538,7 @@ class DiscordChannel(BaseChannel):
             ContentType.FILE,
         }
         text_parts = [
-            p
-            for p in (parts or [])
-            if getattr(p, "type", None) not in media_types
+            p for p in (parts or []) if getattr(p, "type", None) not in media_types
         ]
         media_parts = [
             p for p in (parts or []) if getattr(p, "type", None) in media_types

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -127,7 +127,10 @@ class DiscordChannel(BaseChannel):
                         msg_id,
                     )
                     return
-                if len(self._processed_message_ids) >= self._MAX_CACHED_MESSAGE_IDS:
+                if (
+                    len(self._processed_message_ids)
+                    >= self._MAX_CACHED_MESSAGE_IDS
+                ):
                     oldest = self._processed_message_id_queue.popleft()
                     self._processed_message_ids.discard(oldest)
                 self._processed_message_ids.add(msg_id)
@@ -233,7 +236,8 @@ class DiscordChannel(BaseChannel):
                 is_group = message.guild is not None
                 _is_thread = isinstance(message.channel, discord.Thread)
                 _thread_started = (
-                    not _is_thread and getattr(message, "thread", None) is not None
+                    not _is_thread
+                    and getattr(message, "thread", None) is not None
                 )
                 # Race-condition: thread created simultaneously
                 # with the first message. on_thread_create may
@@ -259,7 +263,9 @@ class DiscordChannel(BaseChannel):
                 meta = {
                     "user_id": str(message.author.id),
                     "channel_id": _effective_channel_id,
-                    "guild_id": (str(message.guild.id) if message.guild else None),
+                    "guild_id": (
+                        str(message.guild.id) if message.guild else None
+                    ),
                     "message_id": str(message.id),
                     "is_dm": not is_group,
                     "is_group": is_group,
@@ -319,7 +325,8 @@ class DiscordChannel(BaseChannel):
                     key = str(starter.id)
                     self._recent_thread_starts[key] = str(thread.id)
                     logger.info(
-                        "discord thread_create: thread=%s " "starter_msg=%s parent=%s",
+                        "discord thread_create: thread=%s "
+                        "starter_msg=%s parent=%s",
                         thread.id,
                         starter.id,
                         thread.parent_id,
@@ -458,7 +465,10 @@ class DiscordChannel(BaseChannel):
             # When inside a code fence, reserve space for the closing
             # suffix that _flush() appends.
             reserved = fence_close_len if fence_open else 0
-            if current and current_len + len(line_with_nl) + reserved > max_len:
+            if (
+                current
+                and current_len + len(line_with_nl) + reserved > max_len
+            ):
                 saved_fence = fence_open
                 _flush()
                 current_len = 0
@@ -538,7 +548,9 @@ class DiscordChannel(BaseChannel):
             ContentType.FILE,
         }
         text_parts = [
-            p for p in (parts or []) if getattr(p, "type", None) not in media_types
+            p
+            for p in (parts or [])
+            if getattr(p, "type", None) not in media_types
         ]
         media_parts = [
             p for p in (parts or []) if getattr(p, "type", None) in media_types

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -86,6 +86,10 @@ class DiscordChannel(BaseChannel):
         self._client = None
         self._processed_message_ids: set[str] = set()
         self._processed_message_id_queue: deque[str] = deque()
+        # Maps parent_channel_msg_id -> thread_id for race-condition
+        # detection when thread creation and first message arrive
+        # simultaneously.
+        self._recent_thread_starts: dict[str, str] = {}
 
         if self.enabled:
             import discord  # type: ignore
@@ -235,13 +239,36 @@ class DiscordChannel(BaseChannel):
                     not _is_thread
                     and getattr(message, "thread", None) is not None
                 )
+                # Race-condition: thread created simultaneously
+                # with the first message. on_thread_create may
+                # have cached the thread_id before on_message
+                # fires for the starter message.
+                _race_thread_id = None
+                if (
+                    not _is_thread
+                    and not _thread_started
+                    and is_group
+                ):
+                    flags = getattr(message, "flags", None)
+                    if flags and getattr(flags, "has_thread", False):
+                        _race_thread_id = (
+                            self._recent_thread_starts.get(
+                                str(message.id),
+                            )
+                        )
+                # Determine effective channel_id for session routing
+                if _is_thread:
+                    _effective_channel_id = str(message.channel.id)
+                elif _thread_started:
+                    _effective_channel_id = str(message.thread.id)
+                elif _race_thread_id:
+                    _effective_channel_id = _race_thread_id
+                else:
+                    _effective_channel_id = str(message.channel.id)
+
                 meta = {
                     "user_id": str(message.author.id),
-                    "channel_id": str(
-                        message.thread.id
-                        if _thread_started
-                        else message.channel.id,
-                    ),
+                    "channel_id": _effective_channel_id,
                     "guild_id": (
                         str(message.guild.id) if message.guild else None
                     ),
@@ -257,9 +284,9 @@ class DiscordChannel(BaseChannel):
                         if message.channel.parent_id
                         else None
                     )
-                elif _thread_started:
+                elif _thread_started or _race_thread_id:
                     meta["is_thread"] = True
-                    meta["thread_id"] = str(message.thread.id)
+                    meta["thread_id"] = _effective_channel_id
                     meta["parent_channel_id"] = str(message.channel.id)
                 if is_bot_mentioned:
                     meta["bot_mentioned"] = True
@@ -292,6 +319,27 @@ class DiscordChannel(BaseChannel):
                     logger.warning(
                         "discord: _enqueue not set, message dropped",
                     )
+
+            @self._client.event
+            async def on_thread_create(thread):
+                """Cache starter_message_id -> thread_id so on_message
+                can detect the race where a thread-starting message
+                arrives on the parent channel before the thread exists
+                in discord.py's cache."""
+                starter = getattr(thread, "starter_message", None)
+                if starter:
+                    key = str(starter.id)
+                    self._recent_thread_starts[key] = str(thread.id)
+                    logger.info(
+                        "discord thread_create: thread=%s "
+                        "starter_msg=%s parent=%s",
+                        thread.id,
+                        starter.id,
+                        thread.parent_id,
+                    )
+                    # Evict after 30s
+                    await asyncio.sleep(30)
+                    self._recent_thread_starts.pop(key, None)
 
     @classmethod
     def from_env(

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -230,9 +230,18 @@ class DiscordChannel(BaseChannel):
                             )
 
                 is_group = message.guild is not None
+                _is_thread = isinstance(message.channel, discord.Thread)
+                _thread_started = (
+                    not _is_thread
+                    and getattr(message, "thread", None) is not None
+                )
                 meta = {
                     "user_id": str(message.author.id),
-                    "channel_id": str(message.channel.id),
+                    "channel_id": str(
+                        message.thread.id
+                        if _thread_started
+                        else message.channel.id
+                    ),
                     "guild_id": (
                         str(message.guild.id) if message.guild else None
                     ),
@@ -240,6 +249,18 @@ class DiscordChannel(BaseChannel):
                     "is_dm": not is_group,
                     "is_group": is_group,
                 }
+                if _is_thread:
+                    meta["is_thread"] = True
+                    meta["thread_id"] = str(message.channel.id)
+                    meta["parent_channel_id"] = (
+                        str(message.channel.parent_id)
+                        if message.channel.parent_id
+                        else None
+                    )
+                elif _thread_started:
+                    meta["is_thread"] = True
+                    meta["thread_id"] = str(message.thread.id)
+                    meta["parent_channel_id"] = str(message.channel.id)
                 if is_bot_mentioned:
                     meta["bot_mentioned"] = True
 

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -240,7 +240,7 @@ class DiscordChannel(BaseChannel):
                     "channel_id": str(
                         message.thread.id
                         if _thread_started
-                        else message.channel.id
+                        else message.channel.id,
                     ),
                     "guild_id": (
                         str(message.guild.id) if message.guild else None


### PR DESCRIPTION
## Problem

Closes #2980.

The Discord channel has no thread awareness. This causes two problems:

### 1. Messages inside threads route to parent channel

`on_message` never checks `isinstance(message.channel, discord.Thread)`, so messages sent inside threads get routed to the parent channel session instead of the thread session.

### 2. Thread creation race condition

When a user creates a thread and sends the first message simultaneously, `MESSAGE_CREATE` may arrive before `THREAD_CREATE` completes in discord.py's cache. The starter message gets routed to the parent channel.

## Fix

**Basic thread awareness** (commit 1):
- Detect `isinstance(message.channel, discord.Thread)` → route to thread session
- Detect `message.thread` (thread created from this message) → route to thread session  
- Add `is_thread`, `thread_id`, `parent_channel_id` to meta dict, consistent with Telegram's `message_thread_id` pattern

**Race condition handling** (commit 3):
- `on_thread_create` handler caches `starter_message_id -> thread_id`
- `on_message` checks `message.flags.has_thread` + cache lookup to detect the race
- Unified `_effective_channel_id` routing for all thread scenarios

No changes to the send path — Discord threads have their own channel IDs and `_resolve_target` already resolves them via `get_channel` / `fetch_channel`.

## Testing

- Send a message inside an existing thread → bot replies in the thread (not parent channel)
- Create a thread and send first message simultaneously → bot replies in the thread
- Messages in non-thread channels → no change in behavior