### PR TITLE
fix: omit tool_choice=auto for vLLM compatibility to avoid 400 error

### DIFF
--- a/src/qwenpaw/token_usage/model_wrapper.py
+++ b/src/qwenpaw/token_usage/model_wrapper.py
@@ -66,6 +66,14 @@ class TokenRecordingModelWrapper(ChatModelBase):
         structured_model: Type[BaseModel] | None = None,
         **kwargs: Any,
     ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        # Fix: Omit tool_choice="auto" for vLLM compatibility
+        # vLLM without --enable-auto-tool-choice will reject requests when
+        # tool_choice="auto" is present, even if tools are provided.
+        # By omitting tool_choice when it's "auto", we bypass the check
+        # while keeping tools available for correct tool calling behavior.
+        if tool_choice == "auto":
+            tool_choice = None
+
         result = await self._model(
             messages=messages,
             tools=tools,


### PR DESCRIPTION
## Summary

When connecting to a self-hosted vLLM OpenAI-compatible API endpoint that does not have `--enable-auto-tool-choice` enabled (which is the default configuration for most vLLM deployments), vLLM will reject any request containing `tool_choice="auto"` with a 400 error:

> "auto" tool choice requires --enable-auto-tool-choice.

This PR fixes the issue by **omitting `tool_choice` entirely when it's set to `auto`**, following the same fix pattern already adopted by OpenClaw/Clawdia for vLLM compatibility:
- Keeps `tools` intact so the model knows what tools are available
- Omits `tool_choice = "auto"` to avoid triggering the vLLM check
- Client-side parsing still works correctly, so full tool calling capability is preserved

## Type of Change
- ✅ Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected
- ✅ Core (token_usage / model_wrapper)

## Checklist
- [x] I have run `pre-commit run --all-files` (or will do so before merging)
- [x] The change is tested and works locally with vLLM endpoint
- [x] No documentation is needed for this small compatibility fix

## Testing
- **Problem**: Connecting QwenPaw to a vLLM OpenAI-compatible endpoint (without `--enable-auto-tool-choice`) with tool calling enabled would result in a 400 error immediately
- **Fix**: After this change, QwenPaw can connect successfully and tool calling works normally
- **Validation**: This matches the same fix that has already been tested and confirmed working in OpenClaw/claudish

Fixes the vLLM 400 compatibility issue that reported in https://github.com/openclaw/openclaw/issues/61197