### PR TITLE
fix(qq): process media-only messages immediately instead of buffering indefinitely

### DIFF
--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1201,6 +1201,27 @@ class QQChannel(BaseChannel):
             )
         return None
 
+    def _apply_no_text_debounce(
+        self,
+        session_id: str,
+        content_parts: list[Any],
+    ) -> tuple[bool, list[Any]]:
+        """Process media-only QQ messages without waiting for text.
+
+        Same approach as TelegramChannel / OneBotChannel: if the message
+        contains any media (image, audio, video, file), process it
+        immediately instead of buffering until a text message arrives.
+        """
+        has_media = any(
+            getattr(part, "type", None)
+            not in (ContentType.TEXT, ContentType.REFUSAL)
+            for part in content_parts
+        )
+        if has_media:
+            pending = self._pending_content_by_session.pop(session_id, [])
+            return True, pending + list(content_parts)
+        return super()._apply_no_text_debounce(session_id, content_parts)
+
     def _parse_qq_attachments(
         self,
         attachments: List[Dict[str, Any]],


### PR DESCRIPTION
## Description

QQ channel buffers media-only messages (images, videos, files) indefinitely because `BaseChannel._apply_no_text_debounce` waits for a follow-up text message that never arrives. When a user sends a standalone image (e.g. a photo of handwritten code for OCR), the bot never processes it.

This override matches the existing behavior in `TelegramChannel` and `OneBotChannel`, which both already process media-only messages immediately.

**Related Issue:** Relates to #2968 (QQ media handling)

**Security Considerations:** N/A — no auth or config changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Send an image-only message via QQ C2C — bot processes immediately (previously buffered forever)
2. Send an image followed by text — both are merged and processed
3. Send text-only message — normal debounce behavior unchanged

## Local Verification Evidence

```bash
pre-commit run --all-files
# all passed (check python ast, black, flake8, pylint, mypy, etc.)
```

## Additional Notes

This fix complements my earlier PR #3012, which enhanced **outgoing** rich-media support (bot → user). This PR fills the remaining gap on the **incoming** side: users can now send media-only messages and have them processed immediately, instead of being buffered indefinitely.

The implementation is identical to the existing overrides in `TelegramChannel` ([telegram/channel.py](https://github.com/agentscope-ai/CoPaw/blob/main/src/copaw/app/channels/telegram/channel.py)) and `OneBotChannel` ([onebot/channel.py](https://github.com/agentscope-ai/CoPaw/blob/main/src/copaw/app/channels/onebot/channel.py)).

Note that `BaseChannel` already handles audio-only messages as a special case (voice messages are processed immediately). This override extends the same behavior to all media types (image, video, file) for the QQ channel.
