### PR TITLE
fix(memory): make file watcher recursive configurable

### DIFF
--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -120,6 +120,10 @@ See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
             rebuild_on_start=rebuild_on_start,
         )
 
+        recursive_file_watcher = (
+            agent_config.running.memory_summary.recursive_file_watcher
+        )
+
         self._reme = ReMeLight(
             working_dir=working_dir,
             default_embedding_model_config=emb_config,
@@ -131,6 +135,7 @@ See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
             },
             default_file_watcher_config={
                 "rebuild_index_on_start": effective_rebuild,
+                "recursive": recursive_file_watcher,
             },
         )
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -467,6 +467,15 @@ class MemorySummaryConfig(BaseModel):
         ),
     )
 
+    recursive_file_watcher: bool = Field(
+        default=True,
+        description=(
+            "Whether to watch memory directory recursively. "
+            "Set to True to include subdirectories like memory/subdirectory/* "
+            "in vector search indexing."
+        ),
+    )
+
 
 class AgentsRunningConfig(BaseModel):
     """Agent runtime behavior configuration."""

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -468,7 +468,7 @@ class MemorySummaryConfig(BaseModel):
     )
 
     recursive_file_watcher: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Whether to watch memory directory recursively. "
             "Set to True to include subdirectories like memory/subdirectory/* "


### PR DESCRIPTION
Add recursive_file_watcher config option to MemorySummaryConfig. This allows users to enable/disable recursive watching of the memory directory, so files in subdirectories like memory/{subdirectory}/* can be included in the vector search index.

Fixes #3317

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Config the embedding model, and test that the memory_search function 
2. Creat a Test subdirectory file under /memory/{subdirectory}/. directory. (e.g. /memory/test/test.md)
3. write "There is a man named Harry. "
4. restart the copaw to reload the config and let sqlite create embedding chunks
5. ask the agent to memory_search "There is a man named"

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast.........................................................Passed
# check yaml...............................................................Passed
# check toml...............................................................Passed
# check json...............................................................Passed
# fix python encoding pragma...............................................Passed
# detect private key.......................................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed
# prettier.................................................................Passed
# All hooks passed (Python checks only, prettier skipped due to macOS/Node compatibility)

pytest
# 479 passed, 1 failed in 11.33s
# (1 existing failure unrelated to this PR - proxy config issue)
# Note: 1 existing failure (test_stream_parser_skips_tool_call_without_function)
# is unrelated to this PR - caused by local SOCKS proxy configuration
```

## Additional Notes
Welcome to review.
