### PR TITLE
chore: async read_file_safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 qwenpaw = "qwenpaw.cli.main:cli"
+copaw = "qwenpaw.cli.main:cli"
 
 [project.optional-dependencies]
 dev = [

--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -132,7 +132,7 @@ async def read_file(  # pylint: disable=too-many-return-statements
         )
 
     try:
-        content = read_file_safe(file_path)
+        content = await read_file_safe(file_path)
         all_lines = content.split("\n")
         total = len(all_lines)
 
@@ -304,7 +304,7 @@ async def edit_file(
         )
 
     try:
-        content = read_file_safe(resolved_path)
+        content = await read_file_safe(resolved_path)
     except Exception as e:
         return ToolResponse(
             content=[

--- a/src/qwenpaw/agents/tools/utils.py
+++ b/src/qwenpaw/agents/tools/utils.py
@@ -7,6 +7,8 @@ import re
 
 import logging
 
+import aiofiles
+
 from ...constant import TRUNCATION_NOTICE_MARKER
 
 logger = logging.getLogger(__name__)
@@ -204,7 +206,7 @@ def truncate_text_output(
         return text
 
 
-def read_file_safe(
+async def read_file_safe(
     file_path: str,
     max_bytes: int = MAX_FILE_READ_BYTES,
 ) -> str:
@@ -219,8 +221,17 @@ def read_file_safe(
     """
     # Use utf-8-sig to auto-remove BOM if present, compatible with plain utf-8
     try:
-        with open(file_path, "r", encoding="utf-8-sig") as f:
-            return f.read(max_bytes)
+        async with aiofiles.open(
+            file_path,
+            "r",
+            encoding="utf-8-sig",
+        ) as f:
+            return await f.read(max_bytes)
     except UnicodeDecodeError:
-        with open(file_path, "r", encoding="utf-8-sig", errors="ignore") as f:
-            return f.read(max_bytes)
+        async with aiofiles.open(
+            file_path,
+            "r",
+            encoding="utf-8-sig",
+            errors="ignore",
+        ) as f:
+            return await f.read(max_bytes)


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
