### PR TITLE
refactor(security): rename copaw references with compatibility fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ dist/
 src/copaw/console/dist/
 src/copaw/console/
 console/.cursor/
+src/qwenpaw/console/dist/
+src/qwenpaw/console/
 
 # frontend (website)
 website/node_modules/

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -478,13 +478,11 @@ class FileGuardUpdateBody(BaseModel):
 async def get_file_guard() -> FileGuardResponse:
     config = load_config()
     fg = config.security.file_guard
-    paths = fg.sensitive_files
-    if not paths:
-        from ...security.tool_guard.guardians.file_guardian import (
-            _DEFAULT_DENY_DIRS,
-        )
+    from ...security.tool_guard.guardians.file_guardian import (
+        ensure_file_guard_paths,
+    )
 
-        paths = list(_DEFAULT_DENY_DIRS)
+    paths = ensure_file_guard_paths(fg.sensitive_files or [])
     return FileGuardResponse(enabled=fg.enabled, paths=paths)
 
 
@@ -502,7 +500,11 @@ async def put_file_guard(
     if body.enabled is not None:
         fg.enabled = body.enabled
     if body.paths is not None:
-        fg.sensitive_files = body.paths
+        from ...security.tool_guard.guardians.file_guardian import (
+            ensure_file_guard_paths,
+        )
+
+        fg.sensitive_files = ensure_file_guard_paths(body.paths)
 
     save_config(config)
 

--- a/src/qwenpaw/security/__init__.py
+++ b/src/qwenpaw/security/__init__.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-Security framework for CoPaw.
+Security framework for QwenPaw.
 
 This package centralises all security-related mechanisms:
 
-* **Tool-call guarding** (``copaw.security.tool_guard``)
+* **Tool-call guarding** (``qwenpaw.security.tool_guard``)
   Pre-execution parameter scanning to detect dangerous tool usage
   patterns (command injection, data exfiltration, etc.).
-* **Skill scanning** (``copaw.security.skill_scanner``)
+* **Skill scanning** (``qwenpaw.security.skill_scanner``)
   Static analysis of skill directories before install / activation.
-* **Secret storage** (``copaw.security.secret_store``)
+* **Secret storage** (``qwenpaw.security.secret_store``)
   Transparent encryption layer for sensitive fields (API keys, tokens)
   stored on disk.  Uses Fernet (AES-128-CBC + HMAC-SHA256) with a
   master key backed by the OS keychain or a fallback file.

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -26,7 +26,8 @@ from ..constant import EnvVarLoader
 logger = logging.getLogger(__name__)
 
 _ENC_PREFIX = "ENC:"
-_KEYRING_SERVICE = "copaw"
+_KEYRING_SERVICE = "qwenpaw"
+_KEYRING_SERVICE_LEGACY = "copaw"
 _KEYRING_ACCOUNT = "master_key"
 
 
@@ -78,7 +79,14 @@ def _try_keyring_get() -> Optional[str]:
         import keyring
 
         value = keyring.get_password(_KEYRING_SERVICE, _KEYRING_ACCOUNT)
-        return value
+        if value:
+            return value
+
+        # Backward compatibility: read legacy CoPaw keyring entry.
+        return keyring.get_password(
+            _KEYRING_SERVICE_LEGACY,
+            _KEYRING_ACCOUNT,
+        )
     except Exception:
         return None
 

--- a/src/qwenpaw/security/skill_scanner/__init__.py
+++ b/src/qwenpaw/security/skill_scanner/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Skill security scanner for CoPaw.
+Skill security scanner for QwenPaw.
 
 Scans skills for security threats before they are activated or installed.
 
@@ -182,7 +182,11 @@ def _get_blocked_history_path() -> Path:
 
         return WORKING_DIR / _BLOCKED_HISTORY_FILE
     except Exception:
-        return Path.home() / ".copaw" / _BLOCKED_HISTORY_FILE
+        legacy_dir = Path.home() / ".copaw"
+        base_dir = (
+            legacy_dir if legacy_dir.exists() else Path.home() / ".qwenpaw"
+        )
+        return base_dir / _BLOCKED_HISTORY_FILE
 
 
 @dataclass

--- a/src/qwenpaw/security/skill_scanner/data/default_policy.yaml
+++ b/src/qwenpaw/security/skill_scanner/data/default_policy.yaml
@@ -1,4 +1,4 @@
-# CoPaw Skill Scanner – Default Scan Policy
+# QwenPaw Skill Scanner – Default Scan Policy
 # ============================================
 # This file defines the built-in security policy.  Every setting here can be
 # overridden in an organisation-specific policy file passed via --policy.

--- a/src/qwenpaw/security/skill_scanner/scan_policy.py
+++ b/src/qwenpaw/security/skill_scanner/scan_policy.py
@@ -284,7 +284,7 @@ class ScanPolicy:
         """Dump the full policy to a YAML file for editing."""
         data = self._to_dict()
         with open(path, "w", encoding="utf-8") as fh:
-            fh.write("# CoPaw Skill Scanner – Scan Policy\n")
+            fh.write("# QwenPaw Skill Scanner – Scan Policy\n")
             fh.write(
                 "# Customise this file to match your"
                 " organisation's security bar.\n",

--- a/src/qwenpaw/security/tool_guard/__init__.py
+++ b/src/qwenpaw/security/tool_guard/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Pre-tool-call guard framework for CoPaw.
+Pre-tool-call guard framework for QwenPaw.
 
 Scans tool execution parameters **before** the agent invokes a tool,
 looking for dangerous patterns such as command injection, data

--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -27,7 +27,27 @@ _TOOL_FILE_PARAMS: dict[str, tuple[str, ...]] = {
     "write_text_file": ("file_path", "path"),
 }
 
-_DEFAULT_DENY_DIRS: list[str] = [str(SECRET_DIR) + "/"]
+_COMPAT_SECRET_DIRS: tuple[str, ...] = (
+    str(SECRET_DIR) + "/",
+    str(Path.home() / ".copaw.secret") + "/",
+    str(Path.home() / ".qwenpaw.secret") + "/",
+)
+
+
+def ensure_file_guard_paths(paths: Iterable[str]) -> list[str]:
+    """Return *paths* plus compatibility secret dirs, de-duplicated."""
+    merged = [p for p in paths if p]
+    merged.extend(_COMPAT_SECRET_DIRS)
+    # Keep order stable while removing duplicates.
+    return list(dict.fromkeys(merged))
+
+
+def _default_deny_dirs() -> list[str]:
+    """Default sensitive dirs with legacy/current compatibility."""
+    return ensure_file_guard_paths([])
+
+
+_DEFAULT_DENY_DIRS: list[str] = _default_deny_dirs()
 
 _SHELL_REDIRECT_OPERATORS = frozenset(
     {">", ">>", "1>", "1>>", "2>", "2>>", "&>", "&>>", "<", "<<", "<<<"},
@@ -74,7 +94,7 @@ def _load_sensitive_files_from_config() -> list[str]:
         configured = list(
             load_config().security.file_guard.sensitive_files or [],
         )
-        return configured if configured else list(_DEFAULT_DENY_DIRS)
+        return ensure_file_guard_paths(configured)
     except Exception:
         return list(_DEFAULT_DENY_DIRS)
 


### PR DESCRIPTION
## Description

This PR completes the security-scope rename from `copaw` to `qwenpaw` and adds backward-compatible fallback behavior to avoid breaking existing user environments.

Main updates:
- Rename security module references/docs from `copaw` to `qwenpaw`.
- Update secret store keyring service to `qwenpaw` **with legacy keyring read fallback** from `copaw`.
- Keep skill scanner blocked-history fallback path compatible:
  - prefer legacy `~/.copaw` when it exists
  - otherwise use `~/.qwenpaw`.
- Improve File Guard compatibility by auto-including both legacy and new secret dirs:
  - `~/.copaw.secret/`
  - `~/.qwenpaw.secret/`
- Backend config API now auto-backfills File Guard sensitive paths on both GET/PUT, so frontend reflects compatible paths without manual config edits.

**Related Issue:** Relates to #<issue_number>

**Security Considerations:**  
Yes. This PR touches security path/key handling:
- preserves legacy encrypted-secret key access (keyring fallback)
- ensures both legacy/new secret directories remain protected by File Guard
- avoids accidental weakening during rename migration

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Suggested validation steps:

1. **Secret store compatibility**
   - Prepare an environment with legacy keyring entry under service `copaw`.
   - Start app and verify secrets can still decrypt after rename.
   - Confirm new writes go to `qwenpaw` service.

2. **Skill scanner path fallback**
   - Simulate constant import failure path and verify:
     - if `~/.copaw` exists, blocked history uses it
     - otherwise falls back to `~/.qwenpaw`.

3. **File Guard auto-backfill behavior**
   - Set `security.file_guard.sensitive_files` to only `~/.copaw.secret/`.
   - Call `GET /config/security/file-guard` and verify response contains both legacy/new secret dirs.
   - Call `PUT /config/security/file-guard` and verify saved config is auto-augmented with compatibility dirs.
   - Verify guarded access is blocked for both secret directories.
