### PR TITLE
fix(console): normalize duplicated preview URL prefixes

### DIFF
--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
+from urllib.parse import unquote
 from fastapi import APIRouter, HTTPException
 from starlette.responses import FileResponse
 
@@ -15,9 +16,30 @@ async def preview_file(
     filepath: str,
 ):
     """Preview file."""
-    path = Path(filepath)
+    normalized = unquote(filepath)
+
+    # Tolerate duplicated preview prefix from some clients, e.g.
+    # /api/files/preview/api/files/preview/C%3A/Users/...
+    while True:
+        trimmed = normalized.lstrip("/")
+        prefix = "api/files/preview/"
+        if trimmed.startswith(prefix):
+            normalized = trimmed[len(prefix) :]
+            continue
+        break
+
+    # Normalize /C:/... to C:/... on Windows.
+    if (
+        len(normalized) >= 4
+        and normalized[0] == "/"
+        and normalized[2] == ":"
+        and normalized[1].isalpha()
+    ):
+        normalized = normalized[1:]
+
+    path = Path(normalized)
     if not path.is_absolute():
-        path = Path("/" + filepath)
+        path = Path("/" + normalized)
     path = path.resolve()
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Not found")


### PR DESCRIPTION
## Summary
- Normalize `filepath` in file preview API to tolerate duplicated `api/files/preview/` prefixes.
- Decode URL-encoded paths before resolving local files.
- Normalize Windows-style `/C:/...` paths to `C:/...` for robust file lookup.

## Why
Some messages/clients may already contain a preview URL path (`/api/files/preview/...`). If another layer prepends the same prefix again, backend currently resolves an invalid filesystem path and returns `404`.

## Reproduction
- Generate an image so local file exists.
- Open preview with duplicated path:
  - `/api/files/preview/api/files/preview/C%3A/Users/.../image.jpg`
- Current behavior: `404 Not Found`.

## Verification
- Normal path still works:
  - `/api/files/preview/C%3A/Users/.../image.jpg`
- Duplicated-prefix path now resolves correctly when file exists.

## Scope
- Backward-compatible server-side normalization only.
- No change to successful normal-path behavior.