### PR TITLE
feat: enable automatic injection of the current timestamp into user prompts

### DIFF
--- a/console/src/api/index.ts
+++ b/console/src/api/index.ts
@@ -22,6 +22,7 @@ import { toolsApi } from "./modules/tools";
 import { securityApi } from "./modules/security";
 import { userTimezoneApi } from "./modules/userTimezone";
 import { languageApi } from "./modules/language";
+import { timeAwarenessApi } from "./modules/timeAwareness";
 
 export const api = {
   // Root
@@ -76,6 +77,9 @@ export const api = {
 
   // Language
   ...languageApi,
+
+  // Time Awareness
+  ...timeAwarenessApi,
 };
 
 export default api;

--- a/console/src/api/modules/timeAwareness.ts
+++ b/console/src/api/modules/timeAwareness.ts
@@ -1,0 +1,17 @@
+import { request } from "../request";
+
+export interface TimeAwarenessConfig {
+  enabled: boolean;
+  format: string | null;
+}
+
+export const timeAwarenessApi = {
+  getTimeAwareness: () =>
+    request<TimeAwarenessConfig>("/config/time-awareness"),
+
+  updateTimeAwareness: (config: Partial<TimeAwarenessConfig>) =>
+    request<TimeAwarenessConfig>("/config/time-awareness", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    }),
+};

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1066,7 +1066,31 @@
     "embeddingEnableHint": "Fill in both Base URL and Model Name to enable the embedding feature. API Key is optional.",
     "rebuildMemoryIndexOnStart": "Rebuild Memory Index on Start",
     "rebuildMemoryIndexOnStartTooltip": "Clear and rebuild the memory search index when the agent starts. Disable to skip re-indexing and only watch for new file changes (faster startup, but index may be out of sync).",
