### PR TITLE
Fix(Local Provider): Fix "Donwload failed: [Errno 22] Invalid argument" on Windows Desktop

### DIFF
--- a/src/qwenpaw/local_models/model_manager.py
+++ b/src/qwenpaw/local_models/model_manager.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import logging
 import multiprocessing as mp
+import os
 import shutil
 import uuid
 from pathlib import Path
@@ -332,11 +334,11 @@ class ModelManager:
                 source=source,
                 local_dir=staging_dir,
             )
-        except Exception as exc:
+        except Exception:
             queue.put(
                 DownloadTaskResult(
                     status=DownloadTaskStatus.FAILED,
-                    error="Download failed: " + str(exc),
+                    error="Download failed: " + traceback.format_exc(),
                 ).to_message(),
             )
             logger.error(
@@ -393,10 +395,20 @@ class ModelManager:
         local_dir: Path,
     ) -> str:
         """Download a model repository from ModelScope."""
-        return ModelManager._get_modelscope_snapshot_download()(
-            model_id=repo_id,
-            local_dir=str(local_dir),
-        )
+        with open(
+            os.devnull,
+            "a",
+            encoding="utf-8",
+            buffering=1,
+            errors="replace",
+        ) as sink_stream:
+            with contextlib.redirect_stdout(
+                sink_stream,
+            ), contextlib.redirect_stderr(sink_stream):
+                return ModelManager._get_modelscope_snapshot_download()(
+                    model_id=repo_id,
+                    local_dir=str(local_dir),
+                )
 
     def _estimate_huggingface_size(
         self,

--- a/tests/unit/local_models/test_model_manager.py
+++ b/tests/unit/local_models/test_model_manager.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -366,3 +367,47 @@ def test_download_worker_sanitizes_standard_streams(
     payload = queue_messages[0]["payload"]
     assert isinstance(payload, dict)
     assert payload["status"] == "completed"
+
+
+def test_download_from_modelscope_redirects_broken_standard_streams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _BrokenStream:
+        encoding = "utf-8"
+
+        def write(self, _text: str) -> int:
+            raise OSError(22, "Invalid argument")
+
+        def flush(self) -> None:
+            raise OSError(22, "Invalid argument")
+
+    captured: dict[str, object] = {}
+
+    def _fake_snapshot_download(*, model_id: str, local_dir: str) -> str:
+        captured["model_id"] = model_id
+        captured["local_dir"] = local_dir
+        captured["stdout"] = sys.stdout
+        captured["stderr"] = sys.stderr
+        sys.stderr.write("")
+        sys.stderr.flush()
+        return local_dir
+
+    monkeypatch.setattr(sys, "stdout", _BrokenStream())
+    monkeypatch.setattr(sys, "stderr", _BrokenStream())
+    monkeypatch.setattr(
+        ModelManager,
+        "_get_modelscope_snapshot_download",
+        staticmethod(lambda: _fake_snapshot_download),
+    )
+
+    result = ModelManager._download_from_modelscope(
+        repo_id="AgentScope/demo",
+        local_dir=tmp_path / "download",
+    )
+
+    assert result == str(tmp_path / "download")
+    assert captured["model_id"] == "AgentScope/demo"
+    assert captured["local_dir"] == str(tmp_path / "download")
+    assert captured["stdout"] is not sys.stdout
+    assert captured["stderr"] is not sys.stderr


### PR DESCRIPTION
## Description

This pull request improves the robustness of the model download process in `ModelManager` and adds a new test to ensure that standard output and error streams are properly redirected, even if they are broken. It also enhances error reporting for download failures.

**Improvements to model download robustness:**

* [`src/qwenpaw/local_models/model_manager.py`](diffhunk://#diff-7b3af445e23836580da609c4dd27653b27cc364a1fd326afe20a34e9d146a238R398-R407): The `_download_from_modelscope` method now redirects `stdout` and `stderr` to a safe stream using `contextlib.redirect_stdout` and `contextlib.redirect_stderr`, ensuring that broken or invalid standard streams do not cause failures during model downloads.
* [`src/qwenpaw/local_models/model_manager.py`](diffhunk://#diff-7b3af445e23836580da609c4dd27653b27cc364a1fd326afe20a34e9d146a238R6-R10): Additional imports of `contextlib` and `os` support the new stream redirection logic.

**Error handling improvements:**

* [`src/qwenpaw/local_models/model_manager.py`](diffhunk://#diff-7b3af445e23836580da609c4dd27653b27cc364a1fd326afe20a34e9d146a238L335-R341): The `_download_worker` function now reports the full traceback in the error message when a download fails, making debugging easier.

**Testing enhancements:**

* [`tests/unit/local_models/test_model_manager.py`](diffhunk://#diff-35f26e424094f097b640658d15be6d29b47f3af86690190c194aff0612b968d5R370-R413): Added a new test, `test_download_from_modelscope_redirects_broken_standard_streams`, which verifies that the download function works correctly even if `sys.stdout` and `sys.stderr` are broken streams.
* [`tests/unit/local_models/test_model_manager.py`](diffhunk://#diff-35f26e424094f097b640658d15be6d29b47f3af86690190c194aff0612b968d5R6): Imports `sys` to support the new test for stream redirection.

**Related Issue:** Fixes #3229

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
