### PR TITLE
fix(wecom): dispatch WS SDK calls to ws_loop to fix asyncio event loop conflict

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -929,12 +929,23 @@ class WecomChannel(BaseChannel):
             return
         try:
             sid = stream_id or generate_req_id("stream")
-            await self._client.reply_stream(
-                frame,
-                stream_id=sid,
-                content=text,
-                finish=True,
-            )
+            if self._ws_loop and self._ws_loop.is_running():
+                reply_coro = self._client.reply_stream(
+                    frame,
+                    stream_id=sid,
+                    content=text,
+                    finish=True,
+                )
+                await asyncio.wrap_future(
+                    asyncio.run_coroutine_threadsafe(reply_coro, self._ws_loop)
+                )
+            else:
+                await self._client.reply_stream(
+                    frame,
+                    stream_id=sid,
+                    content=text,
+                    finish=True,
+                )
         except Exception:
             logger.exception("wecom _send_text_via_frame failed")
 


### PR DESCRIPTION
Fixes #3296

## Problem
When using the WeCom channel with `send_file_to_user` or text replies, the SDK internally uses `asyncio.ensure_future()` which attaches tasks to whatever loop is currently running. Since the WebSocket loop (`_ws_loop`) runs in a dedicated thread separate from the main agent loop (`_loop`), this causes:

```
RuntimeError: Task ... got Future ... attached to a different loop
```

This prevents files/photos from being sent and causes text reply failures.

## Root Cause
Two event loops are running:
1. `self._loop` — main agent/logic loop
2. `self._ws_loop` — WebSocket loop in a dedicated thread

In `_send_ws_cmd()`, `asyncio.get_event_loop()` may return the wrong loop for `Future` creation. More critically, `self._client._ws_manager.send()` and `self._client.reply_stream()` internally call `asyncio.ensure_future()`, attaching tasks to the main loop — but the WS operations need to run on `self._ws_loop`.

## Solution
- **`_send_ws_cmd()`**: Use `self._loop or asyncio.get_running_loop()` for `Future` creation. Dispatch `_ws_manager.send()` to `self._ws_loop` via `asyncio.run_coroutine_threadsafe()` + `asyncio.wrap_future()` when the WS loop is running.
- **`_send_text_via_frame()`**: Similarly dispatch `reply_stream()` to `self._ws_loop` when available.

Both methods fall back to direct `await` when `_ws_loop` is not running (e.g. during tests or single-loop setups).

## Testing
Verified by the bug reporter: after applying the fix, `send_file_to_user` correctly sends photos and files to users via WeCom.