### PR TITLE
feat(Feishu): add quoted message handling for Feishu channel

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -114,6 +114,7 @@ try:
         CreateMessageReactionRequest,
         CreateMessageReactionRequestBody,
         Emoji,
+        GetMessageRequest,
         GetMessageResourceRequest,
         P2ImMessageReceiveV1,
     )
@@ -129,6 +130,7 @@ except ImportError:  # pragma: no cover - optional dependency may be missing
     CreateMessageReactionRequest = None  # type: ignore[assignment]
     CreateMessageReactionRequestBody = None  # type: ignore[assignment]
     Emoji = None  # type: ignore[assignment]
+    GetMessageRequest = None  # type: ignore[assignment]
     GetMessageResourceRequest = None  # type: ignore[assignment]
     P2ImMessageReceiveV1 = None  # type: ignore[assignment]
 finally:
@@ -805,6 +807,24 @@ class FeishuChannel(BaseChannel):
             else:
                 text_parts.append(f"[{msg_type}]")
 
+            # Handle quoted (replied-to) message if present.
+            # Feishu provides two IDs for reply chains:
+            #   - parent_id: the message this one directly replies to
+            #   - root_id:   the root of the entire reply tree
+            # We use parent_id because the user's intent is to reference
+            # the message they directly replied to, not the root of the
+            # thread.  Both IDs are identical when replying to the root
+            # message.  The logic is the same for group and p2p chats.
+            parent_id = str(
+                getattr(message, "parent_id", "") or "",
+            ).strip()
+            if parent_id:
+                await self._process_quoted_message(
+                    parent_id,
+                    text_parts,
+                    content_parts,
+                )
+
             text = "\n".join(text_parts).strip() if text_parts else ""
             if text:
                 content_parts.insert(
@@ -984,6 +1004,195 @@ class FeishuChannel(BaseChannel):
         except Exception:
             logger.exception("feishu _download_file_resource failed")
             return None
+
+    async def _fetch_quoted_message_content(
+        self,
+        parent_id: str,
+    ) -> Optional[Tuple[str, str]]:
+        """Fetch the quoted (replied-to) message via Get Message API.
+
+        Args:
+            parent_id: The message_id of the parent (quoted) message.
+
+        Returns:
+            A tuple of (msg_type, content_json) on success, or None on
+            failure.  ``content_json`` is the raw JSON string from the
+            message body (same format as ``message.content`` in events).
+        """
+        if not self._client or not parent_id:
+            return None
+        try:
+            req = GetMessageRequest.builder().message_id(parent_id).build()
+            resp = await self._client.im.v1.message.aget(req)
+            if not resp.success():
+                logger.info(
+                    "feishu fetch quoted message failed: "
+                    "parent_id=%s code=%s msg=%s",
+                    parent_id[:20],
+                    getattr(resp, "code", ""),
+                    getattr(resp, "msg", ""),
+                )
+                return None
+            items = (resp.data.items or []) if resp.data else []
+            if not items:
+                logger.info(
+                    "feishu fetch quoted message: empty items parent_id=%s",
+                    parent_id[:20],
+                )
+                return None
+            quoted_msg = items[0]
+            msg_type = getattr(quoted_msg, "msg_type", "") or ""
+            body = getattr(quoted_msg, "body", None)
+            content = getattr(body, "content", "") or "" if body else ""
+            return (msg_type, content)
+        except Exception:
+            logger.exception(
+                "feishu _fetch_quoted_message_content failed parent_id=%s",
+                parent_id[:20] if parent_id else "",
+            )
+            return None
+
+    async def _process_quoted_message(
+        self,
+        parent_id: str,
+        text_parts: List[str],
+        content_parts: List[Any],
+    ) -> None:
+        """Fetch and process the quoted (replied-to) message.
+
+        Inserts quoted text at the beginning of ``text_parts`` and appends
+        quoted media to ``content_parts``, following the same pattern as
+        the WeCom channel.
+
+        Args:
+            parent_id: The message_id of the quoted message.
+            text_parts: Mutable list of text strings to prepend quoted text.
+            content_parts: Mutable list of content parts to append media.
+        """
+        result = await self._fetch_quoted_message_content(parent_id)
+        if not result:
+            return
+        quoted_msg_type, quoted_content = result
+        logger.info(
+            "feishu quoted message: parent_id=%s type=%s",
+            parent_id[:20],
+            quoted_msg_type,
+        )
+
+        if quoted_msg_type == "text":
+            quoted_text = extract_json_key(quoted_content, "text")
+            if quoted_text:
+                text_parts.insert(0, f"[quoted message: {quoted_text}]")
+
+        elif quoted_msg_type == "post":
+            quoted_text = extract_post_text(quoted_content)
+            if quoted_text:
+                text_parts.insert(0, f"[quoted message: {quoted_text}]")
+            for img_key in extract_post_image_keys(quoted_content):
+                url_or_path = await self._download_image_resource(
+                    parent_id,
+                    img_key,
+                )
+                if url_or_path:
+                    content_parts.append(
+                        ImageContent(
+                            type=ContentType.IMAGE,
+                            image_url=url_or_path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted image: download failed]")
+            for file_key in extract_post_media_file_keys(quoted_content):
+                url_or_path = await self._download_file_resource(
+                    parent_id,
+                    file_key,
+                )
+                if url_or_path:
+                    content_parts.append(
+                        FileContent(
+                            type=ContentType.FILE,
+                            file_url=url_or_path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted media: download failed]")
+
+        elif quoted_msg_type == "image":
+            image_key = extract_json_key(
+                quoted_content,
+                "image_key",
+                "file_key",
+                "imageKey",
+                "fileKey",
+            )
+            if image_key:
+                url_or_path = await self._download_image_resource(
+                    parent_id,
+                    image_key,
+                )
+                if url_or_path:
+                    content_parts.append(
+                        ImageContent(
+                            type=ContentType.IMAGE,
+                            image_url=url_or_path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted image: download failed]")
+            else:
+                text_parts.insert(0, "[quoted image: missing key]")
+
+        elif quoted_msg_type in ("file", "media", "audio"):
+            file_key = extract_json_key(
+                quoted_content,
+                "file_key",
+                "fileKey",
+            )
+            file_name = extract_json_key(
+                quoted_content,
+                "file_name",
+                "fileName",
+            )
+            hint_map = {
+                "file": "file.bin",
+                "media": "video.mp4",
+                "audio": "audio.opus",
+            }
+            hint = file_name or hint_map.get(quoted_msg_type, "file.bin")
+            if file_key:
+                url_or_path = await self._download_file_resource(
+                    parent_id,
+                    file_key,
+                    filename_hint=hint,
+                )
+                if url_or_path:
+                    if quoted_msg_type == "audio":
+                        content_parts.append(
+                            AudioContent(
+                                type=ContentType.AUDIO,
+                                data=url_or_path,
+                            ),
+                        )
+                    else:
+                        content_parts.append(
+                            FileContent(
+                                type=ContentType.FILE,
+                                file_url=url_or_path,
+                            ),
+                        )
+                else:
+                    text_parts.insert(
+                        0,
+                        f"[quoted {quoted_msg_type}: download failed]",
+                    )
+            else:
+                text_parts.insert(
+                    0,
+                    f"[quoted {quoted_msg_type}: missing key]",
+                )
+
+        else:
+            text_parts.insert(0, f"[quoted {quoted_msg_type} message]")
 
     def _receive_id_store_path(self) -> Path:
         """


### PR DESCRIPTION
## Description

Add support for processing quoted (replied-to) messages in the Feishu channel, similar to the existing WeCom implementation.

### Changes:

- Import GetMessageRequest from lark-oapi SDK
- Add _fetch_quoted_message_content() to retrieve quoted message content via the Get Message API (im.v1.message.aget)
- Add _process_quoted_message() to handle quoted messages by type (text, post, image, file, media, audio), downloading media resources and prepending quoted text
- Integrate quote processing in _on_message() by checking message.parent_id after parsing the incoming message content

**Related Issue:** Fixes #2852 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
