### PR TITLE
feat(models): Use message normalizaiton to enable better switch(e.g. preserve media memory) within same type of model providers

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -33,7 +33,9 @@ except ImportError:  # pragma: no cover - compatibility fallback
     GeminiChatFormatter = None
     GeminiChatModel = None
 
-from .utils.tool_message_utils import _sanitize_tool_messages
+from .utils.message_request_normalizer import (
+    normalize_messages_for_model_request,
+)
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.retry_chat_model import (
@@ -73,6 +75,49 @@ _SUPPORTED_VIDEO_EXTENSIONS: dict[str, str] = {
     ".avi": "video/x-msvideo",
     ".mkv": "video/x-matroska",
 }
+
+
+def _supports_multimodal_for_current_model() -> bool:
+    """Best-effort lookup of current model multimodal support."""
+    try:
+        from .prompt import get_active_model_supports_multimodal
+
+        return get_active_model_supports_multimodal()
+    except Exception:  # pragma: no cover - config lookup safety
+        logger.debug(
+            "Falling back to multimodal=True during OpenAI normalization",
+            exc_info=True,
+        )
+        return True
+
+
+def _normalize_messages_for_formatter(
+    msgs: list,
+    base_formatter_class: Type[FormatterBase],
+    formatter_instance: FormatterBase | None = None,
+) -> tuple[list, bool, bool]:
+    """Return normalized messages and formatter-family flags.
+
+    The returned booleans are
+    ``(is_anthropic_formatter, is_gemini_formatter)``.
+    All formatters receive a copied, normalized message list so
+    request-time repair does not mutate stored history.
+    """
+    is_anthropic_formatter = AnthropicChatFormatter is not None and (
+        issubclass(base_formatter_class, AnthropicChatFormatter)
+    )
+    is_gemini_formatter = GeminiChatFormatter is not None and (
+        issubclass(base_formatter_class, GeminiChatFormatter)
+    )
+    supports_multimodal = _supports_multimodal_for_current_model()
+    if getattr(formatter_instance, "_qwenpaw_force_strip_media", False):
+        supports_multimodal = False
+    normalized_msgs = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=supports_multimodal,
+    )
+
+    return normalized_msgs, is_anthropic_formatter, is_gemini_formatter
 
 
 # TODO: remove after agentscope anthropic formatter updated
