### PR TITLE
feat(console): add autocomplete dropdown for model ID selection for model providers with model discovery support

### DIFF
--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -125,14 +125,21 @@ export const providerApi = {
       },
     ),
 
-  discoverModels: (providerId: string, body?: TestProviderRequest) =>
-    request<DiscoverModelsResponse>(
+  discoverModels: (
+    providerId: string,
+    body?: TestProviderRequest,
+    save: boolean = true,
+  ) => {
+    const url = new URL(
       `/models/${encodeURIComponent(providerId)}/discover`,
-      {
-        method: "POST",
-        body: body ? JSON.stringify(body) : undefined,
-      },
-    ),
+      window.location.origin,
+    );
+    url.searchParams.set("save", save.toString());
+    return request<DiscoverModelsResponse>(url.pathname + url.search, {
+      method: "POST",
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
 
   probeMultimodal: (providerId: string, modelId: string) =>
     request<ProbeMultimodalResponse>(

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Button, Form, Input, Modal, Tag } from "@agentscope-ai/design";
+import { AutoComplete } from "antd";
 import {
   DeleteOutlined,
   PlusOutlined,
@@ -164,6 +165,9 @@ export function RemoteModelManageModal({
   const [form] = Form.useForm();
   const isLocalProvider = provider.is_local ?? false;
   const canDiscover = isLocalProvider && provider.support_model_discovery;
+
+  const [discoveredModels, setDiscoveredModels] = useState<ModelInfo[]>([]);
+  const [loadingDiscoveredModels, setLoadingDiscoveredModels] = useState(false);
 
   // For custom providers ALL models are deletable.
   // For built-in providers only extra_models are deletable.
@@ -353,9 +357,26 @@ export function RemoteModelManageModal({
   };
 
   useEffect(() => {
-    // Do not auto-discover models when modal opens, as it may take some time and we don't want to block the UI.
-    // Instead, users can click the "Discover Models" button to trigger discovery when needed.
-  }, [open, canDiscover, provider.id, provider.models.length]);
+    if (!adding || !provider.support_model_discovery) {
+      setDiscoveredModels([]);
+      return;
+    }
+
+    // Fetch available models without saving them.
+    // User should explicitly click "Discover Models" button to
+    // fetch and save remote models.
+    setLoadingDiscoveredModels(true);
+    api
+      .discoverModels(provider.id, undefined, false)
+      .then((result) => {
+        const sorted = result.models
+          .slice()
+          .sort((a, b) => a.id.localeCompare(b.id));
+        setDiscoveredModels(sorted);
+      })
+      .catch(() => setDiscoveredModels([]))
+      .finally(() => setLoadingDiscoveredModels(false));
+  }, [adding, provider.id, provider.support_model_discovery]);
 
   const all_models = [
     ...(provider.models ?? []),
@@ -585,7 +606,32 @@ export function RemoteModelManageModal({
               rules={[{ required: true, message: t("models.modelIdLabel") }]}
               style={{ marginBottom: 12 }}
             >
-              <Input placeholder={t("models.modelIdPlaceholder")} />
+              {provider.support_model_discovery ? (
+                <AutoComplete
+                  placeholder={t("models.modelIdPlaceholder")}
+                  options={discoveredModels.map((model) => ({
+                    value: model.id,
+                    label: model.id,
+                  }))}
+                  filterOption={(
+                    inputValue: string,
+                    option?: { value?: string },
+                  ) =>
+                    option?.value
+                      ?.toLowerCase()
+                      .includes(inputValue.toLowerCase()) ?? false
+                  }
+                  notFoundContent={
+                    loadingDiscoveredModels
+                      ? t("common.loading")
+                      : t("models.noModels")
+                  }
+                >
+                  <Input />
+                </AutoComplete>
+              ) : (
+                <Input placeholder={t("models.modelIdPlaceholder")} />
+              )}
             </Form.Item>
             <Form.Item
               name="name"

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -129,8 +129,7 @@ def _validate_model_slot(
         raise HTTPException(
             status_code=400,
             detail=(
-                f"Model '{model_id}' not found in provider "
-                f"'{provider_id}'."
+                f"Model '{model_id}' not found in provider '{provider_id}'."
             ),
         )
 
@@ -313,6 +312,10 @@ async def discover_models(
     manager: ProviderManager = Depends(get_provider_manager),
     provider_id: str = Path(...),
     body: Optional[DiscoverModelsRequest] = Body(default=None),
+    save: bool = Query(
+        default=True,
+        description="Save discovered models to provider",
+    ),
 ) -> DiscoverModelsResponse:
     try:
         ok = manager.update_provider(
@@ -330,6 +333,7 @@ async def discover_models(
         try:
             result = await manager.fetch_provider_models(
                 provider_id,
+                save=save,
             )
             success = True
         except Exception:

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -847,19 +847,30 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
     async def fetch_provider_models(
         self,
         provider_id: str,
+        save: bool = True,
     ) -> List[ModelInfo]:
-        """Fetch the list of available models from a provider and update."""
+        """Fetch the list of available models from a provider.
+
+        Args:
+            provider_id: The ID of the provider to fetch models from.
+            save: If True, save the discovered models to the provider
+                configuration. Defaults to True.
+
+        Returns:
+            List of ModelInfo objects representing available models.
+        """
         provider_id = self._normalize_provider_id(provider_id)
         provider = self.get_provider(provider_id)
         if not provider:
             return []
         try:
             models = await provider.fetch_models()
-            provider.extra_models = models
-            self._save_provider(
-                provider,
-                is_builtin=provider_id in self.builtin_providers,
-            )
+            if save:
+                provider.extra_models = models
+                self._save_provider(
+                    provider,
+                    is_builtin=provider_id in self.builtin_providers,
+                )
             return models
         except Exception as e:
             logger.warning(


### PR DESCRIPTION

## Description

When adding models to model providers that support model discovery, replace the plain text input with an AutoComplete dropdown.
Changes:
- **Backend** : Add args `save` to POST `/models/{provider_id}/available-models` endpoint to allow fetch model list  without auto-saving all the model list to provider configs
- **Frontend** :
  - Display models in alphabetically sorted dropdown (by model ID)
  - Support both selection from list and free-text input for custom model IDs
  - Remove unnecessary useCallback for code simplification
  Users can now see and select from available models instead of manually typing IDs, while still retaining the ability to enter custom model IDs not in the provider's list.

- **Search model ids in dropdown**
<img width="1654" height="914" alt="image" src="https://github.com/user-attachments/assets/00cbab61-b255-4063-b484-1f7c20802ec8" />

- **(Unchanged) Discover Model button remains disabled for cloud providers**
<img width="1033" height="475" alt="image" src="https://github.com/user-attachments/assets/6363bbe1-6037-4d1e-bc28-6fac8ecb2f02" />

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
