### PR TITLE
feat(plugins): support pluggable memory manager backends

### DIFF
--- a/src/copaw/app/workspace/workspace.py
+++ b/src/copaw/app/workspace/workspace.py
@@ -36,12 +36,38 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_memory_class(backend: str) -> type:
-    """Return the memory manager class for the given backend name."""
+    """Return the memory manager class for the given backend name.
+
+    Resolution order:
+    1. Built-in backends (remelight)
+    2. Plugin-registered backends (e.g. memos via MemOS plugin)
+    """
     from ...agents.memory import ReMeLightMemoryManager
 
     if backend == "remelight":
         return ReMeLightMemoryManager
-    raise ValueError(f"Unsupported memory manager backend: '{backend}'")
+
+    # Check plugin registry for externally registered backends
+    try:
+        from ...plugins.registry import PluginRegistry
+
+        registry = PluginRegistry()
+        cls = registry.get_memory_manager_class(backend)
+        if cls is not None:
+            logger.info(
+                "Using plugin-registered memory backend: '%s'",
+                backend,
+            )
+            return cls
+    except Exception as e:
+        logger.debug("Plugin registry lookup failed: %s", e)
+
+    raise ValueError(
+        f"Unsupported memory manager backend: '{backend}'. "
+        f"Built-in: 'remelight'. "
+        f"Install a plugin to add more backends "
+        f"(e.g. memos-copaw-plugin for 'memos')."
+    )
 
 
 class Workspace:

--- a/src/copaw/app/workspace/workspace.py
+++ b/src/copaw/app/workspace/workspace.py
@@ -66,7 +66,7 @@ def _resolve_memory_class(backend: str) -> type:
         f"Unsupported memory manager backend: '{backend}'. "
         f"Built-in: 'remelight'. "
         f"Install a plugin to add more backends "
-        f"(e.g. memos-copaw-plugin for 'memos')."
+        f"(e.g. memos-copaw-plugin for 'memos').",
     )
 
 

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -438,6 +438,67 @@ class MemorySummaryConfig(BaseModel):
     )
 
 
+class MemOSConfig(BaseModel):
+    """MemOS Cloud memory backend configuration.
+
+    Used when ``memory_manager_backend`` is set to ``"memos"``.
+    All fields can also be set via environment variables prefixed
+    with ``MEMOS_`` (e.g. ``MEMOS_API_KEY``, ``MEMOS_BASE_URL``).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    base_url: str = Field(
+        default="https://memos.memtensor.cn/api/openmem/v1",
+        description="MemOS Cloud API base URL",
+    )
+    api_key: str = Field(
+        default="",
+        description="MemOS API key (Token auth)",
+    )
+    user_id: str = Field(
+        default="copaw-user",
+        description="MemOS user identifier",
+    )
+    memory_limit_number: int = Field(
+        default=9,
+        ge=1,
+        description="Max memory items to retrieve per search",
+    )
+    include_preference: bool = Field(
+        default=True,
+        description="Include user preferences in recall",
+    )
+    preference_limit_number: int = Field(
+        default=6,
+        ge=0,
+        description="Max preference items to retrieve",
+    )
+    relativity: float = Field(
+        default=0.45,
+        ge=0.0,
+        le=1.0,
+        description="Min relativity score for recalled items",
+    )
+    timeout: float = Field(
+        default=8.0,
+        gt=0.0,
+        description="HTTP timeout in seconds for MemOS API calls",
+    )
+    conversation_id: str = Field(
+        default="",
+        description="Override conversation_id for memory scoping",
+    )
+    knowledgebase_ids: list = Field(
+        default_factory=list,
+        description="Limit search to specific knowledge bases",
+    )
+    async_mode: bool = Field(
+        default=True,
+        description="Non-blocking memory storage",
+    )
+
+
 class AgentsRunningConfig(BaseModel):
     """Agent runtime behavior configuration."""
 
@@ -567,11 +628,19 @@ class AgentsRunningConfig(BaseModel):
         description="Embedding model configuration",
     )
 
-    memory_manager_backend: Literal["remelight"] = Field(
+    memory_manager_backend: str = Field(
         default="remelight",
         description=(
-            "Memory manager backend type. "
-            "Currently only 'remelight' is supported."
+            "Memory manager backend type. Built-in: 'remelight'. "
+            "Plugins can register additional backends (e.g. 'memos')."
+        ),
+    )
+
+    memos_config: MemOSConfig = Field(
+        default_factory=MemOSConfig,
+        description=(
+            "MemOS Cloud memory configuration. "
+            "Used when memory_manager_backend is 'memos'."
         ),
     )
 

--- a/src/copaw/plugins/api.py
+++ b/src/copaw/plugins/api.py
@@ -173,6 +173,37 @@ class PluginApi:
                 f"'{handler.command_name}' (priority={priority_level})",
             )
 
+    def register_memory_manager(
+        self,
+        backend_id: str,
+        manager_class: Type,
+    ):
+        """Register a custom memory manager backend.
+
+        Once registered, users can activate the backend by setting
+        ``memory_manager_backend`` in agent config to *backend_id*.
+
+        Args:
+            backend_id: Unique backend name (e.g. "memos")
+            manager_class: Class that extends BaseMemoryManager
+
+        Example:
+            >>> api.register_memory_manager(
+            ...     backend_id="memos",
+            ...     manager_class=MemOSMemoryManager,
+            ... )
+        """
+        if self._registry:
+            self._registry.register_memory_manager(
+                plugin_id=self.plugin_id,
+                backend_id=backend_id,
+                manager_class=manager_class,
+            )
+            logger.info(
+                f"Plugin '{self.plugin_id}' registered memory manager "
+                f"backend '{backend_id}'",
+            )
+
     @property
     def runtime(self):
         """Access runtime helper functions.

