### PR TITLE
fix(skill): fix skill loading during creation and selection behavior

### DIFF
--- a/console/src/pages/Settings/Agents/components/AgentModal.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentModal.tsx
@@ -51,24 +51,27 @@ export function AgentModal({
 
     const fetchPool = skillApi.listSkillPoolSkills();
     const fetchInstalled = editingAgent
-      ? skillApi
-          .listSkills(editingAgent.id)
-          .then((skills) => skills.map((s) => s.name))
+      ? skillApi.listSkills(editingAgent.id)
       : Promise.resolve([]);
 
     Promise.all([fetchPool, fetchInstalled])
-      .then(([pool, installed]) => {
+      .then(([pool, workspaceSkills]) => {
+        const poolSkillNames = new Set(pool.map((skill) => skill.name));
+        const installedSkills = workspaceSkills
+          .filter((skill) => poolSkillNames.has(skill.name))
+          .map((skill) => skill.name);
+
         setPoolSkills(pool);
-        setInstalledSkills(installed);
-        onInstalledSkillsLoaded(installed);
+        setInstalledSkills(installedSkills);
+        onInstalledSkillsLoaded(installedSkills);
         if (editingAgent) {
-          onSelectedSkillsChange(installed);
+          onSelectedSkillsChange(installedSkills);
         } else {
           onSelectedSkillsChange([]);
         }
       })
       .finally(() => setLoadingSkills(false));
-  }, [open, editingAgent?.id]);
+  }, [editingAgent, onInstalledSkillsLoaded, onSelectedSkillsChange, open]);
 
   const toggleSkill = (name: string) => {
     const isInstalled = editingAgent && installedSkills.includes(name);
@@ -83,9 +86,7 @@ export function AgentModal({
 
   const handleSelectAll = () => {
     const allNames = poolSkills.map((s) => s.name);
-    onSelectedSkillsChange(
-      Array.from(new Set([...installedSkills, ...allNames])),
-    );
+    onSelectedSkillsChange(allNames);
   };
 
   const handleSelectBuiltin = () => {

--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -1,10 +1,10 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Card, Button, Form } from "antd";
 import { useAppMessage } from "../../../hooks/useAppMessage";
 import { PlusOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { agentsApi } from "../../../api/modules/agents";
-import { skillApi } from "../../../api/modules/skill";
+import { invalidateSkillCache, skillApi } from "../../../api/modules/skill";
 import type { AgentSummary } from "../../../api/types/agents";
 import { useAgentStore } from "../../../stores/agentStore";
 import { useAgents } from "./useAgents";
@@ -39,6 +39,9 @@ export default function AgentsPage() {
 
   const handleEdit = async (agent: AgentSummary) => {
     try {
+      setSelectedSkills([]);
+      installedSkillsRef.current = [];
+      invalidateSkillCache({ agentId: agent.id });
       const config = await agentsApi.getAgent(agent.id);
       setEditingAgent(agent);
       form.setFieldsValue(config);
@@ -76,9 +79,9 @@ export default function AgentsPage() {
     }
   };
 
-  const handleInstalledSkillsLoaded = (skills: string[]) => {
+  const handleInstalledSkillsLoaded = useCallback((skills: string[]) => {
     installedSkillsRef.current = skills;
-  };
+  }, []);
 
   const handleSubmit = async () => {
     try {
@@ -91,9 +94,11 @@ export default function AgentsPage() {
       const payload = { ...values, workspace_dir };
 
       if (editingAgent) {
+        const previousInstalledSkills = installedSkillsRef.current;
         const newSkills = selectedSkills.filter(
-          (s) => !installedSkillsRef.current.includes(s),
+          (skill) => !previousInstalledSkills.includes(skill),
         );
+
         for (const skill of newSkills) {
           await skillApi.downloadSkillPoolSkill({
             skill_name: skill,
@@ -101,6 +106,13 @@ export default function AgentsPage() {
           });
         }
         await agentsApi.updateAgent(editingAgent.id, payload);
+        installedSkillsRef.current = [
+          ...previousInstalledSkills,
+          ...newSkills.filter(
+            (skill) => !previousInstalledSkills.includes(skill),
+          ),
+        ];
+        invalidateSkillCache({ agentId: editingAgent.id });
         message.success(t("agent.updateSuccess"));
       } else {
         const result = await agentsApi.createAgent({
@@ -114,6 +126,9 @@ export default function AgentsPage() {
       await loadAgents();
     } catch (error: any) {
       console.error("Failed to save agent:", error);
+      if (editingAgent) {
+        invalidateSkillCache({ agentId: editingAgent.id });
+      }
       message.error(error.message || t("agent.saveFailed"));
     }
   };

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -624,29 +624,6 @@ def _ensure_heartbeat_file(workspace_dir: Path, language: str) -> None:
         file.write(heartbeat_content.strip())
 
 
-def _copy_builtin_skills(workspace_dir: Path) -> None:
-    """Copy builtin skills into a new workspace when missing."""
-    builtin_skills_dir = (
-        Path(__file__).parent.parent.parent / "agents" / "skills"
-    )
-    if not builtin_skills_dir.exists():
-        return
-
-    target_skills_dir = get_workspace_skills_dir(workspace_dir)
-    target_skills_dir.mkdir(parents=True, exist_ok=True)
-
-    for skill_dir in builtin_skills_dir.iterdir():
-        if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
-            continue
-        target_skill_dir = target_skills_dir / skill_dir.name
-        if target_skill_dir.exists():
-            continue
-        try:
-            shutil.copytree(skill_dir, target_skill_dir)
-        except Exception as e:
-            logger.warning("Failed to copy skill %s: %s", skill_dir.name, e)
-
-
 def _install_initial_skills(
     workspace_dir: Path,
     skill_names: list[str] | None,
@@ -685,7 +662,7 @@ def _initialize_agent_workspace(
     skill_names: list[str] | None = None,
     builtin_qa_md_seed: bool = False,
 ) -> None:
-    """Initialize agent workspace (similar to qwenpaw init --defaults)."""
+    """Initialize agent workspace with only explicitly requested skills."""
     from ...config import load_config as load_global_config
 
     (workspace_dir / "sessions").mkdir(exist_ok=True)
@@ -701,7 +678,6 @@ def _initialize_agent_workspace(
         builtin_qa_md_seed=builtin_qa_md_seed,
     )
     _ensure_heartbeat_file(workspace_dir, language)
-    _copy_builtin_skills(workspace_dir)
     _install_initial_skills(workspace_dir, skill_names)
 
     jobs_file = workspace_dir / "jobs.json"

--- a/tests/unit/app/test_agents_workspace_initialization.py
+++ b/tests/unit/app/test_agents_workspace_initialization.py
@@ -15,23 +15,6 @@ def _stub_global_config(language: str = "en") -> SimpleNamespace:
     )
 
 
-def test_copy_builtin_skills_targets_unified_skills_dir(monkeypatch, tmp_path):
-    """Builtin skills should seed into workspace ``skills/``."""
-    copied_targets: list[Path] = []
-
-    def _record_copytree(_source: Path, target: Path) -> None:
-        copied_targets.append(target)
-
-    monkeypatch.setattr(agents_router.shutil, "copytree", _record_copytree)
-
-    agents_router._copy_builtin_skills(tmp_path)
-
-    assert copied_targets
-    assert all(
-        target.parent == tmp_path / "skills" for target in copied_targets
-    )
-
-
 def test_initialize_agent_workspace_creates_runtime_compatible_files(
     monkeypatch,
     tmp_path,
@@ -44,7 +27,6 @@ def test_initialize_agent_workspace_creates_runtime_compatible_files(
         "load_config",
         lambda: _stub_global_config("en"),
     )
-    monkeypatch.setattr(agents_router, "_copy_builtin_skills", lambda _: None)
     monkeypatch.setattr(
         agents_router,
         "_install_initial_skills",
@@ -90,10 +72,9 @@ def test_initialize_agent_workspace_builtin_qa_seed_passes_language_first(
         agents_router,
         "copy_builtin_qa_md_files",
         lambda language, workspace_dir: recorded_calls.append(
-            (language, Path(workspace_dir)),
+            (language, workspace_dir),
         ),
     )
-    monkeypatch.setattr(agents_router, "_copy_builtin_skills", lambda _: None)
     monkeypatch.setattr(
         agents_router,
         "_install_initial_skills",


### PR DESCRIPTION
## Description

This PR fixes the Agent Management skill picker to match the intended add-only behavior.
- It keeps already installed workspace skills selected and non-removable in Agent Management, so this page only **adds** skills from the pool. Actual skill removal remains in the `Skills/`page. 
- It also fixes new agent initialization so only user-selected skills are installed, instead of copying all builtin skills into every new workspace by default.

Fix: #3088, Fix #2931, Fix #3247.
- Do not handle any **delete** operations mentioned in issues, as this edit does not address skills management. Furthermore, the skills shown are from the global pool, not from the workspace's own set of skills. So only skills import is allowed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
