### PR TITLE
fix(session): recover from JSON corruption in session state files

### DIFF
--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -111,7 +111,18 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as f:
                 content = await f.read()
-                states = json.loads(content)
+                try:
+                    states = json.loads(content)
+                except json.JSONDecodeError:
+                    # Fallback: extract first valid JSON object (handles
+                    # race-condition corruption where two writes overlap)
+                    decoder = json.JSONDecoder()
+                    states, _ = decoder.raw_decode(content)
+                    logger.warning(
+                        "Session file %s had corrupted JSON (Extra data). "
+                        "Recovered first valid object.",
+                        session_save_path,
+                    )
 
             for name, state_module in state_modules_mapping.items():
                 if name in states:
@@ -154,7 +165,16 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as f:
                 content = await f.read()
-                states = json.loads(content)
+                try:
+                    states = json.loads(content)
+                except json.JSONDecodeError:
+                    decoder = json.JSONDecoder()
+                    states, _ = decoder.raw_decode(content)
+                    logger.warning(
+                        "Session file %s had corrupted JSON during update. "
+                        "Recovered first valid object.",
+                        session_save_path,
+                    )
 
         else:
             if not create_if_not_exist:
@@ -223,7 +243,16 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as file:
                 content = await file.read()
-                states = json.loads(content)
+                try:
+                    states = json.loads(content)
+                except json.JSONDecodeError:
+                    decoder = json.JSONDecoder()
+                    states, _ = decoder.raw_decode(content)
+                    logger.warning(
+                        "Session file %s had corrupted JSON during get. "
+                        "Recovered first valid object.",
+                        session_save_path,
+                    )
 
             logger.info(
                 "Get session state dict from %s successfully.",

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -21,6 +21,45 @@ from ...exceptions import AgentStateError
 logger = logging.getLogger(__name__)
 
 
+def _safe_json_loads(content: str, filepath: str = "") -> dict:
+    """Parse JSON with corruption recovery.
+
+    Attempts standard ``json.loads`` first.  If that fails due to
+    trailing garbage (a common symptom of concurrent-write race
+    conditions), falls back to ``raw_decode`` to extract the first
+    valid JSON object.  If the file is completely unparseable, returns
+    an empty dict and logs a warning so callers never crash.
+
+    Args:
+        content: Raw file content.
+        filepath: Used only for log messages.
+
+    Returns:
+        Parsed dict, or ``{}`` when the content is beyond recovery.
+    """
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to extract the first valid JSON object.
+    try:
+        result, _ = json.JSONDecoder().raw_decode(content)
+        logger.warning(
+            "Session file %s had corrupted JSON. "
+            "Recovered first valid object via raw_decode.",
+            filepath,
+        )
+        return result
+    except json.JSONDecodeError:
+        logger.warning(
+            "Session file %s is completely corrupted and could not "
+            "be recovered. Returning empty dict.",
+            filepath,
+        )
+        return {}
+
+
 # Characters forbidden in Windows filenames
 _UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
 
@@ -111,18 +150,7 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as f:
                 content = await f.read()
-                try:
-                    states = json.loads(content)
-                except json.JSONDecodeError:
-                    # Fallback: extract first valid JSON object (handles
-                    # race-condition corruption where two writes overlap)
-                    decoder = json.JSONDecoder()
-                    states, _ = decoder.raw_decode(content)
-                    logger.warning(
-                        "Session file %s had corrupted JSON (Extra data). "
-                        "Recovered first valid object.",
-                        session_save_path,
-                    )
+                states = _safe_json_loads(content, session_save_path)
 
             for name, state_module in state_modules_mapping.items():
                 if name in states:
@@ -165,16 +193,7 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as f:
                 content = await f.read()
-                try:
-                    states = json.loads(content)
-                except json.JSONDecodeError:
-                    decoder = json.JSONDecoder()
-                    states, _ = decoder.raw_decode(content)
-                    logger.warning(
-                        "Session file %s had corrupted JSON during update. "
-                        "Recovered first valid object.",
-                        session_save_path,
-                    )
+                states = _safe_json_loads(content, session_save_path)
 
         else:
             if not create_if_not_exist:
@@ -243,16 +262,7 @@ class SafeJSONSession(SessionBase):
                 errors="surrogatepass",
             ) as file:
                 content = await file.read()
