### PR TITLE
refactor(security):use legency variable

### DIFF
--- a/src/qwenpaw/security/skill_scanner/__init__.py
+++ b/src/qwenpaw/security/skill_scanner/__init__.py
@@ -173,6 +173,8 @@ def is_skill_whitelisted(
 # ---------------------------------------------------------------------------
 
 _BLOCKED_HISTORY_FILE = "skill_scanner_blocked.json"
+_WORKING_DIR_CURRENT_NAME = ".qwenpaw"
+_WORKING_DIR_LEGACY_NAME = ".copaw"
 _history_lock = threading.Lock()
 
 
@@ -182,9 +184,11 @@ def _get_blocked_history_path() -> Path:
 
         return WORKING_DIR / _BLOCKED_HISTORY_FILE
     except Exception:
-        legacy_dir = Path.home() / ".copaw"
+        legacy_dir = Path.home() / _WORKING_DIR_LEGACY_NAME
         base_dir = (
-            legacy_dir if legacy_dir.exists() else Path.home() / ".qwenpaw"
+            legacy_dir
+            if legacy_dir.exists()
+            else Path.home() / _WORKING_DIR_CURRENT_NAME
         )
         return base_dir / _BLOCKED_HISTORY_FILE
 

--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -27,10 +27,13 @@ _TOOL_FILE_PARAMS: dict[str, tuple[str, ...]] = {
     "write_text_file": ("file_path", "path"),
 }
 
+_SECRET_DIR_CURRENT_NAME = ".qwenpaw.secret"
+_SECRET_DIR_LEGACY_NAME = ".copaw.secret"
+
 _COMPAT_SECRET_DIRS: tuple[str, ...] = (
     str(SECRET_DIR) + "/",
-    str(Path.home() / ".copaw.secret") + "/",
-    str(Path.home() / ".qwenpaw.secret") + "/",
+    str(Path.home() / _SECRET_DIR_LEGACY_NAME) + "/",
+    str(Path.home() / _SECRET_DIR_CURRENT_NAME) + "/",
 )
 
 


### PR DESCRIPTION
## Description

This PR refines security compatibility handling for the `copaw` → `qwenpaw` transition by introducing centralized compatibility constants and reusable path merge logic in Security modules.

What this PR does:
- Aligns compatibility handling style in `file_guardian` and `skill_scanner` with the global-variable mechanism used in `secret_store` (`current` + `legacy` constants).
- Replaces scattered hardcoded legacy/current path names with centralized constants to simplify future global renaming/migration.
- Keeps behavior backward-compatible while improving maintainability and consistency.

Why:
- Reduces risk of missing hardcoded strings during future migration work.
- Makes compatibility updates easier (single-point constant updates instead of multi-file search/replace).
- Improves readability and long-term maintainability of security path fallback logic.

**Related Issue:** Relates to #<issue_number>

**Security Considerations:**  
Yes. This PR touches security compatibility logic (legacy/current secret/workdir naming and path fallback behavior), but does not weaken protections. It improves consistency and migration safety.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Recommended verification:
1. Start with a config containing only legacy security paths (e.g. `~/.copaw.secret/`).
2. Verify File Guard still blocks both legacy and new secret paths after loading config.
3. Verify Skill Scanner blocked-history fallback still resolves correctly across legacy/new working dirs.
4. Verify behavior is unchanged compared with previous logic (only implementation structure changed).