@@ -481,11 +526,19 @@ def _create_file_block_support_formatter(
             ``extra_content`` on tool_use blocks (e.g. Gemini
             thought_signature) is carried through to the API request.
             """
-            msgs = _sanitize_tool_messages(msgs)
+            (
+                normalized_msgs,
+                is_anthropic_formatter,
+                _is_gemini_formatter,
+            ) = _normalize_messages_for_formatter(
+                msgs,
+                base_formatter_class,
+                self,
+            )
 
             reasoning_contents = {}
             extra_contents: dict[str, Any] = {}
-            for msg in msgs:
+            for msg in normalized_msgs:
                 if msg.role != "assistant":
                     continue
                 for block in msg.get_content_blocks():
@@ -503,7 +556,7 @@ def _create_file_block_support_formatter(
 
             # Convert file:// URLs to paths for all media blocks,
             # TODO: remove this after AgentScope updated
-            for msg in msgs:
+            for msg in normalized_msgs:
                 for block in msg.get_content_blocks():
                     if block.get("type") in ("image", "audio", "video"):
                         source = block.get("source")
@@ -518,35 +571,26 @@ def _create_file_block_support_formatter(
             # For Anthropic, fully override formatting to handle
             # media blocks (top-level & inside tool_result output).
             # TODO: remove after agentscope anthropic formatter updated
-            if AnthropicChatFormatter is not None and issubclass(
-                base_formatter_class,
-                AnthropicChatFormatter,
-            ):
-                messages = _format_anthropic_messages(msgs)
+            if is_anthropic_formatter:
+                messages = _format_anthropic_messages(normalized_msgs)
             else:
                 # Gemini handles video natively; for others
                 # (OpenAI) we inject it via placeholders.
-                _needs_video = not (
-                    GeminiChatFormatter is not None
-                    and issubclass(
-                        base_formatter_class,
-                        GeminiChatFormatter,
-                    )
-                )
+                _needs_video = not _is_gemini_formatter
                 video_subs: dict[str, dict] = {}
                 if _needs_video:
                     video_subs = _substitute_video_blocks(
-                        msgs,
+                        normalized_msgs,
                     )
 
-                messages = await super()._format(msgs)
+                messages = await super()._format(normalized_msgs)
 
                 if video_subs:
                     _replace_video_placeholders(
                         messages,
                         video_subs,
                     )
-                    _restore_video_blocks(msgs, video_subs)
+                    _restore_video_blocks(normalized_msgs, video_subs)
 
                 if _needs_video and getattr(
                     self,
@@ -554,7 +598,7 @@ def _create_file_block_support_formatter(
                     False,
                 ):
                     messages = _promote_tool_result_videos(
-                        msgs,
+                        normalized_msgs,
                         messages,
                     )
 
@@ -571,7 +615,9 @@ def _create_file_block_support_formatter(
                 # thinking-only messages (no content/tool_calls), so we
                 # predict survivors and collect reasoning only for those.
                 aligned_reasoning = []
-                for m in (msg for msg in msgs if msg.role == "assistant"):
+                for m in (
+                    msg for msg in normalized_msgs if msg.role == "assistant"
+                ):
                     is_thinking_only = (
                         isinstance(m.content, list)
                         and m.content

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -85,7 +85,8 @@ def _supports_multimodal_for_current_model() -> bool:
         return get_active_model_supports_multimodal()
     except Exception:  # pragma: no cover - config lookup safety
         logger.debug(
-            "Falling back to multimodal=True during OpenAI normalization",
+            "Falling back to multimodal=True during request-time "
+            "message normalization",
             exc_info=True,
         )
         return True

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -53,6 +53,7 @@ from .tools import (
 )
 from .utils import process_file_and_media_blocks_in_message
 from ..constant import (
+    MEDIA_UNSUPPORTED_PLACEHOLDER,
     WORKING_DIR,
 )
 from ..agents.memory import BaseMemoryManager
@@ -672,6 +673,17 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         """
         return self._strip_media_blocks_from_memory()
 
+    def _uses_request_time_media_normalization(self) -> bool:
+        """Return True when request-time normalization can handle media."""
+        return getattr(self, "formatter", None) is not None
+
+    def _set_formatter_media_strip(self, enabled: bool) -> None:
+        """Toggle request-time media stripping on the active formatter."""
+        formatter = getattr(self, "formatter", None)
+        if formatter is None:
+            return
+        setattr(formatter, "_qwenpaw_force_strip_media", enabled)
+
     async def _reasoning(
         self,
         tool_choice: Literal["auto", "none", "required"] | None = None,
@@ -690,13 +702,19 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         """
         # --- Proactive filtering layer ---
         if not get_active_model_supports_multimodal():
-            n = self._proactive_strip_media_blocks()
-            if n > 0:
-                logger.warning(
-                    "Proactively stripped %d media block(s) - "
-                    "model does not support multimodal.",
-                    n,
+            if self._uses_request_time_media_normalization():
+                logger.debug(
+                    "Formatter will strip media from copied messages "
+                    "before reasoning.",
                 )
+            else:
+                n = self._proactive_strip_media_blocks()
+                if n > 0:
+                    logger.warning(
+                        "Proactively stripped %d media block(s) - "
+                        "model does not support multimodal.",
+                        n,
+                    )
 
         # --- Passive fallback layer (existing logic) ---
         try:
@@ -704,6 +722,24 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         except Exception as e:
             if not self._is_bad_request_or_media_error(e):
                 raise
+
+            if self._uses_request_time_media_normalization():
+                if get_active_model_supports_multimodal():
+                    logger.warning(
+                        "Model marked multimodal but "
+                        "rejected media. "
+                        "Capability flag may be wrong.",
+                    )
+                self._set_formatter_media_strip(True)
+                try:
+                    logger.warning(
+                        "_reasoning failed (%s). "
+                        "Retrying with request-time media stripping.",
+                        e,
+                    )
+                    return await super()._reasoning(tool_choice=tool_choice)
+                finally:
+                    self._set_formatter_media_strip(False)
 
             n_stripped = self._strip_media_blocks_from_memory()
             if n_stripped == 0:
@@ -743,13 +779,19 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         """
         # --- Proactive filtering layer ---
         if not get_active_model_supports_multimodal():
-            n = self._proactive_strip_media_blocks()
-            if n > 0:
-                logger.warning(
-                    "Proactively stripped %d media block(s) - "
-                    "model does not support multimodal.",
-                    n,
+            if self._uses_request_time_media_normalization():
+                logger.debug(
+                    "Formatter will strip media from copied messages "
+                    "before summarizing.",
                 )
+            else:
+                n = self._proactive_strip_media_blocks()
+                if n > 0:
+                    logger.warning(
+                        "Proactively stripped %d media block(s) - "
+                        "model does not support multimodal.",
+                        n,
+                    )
 
         # --- Passive fallback layer ---
         self._in_summarizing = True
@@ -760,24 +802,42 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 if not self._is_bad_request_or_media_error(e):
                     raise
 
-                n_stripped = self._strip_media_blocks_from_memory()
-                if n_stripped == 0:
-                    raise
+                if self._uses_request_time_media_normalization():
+                    if get_active_model_supports_multimodal():
+                        logger.warning(
+                            "Model marked multimodal but "
+                            "rejected media. "
+                            "Capability flag may be wrong.",
+                        )
+                    self._set_formatter_media_strip(True)
+                    try:
+                        logger.warning(
+                            "_summarizing failed (%s). "
+                            "Retrying with request-time media stripping.",
+                            e,
+                        )
+                        msg = await super()._summarizing()
+                    finally:
+                        self._set_formatter_media_strip(False)
+                else:
+                    n_stripped = self._strip_media_blocks_from_memory()
+                    if n_stripped == 0:
+                        raise
 
-                if get_active_model_supports_multimodal():
+                    if get_active_model_supports_multimodal():
+                        logger.warning(
+                            "Model marked multimodal but "
+                            "rejected media. "
+                            "Capability flag may be wrong.",
+                        )
+
                     logger.warning(
-                        "Model marked multimodal but "
-                        "rejected media. "
-                        "Capability flag may be wrong.",
+                        "_summarizing failed (%s). "
+                        "Stripped %d media block(s) from memory, retrying.",
+                        e,
+                        n_stripped,
                     )
-
-                logger.warning(
-                    "_summarizing failed (%s). "
-                    "Stripped %d media block(s) from memory, retrying.",
-                    e,
-                    n_stripped,
-                )
-                msg = await super()._summarizing()
+                    msg = await super()._summarizing()
         finally:
             self._in_summarizing = False
 
@@ -895,10 +955,6 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         ]
         return any(kw in error_str for kw in keywords)
 
-    _MEDIA_PLACEHOLDER = (
-        "[Media content removed - model does not support this media type]"
-    )
-
     def _strip_media_blocks_from_memory(self) -> int:
         """Remove media blocks (image/audio/video) from all messages.
 
@@ -942,13 +998,16 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                     stripped_count = original_len - len(block["output"])
                     total_stripped += stripped_count
                     if stripped_count > 0 and not block["output"]:
-                        block["output"] = self._MEDIA_PLACEHOLDER
+                        block["output"] = MEDIA_UNSUPPORTED_PLACEHOLDER
 
                 new_content.append(block)
 
             if not new_content and total_stripped > 0:
                 new_content.append(
-                    {"type": "text", "text": self._MEDIA_PLACEHOLDER},
+                    {
+                        "type": "text",
+                        "text": MEDIA_UNSUPPORTED_PLACEHOLDER,
+                    },
                 )
 
             msg.content = new_content

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -762,6 +762,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             )
             return await super()._reasoning(tool_choice=tool_choice)
 
+    # pylint: disable=too-many-branches
     async def _summarizing(self) -> Msg:
         """Override summarizing with proactive media filtering,
         passive fallback, and tool_use block filtering.

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -974,12 +974,14 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 continue
 
             new_content = []
+            stripped_this_message = 0
             for block in msg.content:
                 if (
                     isinstance(block, dict)
                     and block.get("type") in media_types
                 ):
                     total_stripped += 1
+                    stripped_this_message += 1
                     continue
 
                 if (
@@ -998,12 +1000,13 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                     ]
                     stripped_count = original_len - len(block["output"])
                     total_stripped += stripped_count
+                    stripped_this_message += stripped_count
                     if stripped_count > 0 and not block["output"]:
                         block["output"] = MEDIA_UNSUPPORTED_PLACEHOLDER
 
                 new_content.append(block)
 
-            if not new_content and total_stripped > 0:
+            if not new_content and stripped_this_message > 0:
                 new_content.append(
                     {
                         "type": "text",

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -97,19 +97,6 @@ def normalize_messages_for_model_request(
     return normalized
 
 
-def normalize_messages_for_openai_compatible(
-    msgs: list[Msg],
-    *,
-    supports_multimodal: bool,
-) -> list[Msg]:
-    """Backward-compatible alias kept for older OpenAI-specific callers."""
-    return normalize_messages_for_model_request(
-        msgs,
-        supports_multimodal=supports_multimodal,
-    )
-
-
 __all__ = [
     "normalize_messages_for_model_request",
-    "normalize_messages_for_openai_compatible",
 ]

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""Normalization helpers for provider chat payloads.
+
+The persisted session history remains AgentScope ``Msg`` objects. For
+provider requests we build a normalized copy before formatting so
+request-time repair and multimodal downgrade logic does not mutate the
+stored conversation state.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from agentscope.message import Msg
+
+from ...constant import MEDIA_UNSUPPORTED_PLACEHOLDER
+from .tool_message_utils import _sanitize_tool_messages
+
+_MEDIA_BLOCK_TYPES = {"image", "audio", "video"}
+
+
+def _clone_msg(msg: Msg) -> Msg:
+    """Return a deep copy of an AgentScope message."""
+    return Msg.from_dict(deepcopy(msg.to_dict()))
+
+
+def _clone_messages(msgs: list[Msg]) -> list[Msg]:
+    """Return deep-copied messages suitable for request-time normalization."""
+    return [_clone_msg(msg) for msg in msgs]
+
+
+def _strip_media_blocks_in_place(msgs: list[Msg]) -> int:
+    """Strip media blocks from copied messages only.
+
+    Mirrors the fallback logic in ``QwenPawAgent`` but operates on normalized
+    copies so the stored memory remains untouched.
+    """
+    total_stripped = 0
+
+    for msg in msgs:
+        if not isinstance(msg.content, list):
+            continue
+
+        new_content = []
+        stripped_this_message = 0
+        for block in msg.content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") in _MEDIA_BLOCK_TYPES
+            ):
+                total_stripped += 1
+                stripped_this_message += 1
+                continue
+
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_result"
+                and isinstance(block.get("output"), list)
+            ):
+                original_len = len(block["output"])
+                block["output"] = [
+                    item
+                    for item in block["output"]
+                    if not (
+                        isinstance(item, dict)
+                        and item.get("type") in _MEDIA_BLOCK_TYPES
+                    )
+                ]
+                stripped_count = original_len - len(block["output"])
+                total_stripped += stripped_count
+                stripped_this_message += stripped_count
+                if stripped_count > 0 and not block["output"]:
+                    block["output"] = MEDIA_UNSUPPORTED_PLACEHOLDER
+
+            new_content.append(block)
+
+        if not new_content and stripped_this_message > 0:
+            new_content.append(
+                {"type": "text", "text": MEDIA_UNSUPPORTED_PLACEHOLDER},
+            )
+
+        msg.content = new_content
+
+    return total_stripped
+
+
+def normalize_messages_for_model_request(
+    msgs: list[Msg],
+    *,
+    supports_multimodal: bool,
+) -> list[Msg]:
+    """Return a normalized copy for provider request formatting."""
+    normalized = _clone_messages(msgs)
+    normalized = _sanitize_tool_messages(normalized)
+    if not supports_multimodal:
+        _strip_media_blocks_in_place(normalized)
+    return normalized
+
+
+def normalize_messages_for_openai_compatible(
+    msgs: list[Msg],
+    *,
+    supports_multimodal: bool,
+) -> list[Msg]:
+    """Backward-compatible alias kept for older OpenAI-specific callers."""
+    return normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=supports_multimodal,
+    )
+
+
+__all__ = [
+    "normalize_messages_for_model_request",
+    "normalize_messages_for_openai_compatible",
+]

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -304,3 +304,9 @@ except (TypeError, ValueError):
 # Split output on this marker to recover the original (untruncated) portion:
 #   original = output.split(TRUNCATION_NOTICE_MARKER)[0]
 TRUNCATION_NOTICE_MARKER = "<<<TRUNCATED>>>"
+
+# Placeholder text used when media blocks are stripped from messages
+# because the model does not support multimodal content.
+MEDIA_UNSUPPORTED_PLACEHOLDER = (
+    "[Media content removed - model does not support this media type]"
+)

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -10,7 +10,6 @@ from qwenpaw.agents.utils.message_request_normalizer import (
     _clone_messages,
     _strip_media_blocks_in_place,
     normalize_messages_for_model_request,
-    normalize_messages_for_openai_compatible,
 )
 from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
 
@@ -332,23 +331,6 @@ def test_normalize_returns_new_message_instances(text_message):
 
     assert normalized[0] is not msgs[0]
     assert normalized[0].content is not msgs[0].content
-
-
-# -----------------------------------------------------------------------------
-# normalize_messages_for_openai_compatible tests (alias)
-# -----------------------------------------------------------------------------
-
-
-def test_openai_compatible_alias_works(image_message):
-    """Test that the OpenAI-compatible alias works correctly."""
-    msgs = [image_message]
-    normalized = normalize_messages_for_openai_compatible(
-        msgs,
-        supports_multimodal=False,
-    )
-
-    assert normalized[0].content[0]["type"] == "text"
-    assert normalized[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
 
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -1,0 +1,409 @@
+# -*- coding: utf-8 -*-
+"""Tests for message_request_normalizer module."""
+
+# pylint: disable=redefined-outer-name,protected-access
+import pytest
+from agentscope.message import Msg, ToolResultBlock
+
+from qwenpaw.agents.utils.message_request_normalizer import (
+    _clone_msg,
+    _clone_messages,
+    _strip_media_blocks_in_place,
+    normalize_messages_for_model_request,
+    normalize_messages_for_openai_compatible,
+)
+from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def text_message():
+    """Create a simple text message."""
+    return Msg(
+        name="user",
+        role="user",
+        content=[{"type": "text", "text": "Hello world"}],
+    )
+
+
+@pytest.fixture
+def image_message():
+    """Create a message with an image block."""
+    return Msg(
+        name="user",
+        role="user",
+        content=[
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/test.png",
+                },
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def video_message():
+    """Create a message with a video block."""
+    return Msg(
+        name="user",
+        role="user",
+        content=[
+            {
+                "type": "video",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/test.mp4",
+                },
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def audio_message():
+    """Create a message with an audio block."""
+    return Msg(
+        name="user",
+        role="user",
+        content=[
+            {
+                "type": "audio",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/test.mp3",
+                },
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def tool_result_with_image():
+    """Create a tool result message with image in output."""
+    return Msg(
+        name="system",
+        role="system",
+        content=[
+            ToolResultBlock(
+                type="tool_result",
+                id="call_1",
+                name="view_image",
+                output=[
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "file:///tmp/result.png",
+                        },
+                    },
+                ],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def mixed_content_message():
+    """Create a message with mixed content including media."""
+    return Msg(
+        name="user",
+        role="user",
+        content=[
+            {"type": "text", "text": "Look at this:"},
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/image.png",
+                },
+            },
+            {"type": "text", "text": "And this video:"},
+            {
+                "type": "video",
+                "source": {
+                    "type": "url",
+                    "url": "file:///tmp/video.mp4",
+                },
+            },
+        ],
+    )
+
+
+# -----------------------------------------------------------------------------
+# _clone_msg tests
+# -----------------------------------------------------------------------------
+
+
+def test_clone_msg_creates_independent_copy(text_message):
+    """Test that _clone_msg creates a deep copy of the message."""
+    cloned = _clone_msg(text_message)
+
+    # Should be equal but not the same object
+    assert cloned.to_dict() == text_message.to_dict()
+    assert cloned is not text_message
+    assert cloned.content is not text_message.content
+
+
+def test_clone_msg_modifications_dont_affect_original(text_message):
+    """Test that modifying clone doesn't affect original message."""
+    cloned = _clone_msg(text_message)
+
+    # Modify the clone
+    cloned.content[0]["text"] = "Modified text"
+
+    # Original should be unchanged
+    assert text_message.content[0]["text"] == "Hello world"
+
+
+# -----------------------------------------------------------------------------
+# _clone_messages tests
+# -----------------------------------------------------------------------------
+
+
+def test_clone_messages_copies_list(text_message, image_message):
+    """Test that _clone_messages copies a list of messages."""
+    msgs = [text_message, image_message]
+    cloned = _clone_messages(msgs)
+
+    assert len(cloned) == 2
+    assert cloned[0].to_dict() == text_message.to_dict()
+    assert cloned[1].to_dict() == image_message.to_dict()
+    assert cloned[0] is not text_message
+    assert cloned[1] is not image_message
+
+
+# -----------------------------------------------------------------------------
+# _strip_media_blocks_in_place tests
+# -----------------------------------------------------------------------------
+
+
+def test_strip_media_blocks_removes_image(image_message):
+    """Test that image blocks are removed and replaced with placeholder."""
+    msgs = [image_message]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 1
+    assert len(msgs[0].content) == 1
+    assert msgs[0].content[0]["type"] == "text"
+    assert msgs[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_strip_media_blocks_removes_video(video_message):
+    """Test that video blocks are removed and replaced with placeholder."""
+    msgs = [video_message]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 1
+    assert len(msgs[0].content) == 1
+    assert msgs[0].content[0]["type"] == "text"
+    assert msgs[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_strip_media_blocks_removes_audio(audio_message):
+    """Test that audio blocks are removed and replaced with placeholder."""
+    msgs = [audio_message]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 1
+    assert len(msgs[0].content) == 1
+    assert msgs[0].content[0]["type"] == "text"
+    assert msgs[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_strip_media_blocks_handles_tool_result_with_media(
+    tool_result_with_image,
+):
+    """Test that media blocks inside tool_result output are removed."""
+    msgs = [tool_result_with_image]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 1
+    tool_result = msgs[0].content[0]
+    assert tool_result["output"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_strip_media_blocks_handles_mixed_content(mixed_content_message):
+    """Test that mixed content has only media blocks removed."""
+    msgs = [mixed_content_message]
+    original_content = mixed_content_message.content.copy()
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 2  # image + video
+    # Should have 2 text blocks remaining
+    assert len(msgs[0].content) == 2
+    assert msgs[0].content[0]["type"] == "text"
+    assert msgs[0].content[0]["text"] == "Look at this:"
+    assert msgs[0].content[1]["type"] == "text"
+    assert msgs[0].content[1]["text"] == "And this video:"
+
+
+def test_strip_media_blocks_preserves_non_media_content(text_message):
+    """Test that non-media content is preserved."""
+    msgs = [text_message]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 0
+    assert msgs[0].content == text_message.content
+
+
+def test_strip_media_blocks_handles_empty_content():
+    """Test that messages with empty content are handled gracefully."""
+    msg = Msg(name="user", role="user", content=[])
+    msgs = [msg]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 0
+    assert msgs[0].content == []
+
+
+def test_strip_media_blocks_handles_string_content():
+    """Test that messages with string content are skipped."""
+    msg = Msg(name="user", role="user", content="Plain text message")
+    msgs = [msg]
+    count = _strip_media_blocks_in_place(msgs)
+
+    assert count == 0
+    assert msgs[0].content == "Plain text message"
+
+
+# -----------------------------------------------------------------------------
+# normalize_messages_for_model_request tests
+# -----------------------------------------------------------------------------
+
+
+def test_normalize_with_multimodal_support_keeps_media(image_message):
+    """Test that media is preserved when multimodal is supported."""
+    msgs = [image_message]
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+    )
+
+    # Original should be unchanged
+    assert msgs[0].content[0]["type"] == "image"
+
+    # Normalized copy should also have media
+    assert normalized[0].content[0]["type"] == "image"
+    assert normalized[0] is not msgs[0]
+
+
+def test_normalize_without_multimodal_support_strips_media(image_message):
+    """Test that media is stripped when multimodal is not supported."""
+    msgs = [image_message]
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=False,
+    )
+
+    # Original should be unchanged
+    assert msgs[0].content[0]["type"] == "image"
+
+    # Normalized should have placeholder
+    assert normalized[0].content[0]["type"] == "text"
+    assert normalized[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_normalize_preserves_original_messages(mixed_content_message):
+    """Test that original messages are never modified."""
+    original_dict = mixed_content_message.to_dict()
+
+    normalize_messages_for_model_request(
+        [mixed_content_message],
+        supports_multimodal=False,
+    )
+
+    # Original should be exactly the same
+    assert mixed_content_message.to_dict() == original_dict
+
+
+def test_normalize_returns_new_message_instances(text_message):
+    """Test that normalized messages are new instances."""
+    msgs = [text_message]
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+    )
+
+    assert normalized[0] is not msgs[0]
+    assert normalized[0].content is not msgs[0].content
+
+
+# -----------------------------------------------------------------------------
+# normalize_messages_for_openai_compatible tests (alias)
+# -----------------------------------------------------------------------------
+
+
+def test_openai_compatible_alias_works(image_message):
+    """Test that the OpenAI-compatible alias works correctly."""
+    msgs = [image_message]
+    normalized = normalize_messages_for_openai_compatible(
+        msgs,
+        supports_multimodal=False,
+    )
+
+    assert normalized[0].content[0]["type"] == "text"
+    assert normalized[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+# -----------------------------------------------------------------------------
+# Integration tests with multiple messages
+# -----------------------------------------------------------------------------
+
+
+def test_normalize_conversation_with_multiple_messages():
+    """Test normalizing a conversation with multiple messages."""
+    msgs = [
+        Msg(
+            name="user",
+            role="user",
+            content=[
+                {"type": "text", "text": "Hello"},
+                {
+                    "type": "image",
+                    "source": {"type": "url", "url": "file:///tmp/1.png"},
+                },
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[{"type": "text", "text": "I see the image"}],
+        ),
+        Msg(
+            name="user",
+            role="user",
+            content=[
+                {
+                    "type": "video",
+                    "source": {"type": "url", "url": "file:///tmp/1.mp4"},
+                },
+            ],
+        ),
+    ]
+
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=False,
+    )
+
+    # First message: text preserved, image stripped
+    assert len(normalized[0].content) == 1
+    assert normalized[0].content[0]["text"] == "Hello"
+
+    # Second message: unchanged
+    assert normalized[1].content == [{"type": "text", "text": "I see the image"}]
+
+    # Third message: video replaced with placeholder
+    assert len(normalized[2].content) == 1
+    assert normalized[2].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+    # Originals unchanged
+    assert msgs[0].content[1]["type"] == "image"
+    assert msgs[2].content[0]["type"] == "video"

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -232,7 +232,6 @@ def test_strip_media_blocks_handles_tool_result_with_media(
 def test_strip_media_blocks_handles_mixed_content(mixed_content_message):
     """Test that mixed content has only media blocks removed."""
     msgs = [mixed_content_message]
-    original_content = mixed_content_message.content.copy()
     count = _strip_media_blocks_in_place(msgs)
 
     assert count == 2  # image + video
@@ -398,7 +397,9 @@ def test_normalize_conversation_with_multiple_messages():
     assert normalized[0].content[0]["text"] == "Hello"
 
     # Second message: unchanged
-    assert normalized[1].content == [{"type": "text", "text": "I see the image"}]
+    assert normalized[1].content == [
+        {"type": "text", "text": "I see the image"},
+    ]
 
     # Third message: video replaced with placeholder
     assert len(normalized[2].content) == 1

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -113,7 +113,7 @@ def test_openai_formatter_normalizes_on_copy(monkeypatch) -> None:
 
 
 def test_anthropic_formatter_normalizes_on_copy(monkeypatch) -> None:
-    """Test that Anthropic formatter normalizes messages with media stripped."""
+    """Test Anthropic formatter normalizes messages with media stripped."""
     if AnthropicChatFormatter is None:
         pytest.skip("AnthropicChatFormatter not available")
 
@@ -165,7 +165,9 @@ def test_multimodal_support_preserves_media(monkeypatch) -> None:
     assert original[0].content[0]["type"] == "image"
 
 
-def test_force_strip_media_flag_overrides_multimodal_support(monkeypatch) -> None:
+def test_force_strip_media_flag_overrides_multimodal_support(
+    monkeypatch,
+) -> None:
     """Test that _qwenpaw_force_strip_media flag forces media stripping."""
     monkeypatch.setattr(
         model_factory,
@@ -226,7 +228,7 @@ def test_anthropic_flag_detected(monkeypatch) -> None:
     (
         _normalized,
         is_anthropic,
-        is_gemini,
+        _is_gemini,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         AnthropicChatFormatter,
@@ -251,7 +253,7 @@ def test_gemini_flag_detected(monkeypatch) -> None:
 
     (
         _normalized,
-        is_anthropic,
+        _is_anthropic,
         is_gemini,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+"""Tests for model_factory message normalization integration."""
+
+# pylint: disable=protected-access,redefined-outer-name
+from types import SimpleNamespace
+
+import pytest
+from agentscope.formatter import OpenAIChatFormatter
+from agentscope.message import Msg, ToolResultBlock
+
+try:
+    from agentscope.formatter import AnthropicChatFormatter
+except ImportError:  # pragma: no cover - compatibility fallback
+    AnthropicChatFormatter = None
+
+try:
+    from agentscope.formatter import GeminiChatFormatter
+except ImportError:  # pragma: no cover - compatibility fallback
+    GeminiChatFormatter = None
+
+from qwenpaw.agents import model_factory
+from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def _media_messages() -> list[Msg]:
+    """Create a list of messages with media blocks for testing."""
+    return [
+        Msg(
+            name="user",
+            role="user",
+            content=[
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "url",
+                        "url": "file:///tmp/demo.png",
+                    },
+                },
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "view_image",
+                    "input": {},
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="call_1",
+                    name="view_image",
+                    output=[
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "url",
+                                "url": "file:///tmp/demo.png",
+                            },
+                        },
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+
+def _assert_request_time_stripped(formatter_class) -> None:
+    """Helper to assert that media is stripped from normalized messages."""
+    original = _media_messages()
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        original,
+        formatter_class,
+        SimpleNamespace(),
+    )
+
+    # First message (user image) should be replaced with placeholder
+    assert normalized[0].content == [
+        {
+            "type": "text",
+            "text": MEDIA_UNSUPPORTED_PLACEHOLDER,
+        },
+    ]
+
+    # Third message (tool result with image) should have output replaced
+    assert normalized[2].content[0]["output"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+    # Original messages should be unchanged
+    assert original[0].content[0]["type"] == "image"
+    assert original[2].content[0]["output"][0]["type"] == "image"
+
+
+def test_openai_formatter_normalizes_on_copy(monkeypatch) -> None:
+    """Test that OpenAI formatter normalizes messages with media stripped."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: False,
+    )
+    _assert_request_time_stripped(OpenAIChatFormatter)
+
+
+def test_anthropic_formatter_normalizes_on_copy(monkeypatch) -> None:
+    """Test that Anthropic formatter normalizes messages with media stripped."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: False,
+    )
+    _assert_request_time_stripped(AnthropicChatFormatter)
+
+
+def test_gemini_formatter_normalizes_on_copy(monkeypatch) -> None:
+    """Test that Gemini formatter normalizes messages with media stripped."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: False,
+    )
+    _assert_request_time_stripped(GeminiChatFormatter)
+
+
+def test_multimodal_support_preserves_media(monkeypatch) -> None:
+    """Test that when multimodal is supported, media is preserved."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    original = _media_messages()
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        original,
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    # Media should be preserved in normalized messages
+    assert normalized[0].content[0]["type"] == "image"
+    assert normalized[2].content[0]["output"][0]["type"] == "image"
+
+    # Original should be unchanged
+    assert original[0].content[0]["type"] == "image"
+
+
+def test_force_strip_media_flag_overrides_multimodal_support(monkeypatch) -> None:
+    """Test that _qwenpaw_force_strip_media flag forces media stripping."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,  # Model supports multimodal
+    )
+
+    original = _media_messages()
+    formatter_instance = SimpleNamespace(_qwenpaw_force_strip_media=True)
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        original,
+        OpenAIChatFormatter,
+        formatter_instance,
+    )
+
+    # Media should be stripped despite multimodal support
+    assert normalized[0].content[0]["type"] == "text"
+    assert normalized[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
+
+
+def test_formatter_flags_returned_correctly() -> None:
+    """Test that formatter family flags are returned correctly."""
+    msgs = [Msg(name="user", role="user", content="Hello")]
+
+    (
+        _normalized,
+        is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        msgs,
+        OpenAIChatFormatter,
+        None,
+    )
+
+    # OpenAI formatter should not be anthropic or gemini
+    assert is_anthropic is False
+    assert is_gemini is False
+
+
+def test_anthropic_flag_detected(monkeypatch) -> None:
+    """Test that Anthropic formatter is correctly detected."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    msgs = [Msg(name="user", role="user", content="Hello")]
+
+    (
+        _normalized,
+        is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        msgs,
+        AnthropicChatFormatter,
+        None,
+    )
+
+    assert is_anthropic is True
+
+
+def test_gemini_flag_detected(monkeypatch) -> None:
+    """Test that Gemini formatter is correctly detected."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    msgs = [Msg(name="user", role="user", content="Hello")]
+
+    (
+        _normalized,
+        is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        msgs,
+        GeminiChatFormatter,
+        None,
+    )
+
+    assert is_gemini is True
+
+
+def test_original_messages_not_modified_by_formatter_prep() -> None:
+    """Test that preparing messages for formatter doesn't modify originals."""
+    original = Msg(
+        name="user",
+        role="user",
+        content=[
+            {"type": "text", "text": "Hello"},
+            {
+                "type": "image",
+                "source": {"type": "url", "url": "file:///tmp/test.png"},
+            },
+        ],
+    )
+    original_dict = original.to_dict()
+
+    (
+        _normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        [original],
+        OpenAIChatFormatter,
+        SimpleNamespace(_qwenpaw_force_strip_media=False),
+    )
+
+    # Original message should be completely unchanged
+    assert original.to_dict() == original_dict
+    assert original.content[1]["type"] == "image"


### PR DESCRIPTION
## Description

This PR improves conversation stability when switching between provider models within the same session.

Previously, some request-time repair and multimodal fallback logic could operate directly on the in-memory AgentScope `Msg` objects. 

That meant backend-specific adaptation could mutate stored conversation history, especially when temporarily switching to a stricter or non-multimodal backend. In those cases, switching back later could no longer recover the original full context.

This PR keeps the existing session/history storage format unchanged and makes the OpenAI-compatible path safer in two places:

1. Before formatting, it now builds a normalized copy of the message list instead of repairing the persisted history in place.
2. During media fallback/retry, it avoids stripping media from stored memory and instead applies request-time media stripping only to the formatter path.

As a result, model backends still receive repaired and downgraded messages when needed, while the original persisted history is preserved.

### What Changed

- Added a request-time normalizer for model message formatting
- Reused existing tool-message sanitization on copied messages
- Applied multimodal downgrade on copied messages only
- Wired the normalizer into the model formatter path
- Updated the reasoning/summarizing media fallback path to avoid mutating stored memory
- Kept session persistence, `/dump_history`, `/load_history`, and chat history API behavior unchanged
- Added unit tests for:
  - tool input repair without mutating original messages
  - media downgrade without mutating original messages
  - stable text-only message normalization
  - Model formatter detection / request-time media-strip flag behavior

### Why This Approach

This is intentionally a narrow first step toward provider-family-safe message replay for [#2314](https://github.com/agentscope-ai/QwenPaw/issues/2314). It does not introduce a new canonical transcript schema or migrate persisted session files.

The goal is to improve model-switching stability with minimal risk. By keeping persisted history unchanged, a conversation that temporarily downgrades for a weaker OpenAI-compatible backend can later switch back and still reuse the original context instead of a permanently stripped version.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit` locally and it passes for the changed files
- [x] If pre-commit auto-fixed files, I reran checks
- [x] I ran relevant tests locally and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

I tested locally, and it works.
The new tests are AI-generated.