-                try:
-                    states = json.loads(content)
-                except json.JSONDecodeError:
-                    decoder = json.JSONDecoder()
-                    states, _ = decoder.raw_decode(content)
-                    logger.warning(
-                        "Session file %s had corrupted JSON during get. "
-                        "Recovered first valid object.",
-                        session_save_path,
-                    )
+                states = _safe_json_loads(content, session_save_path)
 
             logger.info(
                 "Get session state dict from %s successfully.",

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -180,3 +180,57 @@ async def test_get_nonexistent(sess):
         user_id="",
     )
     assert result == {}
+
+
+# ── completely corrupted file ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_completely_corrupted(sess, tmp_session_dir):
+    """File with no valid JSON at all should not crash (returns empty)."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("{{{THIS IS NOT JSON AT ALL!!!")
+
+    mod = FakeModule()
+    await sess.load_session_state(
+        "test:session",
+        user_id="",
+        memory=mod,
+    )
+    # memory key not in recovered (empty) dict → data stays None
+    assert mod.data is None
+
+
+@pytest.mark.asyncio
+async def test_get_completely_corrupted(sess, tmp_session_dir):
+    """get_session_state_dict returns empty dict for totally garbled file."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("NOT JSON {{{{")
+
+    result = await sess.get_session_state_dict(
+        "test:session",
+        user_id="",
+    )
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_update_completely_corrupted(sess, tmp_session_dir):
+    """update_session_state recovers from total corruption
+    by starting fresh."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("GARBAGE DATA !!!")
+
+    await sess.update_session_state(
+        "test:session",
+        key="memory.content",
+        value=["recovered"],
+        user_id="",
+    )
+
+    with open(path, encoding="utf-8") as f:
+        result = json.load(f)
+    assert result["memory"]["content"] == ["recovered"]

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+"""Tests for SafeJSONSession JSON corruption resilience."""
+# pylint: disable=redefined-outer-name
+import json
+import os
+import tempfile
+
+import pytest
+
+from copaw.app.runner.session import SafeJSONSession
+
+
+@pytest.fixture
+def tmp_session_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def sess(tmp_session_dir):
+    return SafeJSONSession(save_dir=tmp_session_dir)
+
+
+def _corrupt_file(path, valid_json, tail_garbage):
+    """Write a valid JSON object followed by garbage bytes."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(valid_json + tail_garbage)
+
+
+class FakeModule:
+    """Minimal state module mock for testing."""
+
+    def __init__(self):
+        self.data = None
+
+    def state_dict(self):
+        return self.data
+
+    def load_state_dict(self, d):
+        self.data = d
+
+
+# ── load_session_state ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_valid_json(sess, tmp_session_dir):
+    """Normal case: valid JSON loads without error."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    data = {"memory": {"content": ["hello"], "_compressed_summary": ""}}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    mod = FakeModule()
+    await sess.load_session_state(
+        "test:session",
+        user_id="",
+        memory=mod,
+    )
+    assert mod.data == data["memory"]
+
+
+@pytest.mark.asyncio
+async def test_load_corrupted_json_extra_data(sess, tmp_session_dir):
+    """Corrupted file with extra data after valid JSON should recover."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    valid = json.dumps(
+        {"memory": {"content": [], "_compressed_summary": ""}},
+        ensure_ascii=False,
+    )
+    garbage = '=============="}}'
+    _corrupt_file(path, valid, garbage)
+
+    mod = FakeModule()
+    await sess.load_session_state(
+        "test:session",
+        user_id="",
+        memory=mod,
+    )
+    assert mod.data == {"content": [], "_compressed_summary": ""}
+
+
+@pytest.mark.asyncio
+async def test_load_corrupted_json_real_world_tail(sess, tmp_session_dir):
+    """Real-world corruption pattern from QQ session (203-char tail)."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    valid = json.dumps(
+        {
+            "memory": {"content": [], "_compressed_summary": ""},
+            "toolkit": {"active_groups": []},
+        },
+        ensure_ascii=False,
+    )
+    # Actual garbage observed in production
+    garbage = (
+        "perform actions. A response without a tool call indicates "
+        "the task is complete. To continue a task, you must generate "
+        "a tool call or provide useful feedback if you are blocked."
+        '\\n\\n===================="}}'
+    )
+    _corrupt_file(path, valid, garbage)
+
+    mod_mem = FakeModule()
+    mod_tool = FakeModule()
+    await sess.load_session_state(
+        "test:session",
+        user_id="",
+        memory=mod_mem,
+        toolkit=mod_tool,
+    )
+    assert mod_mem.data == {"content": [], "_compressed_summary": ""}
+    assert mod_tool.data == {"active_groups": []}
+
+
+# ── get_session_state_dict ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_corrupted_json(sess, tmp_session_dir):
+    """get_session_state_dict should recover from corrupted files."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    valid = json.dumps(
+        {"memory": {"content": ["x"], "_compressed_summary": ""}},
+        ensure_ascii=False,
+    )
+    _corrupt_file(path, valid, "GARBAGE}}")
+
+    result = await sess.get_session_state_dict(
+        "test:session",
+        user_id="",
+    )
+    assert "memory" in result
+    assert result["memory"]["content"] == ["x"]
+
+
+# ── update_session_state ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_corrupted_json(sess, tmp_session_dir):
+    """update_session_state should recover corrupted file then write clean."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    valid = json.dumps(
+        {"memory": {"content": [], "_compressed_summary": ""}},
+        ensure_ascii=False,
+    )
+    _corrupt_file(path, valid, "EXTRA")
+
+    await sess.update_session_state(
+        "test:session",
+        key="memory.content",
+        value=["updated"],
+        user_id="",
+    )
+
+    # Verify the file is now clean JSON
+    with open(path, encoding="utf-8") as f:
+        result = json.load(f)
+    assert result["memory"]["content"] == ["updated"]
+
+
+# ── non-existent session ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_nonexistent(sess):
+    """Non-existent session should not raise when allow_not_exist=True."""
+    await sess.load_session_state(
+        "no:exist",
+        user_id="",
+        memory=FakeModule(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent(sess):
+    """Non-existent session should return empty dict."""
+    result = await sess.get_session_state_dict(
+        "no:exist",
+        user_id="",
+    )
+    assert result == {}

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -3,11 +3,12 @@
 # pylint: disable=redefined-outer-name
 import json
 import os
+import pathlib
 import tempfile
 
 import pytest
 
-from copaw.app.runner.session import SafeJSONSession
+from qwenpaw.app.runner.session import SafeJSONSession
 
 
 @pytest.fixture
@@ -234,3 +235,102 @@ async def test_update_completely_corrupted(sess, tmp_session_dir):
     with open(path, encoding="utf-8") as f:
         result = json.load(f)
     assert result["memory"]["content"] == ["recovered"]
+
+
+# ── edge-case: empty file ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_empty_file(sess, tmp_session_dir):
+    """Zero-byte file should recover as empty dict without crash."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    pathlib.Path(path).touch()  # create empty file
+
+    mod = FakeModule()
+    await sess.load_session_state(
+        "test:session",
+        user_id="",
+        memory=mod,
+    )
+    assert mod.data is None  # "memory" key absent from empty dict
+
+
+@pytest.mark.asyncio
+async def test_get_empty_file(sess, tmp_session_dir):
+    """Zero-byte file returns empty dict via get_session_state_dict."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    pathlib.Path(path).touch()
+
+    result = await sess.get_session_state_dict("test:session", user_id="")
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_update_empty_file(sess, tmp_session_dir):
+    """update_session_state on empty file creates clean structure."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "w", encoding="utf-8") as f:
+        pass
+
+    await sess.update_session_state(
+        "test:session",
+        key="memory.content",
+        value=["fresh"],
+        user_id="",
+    )
+
+    with open(path, encoding="utf-8") as f:
+        result = json.load(f)
+    assert result["memory"]["content"] == ["fresh"]
+
+
+# ── edge-case: binary / null bytes ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_null_bytes(sess, tmp_session_dir):
+    """File filled with null bytes should not crash."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "wb") as f:
+        f.write(b"\x00" * 256)
+
+    mod = FakeModule()
+    await sess.load_session_state("test:session", user_id="", memory=mod)
+    assert mod.data is None
+
+
+# ── edge-case: multiple concatenated JSON objects ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_double_write_overlap(sess, tmp_session_dir):
+    """Simulates race condition: two full JSON objects concatenated."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    obj1 = json.dumps(
+        {"memory": {"content": ["first"], "_compressed_summary": ""}},
+    )
+    obj2 = json.dumps(
+        {"memory": {"content": ["second"], "_compressed_summary": ""}},
+    )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(obj1 + obj2)
+
+    mod = FakeModule()
+    await sess.load_session_state("test:session", user_id="", memory=mod)
+    # Should recover the FIRST object (raw_decode behavior)
+    assert mod.data == {"content": ["first"], "_compressed_summary": ""}
+
+
+# ── edge-case: only whitespace ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_load_whitespace_only(sess, tmp_session_dir):
+    """File with only whitespace should not crash."""
+    path = os.path.join(tmp_session_dir, "test--session.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("   \n\n\t  ")
+
+    mod = FakeModule()
+    await sess.load_session_state("test:session", user_id="", memory=mod)
+    assert mod.data is None


### PR DESCRIPTION
## Description

Fix a P0 availability issue where session state JSON files become corrupted due to concurrent write race conditions, causing `JSONDecodeError: Extra data` on every subsequent request to the affected session.

**Root cause:** `save_session_state`, `update_session_state`, and `get_session_state_dict` access the same session file concurrently without any locking mechanism. When two coroutines execute `open("w")` on the same file nearly simultaneously, the OS-level writes interleave, producing a file with a valid JSON object followed by garbage fragments. Once corrupted, every request to that session fails with a 422 error — no recovery is possible without manual intervention.

**Fix:** Add `JSONDecodeError` catch with `raw_decode` fallback at all three `json.loads` call sites in `SafeJSONSession`. When corruption is detected, the first valid JSON object is extracted and a warning is logged, instead of crashing the request.

**Related Issue:** Fixes #3277

**Security Considerations:** No changes to auth, config handling, or external-facing interfaces. Pure defensive parsing change.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

### New tests added

`tests/unit/agents/test_session.py` — 7 test cases covering:

| Test | Scenario |
|------|----------|
| `test_load_valid_json` | Normal JSON loads without error (baseline) |
| `test_load_corrupted_json_extra_data` | 17-char garbage tail (first observed pattern) |
| `test_load_corrupted_json_real_world_tail` | 203-char garbage tail (second observed pattern) |
| `test_get_corrupted_json` | `get_session_state_dict` recovers from corruption |
| `test_update_corrupted_json` | `update_session_state` recovers, then writes clean JSON |
| `test_load_nonexistent` | Non-existent session returns gracefully |
| `test_get_nonexistent` | Non-existent session returns empty dict |

## Local Verification Evidence

```bash
pre-commit run --files src/copaw/app/runner/session.py tests/unit/agents/test_session.py
# check python ast.........................................Passed
# check docstring is first.........................................Passed
# detect private key.......................................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed

pytest tests/unit/agents/test_session.py -v
# 7 passed, 1 warning in 0.16s
```

## Additional Notes

### Files changed

| File | Change |
|------|--------|
| `src/copaw/app/runner/session.py` | Add `JSONDecodeError` → `raw_decode` fallback in `load_session_state`, `update_session_state`, `get_session_state_dict` |
| `tests/unit/agents/test_session.py` | **New** — 7 test cases for corruption resilience |

### Recommended follow-ups (out of scope)

1. **`asyncio.Lock`** — Serialize concurrent reads/writes to eliminate race at source
2. **Atomic writes** — Write to temp file then `os.rename()`
3. **Session file rotation** — Files grow unboundedly; compaction would help
