### PR TITLE
fix(FeiShu): replace static loop swap with _EventLoopProxy

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -101,6 +101,17 @@ else:
         )
         _declare_namespace_patched = True
 
+
+class _EventLoopProxy:
+    """Resolve ``lark_oapi.ws.client.loop`` to the calling thread's loop."""
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return getattr(asyncio.get_running_loop(), name)
+        except RuntimeError:
+            return getattr(asyncio.get_event_loop(), name)
+
+
 try:
     import lark_oapi as lark
     from lark_oapi.api.contact.v3 import GetUserRequest
@@ -118,6 +129,10 @@ try:
         GetMessageResourceRequest,
         P2ImMessageReceiveV1,
     )
+
+    import lark_oapi.ws.client as _ws_mod
+
+    _ws_mod.loop = _EventLoopProxy()
 except ImportError:  # pragma: no cover - optional dependency may be missing
     lark = None  # type: ignore[assignment]
     GetUserRequest = None  # type: ignore[assignment]
@@ -1966,68 +1981,8 @@ class FeishuChannel(BaseChannel):
                 receive_id_type,
             )
 
-    def _create_ws_client(self) -> Any:
-        """Create a fresh ``lark.ws.Client`` with loop-isolated internals.
-
-        The SDK uses a module-level ``loop`` for ``create_task`` calls,
-        which causes cross-loop errors when multiple agents run in
-        separate threads.  We patch ``_connect`` and
-        ``_receive_message_loop`` to swap in the running loop before
-        delegating to the originals.
-        """
-        event_handler = (
-            lark.EventDispatcherHandler.builder(
-                self.encrypt_key,
-                self.verification_token,
-            )
-            .register_p2_im_message_receive_v1(self._on_message_sync)
-            .build()
-        )
-        client = lark.ws.Client(
-            self.app_id,
-            self.app_secret,
-            event_handler=event_handler,
-            log_level=lark.LogLevel.INFO,
-            domain=(
-                lark.LARK_DOMAIN
-                if self.domain == "lark"
-                else lark.FEISHU_DOMAIN
-            ),
-        )
-
-        _original_connect = client._connect
-        _original_recv_loop = client._receive_message_loop
-
-        async def _patched_connect() -> None:
-            import lark_oapi.ws.client as _ws_mod
-
-            saved, _ws_mod.loop = _ws_mod.loop, asyncio.get_running_loop()
-            try:
-                await _original_connect()
-            finally:
-                _ws_mod.loop = saved
-
-        async def _patched_receive_message_loop() -> None:
-            import lark_oapi.ws.client as _ws_mod
-
-            saved, _ws_mod.loop = _ws_mod.loop, asyncio.get_running_loop()
-            try:
-                await _original_recv_loop()
-            finally:
-                _ws_mod.loop = saved
-
-        client._connect = _patched_connect
-        client._receive_message_loop = _patched_receive_message_loop
-        return client
-
     def _run_ws_forever(self) -> None:
-        """Run WebSocket with automatic reconnection (exponential backoff).
-
-        Each iteration creates a fresh event loop and ``ws.Client``, then
-        drives the connection directly (``_connect`` → ``_ping_loop`` →
-        ``_select``) instead of calling the SDK's ``start()`` which relies
-        on a shared module-level ``loop``.
-        """
+        """Run WebSocket with exponential-backoff reconnection."""
         retry_delay = FEISHU_WS_INITIAL_RETRY_DELAY
 
         while not self._stop_event.is_set() and not self._closed:
@@ -2035,7 +1990,27 @@ class FeishuChannel(BaseChannel):
             asyncio.set_event_loop(self._ws_loop)
             connection_started = False
             try:
-                self._ws_client = self._create_ws_client()
+                event_handler = (
+                    lark.EventDispatcherHandler.builder(
+                        self.encrypt_key,
+                        self.verification_token,
+                    )
+                    .register_p2_im_message_receive_v1(
+                        self._on_message_sync,
+                    )
+                    .build()
+                )
+                self._ws_client = lark.ws.Client(
+                    self.app_id,
+                    self.app_secret,
+                    event_handler=event_handler,
+                    log_level=lark.LogLevel.INFO,
+                    domain=(
+                        lark.LARK_DOMAIN
+                        if self.domain == "lark"
+                        else lark.FEISHU_DOMAIN
+                    ),
+                )
 
                 async def _select() -> None:
                     while True:


### PR DESCRIPTION
## Description

Replace the saved / restore loop-swap pattern in _patched_connect and _patched_receive_message_loop with a module-level _EventLoopProxy installed at import time. The proxy dynamically resolves asyncio.get_running_loop() on every attribute access, preventing stale-loop references after reconnect cycles.

### Changes:

- Add _EventLoopProxy class and install it as lark_oapi.ws.client.loop at import time
- Remove _create_ws_client() method; inline client creation into _run_ws_forever()
- Remove _patched_connect / _patched_receive_message_loop wrappers (no longer needed)


**Related Issue:** Fixes #3331 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
