### PR TITLE
chore: add manual PyPI publish trigger to CI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,18 @@
 # Publish Python package to PyPI when a release is created.
 # Build includes console frontend (see scripts/wheel_build.sh).
-# Manual trigger: uploads whl to GitHub artifacts for download.
+# Manual trigger: can optionally force push to PyPI or just upload artifacts.
 # Release trigger: publishes to PyPI.
 
 name: Publish Python Package to PyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      force_push_to_pypi:
+        description: 'Force push to PyPI (even without release)'
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -49,16 +55,16 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload wheel to artifacts (manual trigger only)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload wheel to artifacts (manual trigger without force push)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: qwenpaw-wheel
           path: dist/*.whl
           retention-days: 30
 
-      - name: Publish package to PyPI (release trigger only)
-        if: github.event_name == 'release'
+      - name: Publish package to PyPI
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi == 'true')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
