### PR TITLE
refactor(tools): rename CoPaw to QwenPaw in tools module

### DIFF
--- a/src/qwenpaw/agents/tool_guard_mixin.py
+++ b/src/qwenpaw/agents/tool_guard_mixin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tool-guard mixin for CoPawAgent.
+"""Tool-guard mixin for QwenPawAgent.
 
 Provides ``_acting`` and ``_reasoning`` overrides that intercept
 sensitive tool calls before execution, implementing the deny /

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -267,7 +267,7 @@ def _ensure_playwright_async():
         return async_playwright
     except ImportError as exc:
         raise ImportError(
-            "Playwright not installed. Use the same Python that runs CoPaw (e.g. "
+            "Playwright not installed. Use the same Python that runs QwenPaw (e.g. "
             "activate your venv or use 'uv run'): "
             f"'{sys.executable}' -m pip install playwright && "
             f"'{sys.executable}' -m playwright install",
@@ -282,7 +282,7 @@ def _ensure_playwright_sync():
         return sync_playwright
     except ImportError as exc:
         raise ImportError(
-            "Playwright not installed. Use the same Python that runs CoPaw (e.g. "
+            "Playwright not installed. Use the same Python that runs QwenPaw (e.g. "
             "activate your venv or use 'uv run'): "
             f"'{sys.executable}' -m pip install playwright && "
             f"'{sys.executable}' -m playwright install",

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -209,8 +209,8 @@ def _execute_subprocess_sync(
         cmd = _sanitize_win_cmd(cmd)
         wrapped = f'cmd /D /S /C "{cmd}"'
 
-        stdout_fd, stdout_path = tempfile.mkstemp(prefix="copaw_out_")
-        stderr_fd, stderr_path = tempfile.mkstemp(prefix="copaw_err_")
+        stdout_fd, stdout_path = tempfile.mkstemp(prefix="qwenpaw_out_")
+        stderr_fd, stderr_path = tempfile.mkstemp(prefix="qwenpaw_err_")
         stdout_file = os.fdopen(stdout_fd, "wb")
         stderr_file = os.fdopen(stderr_fd, "wb")
 

--- a/src/qwenpaw/security/tool_guard/__init__.py
+++ b/src/qwenpaw/security/tool_guard/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Pre-tool-call guard framework for CoPaw.
+Pre-tool-call guard framework for QwenPaw.
 
 Scans tool execution parameters **before** the agent invokes a tool,
 looking for dangerous patterns such as command injection, data


### PR DESCRIPTION
## Description

Replace residual `CoPaw` references with `QwenPaw` in the tools module as part of the project-wide rename.

**Related Issue:** Relates to the ongoing CoPaw → QwenPaw rename refactoring.

## Type of Change

- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Changes

- `agents/tools/shell.py`: rename temp file prefixes `copaw_out_` / `copaw_err_` to `qwenpaw_out_` / `qwenpaw_err_`
- `agents/tools/browser_control.py`: update Playwright error message strings
- `agents/tool_guard_mixin.py`: update module docstring (`CoPawAgent` to `QwenPawAgent`)
- `security/tool_guard/__init__.py`: update module docstring

## Checklist

- [x] I ran local checks relevant to changed files and they pass
- [x] I ran tests locally (`pytest`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Local Verification Evidence

```
pre-commit hooks on changed files:
check-ast, check-docstring-first, fix-encoding-pragma,
detect-private-key, trailing-whitespace, add-trailing-comma,
flake8, pylint
=> Passed

black --line-length=79 --check (changed files)
=> 4 files would be left unchanged

pytest tests/unit/agents/tools/ -v
=> 33 passed in 7.00s
```

