### PR TITLE
fix(console): clear chat history on /clear

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -61,6 +61,46 @@ interface CommandSuggestion {
   description: string;
 }
 
+function messageRequestsHistoryClear(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const metadata = (message as Record<string, unknown>).metadata;
+  if (!metadata || typeof metadata !== "object") return false;
+
+  const meta = metadata as Record<string, unknown>;
+  if (meta.clear_history === true) return true;
+
+  const nested = meta.metadata;
+  return (
+    !!nested &&
+    typeof nested === "object" &&
+    (nested as Record<string, unknown>).clear_history === true
+  );
+}
+
+function payloadRequestsHistoryClear(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+
+  const record = payload as Record<string, unknown>;
+  const candidates: unknown[] = [];
+
+  if (record.object === "message") {
+    candidates.push(record);
+  }
+
+  if (record.object === "response" && Array.isArray(record.output)) {
+    candidates.push(...record.output);
+  }
+
+  return candidates.some(messageRequestsHistoryClear);
+}
+
+function payloadCompletesResponse(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+
+  const record = payload as Record<string, unknown>;
+  return record.object === "response" && record.status === "completed";
+}
+
 function renderSuggestionLabel(command: string, description: string) {
   return (
     <div className={styles.suggestionLabel}>
@@ -433,10 +473,19 @@ export default function ChatPage() {
   const chatIdRef = useRef(chatId);
   const navigateRef = useRef(navigate);
   const chatRef = useRef<IAgentScopeRuntimeWebUIRef>(null);
+  const pendingClearHistoryRef = useRef(false);
 
   useMessageHistoryNavigation(chatRef, isChatActive, isComposingRef);
   chatIdRef.current = chatId;
   navigateRef.current = navigate;
+
+  const scheduleHistoryClear = useCallback(() => {
+    queueMicrotask(() => {
+      if (!pendingClearHistoryRef.current) return;
+      pendingClearHistoryRef.current = false;
+      chatRef.current?.messages.removeAllMessages();
+    });
+  }, []);
 
   // Tell sessionApi which session to put first in getSessionList, so the library's
   // useMount auto-selects the correct session without an extra getSession round-trip.
@@ -777,6 +826,16 @@ export default function ChatPage() {
       api: {
         ...defaultConfig.api,
         fetch: customFetch,
+        responseParser: (chunk: string) => {
+          const payload = JSON.parse(chunk) as Record<string, unknown>;
+          if (payloadRequestsHistoryClear(payload)) {
+            pendingClearHistoryRef.current = true;
+            if (payloadCompletesResponse(payload)) {
+              scheduleHistoryClear();
+            }
+          }
+          return payload as any;
+        },
         replaceMediaURL: (url: string) => {
           return toDisplayUrl(url);
         },
@@ -824,7 +883,15 @@ export default function ChatPage() {
         replace: true,
       },
     } as unknown as IAgentScopeRuntimeWebUIOptions;
-  }, [customFetch, copyResponse, handleFileUpload, t, isDark, multimodalCaps]);
+  }, [
+    customFetch,
+    copyResponse,
+    handleFileUpload,
+    t,
+    isDark,
+    multimodalCaps,
+    scheduleHistoryClear,
+  ]);
 
   return (
     <div

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -51,7 +51,7 @@ interface ContentItem {
 /** A backend message after role-normalisation (output of toOutputMessage). */
 interface OutputMessage extends Omit<Message, "role"> {
   role: string;
-  metadata: null;
+  metadata: unknown;
   sequence_number?: number;
 }
 
@@ -155,7 +155,7 @@ const toOutputMessage = (msg: Message): OutputMessage => ({
     msg.type === TYPE_PLUGIN_CALL_OUTPUT && msg.role === "system"
       ? ROLE_TOOL
       : msg.role,
-  metadata: null,
+  metadata: msg.metadata ?? null,
 });
 
 /** Build a user card (AgentScopeRuntimeRequestCard) from a user message. */

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -94,11 +94,16 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Check if the query is a system command (alias for mixin)."""
         return self.is_conversation_command(query)
 
-    async def _make_system_msg(self, text: str) -> Msg:
+    async def _make_system_msg(
+        self,
+        text: str,
+        metadata: dict | None = None,
+    ) -> Msg:
         """Create a system response message.
 
         Args:
             text: Message text content
+            metadata: Optional structured metadata for downstream consumers
 
         Returns:
             System message
@@ -107,6 +112,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
             name=self.agent_name,
             role="assistant",
             content=[TextBlock(type="text", text=text)],
+            metadata=metadata or {},
         )
 
     def _has_memory_manager(self) -> bool:
@@ -198,6 +204,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
             "**History Cleared!**\n\n"
             "- Compressed summary reset\n"
             "- Memory is now empty",
+            metadata={"clear_history": True},
         )
 
     async def _process_compact_str(

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from qwenpaw.agents.command_handler import CommandHandler
+
+
+class DummyMemory:
+    def __init__(self) -> None:
+        self.clear_content_called = 0
+        self.clear_summary_called = 0
+
+    def clear_content(self) -> None:
+        self.clear_content_called += 1
+
+    def clear_compressed_summary(self) -> None:
+        self.clear_summary_called += 1
+
+    async def get_memory(self, prepend_summary: bool = False) -> list:
+        assert prepend_summary is False
+        return []
+
+
+@pytest.mark.asyncio
+async def test_process_clear_returns_clear_history_metadata() -> None:
+    memory = DummyMemory()
+    handler = CommandHandler(agent_name="QwenPaw", memory=memory)
+
+    msg = await handler.handle_command("/clear")
+
+    assert memory.clear_content_called == 1
+    assert memory.clear_summary_called == 1
+    assert msg.metadata == {"clear_history": True}


### PR DESCRIPTION
## Summary
- propagate a `clear_history` metadata flag from the `/clear` command response
- preserve response metadata in the console session adapter and clear the active UI history when that flag is received
- add a regression test covering the `/clear` command metadata contract

## Root cause
The backend cleared agent memory, but the active console session never received a UI-level signal to drop already-rendered chat cards. Re-entering the session reloaded the empty persisted history, so the bug only affected the live view.

## Validation
- `./.venv/bin/pytest -v tests/unit/agents/test_command_handler.py`
- `./.venv/bin/pre-commit run --files src/qwenpaw/agents/command_handler.py console/src/pages/Chat/index.tsx console/src/pages/Chat/sessionApi/index.ts tests/unit/agents/test_command_handler.py`

Closes #3297
