### PR TITLE
perf(QQ): fix QQ channel stop() blocking for 8s by force-closing WebSocket

### DIFF
--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1495,7 +1495,8 @@ class QQChannel(BaseChannel):
         except websocket.WebSocketConnectionClosedException:
             pass
         except OSError:
-            pass
+            if not self._stop_event.is_set():
+                raise
         except Exception as e:
             logger.exception("qq ws loop: %s", e)
         finally:
@@ -1568,9 +1569,10 @@ class QQChannel(BaseChannel):
         if not self.enabled:
             return
         self._stop_event.set()
-        if self._ws is not None:
+        ws = self._ws
+        if ws is not None:
             try:
-                self._ws.close()
+                ws.close()
             except Exception:
                 pass
         if self._ws_thread:

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -664,6 +664,7 @@ class QQChannel(BaseChannel):
 
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._ws_thread: Optional[threading.Thread] = None
+        self._ws: Any = None
         self._stop_event = threading.Event()
         self._account_id = "default"
         self._token_cache: Optional[Dict[str, Any]] = None
@@ -1475,6 +1476,7 @@ class QQChannel(BaseChannel):
             logger.warning("qq ws connect failed: %s", e)
             return True
 
+        self._ws = ws
         hb = _HeartbeatController(ws, self._stop_event, state)
         try:
             while not self._stop_event.is_set():
@@ -1492,9 +1494,12 @@ class QQChannel(BaseChannel):
                     break
         except websocket.WebSocketConnectionClosedException:
             pass
+        except OSError:
+            pass
         except Exception as e:
             logger.exception("qq ws loop: %s", e)
         finally:
+            self._ws = None
             hb.stop()
             try:
                 ws.close()
@@ -1563,8 +1568,14 @@ class QQChannel(BaseChannel):
         if not self.enabled:
             return
         self._stop_event.set()
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            except Exception:
+                pass
         if self._ws_thread:
-            self._ws_thread.join(timeout=8)
+            self._ws_thread.join(timeout=2)
+            self._ws_thread = None
         if self._http is not None:
             await self._http.close()
             self._http = None


### PR DESCRIPTION
## Description

- Store the WebSocket connection as self._ws so stop() can force-close it, interrupting the blocking ws.recv() call immediately
- Reduce thread.join timeout from 8s to 2s since the thread now exits promptly
- Catch OSError (Bad file descriptor) which is expected when the socket is force-closed during recv()

**Related Issue:** Fixes #3136 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