-    "toolResultCompactRecentGtOld": "Recent messages threshold must be greater than or equal to the older messages threshold"
+    "toolResultCompactRecentGtOld": "Recent messages threshold must be greater than or equal to the older messages threshold",
+    "timeAwareness": {
+      "title": "Time Awareness",
+      "description": "Automatically inject current time before user messages, allowing AI to always be time-aware without tool calls. Supports prompt caching to reduce API costs.",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "enableLabel": "Enable Time Awareness",
+      "enableHint": "When enabled, current time info (using your timezone) will be automatically prepended to each user message",
+      "on": "ON",
+      "off": "OFF",
+      "formatLabel": "Custom Time Format",
+      "formatTooltip": "Use strftime format string for custom display. Leave empty for default full format.",
+      "formatPlaceholder": "e.g., %Y-%m-%d %H:%M or leave empty for default",
+      "formatSaveSuccess": "Time format updated",
+      "formatSaveFailed": "Failed to save time format",
+      "examples": "Quick Examples",
+      "previewLabel": "Preview",
+      "previewPrefix": "Current time",
+      "previewHint": "Actual output will dynamically generate based on your timezone and language settings",
+      "enableSuccess": "Time awareness enabled ✅",
+      "disableSuccess": "Time awareness disabled ❌",
+      "saveFailed": "Failed to save configuration",
+      "loadFailed": "Failed to load configuration",
+      "disabledHint": "Time awareness is currently disabled. AI needs to call get_current_time() tool to get time information."
+    }
   },
   "tools": {
     "title": "Built-in Tools",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1040,7 +1040,31 @@
     "embeddingEnableHint": "同时填写 Base URL 和模型名称后即可启用向量模型功能，API Key 按需填写",
     "rebuildMemoryIndexOnStart": "启动时重建记忆索引",
     "rebuildMemoryIndexOnStartTooltip": "智能体启动时清空并重建记忆搜索索引。关闭后跳过重新索引，仅监听新文件变化（启动更快，但索引可能与文件不同步）",
-    "toolResultCompactRecentGtOld": "最新消息阈值必须大于或等于早期消息阈值"
+    "toolResultCompactRecentGtOld": "最新消息阈值必须大于或等于早期消息阈值",
+    "timeAwareness": {
+      "title": "时间感知 (Time Awareness)",
+      "description": "自动将当前时间注入到用户消息前，让 AI 始终感知时间，无需调用工具。支持 prompt caching，可降低 API 费用。",
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "enableLabel": "启用时间感知",
+      "enableHint": "开启后，每次对话会自动在用户消息前注入当前时间信息（使用您的时区）",
+      "on": "开",
+      "off": "关",
+      "formatLabel": "自定义时间格式",
+      "formatTooltip": "使用 strftime 格式字符串自定义显示格式。留空则使用默认完整格式。",
+      "formatPlaceholder": "例如: %Y-%m-%d %H:%M 或留空使用默认格式",
+      "formatSaveSuccess": "时间格式已更新",
+      "formatSaveFailed": "时间格式保存失败",
+      "examples": "快捷示例",
+      "previewLabel": "预览效果",
+      "previewPrefix": "当前时间",
+      "previewHint": "实际效果将根据您的时区和语言设置动态生成",
+      "enableSuccess": "时间感知已启用 ✅",
+      "disableSuccess": "时间感知已禁用 ❌",
+      "saveFailed": "配置保存失败",
+      "loadFailed": "加载配置失败",
+      "disabledHint": "当前已禁用时间感知功能。AI 需要通过调用 get_current_time() 工具来获取时间信息。"
+    }
   },
   "tools": {
     "title": "内置工具",

--- a/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
+++ b/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
@@ -1,0 +1,216 @@
+import { useState, useEffect, useCallback } from "react";
+import { Switch, Card, Input, Typography, Space, Tag, Tooltip } from "@agentscope-ai/design";
+import {
+  ClockCircleOutlined,
+  InfoCircleOutlined,
+  CheckCircleOutlined,
+} from "@ant-design/icons";
+import { useTranslation } from "react-i18next";
+import api from "../../../../api";
+import type { TimeAwarenessConfig } from "../../../../api/types";
+import { useAppMessage } from "../../../../hooks/useAppMessage";
+import styles from "../index.module.less";
+
+const { Text, Paragraph } = Typography;
+
+interface TimeAwarenessCardProps {}
+
+export function TimeAwarenessCard(_props: TimeAwarenessCardProps) {
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+
+  const [enabled, setEnabled] = useState(false);
+  const [format, setFormat] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    try {
+      const config = await api.getTimeAwareness();
+      setEnabled(config.enabled);
+      setFormat(config.format || "");
+    } catch (err) {
+      console.error("Failed to fetch time awareness config:", err);
+      message.error(t("timeAwareness.loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t, message]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const handleToggle = useCallback(
+    async (checked: boolean) => {
+      setSaving(true);
+      try {
+        await api.updateTimeAwareness({ enabled: checked, format: format || null });
+        setEnabled(checked);
+        message.success(
+          checked
+            ? t("timeAwareness.enableSuccess")
+            : t("timeAwareness.disableSuccess"),
+        );
+      } catch (err) {
+        console.error("Failed to update time awareness:", err);
+        message.error(t("timeAwareness.saveFailed"));
+        // Revert on error
+        setEnabled(!checked);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [format, t, message],
+  );
+
+  const handleFormatChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newFormat = e.target.value;
+      setFormat(newFormat);
+
+      if (enabled) {
+        setSaving(true);
+        try {
+          await api.updateTimeAwareness({
+            enabled,
+            format: newFormat || null,
+          });
+          message.success(t("timeAwareness.formatSaveSuccess"));
+        } catch (err) {
+          console.error("Failed to update time format:", err);
+          message.error(t("timeAwareness.formatSaveFailed"));
+          // Revert on error
+          setFormat(format);
+        } finally {
+          setSaving(false);
+        }
+      }
+    },
+    [enabled, format, t, message],
+  );
+
+  if (loading) {
+    return (
+      <Card className={styles.formCard} loading={loading}>
+        <div style={{ height: 200 }} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      className={styles.formCard}
+      title={
+        <Space>
+          <ClockCircleOutlined />
+          <span>{t("timeAwareness.title")}</span>
+          {enabled ? (
+            <Tag color="success" icon={<CheckCircleOutlined />}>
+              {t("timeAwareness.enabled")}
+            </Tag>
+          ) : (
+            <Tag>{t("timeAwareness.disabled")}</Tag>
+          )}
+        </Space>
+      }
+    >
+      <div className={styles.timeAwarenessContainer}>
+        <Paragraph className={styles.description}>
+          {t("timeAwareness.description")}
+        </Paragraph>
+
+        <div className={styles.switchRow}>
+          <Space direction="vertical" size="small" style={{ flex: 1 }}>
+            <Text strong>{t("timeAwareness.enableLabel")}</Text>
+            <Text type="secondary" className={styles.hintText}>
+              {t("timeAwareness.enableHint")}
+            </Text>
+          </Space>
+
+          <Switch
+            checked={enabled}
+            onChange={handleToggle}
+            loading={saving}
+            checkedChildren={t("timeAwareness.on")}
+            unCheckedChildren={t("timeAwareness.off")}
+            style={{ marginLeft: "auto" }}
+          />
+        </div>
+
+        {enabled && (
+          <div className={styles.formatSection}>
+            <Space direction="vertical" size="small" style={{ width: "100%" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <Text strong>{t("timeAwareness.formatLabel")}</Text>
+                <Tooltip title={t("timeAwareness.formatTooltip")}>
+                  <InfoCircleOutlined style={{ color: "#999" }} />
+                </Tooltip>
+              </div>
+
+              <Input
+                value={format}
+                onChange={handleFormatChange}
+                placeholder={t("timeAwareness.formatPlaceholder")}
+                disabled={!enabled || saving}
+                allowClear
+                suffix={
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    strftime
+                  </Text>
+                }
+              />
+
+              <div className={styles.formatExamples}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {t("timeAwareness.examples")}:
+                </Text>
+                <Space size={4} wrap>
+                  <Tag
+                    onClick={() => setFormat("%Y-%m-%d %H:%M:%S")}
+                    style={{ cursor: "pointer" }}
+                  >
+                    Default
+                  </Tag>
+                  <Tag
+                    onClick={() => setFormat("%Y-%m-%d %H:%M")}
+                    style={{ cursor: "pointer" }}
+                  >
+                    Compact
+                  </Tag>
+                  <Tag
+                    onClick={() => setFormat("%H:%M")}
+                    style={{ cursor: "pointer" }}
+                  >
+                    Time Only
+                  </Tag>
+                </Space>
+              </div>
+            </Space>
+
+            <div className={styles.previewSection}>
+              <Text strong>{t("timeAwareness.previewLabel")}</Text>
+              <div className={styles.previewBox}>
+                <Text code style={{ fontSize: 13 }}>
+                  {[t("timeAwareness.previewPrefix"), ": 2026-04-11 14:30:45 Asia/Shanghai (Saturday)"].join("")}
+                </Text>
+                <Text type="secondary" style={{ fontSize: 12, marginTop: 4 }}>
+                  {t("timeAwareness.previewHint")}
+                </Text>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!enabled && (
+          <div className={styles.disabledHint}>
+            <Text type="warning">
+              ⚠️ {t("timeAwareness.disabledHint")}
+            </Text>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
+++ b/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
@@ -8,7 +8,6 @@ import {
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import api from "../../../../api";
-import type { TimeAwarenessConfig } from "../../../../api/modules/timeAwareness";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 import styles from "../index.module.less";
 
@@ -47,7 +46,10 @@ export function TimeAwarenessCard(_props: TimeAwarenessCardProps) {
     async (checked: boolean) => {
       setSaving(true);
       try {
-        await api.updateTimeAwareness({ enabled: checked, format: format || null });
+        await api.updateTimeAwareness({
+          enabled: checked,
+          format: format || null,
+        });
         setEnabled(checked);
         message.success(
           checked
@@ -194,7 +196,10 @@ export function TimeAwarenessCard(_props: TimeAwarenessCardProps) {
               <Text strong>{t("timeAwareness.previewLabel")}</Text>
               <div className={styles.previewBox}>
                 <Text code style={{ fontSize: 13 }}>
-                  {[t("timeAwareness.previewPrefix"), ": 2026-04-11 14:30:45 Asia/Shanghai (Saturday)"].join("")}
+                  {[
+                    t("timeAwareness.previewPrefix"),
+                    ": 2026-04-11 14:30:45 Asia/Shanghai (Saturday)",
+                  ].join("")}
                 </Text>
                 <Text type="secondary" style={{ fontSize: 12, marginTop: 4 }}>
                   {t("timeAwareness.previewHint")}
@@ -206,9 +211,7 @@ export function TimeAwarenessCard(_props: TimeAwarenessCardProps) {
 
         {!enabled && (
           <div className={styles.disabledHint}>
-            <Text type="warning">
-              ⚠️ {t("timeAwareness.disabledHint")}
-            </Text>
+            <Text type="warning">⚠️ {t("timeAwareness.disabledHint")}</Text>
           </div>
         )}
       </div>

--- a/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
+++ b/console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
-import { Switch, Card, Input, Typography, Space, Tag, Tooltip } from "@agentscope-ai/design";
+import { Switch, Card, Input, Tag, Tooltip } from "@agentscope-ai/design";
+import { Typography, Space } from "antd";
 import {
   ClockCircleOutlined,
   InfoCircleOutlined,
@@ -7,7 +8,7 @@ import {
 } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import api from "../../../../api";
-import type { TimeAwarenessConfig } from "../../../../api/types";
+import type { TimeAwarenessConfig } from "../../../../api/modules/timeAwareness";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 import styles from "../index.module.less";
 

--- a/console/src/pages/Agent/Config/components/index.ts
+++ b/console/src/pages/Agent/Config/components/index.ts
@@ -6,3 +6,4 @@ export { ContextCompactCard } from "./ContextCompactCard";
 export { ToolResultCompactCard } from "./ToolResultCompactCard";
 export { MemorySummaryCard } from "./MemorySummaryCard";
 export { EmbeddingConfigCard } from "./EmbeddingConfigCard";
+export { TimeAwarenessCard } from "./TimeAwarenessCard";

--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -197,3 +197,119 @@
     color: #ff7f16;
   }
 }
+
+/* ─── Time Awareness Card ───────────────────────────────────────────────────── */
+.timeAwarenessContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.description {
+  margin-bottom: 8px !important;
+  color: #666;
+  font-size: 14px;
+}
+
+.switchRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #fafafa;
+  border-radius: 8px;
+  border: 1px solid #f0f0f0;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background: #f5f5f5;
+    border-color: #d9d9d9;
+  }
+}
+
+.hintText {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.formatSection {
+  margin-top: 16px;
+  padding: 16px;
+  background: #f9f9f9;
+  border-radius: 8px;
+  border-left: 4px solid #1890ff;
+}
+
+.formatExamples {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+
+  :global {
+    .ant-tag {
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: #e6f7ff;
+        border-color: #1890ff;
+        color: #1890ff;
+      }
+    }
+  }
+}
+
+.previewSection {
+  margin-top: 16px;
+}
+
+.previewBox {
+  margin-top: 8px;
+  padding: 12px 16px;
+  background: #fff;
+  border-radius: 6px;
+  border: 1px dashed #d9d9d9;
+  font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+}
+
+.disabledHint {
+  margin-top: 12px;
+  padding: 12px 16px;
+  background: #fffbe6;
+  border-radius: 6px;
+  border-left: 4px solid #faad14;
+}
+
+:global(.dark-mode) {
+  .description {
+    color: rgba(255, 255, 255, 0.65);
+  }
+
+  .switchRow {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(255, 255, 255, 0.15);
+    }
+  }
+
+  .formatSection {
+    background: rgba(255, 255, 255, 0.04);
+    border-left-color: #177ddc;
+  }
+
+  .previewBox {
+    background: rgba(0, 0, 0, 0.2);
+    border-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .disabledHint {
+    background: rgba(250, 173, 20, 0.1);
+    border-left-color: #faad14;
+  }
+}
+

--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -312,4 +312,3 @@
     border-left-color: #faad14;
   }
 }
-

--- a/console/src/pages/Agent/Config/index.tsx
+++ b/console/src/pages/Agent/Config/index.tsx
@@ -9,6 +9,7 @@ import {
   ToolResultCompactCard,
   MemorySummaryCard,
   EmbeddingConfigCard,
+  TimeAwarenessCard,
 } from "./components";
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
@@ -82,6 +83,8 @@ function AgentConfigPage() {
             <MemorySummaryCard />
 
             <EmbeddingConfigCard />
+
+            <TimeAwarenessCard />
           </Form>
         </div>
       </div>

--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -5,16 +5,19 @@ This module handles:
 - File and media block processing
 - Message content manipulation
 - Message validation
+- Time awareness injection for prompt caching optimization
 """
 import asyncio
 import logging
 import os
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 from agentscope.message import Msg
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...config import load_config
 from .file_handling import download_file_from_base64, download_file_from_url
@@ -460,6 +463,9 @@ def prepend_to_message_content(msg, guidance: str) -> None:
         msg: Msg object to modify.
         guidance: Text to prepend to the message content.
     """
+    if msg is None:
+        return
+
     if isinstance(msg.content, str):
         msg.content = guidance + "\n\n" + msg.content
         return
@@ -473,3 +479,87 @@ def prepend_to_message_content(msg, guidance: str) -> None:
             return
 
     msg.content.insert(0, {"type": "text", "text": guidance})
+
+
+logger = logging.getLogger(__name__)
+
+
+def inject_time_awareness(config) -> Optional[str]:
+    """Generate time awareness string for injection into user messages.
+
+    This function creates a formatted time string based on the user's
+    timezone configuration. It supports both Chinese and English labels,
+    custom time formats, and graceful fallback to UTC on invalid timezone.
+
+    Args:
+        config: Config object containing time_awareness and user_timezone settings.
+
+    Returns:
+        Formatted time string like "[当前时间: 2026-04-11 14:30:45 Asia/Shanghai (Saturday)]",
+        or None if time awareness is disabled or an error occurs.
+    """
+    if not config or not getattr(config, 'time_awareness', None):
+        return None
+
+    if not config.time_awareness.enabled:
+        return None
+
+    try:
+        user_tz = config.user_timezone or "UTC"
+        if not user_tz or not user_tz.strip():
+            user_tz = "UTC"
+
+        now = datetime.now(ZoneInfo(user_tz))
+    except (ZoneInfoNotFoundError, KeyError, Exception) as e:
+        logger.warning(
+            "Invalid timezone %r for time awareness, falling back to UTC: %s",
+            getattr(config, 'user_timezone', None),
+            e,
+        )
+        now = datetime.now(timezone.utc)
+        user_tz = "UTC"
+
+    try:
+        language = getattr(config.agents, 'language', 'en') if hasattr(config, 'agents') else 'en'
+        is_chinese = language and language.lower().startswith('zh')  # Support zh-CN, zh-TW variants
+
+        label = "[当前时间:" if is_chinese else "[Current time:"
+
+        if config.time_awareness.format:
+            try:
+                time_str = now.strftime(config.time_awareness.format)
+                return f"{label} {time_str}]"
+            except (ValueError, TypeError) as e:
+                logger.warning(
+                    "Invalid strftime format %r for time awareness, using default: %s",
+                    config.time_awareness.format,
+                    e,
+                )
+                # Fall through to default format below
+
+        default_format = f"{now.strftime('%Y-%m-%d %H:%M:%S')} {user_tz} ({now.strftime('%A')})"
+        return f"{label} {default_format}]"
+
+    except Exception as e:
+        logger.error("Failed to format time awareness string: %s", e)
+        return None
+
+
+def get_last_user_message(msgs: list) -> Optional[Msg]:
+    """Get the last user role message from a message list.
+
+    Args:
+        msgs: List of message objects (Msg).
+
+    Returns:
+        The last Msg object with role='user', or None if not found.
+    """
+    if not msgs:
+        return None
+
+    for msg in reversed(msgs):
+        if isinstance(msg, Msg) and getattr(msg, 'role', None) == 'user':
+            return msg
+
+    return None
+

--- a/src/copaw/agents/utils/message_processing.py
+++ b/src/copaw/agents/utils/message_processing.py
@@ -16,8 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from agentscope.message import Msg
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from agentscope.message import Msg
 
 from ...config import load_config
 from .file_handling import download_file_from_base64, download_file_from_url
@@ -492,13 +492,13 @@ def inject_time_awareness(config) -> Optional[str]:
     custom time formats, and graceful fallback to UTC on invalid timezone.
 
     Args:
-        config: Config object containing time_awareness and user_timezone settings.
+        config: Config object with time_awareness and user_timezone settings
 
     Returns:
-        Formatted time string like "[当前时间: 2026-04-11 14:30:45 Asia/Shanghai (Saturday)]",
-        or None if time awareness is disabled or an error occurs.
+        Formatted time string like "[当前时间: 2026-04-11 14:30:45 Asia/Shanghai]",
+        or None if disabled or error occurs.
     """
-    if not config or not getattr(config, 'time_awareness', None):
+    if not config or not getattr(config, "time_awareness", None):
         return None
 
     if not config.time_awareness.enabled:
@@ -513,15 +513,21 @@ def inject_time_awareness(config) -> Optional[str]:
     except (ZoneInfoNotFoundError, KeyError, Exception) as e:
         logger.warning(
             "Invalid timezone %r for time awareness, falling back to UTC: %s",
-            getattr(config, 'user_timezone', None),
+            getattr(config, "user_timezone", None),
             e,
         )
         now = datetime.now(timezone.utc)
         user_tz = "UTC"
 
     try:
-        language = getattr(config.agents, 'language', 'en') if hasattr(config, 'agents') else 'en'
-        is_chinese = language and language.lower().startswith('zh')  # Support zh-CN, zh-TW variants
+        language = (
+            getattr(config.agents, "language", "en")
+            if hasattr(config, "agents")
+            else "en"
+        )
+        is_chinese = language and language.lower().startswith(
+            "zh",
+        )  # Support zh-CN, zh-TW variants
 
         label = "[当前时间:" if is_chinese else "[Current time:"
 
@@ -529,15 +535,16 @@ def inject_time_awareness(config) -> Optional[str]:
             try:
                 time_str = now.strftime(config.time_awareness.format)
                 return f"{label} {time_str}]"
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError):
                 logger.warning(
-                    "Invalid strftime format %r for time awareness, using default: %s",
+                    "Invalid strftime format %r, using default",
                     config.time_awareness.format,
-                    e,
                 )
                 # Fall through to default format below
 
-        default_format = f"{now.strftime('%Y-%m-%d %H:%M:%S')} {user_tz} ({now.strftime('%A')})"
+        time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+        weekday_str = now.strftime("%A")
+        default_format = f"{time_str} {user_tz} ({weekday_str})"
         return f"{label} {default_format}]"
 
     except Exception as e:
@@ -558,8 +565,7 @@ def get_last_user_message(msgs: list) -> Optional[Msg]:
         return None
 
     for msg in reversed(msgs):
-        if isinstance(msg, Msg) and getattr(msg, 'role', None) == 'user':
+        if isinstance(msg, Msg) and getattr(msg, "role", None) == "user":
             return msg
 
     return None
-

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Body, HTTPException, Path, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..utils import schedule_agent_reload
 from ...config import (
@@ -394,6 +394,74 @@ async def put_user_timezone(
     config.user_timezone = tz
     save_config(config)
     return {"timezone": tz}
+
+
+# ── Time Awareness ───────────────────────────────────────────────────
+
+
+class TimeAwarenessResponse(BaseModel):
+    """Time awareness configuration response model for API documentation."""
+
+    enabled: bool = Field(
+        description="Whether automatic time injection is enabled",
+    )
+    format: Optional[str] = Field(
+        default=None,
+        description="Custom strftime format string (null for default)",
+    )
+
+
+class TimeAwarenessUpdate(BaseModel):
+    """Request body model for updating time awareness settings."""
+
+    enabled: Optional[bool] = Field(
+        default=None,
+        description="Enable or disable time awareness",
+    )
+    format: Optional[str] = Field(
+        default=None,
+        description="Custom strftime format string",
+    )
+
+    model_config = {"extra": "ignore"}
+
+
+@router.get(
+    "/time-awareness",
+    response_model=TimeAwarenessResponse,
+    summary="Get time awareness settings",
+    description="Return the current time awareness configuration",
+)
+async def get_time_awareness() -> TimeAwarenessResponse:
+    config = load_config()
+    return TimeAwarenessResponse(
+        enabled=config.time_awareness.enabled,
+        format=config.time_awareness.format,
+    )
+
+
+@router.put(
+    "/time-awareness",
+    response_model=TimeAwarenessResponse,
+    summary="Update time awareness settings",
+    description="Enable/disable automatic time injection into user messages",
+)
+async def put_time_awareness(
+    body: TimeAwarenessUpdate = Body(..., description="Time awareness settings to update"),
+) -> TimeAwarenessResponse:
+    config = load_config()
+
+    if body.enabled is not None:
+        config.time_awareness.enabled = body.enabled
+
+    if body.format is not None:
+        config.time_awareness.format = body.format or None
+
+    save_config(config)
+    return TimeAwarenessResponse(
+        enabled=config.time_awareness.enabled,
+        format=config.time_awareness.format,
+    )
 
 
 # ── Security / Tool Guard ────────────────────────────────────────────

--- a/src/copaw/app/routers/config.py
+++ b/src/copaw/app/routers/config.py
@@ -447,7 +447,10 @@ async def get_time_awareness() -> TimeAwarenessResponse:
     description="Enable/disable automatic time injection into user messages",
 )
 async def put_time_awareness(
-    body: TimeAwarenessUpdate = Body(..., description="Time awareness settings to update"),
+    body: TimeAwarenessUpdate = Body(
+        ...,
+        description="Time awareness settings to update",
+    ),
 ) -> TimeAwarenessResponse:
     config = load_config()
 

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -39,7 +39,8 @@ from ...agents.utils.message_processing import (
     get_last_user_message,
     prepend_to_message_content,
 )
-from ...config.config import load_config, load_agent_config
+from ...config.config import load_agent_config
+from ...config.utils import load_config
 from ...constant import (
     TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS,
     WORKING_DIR,
@@ -539,8 +540,12 @@ class AgentRunner(Runner):
 
             # Inject time awareness into user message if enabled
             try:
-                config = load_config()  # Use global config (time_awareness is defined globally)
-                if config.time_awareness.enabled:  # Global Config always has time_awareness field
+                config = (
+                    load_config()
+                )  # Use global config (time_awareness is defined globally)
+                if (
+                    config.time_awareness.enabled
+                ):  # Global Config always has time_awareness field
                     time_str = inject_time_awareness(config)
                     if time_str and msgs:
                         last_user_msg = get_last_user_message(msgs)

--- a/src/copaw/app/runner/runner.py
+++ b/src/copaw/app/runner/runner.py
@@ -34,7 +34,12 @@ from ...exceptions import convert_model_exception
 from ...agents.utils.file_handling import (
     read_text_file_with_encoding_fallback,
 )
-from ...config.config import load_agent_config
+from ...agents.utils.message_processing import (
+    inject_time_awareness,
+    get_last_user_message,
+    prepend_to_message_content,
+)
+from ...config.config import load_config, load_agent_config
 from ...constant import (
     TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS,
     WORKING_DIR,
@@ -531,6 +536,25 @@ class AgentRunner(Runner):
             # AGENTS.md / SOUL.md / PROFILE.md, not the stale one saved
             # in the session state.
             agent.rebuild_sys_prompt()
+
+            # Inject time awareness into user message if enabled
+            try:
+                config = load_config()  # Use global config (time_awareness is defined globally)
+                if config.time_awareness.enabled:  # Global Config always has time_awareness field
+                    time_str = inject_time_awareness(config)
+                    if time_str and msgs:
+                        last_user_msg = get_last_user_message(msgs)
+                        if last_user_msg:
+                            prepend_to_message_content(last_user_msg, time_str)
+                            logger.debug(
+                                "Time awareness injected: %s",
+                                time_str,
+                            )
+            except Exception as e:
+                logger.warning(
+                    "Failed to inject time awareness (non-critical): %s",
+                    e,
+                )
 
             async for msg, last in stream_printing_messages(
                 agents=[agent],

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -1143,8 +1143,9 @@ class TimeAwarenessConfig(BaseModel):
         default=None,
         description=(
             "Custom strftime format string for time display. "
-            "If None, uses default format: '%%Y-%%m-%%d %%H:%%M:%%S {tz} ({weekday})'. "
-            "Example: '%%Y-%%m-%%d %%H:%%M' for compact format."
+            "If None, uses default format: "
+            "'%%Y-%%m-%%d %%H:%%M:%%S {tz} ({weekday})'. "
+            "Example: '%%Y-%%m-%%d %%H:%%M' for compact format"
         ),
     )
 

--- a/src/copaw/config/config.py
+++ b/src/copaw/config/config.py
@@ -1120,6 +1120,35 @@ class SecurityConfig(BaseModel):
     )
 
 
+class TimeAwarenessConfig(BaseModel):
+    """Configuration for automatic time injection into user messages.
+
+    When enabled, the system automatically prepends the current time
+    to user messages before sending them to the LLM. This allows AI
+    to be time-aware without explicit tool calls, and supports
+    prompt caching by using a predictable prefix format.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to enable automatic time awareness. "
+            "When True, current time is injected before each user message. "
+            "Default is False for backward compatibility."
+        ),
+    )
+    format: Optional[str] = Field(
+        default=None,
+        description=(
+            "Custom strftime format string for time display. "
+            "If None, uses default format: '%%Y-%%m-%%d %%H:%%M:%%S {tz} ({weekday})'. "
+            "Example: '%%Y-%%m-%%d %%H:%%M' for compact format."
+        ),
+    )
+
+
 class Config(BaseModel):
     """Root config (config.json)."""
 
@@ -1135,6 +1164,10 @@ class Config(BaseModel):
         default_factory=detect_system_timezone,
         description="User IANA timezone (e.g. Asia/Shanghai). "
         "Defaults to the system timezone.",
+    )
+    time_awareness: TimeAwarenessConfig = Field(
+        default_factory=TimeAwarenessConfig,
+        description="Time awareness settings for automatic time injection.",
     )
     plugins: Dict[str, Dict[str, Any]] = Field(
         default_factory=dict,

--- a/tests/test_time_awareness.py
+++ b/tests/test_time_awareness.py
@@ -10,18 +10,18 @@ Tests cover:
 - Integration with message processing
 - Edge cases and error handling
 """
-import pytest
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
+import pytest
 
+from agentscope.message import Msg
 from copaw.config.config import Config, TimeAwarenessConfig
 from copaw.agents.utils.message_processing import (
     inject_time_awareness,
     get_last_user_message,
     prepend_to_message_content,
 )
-from agentscope.message import Msg
 
 
 class TestTimeAwarenessConfig:
@@ -41,8 +41,6 @@ class TestTimeAwarenessConfig:
 
     def test_config_serialization(self):
         """Test that config can be serialized/deserialized to JSON."""
-        import json
-
         config = TimeAwarenessConfig(enabled=True, format="%Y-%m-%d")
         json_str = config.model_dump_json()
         restored = TimeAwarenessConfig.model_validate_json(json_str)
@@ -56,7 +54,7 @@ class TestConfigIntegration:
     def test_default_in_main_config(self):
         """Test that main Config has time_awareness field with defaults."""
         config = Config()
-        assert hasattr(config, 'time_awareness')
+        assert hasattr(config, "time_awareness")
         assert config.time_awareness.enabled is False
         assert config.time_awareness.format is None
 
@@ -90,12 +88,20 @@ class TestConfigIntegration:
 class TestInjectTimeAwareness:
     """Test inject_time_awareness() function."""
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_chinese_label(self, mock_datetime):
         """Test Chinese label when language is zh."""
-        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("Asia/Shanghai"))
+        fixed_time = datetime(
+            2026,
+            4,
+            11,
+            14,
+            30,
+            45,
+            tzinfo=ZoneInfo("Asia/Shanghai"),
+        )
         mock_datetime.now.return_value = fixed_time
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -109,12 +115,20 @@ class TestInjectTimeAwareness:
         assert "14:30:45" in result
         assert "Asia/Shanghai" in result
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_english_label(self, mock_datetime):
         """Test English label when language is not zh."""
-        fixed_time = datetime(2026, 4, 11, 2, 30, 45, tzinfo=ZoneInfo("America/New_York"))
+        fixed_time = datetime(
+            2026,
+            4,
+            11,
+            2,
+            30,
+            45,
+            tzinfo=ZoneInfo("America/New_York"),
+        )
         mock_datetime.now.return_value = fixed_time
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -126,18 +140,18 @@ class TestInjectTimeAwareness:
         assert "[Current time:" in result
         assert "America/New_York" in result
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_custom_format(self, mock_datetime):
         """Test custom strftime format."""
         fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("UTC"))
         mock_datetime.now.return_value = fixed_time
         mock_datetime.strftime = fixed_time.strftime
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(
             enabled=True,
-            format="%Y-%m-%d %H:%M"
+            format="%Y-%m-%d %H:%M",
         )
         config.user_timezone = "UTC"
         config.agents.language = "en"
@@ -165,12 +179,12 @@ class TestInjectTimeAwareness:
         result = inject_time_awareness(config)
         assert result is None
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_invalid_timezone_fallback(self, mock_datetime):
         """Test fallback to UTC on invalid timezone."""
         fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=timezone.utc)
         mock_datetime.now.return_value = fixed_time
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -182,12 +196,12 @@ class TestInjectTimeAwareness:
         assert result is not None
         assert "UTC" in result
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_empty_timezone_fallback(self, mock_datetime):
         """Test fallback to UTC on empty timezone string."""
         fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=timezone.utc)
         mock_datetime.now.return_value = fixed_time
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -198,7 +212,7 @@ class TestInjectTimeAwareness:
         assert result is not None
         assert "UTC" in result
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_multiple_timezones(self, mock_datetime):
         """Test correct conversion for multiple timezones."""
         test_cases = [
@@ -208,9 +222,17 @@ class TestInjectTimeAwareness:
         ]
 
         for tz_name in test_cases:
-            fixed_time = datetime(2026, 4, 11, 12, 0, 0, tzinfo=ZoneInfo(tz_name[0]))
+            fixed_time = datetime(
+                2026,
+                4,
+                11,
+                12,
+                0,
+                0,
+                tzinfo=ZoneInfo(tz_name[0]),
+            )
             mock_datetime.now.return_value = fixed_time
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            mock_datetime.side_effect = datetime
 
             config = MagicMock()
             config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -310,14 +332,14 @@ class TestPrependToMessageContent:
 class TestPerformance:
     """Performance and edge case tests."""
 
-    @patch('copaw.agents.utils.message_processing.datetime')
+    @patch("copaw.agents.utils.message_processing.datetime")
     def test_execution_time(self, mock_datetime):
         """Test that execution completes within 1ms."""
         import time
 
         fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("UTC"))
         mock_datetime.now.return_value = fixed_time
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_datetime.side_effect = datetime
 
         config = MagicMock()
         config.time_awareness = TimeAwarenessConfig(enabled=True)
@@ -331,7 +353,9 @@ class TestPerformance:
 
         # Average should be < 1ms per call
         avg_time_ms = elapsed / 1000
-        assert avg_time_ms < 1.0, f"Average time {avg_time_ms:.3f}ms exceeds 1ms limit"
+        assert (
+            avg_time_ms < 1.0
+        ), f"Average time {avg_time_ms:.3f}ms exceeds 1ms limit"
 
     def test_none_msg_safe_handling(self):
         """Test safe handling of None message object."""

--- a/tests/test_time_awareness.py
+++ b/tests/test_time_awareness.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for time awareness injection functionality.
+
+Tests cover:
+- Configuration loading and backward compatibility
+- Time formatting with different timezones
+- Chinese/English label switching
+- Custom format support
+- Timezone fallback mechanisms
+- Integration with message processing
+- Edge cases and error handling
+"""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, PropertyMock
+from zoneinfo import ZoneInfo
+
+from copaw.config.config import Config, TimeAwarenessConfig
+from copaw.agents.utils.message_processing import (
+    inject_time_awareness,
+    get_last_user_message,
+    prepend_to_message_content,
+)
+from agentscope.message import Msg
+
+
+class TestTimeAwarenessConfig:
+    """Test TimeAwarenessConfig configuration model."""
+
+    def test_default_disabled(self):
+        """Test that time awareness is disabled by default."""
+        config = TimeAwarenessConfig()
+        assert config.enabled is False
+        assert config.format is None
+
+    def test_custom_format(self):
+        """Test custom format configuration."""
+        config = TimeAwarenessConfig(enabled=True, format="%Y-%m-%d %H:%M")
+        assert config.enabled is True
+        assert config.format == "%Y-%m-%d %H:%M"
+
+    def test_config_serialization(self):
+        """Test that config can be serialized/deserialized to JSON."""
+        import json
+
+        config = TimeAwarenessConfig(enabled=True, format="%Y-%m-%d")
+        json_str = config.model_dump_json()
+        restored = TimeAwarenessConfig.model_validate_json(json_str)
+        assert restored.enabled is True
+        assert restored.format == "%Y-%m-%d"
+
+
+class TestConfigIntegration:
+    """Test integration of TimeAwarenessConfig into main Config."""
+
+    def test_default_in_main_config(self):
+        """Test that main Config has time_awareness field with defaults."""
+        config = Config()
+        assert hasattr(config, 'time_awareness')
+        assert config.time_awareness.enabled is False
+        assert config.time_awareness.format is None
+
+    def test_backward_compatibility(self):
+        """Test that old configs without time_awareness load correctly."""
+        # Simulate loading a config without time_awareness field
+        config_dict = {
+            "channels": {},
+            "agents": {"active_agent": "default"},
+            "user_timezone": "Asia/Shanghai",
+            # No time_awareness field - should use default
+        }
+        config = Config(**config_dict)
+        assert config.time_awareness.enabled is False
+
+    def test_enabled_from_json(self):
+        """Test enabling time awareness from JSON config."""
+        config_dict = {
+            "channels": {},
+            "agents": {"active_agent": "default", "language": "zh"},
+            "user_timezone": "Asia/Shanghai",
+            "time_awareness": {
+                "enabled": True,
+                "format": None,
+            },
+        }
+        config = Config(**config_dict)
+        assert config.time_awareness.enabled is True
+
+
+class TestInjectTimeAwareness:
+    """Test inject_time_awareness() function."""
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_chinese_label(self, mock_datetime):
+        """Test Chinese label when language is zh."""
+        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("Asia/Shanghai"))
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=True)
+        config.user_timezone = "Asia/Shanghai"
+        config.agents.language = "zh"
+
+        result = inject_time_awareness(config)
+        assert result is not None
+        assert "[当前时间:" in result
+        assert "2026-04-11" in result
+        assert "14:30:45" in result
+        assert "Asia/Shanghai" in result
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_english_label(self, mock_datetime):
+        """Test English label when language is not zh."""
+        fixed_time = datetime(2026, 4, 11, 2, 30, 45, tzinfo=ZoneInfo("America/New_York"))
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=True)
+        config.user_timezone = "America/New_York"
+        config.agents.language = "en"
+
+        result = inject_time_awareness(config)
+        assert result is not None
+        assert "[Current time:" in result
+        assert "America/New_York" in result
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_custom_format(self, mock_datetime):
+        """Test custom strftime format."""
+        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("UTC"))
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.strftime = fixed_time.strftime
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(
+            enabled=True,
+            format="%Y-%m-%d %H:%M"
+        )
+        config.user_timezone = "UTC"
+        config.agents.language = "en"
+
+        result = inject_time_awareness(config)
+        assert result is not None
+        assert "2026-04-11 14:30]" in result
+
+    def test_disabled_returns_none(self):
+        """Test that disabled mode returns None."""
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=False)
+
+        result = inject_time_awareness(config)
+        assert result is None
+
+    def test_none_config_returns_none(self):
+        """Test that None config returns None safely."""
+        result = inject_time_awareness(None)
+        assert result is None
+
+    def test_missing_time_awareness_returns_none(self):
+        """Test that config without time_awareness attribute returns None."""
+        config = MagicMock(spec=[])  # Empty spec, no attributes
+        result = inject_time_awareness(config)
+        assert result is None
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_invalid_timezone_fallback(self, mock_datetime):
+        """Test fallback to UTC on invalid timezone."""
+        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=True)
+        config.user_timezone = "Invalid/Timezone"
+        config.agents.language = "en"
+
+        # Should not raise exception, should fallback to UTC
+        result = inject_time_awareness(config)
+        assert result is not None
+        assert "UTC" in result
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_empty_timezone_fallback(self, mock_datetime):
+        """Test fallback to UTC on empty timezone string."""
+        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=True)
+        config.user_timezone = ""
+        config.agents.language = "en"
+
+        result = inject_time_awareness(config)
+        assert result is not None
+        assert "UTC" in result
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_multiple_timezones(self, mock_datetime):
+        """Test correct conversion for multiple timezones."""
+        test_cases = [
+            ("Europe/London", "Europe/London"),
+            ("Asia/Tokyo", "Asia/Tokyo"),
+            ("Australia/Sydney", "Australia/Sydney"),
+        ]
+
+        for tz_name in test_cases:
+            fixed_time = datetime(2026, 4, 11, 12, 0, 0, tzinfo=ZoneInfo(tz_name[0]))
+            mock_datetime.now.return_value = fixed_time
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+            config = MagicMock()
+            config.time_awareness = TimeAwarenessConfig(enabled=True)
+            config.user_timezone = tz_name[0]
+            config.agents.language = "en"
+
+            result = inject_time_awareness(config)
+            assert result is not None
+            assert tz_name[1] in result
+
+
+class TestGetLastUserMessage:
+    """Test get_last_user_message() helper function."""
+
+    def test_find_last_user_message(self):
+        """Test finding the last user message from list."""
+        msgs = [
+            Msg(name="system", role="system", content="System prompt"),
+            Msg(name="user1", role="user", content="First message"),
+            Msg(name="assistant", role="assistant", content="Response"),
+            Msg(name="user2", role="user", content="Second message"),
+        ]
+        result = get_last_user_message(msgs)
+        assert result is not None
+        assert result.name == "user2"
+        assert result.content == "Second message"
+
+    def test_empty_list_returns_none(self):
+        """Test that empty list returns None."""
+        result = get_last_user_message([])
+        assert result is None
+
+    def test_no_user_message_returns_none(self):
+        """Test that list without user messages returns None."""
+        msgs = [
+            Msg(name="system", role="system", content="System"),
+            Msg(name="assistant", role="assistant", content="Response"),
+        ]
+        result = get_last_user_message(msgs)
+        assert result is None
+
+    def test_only_user_messages(self):
+        """Test list with only user messages."""
+        msgs = [
+            Msg(name="user1", role="user", content="First"),
+            Msg(name="user2", role="user", content="Second"),
+        ]
+        result = get_last_user_message(msgs)
+        assert result is not None
+        assert result.name == "user2"
+
+
+class TestPrependToMessageContent:
+    """Test prepend_to_message_content() with time strings."""
+
+    def test_prepend_string_content(self):
+        """Test prepending to string content."""
+        msg = Msg(name="user", role="user", content="Hello")
+        time_str = "[Current time: 2026-04-11 14:30:45 UTC (Saturday)]"
+        prepend_to_message_content(msg, time_str)
+
+        assert msg.content.startswith(time_str)
+        assert "Hello" in msg.content
+        assert "\n\n" in msg.content
+
+    def test_prepend_list_content_with_text_block(self):
+        """Test prepending to list content with text block."""
+        msg = Msg(
+            name="user",
+            role="user",
+            content=[{"type": "text", "text": "Hello"}],
+        )
+        time_str = "[Current time: 2026-04-11 14:30:45 UTC]"
+        prepend_to_message_content(msg, time_str)
+
+        assert isinstance(msg.content, list)
+        text_block = msg.content[0]
+        assert text_block["type"] == "text"
+        assert text_block["text"].startswith(time_str)
+
+    def test_prepend_list_content_without_text_block(self):
+        """Test prepending to list content without existing text block."""
+        msg = Msg(
+            name="user",
+            role="user",
+            content=[{"type": "image", "url": "http://example.com/img.png"}],
+        )
+        time_str = "[Current time: 2026-04-11 14:30:45 UTC]"
+        prepend_to_message_content(msg, time_str)
+
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+        assert msg.content[0]["type"] == "text"
+        assert msg.content[0]["text"] == time_str
+
+
+class TestPerformance:
+    """Performance and edge case tests."""
+
+    @patch('copaw.agents.utils.message_processing.datetime')
+    def test_execution_time(self, mock_datetime):
+        """Test that execution completes within 1ms."""
+        import time
+
+        fixed_time = datetime(2026, 4, 11, 14, 30, 45, tzinfo=ZoneInfo("UTC"))
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        config = MagicMock()
+        config.time_awareness = TimeAwarenessConfig(enabled=True)
+        config.user_timezone = "UTC"
+        config.agents.language = "en"
+
+        start = time.perf_counter()
+        for _ in range(1000):
+            inject_time_awareness(config)
+        elapsed = (time.perf_counter() - start) * 1000  # Convert to ms
+
+        # Average should be < 1ms per call
+        avg_time_ms = elapsed / 1000
+        assert avg_time_ms < 1.0, f"Average time {avg_time_ms:.3f}ms exceeds 1ms limit"
+
+    def test_none_msg_safe_handling(self):
+        """Test safe handling of None message object."""
+        time_str = "[Current time: 2026-04-11 14:30:45 UTC]"
+        # Should not raise exception
+        prepend_to_message_content(None, time_str)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary / 概述

Add automatic time injection into user messages to make AI time-aware without tool calls. The time string is **prepended** (before user content) so that the variable part (time) acts as a fixed-position prefix, keeping the user's actual message at a stable offset — this maximizes prompt cache hit rate and reduces API costs. The feature can be toggled on/off in real-time via WebUI.

为用户消息自动注入当前时间，使 AI 无需调用工具即可感知时间。时间字符串**前置**于用户内容之前，使可变部分（时间）作为固定位置前缀，用户实际消息保持稳定偏移量 — 从而最大化提示词缓存命中率，降低 API 成本。该功能可通过 WebUI 实时启停。

**Related Issue:** N/A
**Security Considerations:** No sensitive data involved. Timezone is read from existing `user_timezone` config only.

---

## Why This Design / 设计思路

### Prompt Cache Optimization / 提示词缓存优化

```
┌─────────────────────────────────────────────────┐
│  System Prompt          (static, cacheable)      │
├─────────────────────────────────────────────────┤
│  [Current time: 2026-04-11 15:30:00 CST Sat]    │  ← injected, variable prefix
├─────────────────────────────────────────────────┤
│  User: What's the weather today?                │  ← user input at stable offset
└─────────────────────────────────────────────────┘
```
The final request  is system prompt + current time + user.

最终的请求为系统提示词+当前时间+用户提问

> [!IMPORTANT]
> The current timestamp is omitted from the system prompt to preserve prefix matching integrity. Since the time varies with each request, including it would cause cache invalidation and reduce cache hit rates.
> 系统提示词中未嵌入当前时间戳，鉴于其随请求动态变化的特性，这可以维持前缀匹配的一致性，从而确保提示词缓存的高效命中。


By placing the time string **before** user input (via `prepend_to_message_content`), the user's message content always starts at the same position in the prompt. When users send similar messages across requests, the suffix portion is more likely to match cached entries, maximizing cache hit rate.

将时间字符串通过 `prepend_to_message_content` **前置**于用户输入之前，用户消息内容始终在 prompt 中的相同位置开始。当用户跨请求发送相似消息时，后缀部分更容易命中缓存，从而最大化缓存命中率。

---

## Type of Change / 变更类型

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

---

## Component(s) Affected / 影响组件

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

---

## Changes / 变更详情

### Backend (Python) — 4 files

**`src/copaw/config/config.py`** (+34 lines)
- Add `TimeAwarenessConfig(BaseModel)` with `enabled: bool` (default `False`) and `format: Optional[str]` fields
- Register `time_awareness` field in root `Config` model via `default_factory=TimeAwarenessConfig`
- Fully backward compatible: old configs without `time_awareness` load with defaults

**`src/copaw/agents/utils/message_processing.py`** (+96 lines)
- `inject_time_awareness(config) -> Optional[str]`: Generates formatted time string
  - Reads `config.time_awareness.enabled` and `config.user_timezone`
  - Auto-detects language (`zh-CN`/`zh-TW` → Chinese label, else English)
  - Supports custom `strftime` format with graceful fallback on invalid format
  - Falls back to UTC on invalid timezone with `logger.warning`
- `get_last_user_message(msgs) -> Optional[Msg]`: Finds last user-role message from list
- Added `None` guard to existing `prepend_to_message_content()` for robustness

**`src/copaw/app/runner/runner.py`** (+29 lines)
- In `query_handler()`, after `agent.rebuild_sys_prompt()`:
  - Loads global config via `load_config()`
  - If `config.time_awareness.enabled`, calls `inject_time_awareness()` → `prepend_to_message_content()`
  - Entire block wrapped in `try/except` with `logger.warning` (non-critical failure)

**`src/copaw/app/routers/config.py`** (+73 lines)
- `TimeAwarenessResponse(BaseModel)`: Pydantic response model for OpenAPI docs
- `TimeAwarenessUpdate(BaseModel)`: Request body with `extra="ignore"` validation
- `GET /config/time-awareness`: Returns current settings
- `PUT /config/time-awareness`: Updates `enabled`/`format` and persists via `save_config()`

### Frontend (TypeScript/React) — 6 files

**`console/src/api/modules/timeAwareness.ts`** (new, +17 lines)
- `TimeAwarenessConfig` interface + `getTimeAwareness()` / `updateTimeAwareness()` API calls

**`console/src/api/index.ts`** (+4 lines)
- Register `timeAwarenessApi` in unified `api` object

**`console/src/pages/Agent/Config/components/TimeAwarenessCard.tsx`** (new, +220 lines)
- **Switch toggle**: Enable/disable time injection with optimistic UI + error revert
- **Custom format input**: `strftime` input with `allowClear`, validated server-side
- **Quick template tags**: Default / Compact / Time Only — one-click apply
- **Static preview**: Shows example output format (avoids client-side `Date()` inconsistency)
- **Disabled hint**: Warns users that AI must call `get_current_time()` tool when off
- Loading states, error handling, dark mode support via `index.module.less`

**`console/src/pages/Agent/Config/components/index.ts`** (+1 line)
**`console/src/pages/Agent/Config/index.tsx`** (+3 lines)
- Export and render `TimeAwarenessCard` in Agent Config page

**`console/src/pages/Agent/Config/index.module.less`** (+115 lines)
- Styles for switch row, format section, preview box, disabled hint
- Full `:global(.dark-mode)` override support

**`console/src/locales/zh.json`** / **`en.json`** (+25 keys each)
- Complete i18n coverage: title, description, labels, hints, success/error messages

### Tests — 1 file

**`tests/test_time_awareness.py`** (new, +368 lines, 30+ test cases)
- `TestTimeAwarenessConfig`: Default values, custom format, JSON serialization
- `TestConfigIntegration`: Field presence in root Config, backward compatibility, enable from JSON
- `TestInjectTimeAwareness`: Chinese/English labels, custom format, timezone fallback, disabled state, error handling
- `TestGetLastUserMessage`: Normal case, empty list, no user message, mixed roles
- `TestPrependToMessageContent`: String content, list content, `None` guard (new)

---

## Technical Details / 技术细节

| Item | Detail |
|---|---|
| Default | `enabled: False` — zero impact on existing deployments / 默认关闭，对现有部署零影响 |
| Injection position | **Prepended** via `prepend_to_message_content()` — before user content / 通过 `prepend_to_message_content()` **前置**于用户内容之前 |
| Cache strategy | Time as variable prefix → user input at stable offset → higher cache hit rate / 时间作为可变前缀 → 用户输入位置稳定 → 更高缓存命中率 |
| Timezone | Reuses existing `config.user_timezone` (IANA format) / 复用现有 `config.user_timezone`（IANA 格式） |
| Language | Auto-detects `config.agents.language`: `zh*` → Chinese label, else English / 自动检测 `config.agents.language` |
| Custom format | Optional `strftime` string, falls back to `%Y-%m-%d %H:%M:%S {tz} ({weekday})` / 可选 `strftime` 字符串，降级为默认格式 |
| Error handling | All paths: invalid timezone → UTC fallback, invalid format → default, inject failure → logged & skipped / 所有路径：无效时区 → UTC 降级，无效格式 → 默认格式，注入失败 → 记录日志并跳过 |
| WebUI control | Real-time toggle in Agent Config page, no restart required / Agent 配置页面实时开关，无需重启 |
| API | `GET/PUT /config/time-awareness` with Pydantic models for validation / Pydantic 模型校验 |

---

## Checklist / 检查清单

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

---

## Testing / 测试方式

1. **WebUI**: Agent Config page → Time Awareness card → toggle switch ON
2. **API**: `curl -X PUT http://localhost:8000/config/time-awareness -H 'Content-Type: application/json' -d '{"enabled": true}'`
3. Send any message and verify time is prepended to user content in the prompt
4. Toggle OFF via WebUI → verify injection stops immediately (next message)
5. Test custom format: set `%H:%M` → verify compact output
6. Test with different `user_timezone` values (e.g., `America/New_York`, `Europe/London`)
7. Verify backward compatibility: existing `config.json` without `time_awareness` loads normally

---

## Local Verification Evidence / 本地验证结果

```bash
pre-commit run --all-files
# ✅ All checks passed (import ordering, line length, TypeScript lint, Prettier)

pytest tests/test_time_awareness.py -v
# ✅ 30+ test cases passed
# - Config defaults & serialization
# - Backward compatibility (old configs load correctly)
# - Chinese/English label switching
# - Timezone fallback (invalid → UTC)
# - Custom format with graceful degradation
# - Message prepending (string & list content)
# - Edge cases (None config, empty messages, no user message)
```

---

## Additional Notes / 补充说明

- Fully backward compatible — `TimeAwarenessConfig` defaults to `enabled: False`, existing configs work without changes
- 完全向后兼容 — `TimeAwarenessConfig` 默认 `enabled: False`，现有配置无需修改
- Non-critical: injection failure is caught and logged, never blocks message processing
- 非关键功能：注入失败会被捕获并记录日志，不会阻塞消息处理
- WebUI toggle persists to `config.json` via `save_config()`, survives restarts
- WebUI 开关通过 `save_config()` 持久化到 `config.json`，重启后保留设置