--- a/src/copaw/plugins/registry.py
+++ b/src/copaw/plugins/registry.py
@@ -66,6 +66,7 @@ class PluginRegistry:
         self._startup_hooks: List[HookRegistration] = []
         self._shutdown_hooks: List[HookRegistration] = []
         self._control_commands: List[ControlCommandRegistration] = []
+        self._memory_managers: Dict[str, Type] = {}
         self._runtime_helpers = None
 
         self._initialized = True
@@ -251,3 +252,43 @@ class PluginRegistry:
             List of ControlCommandRegistration
         """
         return self._control_commands.copy()
+
+    def register_memory_manager(
+        self,
+        plugin_id: str,
+        backend_id: str,
+        manager_class: Type,
+    ):
+        """Register a memory manager backend.
+
+        Args:
+            plugin_id: Plugin identifier
+            backend_id: Backend name (e.g. "memos")
+            manager_class: Class extending BaseMemoryManager
+
+        Raises:
+            ValueError: If backend_id already registered
+        """
+        if backend_id in self._memory_managers:
+            raise ValueError(
+                f"Memory manager backend '{backend_id}' already registered",
+            )
+        self._memory_managers[backend_id] = manager_class
+        logger.info(
+            f"Registered memory manager '{backend_id}' "
+            f"from plugin '{plugin_id}'",
+        )
+
+    def get_memory_manager_class(
+        self,
+        backend_id: str,
+    ) -> Optional[Type]:
+        """Get memory manager class for a backend.
+
+        Args:
+            backend_id: Backend identifier
+
+        Returns:
+            Memory manager class or None if not found
+        """
+        return self._memory_managers.get(backend_id)


### PR DESCRIPTION
## 背景

MemOS（MemTensor/MemOS#1440）希望作为 CoPaw 的可选 memory backend 接入。CoPaw 目前的 `_resolve_memory_class` 只硬编码了 `remelight`，没法通过插件添加新的 memory backend。

这个 PR 做了一个小改动：让 memory backend 可以通过插件系统注册，而不是只能硬编码。

## 改了什么

4 个文件，+172 行：

**`plugins/api.py`** — 新增 `register_memory_manager(backend_id, manager_class)` 方法，和现有的 `register_provider` 模式一致。

**`plugins/registry.py`** — 新增 `_memory_managers` 字典 + 对应的注册/查询方法。

**`app/workspace/workspace.py`** — `_resolve_memory_class` 在内置 backend 匹配不到时，去 plugin registry 里找。找不到给出明确的错误提示。

**`config/config.py`** — `memory_manager_backend` 从 `Literal["remelight"]` 改为 `str`（插件可以注册任意名称）。新增 `MemOSConfig` 数据类和 `memos_config` 字段（MemOS 插件读取配置用）。

## 不影响现有行为

- `memory_manager_backend` 默认值还是 `"remelight"`，不装插件一切不变
- `_resolve_memory_class` 先查内置再查插件，内置优先级不变
- pre-commit 全部通过

## 关于 MemOSConfig 硬编码到 config 里

目前 `MemOSConfig` 直接写在 `config.py` 里了。如果后续有更多第三方 memory backend 接入，可能需要改成通用的 `Dict[str, Any]` 字段，让插件自己校验 schema。当前只有一个 MemOS 插件，先这么处理比较简单。如果你们觉得不合适可以讨论。

## 配套 PR

MemOS 侧的插件实现在 MemTensor/MemOS `feat/copaw-plugin` 分支。

## 本地验证

- pre-commit 通过
- 插件注册 → `_resolve_memory_class` 解析 → 实例化 MemOSMemoryManager：全链路验证通过
- 实际启动 CoPaw + 对话测试：记忆召回正常，上下文无污染

cc @xieyxclack @rayrayraykk 这个 PR 的改动不大，核心就是让 memory backend 可插拔。想确认一下这个方向是否合适，或者你们有更好的扩展方式。

Ref: MemTensor/MemOS#1440
