### PR TITLE
feat(cli): add cli `qwenpaw doctor` to diagnose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ build-backend = "setuptools.build_meta"
 qwenpaw = "qwenpaw.cli.main:cli"
 copaw = "qwenpaw.cli.main:cli"
 
+# Optional doctor plugins: callable (DoctorRunContext) -> list[str]
+# [project.entry-points."copaw.doctor"]
+# my_pkg = "my_pkg.doctor:doctor_notes"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,9 @@ qwenpaw = "qwenpaw.cli.main:cli"
 copaw = "qwenpaw.cli.main:cli"
 
 # Optional doctor plugins: callable (DoctorRunContext) -> list[str]
-# [project.entry-points."copaw.doctor"]
+# [project.entry-points."qwenpaw.doctor"]
 # my_pkg = "my_pkg.doctor:doctor_notes"
+# Legacy group "copaw.doctor" is still loaded when present.
 
 [project.optional-dependencies]
 dev = [

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -32,6 +32,7 @@ from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
 from .routers.voice import voice_router
 from ..envs import load_envs_into_environ
+from ..utils.console_static import resolve_console_static_dir
 from ..providers.provider_manager import ProviderManager
 from ..local_models.manager import LocalModelManager
 from .multi_agent_manager import MultiAgentManager

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name,unused-argument
 import mimetypes
 import os
+import sys
 import time
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -27,12 +28,12 @@ from ..constant import (
 )
 from ..__version__ import __version__
 from ..utils.logging import setup_logger, add_project_file_handler
+from ..utils.system_info import summarize_python_environment
 from .auth import AuthMiddleware
 from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
 from .routers.voice import voice_router
 from ..envs import load_envs_into_environ
-from ..utils.console_static import resolve_console_static_dir
 from ..providers.provider_manager import ProviderManager
 from ..local_models.manager import LocalModelManager
 from .multi_agent_manager import MultiAgentManager
@@ -506,8 +507,12 @@ def read_root():
 
 @app.get("/api/version")
 def get_version():
-    """Return the current application version."""
-    return {"version": __version__}
+    """Return the current application version and server Python runtime."""
+    return {
+        "version": __version__,
+        "python_executable": sys.executable,
+        "python_environment": summarize_python_environment(),
+    }
 
 
 app.include_router(api_router, prefix="/api")

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -507,9 +507,16 @@ def read_root():
 
 @app.get("/api/version")
 def get_version():
-    """Return the current application version and server Python runtime."""
+    """Return the current application version (public-safe payload)."""
     return {
         "version": __version__,
+    }
+
+
+@app.get("/api/doctor/runtime")
+def get_doctor_runtime():
+    """Return server runtime diagnostics for authenticated troubleshooting."""
+    return {
         "python_executable": sys.executable,
         "python_environment": summarize_python_environment(),
     }

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -85,10 +85,11 @@ class BaseChannel(ABC):
         *,
         timeout: float,
     ) -> list[str]:
-        """Optional ``copaw doctor --deep`` reachability checks for this channel.
+        """Optional ``copaw doctor --deep`` reachability checks.
 
-        Override in custom channels. Default: no extra checks (built-in channels
-        use shared probes in ``doctor_connectivity`` unless this returns notes).
+        Override in custom channels. Default: no extra checks
+        (built-in channels use shared probes in ``doctor_connectivity``
+        unless this returns notes).
 
         Args:
             agent_id: Profile id from ``agents.profiles``.

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -77,6 +77,29 @@ class BaseChannel(ABC):
     # If True, manager creates a queue and consumer loop for this channel.
     uses_manager_queue: bool = True
 
+    @classmethod
+    def doctor_connectivity_notes(
+        cls,
+        agent_id: str,
+        config: Any,
+        *,
+        timeout: float,
+    ) -> list[str]:
+        """Optional ``copaw doctor --deep`` reachability checks for this channel.
+
+        Override in custom channels. Default: no extra checks (built-in channels
+        use shared probes in ``doctor_connectivity`` unless this returns notes).
+
+        Args:
+            agent_id: Profile id from ``agents.profiles``.
+            config: Channel subsection (Pydantic model or dict for extras).
+            timeout: Seconds for TCP/HTTP probes.
+
+        Returns:
+            Informational lines (empty if OK / skipped).
+        """
+        return []
+
     def __init__(
         self,
         process: ProcessHandler,

--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -1,0 +1,1180 @@
+# -*- coding: utf-8 -*-
+"""Read-only diagnostics for `copaw doctor` (no config or disk mutations)."""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import platform
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from ..__version__ import __version__
+from ..agents.skills_manager import get_workspace_skills_dir, read_skill_manifest
+from ..app.crons.models import JobsFile
+from ..config.config import (
+    AgentProfileConfig,
+    AgentProfileRef,
+    AgentsConfig,
+    ChannelConfig,
+    Config,
+    MCPConfig,
+    SecurityConfig,
+    ToolsConfig,
+    load_agent_config,
+)
+from ..config.utils import (
+    _normalize_working_dir_bound_paths,
+    _read_config_data,
+    get_config_path,
+    get_jobs_path,
+    get_playwright_chromium_executable_path,
+    is_running_in_container,
+)
+from ..constant import (
+    HEARTBEAT_FILE,
+    JOBS_FILE,
+    MEMORY_DIR,
+    PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV,
+    SECRET_DIR,
+    WORKING_DIR,
+)
+from ..providers.provider import Provider
+
+
+# Log file opened on app startup (see ``copaw.app._app`` lifespan).
+COPAW_APP_LOG_NAME = "copaw.log"
+
+
+def _resolve_existing_path_anchor(path: Path) -> Path | None:
+    """First existing path walking up from *path* (for ``stat`` / ``disk_usage``)."""
+    cur = path.expanduser()
+    try:
+        cur = cur.resolve(strict=False)
+    except (OSError, RuntimeError):
+        cur = path.expanduser()
+    for _ in range(128):
+        try:
+            if cur.exists():
+                return cur
+        except OSError:
+            return None
+        parent = cur.parent
+        if parent == cur:
+            return None
+        cur = parent
+    return None
+
+
+def check_copaw_log_writable() -> tuple[bool, str]:
+    """``copaw app`` appends to ``WORKING_DIR / copaw.log`` during startup."""
+    log_path = WORKING_DIR / COPAW_APP_LOG_NAME
+    try:
+        with open(log_path, "a", encoding="utf-8"):
+            pass
+    except OSError as exc:
+        return (
+            False,
+            f"cannot append to {log_path} (required when starting `copaw app`): {exc}",
+        )
+    return True, str(log_path)
+
+
+def check_agent_workspace_writable(cfg: Config) -> tuple[bool, str]:
+    """Existing agent workspace directories must be writable for runtime state."""
+    problems: list[str] = []
+    checked = 0
+    for agent_id, ref in cfg.agents.profiles.items():
+        wd = Path(ref.workspace_dir).expanduser()
+        if not wd.is_dir():
+            continue
+        checked += 1
+        if not os.access(wd, os.W_OK):
+            problems.append(f"{agent_id}: workspace not writable: {wd}")
+    if problems:
+        return False, "\n".join(problems)
+    if checked == 0:
+        return True, "no existing workspace dirs (skipped writability)"
+    return True, f"{checked} workspace dir(s) writable"
+
+
+def startup_extra_volume_disk_notes(cfg: Config | None) -> list[str]:
+    """Low free space on volumes other than ``WORKING_DIR`` that hold persistence."""
+    notes: list[str] = []
+    try:
+        wd_dev = WORKING_DIR.stat().st_dev
+    except OSError:
+        return notes
+
+    anchors: dict[int, Path] = {}
+
+    def consider(p: Path) -> None:
+        anchor = _resolve_existing_path_anchor(p)
+        if anchor is None:
+            return
+        try:
+            dev = anchor.stat().st_dev
+        except OSError:
+            return
+        if dev != wd_dev:
+            anchors.setdefault(dev, anchor)
+
+    consider(SECRET_DIR)
+    if cfg is not None:
+        for ref in cfg.agents.profiles.values():
+            consider(Path(ref.workspace_dir))
+
+    low_gib = 0.5
+    for anchor in anchors.values():
+        try:
+            du = shutil.disk_usage(anchor)
+        except OSError:
+            continue
+        free_gib = du.free / (1024**3)
+        if free_gib < low_gib:
+            notes.append(
+                f"persistence path on another volume ({anchor}): {free_gib:.2f} GiB free "
+                f"(below {low_gib} GiB) — writes may fail even if working_dir volume is healthy.",
+            )
+    return notes
+
+
+def _active_python_environment_summary() -> str:
+    """Short label for the venv/conda context of this Python (CoPaw CLI)."""
+    ve = (os.environ.get("VIRTUAL_ENV") or "").strip()
+    if ve:
+        return f"{ve}"
+    cenv = (os.environ.get("CONDA_DEFAULT_ENV") or "").strip()
+    cpfx = (os.environ.get("CONDA_PREFIX") or "").strip()
+    if cenv and cpfx:
+        return f"conda {cenv} ({cpfx})"
+    base = getattr(sys, "base_prefix", sys.prefix)
+    if sys.prefix != base:
+        return f"venv (sys.prefix={sys.prefix})"
+    return "system interpreter (no virtualenv in effect)"
+
+
+def environment_summary_lines() -> list[str]:
+    """One line per fact; safe to paste into bug reports."""
+    py_ver = sys.version.split()[0]
+    lines = [
+        f"python: {py_ver}",
+        f"copaw: {__version__}",
+        f"platform: {platform.system()} {platform.machine()}",
+        f"copaw_environment: {_active_python_environment_summary()}",
+        f"doctor_environment: {sys.executable}",
+        f"working_dir: {WORKING_DIR}",
+    ]
+    copaw_wd = os.getenv("COPAW_WORKING_DIR")
+    if copaw_wd:
+        lines.append(f"COPAW_WORKING_DIR (env): {copaw_wd}")
+    lines.append(f"sqlite library: {sqlite3.sqlite_version}")
+    try:
+        ver_tuple = tuple(
+            map(int, sqlite3.sqlite_version.split(".")[:3]),
+        )
+        if ver_tuple < (3, 35):
+            lines.append(
+                "Note: SQLite < 3.35 may break Chroma / some vector stores; "
+                "upgrade system SQLite if embeddings fail.",
+            )
+    except (ValueError, TypeError):
+        pass
+    try:
+        du = shutil.disk_usage(WORKING_DIR)
+        free_gib = du.free / (1024**3)
+        lines.append(f"disk free (working dir volume): {free_gib:.2f} GiB")
+        if free_gib < 0.5:
+            lines.append(
+                "Note: very low free space — risk of failed writes and corrupted state.",
+            )
+    except OSError:
+        lines.append("disk free: (could not stat working dir volume)")
+    return lines
+
+
+def load_raw_config_dict() -> dict[str, Any] | None:
+    path = get_config_path()
+    if not path.is_file():
+        return None
+    data = _read_config_data(path)
+    return data if isinstance(data, dict) else None
+
+
+def scan_unknown_config_keys(raw: dict[str, Any]) -> list[str]:
+    """Shallow unknown keys vs current Pydantic models (read-only; never delete).
+
+    ``channels.*`` extras may still be valid (plugins); we flag with a note.
+    """
+    found: list[str] = []
+
+    allowed_root = set(Config.model_fields.keys()) | {
+        "last_api_host",
+        "last_api_port",
+    }
+    for key in raw:
+        if key not in allowed_root:
+            found.append(f"top-level key {key!r} (not on root Config model)")
+
+    agents = raw.get("agents")
+    if isinstance(agents, dict):
+        allowed = set(AgentsConfig.model_fields.keys())
+        for key in agents:
+            if key not in allowed:
+                found.append(f"agents.{key!r} (not on AgentsConfig model)")
+
+    tools = raw.get("tools")
+    if isinstance(tools, dict):
+        allowed = set(ToolsConfig.model_fields.keys())
+        for key in tools:
+            if key not in allowed:
+                found.append(f"tools.{key!r} (not on ToolsConfig model)")
+
+    security = raw.get("security")
+    if isinstance(security, dict):
+        allowed = set(SecurityConfig.model_fields.keys())
+        for key in security:
+            if key not in allowed:
+                found.append(f"security.{key!r} (not on SecurityConfig model)")
+
+    mcp = raw.get("mcp")
+    if isinstance(mcp, dict):
+        allowed = set(MCPConfig.model_fields.keys())
+        for key in mcp:
+            if key not in allowed:
+                found.append(f"mcp.{key!r} (not on MCPConfig model)")
+
+    channels = raw.get("channels")
+    if isinstance(channels, dict):
+        allowed = set(ChannelConfig.model_fields.keys())
+        for key in channels:
+            if key not in allowed:
+                found.append(
+                    f"channels.{key!r} — not a built-in channel field "
+                    f"(may be a plugin; root ChannelConfig allows extra keys)",
+                )
+
+    return found
+
+
+def legacy_single_agent_workspace_note(cfg: Config) -> str | None:
+    """Align with ``migrate_legacy_workspace_to_default_agent`` preconditions.
+
+    When this applies, ``copaw app`` may run an automatic migration; doctor only
+    informs — it does not migrate.
+    """
+    profiles = cfg.agents.profiles
+    if len(profiles) != 1 or "default" not in profiles:
+        return None
+    ref = profiles["default"]
+    if not isinstance(ref, AgentProfileRef):
+        return None
+    agent_json = Path(ref.workspace_dir).expanduser() / "agent.json"
+    if agent_json.is_file():
+        return None
+    return (
+        "Only `default` is listed and workspace "
+        f"`{agent_json}` is missing — the same situation "
+        "`copaw app` uses to trigger legacy → multi-agent workspace migration. "
+        "Start `copaw app` once (or see docs / `copaw init`). "
+        "Doctor does not change config or files."
+    )
+
+
+def check_agent_profile_workspaces(cfg: Config) -> tuple[bool, str]:
+    """Each ``agents.profiles`` entry should have a directory and ``agent.json``."""
+    problems: list[str] = []
+    for agent_id, ref in cfg.agents.profiles.items():
+        wd = Path(ref.workspace_dir).expanduser()
+        if not wd.is_dir():
+            problems.append(
+                f"{agent_id}: workspace_dir is not a directory: {wd}",
+            )
+            continue
+        agent_json = wd / "agent.json"
+        if not agent_json.is_file():
+            problems.append(f"{agent_id}: missing {agent_json}")
+    if problems:
+        return False, "\n".join(problems)
+    n = len(cfg.agents.profiles)
+    return True, f"{n} agent profile(s); each workspace contains agent.json"
+
+
+# --- OpenClaw-inspired read-only checks (cron, security hints, memory, hygiene) ---
+
+_LARGE_PROMPT_BYTES = 350 * 1024
+# Disabled: long-lived lock carrier files (e.g. .skill.json.lock) often stay on
+# disk with old mtime while locks are still meaningful — too many false positives.
+# _STALE_LOCK_SECS = 86400
+_TOOL_RESULT_MANY = 400
+_DIALOG_MANY = 200
+
+
+def check_cron_jobs_files(cfg: Config) -> tuple[bool, str]:
+    """Validate each agent workspace ``jobs.json`` and optional legacy root file."""
+    problems: list[str] = []
+    validated_paths: list[tuple[str, Path, int]] = []
+
+    for agent_id, ref in cfg.agents.profiles.items():
+        path = Path(ref.workspace_dir).expanduser() / JOBS_FILE
+        if not path.is_file():
+            continue
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            jf = JobsFile.model_validate(raw)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            problems.append(f"{agent_id}: {path} — JSON error ({exc})")
+            continue
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            problems.append(f"{agent_id}: {path} — schema ({exc})")
+            continue
+        validated_paths.append((agent_id, path, len(jf.jobs)))
+
+    legacy = get_jobs_path()
+    if legacy.is_file():
+        try:
+            raw = json.loads(legacy.read_text(encoding="utf-8"))
+            jf = JobsFile.model_validate(raw)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            problems.append(f"legacy root: {legacy} — JSON error ({exc})")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            problems.append(f"legacy root: {legacy} — schema ({exc})")
+        else:
+            validated_paths.append(("(root)", legacy, len(jf.jobs)))
+
+    if problems:
+        return False, "\n".join(problems)
+    if not validated_paths:
+        return True, "no jobs.json under agent workspaces (OK if you do not use cron)"
+    summary = "; ".join(
+        f"{aid}: {n} job(s)" for aid, _p, n in validated_paths
+    )
+    return True, f"{len(validated_paths)} file(s) OK — {summary}"
+
+
+def _ms_playwright_browser_cache_roots() -> list[Path]:
+    roots: list[Path] = []
+    env = (os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or "").strip()
+    if env:
+        roots.append(Path(env).expanduser())
+    roots.append(Path.home() / ".cache" / "ms-playwright")
+    if sys.platform == "darwin":
+        roots.append(Path.home() / "Library" / "Caches" / "ms-playwright")
+    localappdata = os.environ.get("LOCALAPPDATA")
+    if localappdata:
+        roots.append(Path(localappdata) / "ms-playwright")
+    return roots
+
+
+def _playwright_chromium_bundle_present() -> bool:
+    """Best-effort: Playwright ``playwright install chromium`` cache directory."""
+    for root in _ms_playwright_browser_cache_roots():
+        try:
+            if not root.is_dir():
+                continue
+            for child in root.iterdir():
+                if child.is_dir() and child.name.startswith("chromium"):
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def browser_automation_notes(cfg: Config | None) -> list[str]:
+    """``browser_use`` / Playwright readiness (read-only hints).
+
+    Does not start a browser; only checks imports, typical paths, and
+    workspace ``browser/user_data`` layout.
+    """
+    notes: list[str] = []
+
+    if importlib.util.find_spec("playwright") is None:
+        notes.append(
+            "browser_use needs the Playwright Python package — install with: "
+            f"'{sys.executable}' -m pip install playwright && "
+            f"'{sys.executable}' -m playwright install chromium",
+        )
+        return notes
+
+    try:
+        from playwright.async_api import async_playwright  # noqa: F401
+    except ImportError:
+        notes.append(
+            "playwright is installed but async_api failed to import — reinstall "
+            "the playwright package for this Python.",
+        )
+        return notes
+
+    use_default = os.environ.get("COPAW_BROWSER_USE_DEFAULT", "1").strip().lower()
+    if use_default in ("0", "false", "no", "off"):
+        notes.append(
+            "COPAW_BROWSER_USE_DEFAULT is off — browser_use will not prefer the "
+            "OS default Chrome/Edge path; bundled or scanned Chromium paths apply.",
+        )
+
+    if is_running_in_container():
+        notes.append(
+            "Container environment: use headless browser_use unless you add "
+            "display forwarding; install Chromium in the image or run "
+            f"'{sys.executable}' -m playwright install chromium if launches fail.",
+        )
+
+    exe = get_playwright_chromium_executable_path()
+    if not exe and sys.platform != "darwin":
+        if not _playwright_chromium_bundle_present():
+            notes.append(
+                "No system Chrome/Chromium path found and no Playwright chromium "
+                "cache detected — run "
+                f"'{sys.executable}' -m playwright install chromium' or install "
+                "Chrome/Edge, or set "
+                f"{PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV}.",
+            )
+    elif not exe and sys.platform == "darwin":
+        if not _playwright_chromium_bundle_present():
+            notes.append(
+                "No Chrome/Edge/Chromium on PATH — browser_use falls back to "
+                "WebKit on macOS; install Chrome/Edge or run "
+                f"'{sys.executable}' -m playwright install chromium' if you need "
+                "Chromium specifically.",
+            )
+
+    if sys.platform.startswith("linux") and not is_running_in_container():
+        if not (os.environ.get("DISPLAY") or "").strip():
+            notes.append(
+                "DISPLAY is unset — headed browser_use (visible window) may fail; "
+                "use the default headless mode or configure X11/Wayland.",
+            )
+
+    if cfg is not None:
+        for agent_id, ref in cfg.agents.profiles.items():
+            ws = Path(ref.workspace_dir).expanduser()
+            ud = ws / "browser" / "user_data"
+            try:
+                if ud.is_file():
+                    notes.append(
+                        f"{agent_id}: {ud} exists as a file — remove or rename it "
+                        "so browser_use can use a profile directory.",
+                    )
+                elif ud.is_dir() and not os.access(ud, os.W_OK):
+                    notes.append(
+                        f"{agent_id}: {ud} is not writable — persistent browser "
+                        "profiles may fail.",
+                    )
+            except OSError:
+                pass
+
+    return notes
+
+
+def security_baseline_notes(cfg: Config) -> list[str]:
+    """Non-fatal security posture hints (aligned with OpenClaw ``doctor:security``)."""
+    notes: list[str] = []
+    if not cfg.security.tool_guard.enabled:
+        notes.append(
+            "security.tool_guard.enabled is false — dangerous shell commands "
+            "are not filtered.",
+        )
+    if cfg.security.skill_scanner.mode == "off":
+        notes.append(
+            "security.skill_scanner.mode is off — skills are not scanned "
+            "before install.",
+        )
+    if not cfg.security.file_guard.enabled:
+        notes.append(
+            "security.file_guard.enabled is false — sensitive path blocking "
+            "is off.",
+        )
+    return notes
+
+
+def _embedding_has_credentials(emb_api_key: str) -> bool:
+    if (emb_api_key or "").strip():
+        return True
+    return bool(
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("DASHSCOPE_API_KEY")
+        or os.getenv("ANTHROPIC_API_KEY"),
+    )
+
+
+def memory_embedding_notes(cfg: Config) -> list[str]:
+    """Embedding / vector memory readiness (per agent ``agent.json``)."""
+    notes: list[str] = []
+    for agent_id in cfg.agents.profiles:
+        try:
+            ac = load_agent_config(agent_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue
+        emb = ac.running.embedding_config
+        ms = ac.running.memory_summary
+        if ms.force_memory_search and not _embedding_has_credentials(emb.api_key):
+            notes.append(
+                f"{agent_id}: running.memory_summary.force_memory_search is on "
+                "but no embedding API key is set in running.embedding_config.api_key "
+                "and no common OPENAI_/DASHSCOPE_/ANTHROPIC_ API key env was found.",
+            )
+    return notes
+
+
+def workspace_hygiene_notes(cfg: Config) -> list[str]:
+    """Large prompt files, heavy tool_result/dialog dirs; memory tree size."""
+    notes: list[str] = []
+    bootstrap_names = (
+        "AGENTS.md",
+        "SOUL.md",
+        "PROFILE.md",
+        HEARTBEAT_FILE,
+    )
+    for agent_id, ref in cfg.agents.profiles.items():
+        wd = Path(ref.workspace_dir).expanduser()
+        if not wd.is_dir():
+            continue
+        for name in bootstrap_names:
+            p = wd / name
+            if not p.is_file():
+                continue
+            try:
+                sz = p.stat().st_size
+            except OSError:
+                continue
+            if sz > _LARGE_PROMPT_BYTES:
+                notes.append(
+                    f"{agent_id}: {name} is {sz // 1024} KiB — large prompts "
+                    "burn context; consider splitting or summarizing.",
+                )
+        for sub, many, label in (
+            ("tool_result", _TOOL_RESULT_MANY, "tool_result"),
+            ("dialog", _DIALOG_MANY, "dialog"),
+        ):
+            d = wd / sub
+            if not d.is_dir():
+                continue
+            try:
+                n = sum(1 for _ in d.iterdir())
+            except OSError:
+                continue
+            if n > many:
+                notes.append(
+                    f"{agent_id}: {label}/ has {n} entries — cleanup or archival "
+                    "may improve performance.",
+                )
+        # Stale *.lock scan disabled — see _STALE_LOCK_SECS comment above.
+        # stale = 0
+        # for lock_path in wd.rglob("*.lock"):
+        #     if not lock_path.is_file():
+        #         continue
+        #     try:
+        #         if now - lock_path.stat().st_mtime > _STALE_LOCK_SECS:
+        #             stale += 1
+        #     except OSError:
+        #         continue
+        #     if stale >= 8:
+        #         break
+        # if stale > 0:
+        #     notes.append(
+        #         f"{agent_id}: {stale}+ stale *.lock file(s) under workspace "
+        #         "(older than 24h) — possible crashed process; safe to inspect.",
+        #     )
+
+    if MEMORY_DIR.is_dir():
+        try:
+            mcount = sum(1 for p in MEMORY_DIR.rglob("*") if p.is_file())
+        except OSError:
+            mcount = 0
+        if mcount > 5000:
+            notes.append(
+                f"global memory tree {MEMORY_DIR} has many files ({mcount}+) — "
+                "expect slower indexing or backup size.",
+            )
+    return notes
+
+
+# --- CoPaw-specific profile checks (agent.json, channels, MCP, skills, providers) ---
+
+
+def _read_workspace_agent_json(ref: AgentProfileRef) -> dict[str, Any] | None:
+    path = Path(ref.workspace_dir).expanduser() / "agent.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        data = _normalize_working_dir_bound_paths(data)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return data
+
+
+def check_agent_json_profiles(cfg: Config) -> tuple[bool, str]:
+    """Validate ``agent.json`` with ``AgentProfileConfig`` (read-only; no ``load_agent_config``)."""
+    problems: list[str] = []
+    n_ok = 0
+    for agent_id, ref in cfg.agents.profiles.items():
+        path = Path(ref.workspace_dir).expanduser() / "agent.json"
+        if not path.is_file():
+            continue
+        raw = _read_workspace_agent_json(ref)
+        if raw is None:
+            problems.append(f"{agent_id}: {path} — invalid or unreadable JSON")
+            continue
+        try:
+            AgentProfileConfig.model_validate(raw)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            problems.append(f"{agent_id}: agent.json — {exc}")
+            continue
+        n_ok += 1
+    if problems:
+        return False, "\n".join(problems)
+    if n_ok == 0:
+        return True, "no agent.json files to validate"
+    return True, f"{n_ok} agent.json file(s) match AgentProfileConfig"
+
+
+def check_enabled_agents_load_agent_config(cfg: Config) -> tuple[bool, str]:
+    """Dry-run :func:`~copaw.config.config.load_agent_config` for enabled profiles only.
+
+    Matches agents started by ``MultiAgentManager.start_all_configured_agents``.
+    When ``agent.json`` is missing, we do **not** call ``load_agent_config`` (that
+    would write a fallback file on disk); we report FAIL for enabled agents instead.
+    """
+    problems: list[str] = []
+    ok_n = 0
+    enabled_n = 0
+    for agent_id, ref in cfg.agents.profiles.items():
+        if not getattr(ref, "enabled", True):
+            continue
+        enabled_n += 1
+        ws = Path(ref.workspace_dir).expanduser()
+        path = ws / "agent.json"
+        if not path.is_file():
+            problems.append(
+                f"{agent_id}: enabled but missing {path} — at startup "
+                "`load_agent_config` would create a fallback agent.json on disk; "
+                "ensure the file exists or use `copaw doctor fix` where applicable.",
+            )
+            continue
+        try:
+            load_agent_config(agent_id)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            problems.append(f"{agent_id}: load_agent_config failed — {exc}")
+            continue
+        ok_n += 1
+    if problems:
+        return False, "\n".join(problems)
+    if enabled_n == 0:
+        return True, "no enabled agents in config"
+    return True, f"{ok_n} enabled agent(s); load_agent_config OK"
+
+
+def _effective_channels_mcp(
+    cfg: Config,
+    raw: dict[str, Any] | None,
+) -> tuple[ChannelConfig, MCPConfig]:
+    ch = cfg.channels
+    mcp = cfg.mcp
+    if raw is None:
+        return ch, mcp
+    if raw.get("channels") is not None:
+        try:
+            ch = ChannelConfig.model_validate(raw["channels"])
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+    if raw.get("mcp") is not None:
+        try:
+            mcp = MCPConfig.model_validate(raw["mcp"])
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+    return ch, mcp
+
+
+def enabled_channel_notes(cfg: Config) -> list[str]:
+    """Static checks for built-in channels with ``enabled`` and empty credentials."""
+    notes: list[str] = []
+    for agent_id, ref in cfg.agents.profiles.items():
+        raw = _read_workspace_agent_json(ref)
+        ch, _ = _effective_channels_mcp(cfg, raw)
+        for name in ChannelConfig.model_fields:
+            sub = getattr(ch, name, None)
+            if sub is None:
+                continue
+            if not getattr(sub, "enabled", False):
+                continue
+            if name == "console":
+                continue
+            if name == "discord" and not (sub.bot_token or "").strip():
+                notes.append(f"{agent_id}: discord enabled but bot_token is empty")
+            elif name == "dingtalk":
+                if not (sub.client_id or "").strip() or not (
+                    sub.client_secret or ""
+                ).strip():
+                    notes.append(
+                        f"{agent_id}: dingtalk enabled but client_id/client_secret incomplete",
+                    )
+            elif name == "feishu":
+                if not (sub.app_id or "").strip() or not (
+                    sub.app_secret or ""
+                ).strip():
+                    notes.append(
+                        f"{agent_id}: feishu enabled but app_id/app_secret incomplete",
+                    )
+            elif name == "qq":
+                if not (sub.app_id or "").strip() or not (
+                    sub.client_secret or ""
+                ).strip():
+                    notes.append(
+                        f"{agent_id}: qq enabled but app_id/client_secret incomplete",
+                    )
+            elif name == "telegram" and not (sub.bot_token or "").strip():
+                notes.append(f"{agent_id}: telegram enabled but bot_token is empty")
+            elif name == "mattermost":
+                if not (sub.url or "").strip() or not (sub.bot_token or "").strip():
+                    notes.append(
+                        f"{agent_id}: mattermost enabled but url/bot_token incomplete",
+                    )
+            elif name == "mqtt" and not (sub.host or "").strip():
+                notes.append(f"{agent_id}: mqtt enabled but host is empty")
+            elif name == "matrix":
+                if (
+                    not (sub.homeserver or "").strip()
+                    or not (sub.user_id or "").strip()
+                    or not (sub.access_token or "").strip()
+                ):
+                    notes.append(
+                        f"{agent_id}: matrix enabled but homeserver/user_id/access_token incomplete",
+                    )
+            elif name == "voice":
+                if (
+                    not (sub.twilio_account_sid or "").strip()
+                    or not (sub.twilio_auth_token or "").strip()
+                    or not (sub.phone_number or "").strip()
+                ):
+                    notes.append(
+                        f"{agent_id}: voice enabled but Twilio fields incomplete",
+                    )
+            elif name == "wecom":
+                if not (sub.bot_id or "").strip() or not (sub.secret or "").strip():
+                    notes.append(
+                        f"{agent_id}: wecom enabled but bot_id/secret incomplete",
+                    )
+            elif name == "xiaoyi":
+                if (
+                    not (sub.ak or "").strip()
+                    or not (sub.sk or "").strip()
+                    or not (sub.agent_id or "").strip()
+                ):
+                    notes.append(
+                        f"{agent_id}: xiaoyi enabled but ak/sk/agent_id incomplete",
+                    )
+            elif name == "weixin":
+                tok = (sub.bot_token or "").strip()
+                fp = (sub.bot_token_file or "").strip()
+                if tok:
+                    pass
+                elif fp:
+                    p = Path(fp).expanduser()
+                    if not p.is_file():
+                        notes.append(
+                            f"{agent_id}: weixin enabled but bot_token_file missing: {p}",
+                        )
+                else:
+                    notes.append(
+                        f"{agent_id}: weixin enabled but bot_token and bot_token_file unset",
+                    )
+            elif name == "imessage":
+                dbp = Path(sub.db_path).expanduser()
+                if not dbp.is_file():
+                    notes.append(
+                        f"{agent_id}: imessage enabled but chat.db not found at {dbp}",
+                    )
+        extra = getattr(ch, "__pydantic_extra__", None) or {}
+        for key, val in extra.items():
+            en = False
+            if isinstance(val, dict):
+                en = bool(val.get("enabled"))
+            elif hasattr(val, "enabled"):
+                en = bool(getattr(val, "enabled"))
+            if en:
+                notes.append(
+                    f"{agent_id}: custom/plugin channel {key!r} is enabled — "
+                    "verify credentials and connectivity.",
+                )
+    return notes
+
+
+def _url_looks_httpish(url: str) -> bool:
+    p = urlparse(url.strip())
+    return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+def _mcp_client_problems(mcp: MCPConfig | None, label: str) -> list[str]:
+    if mcp is None:
+        return []
+    problems: list[str] = []
+    for cid, client in mcp.clients.items():
+        if not client.enabled:
+            continue
+        if client.transport == "stdio":
+            cmd0 = (client.command or "").strip().split()
+            if not cmd0:
+                problems.append(f"{label} MCP {cid!r}: stdio command is empty")
+                continue
+            exe = cmd0[0]
+            if not shutil.which(exe):
+                problems.append(
+                    f"{label} MCP {cid!r}: stdio executable {exe!r} not found on PATH",
+                )
+        elif client.transport in ("streamable_http", "sse"):
+            u = (client.url or "").strip()
+            if not u:
+                problems.append(
+                    f"{label} MCP {cid!r}: {client.transport} url is empty",
+                )
+            elif not _url_looks_httpish(u):
+                problems.append(
+                    f"{label} MCP {cid!r}: url does not look like http(s)://…",
+                )
+    return problems
+
+
+def mcp_client_notes(cfg: Config) -> list[str]:
+    """Enabled MCP clients: PATH / URL sanity (root + per-agent ``agent.json`` mcp)."""
+    notes: list[str] = []
+    notes.extend(_mcp_client_problems(cfg.mcp, "root"))
+    for agent_id, ref in cfg.agents.profiles.items():
+        raw = _read_workspace_agent_json(ref)
+        if raw is None or raw.get("mcp") is None:
+            continue
+        try:
+            mcp = MCPConfig.model_validate(raw["mcp"])
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue
+        notes.extend(_mcp_client_problems(mcp, f"agent {agent_id}"))
+    return notes
+
+
+def skill_layout_notes(cfg: Config) -> list[str]:
+    """Enabled skills in skill.json vs on-disk directories under the workspace."""
+    notes: list[str] = []
+    for agent_id, ref in cfg.agents.profiles.items():
+        wd = Path(ref.workspace_dir).expanduser()
+        if not wd.is_dir():
+            continue
+        manifest = read_skill_manifest(wd)
+        skills = manifest.get("skills") or {}
+        if not isinstance(skills, dict):
+            continue
+        root = get_workspace_skills_dir(wd)
+        for sname, entry in skills.items():
+            if not isinstance(entry, dict):
+                continue
+            if not entry.get("enabled", False):
+                continue
+            d = root / str(sname)
+            if not d.is_dir():
+                notes.append(
+                    f"{agent_id}: skill {sname!r} enabled in skill.json but directory missing: {d}",
+                )
+    return notes
+
+
+def provider_overview_notes() -> list[str]:
+    """Custom providers with missing required fields (async provider registry)."""
+    from ..providers.provider_manager import ProviderManager
+
+    async def _run() -> list[str]:
+        infos = await ProviderManager.get_instance().list_provider_info()
+        out: list[str] = []
+        for info in infos:
+            if not info.is_custom:
+                continue
+            if info.require_api_key and not (info.api_key or "").strip():
+                out.append(
+                    f"custom provider {info.id!r}: API key required but empty",
+                )
+            if not info.is_local and not (info.base_url or "").strip():
+                out.append(
+                    f"custom provider {info.id!r}: base_url is empty",
+                )
+        return out
+
+    return asyncio.run(_run())
+
+
+def active_llm_local_failure_hint(provider: Provider, provider_id: str) -> str:
+    """Short hint when ``check_model_connection`` failed for a local-oriented provider."""
+    if provider_id == "ollama":
+        base = (getattr(provider, "base_url", None) or "").strip()
+        if not base:
+            base = (os.environ.get("OLLAMA_HOST") or "http://127.0.0.1:11434").strip()
+        return (
+            f"Hint: start Ollama (e.g. `ollama serve`) and ensure the model is "
+            f"available (`ollama pull …`). OpenAI-compatible API is usually "
+            f"{base.rstrip('/')}/v1 ."
+        )
+    if provider_id == "lmstudio":
+        base = (getattr(provider, "base_url", None) or "").strip() or "http://127.0.0.1:1234/v1"
+        return (
+            f"Hint: open LM Studio, load a model, and enable the local server. "
+            f"Typical base URL: {base.rstrip('/')}"
+        )
+    if provider_id == "copaw-local":
+        return (
+            "Hint: CoPaw Local uses llama.cpp. Start the local server from the CoPaw "
+            "console or install the llama.cpp binary from there. "
+            "Run `copaw doctor --deep` to see llama.cpp install and server status."
+        )
+    if getattr(provider, "is_local", False):
+        base = (getattr(provider, "base_url", None) or "").strip() or "your configured base_url"
+        return (
+            f"Hint: this provider is marked local — ensure the inference HTTP server "
+            f"is running and matches {base}."
+        )
+    return ""
+
+
+def copaw_local_llm_deep_notes() -> list[str]:
+    """Read-only llama.cpp install + server snapshot (for ``--deep`` + ``copaw-local``)."""
+    try:
+        from ..local_models.manager import LocalModelManager
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return [f"LocalModelManager unavailable: {exc}"]
+    try:
+        lm = LocalModelManager.get_instance()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return [f"LocalModelManager: {exc}"]
+    notes: list[str] = []
+    try:
+        ok, msg = lm.check_llamacpp_installation()
+        line = (
+            "llama.cpp binary: OK"
+            if ok
+            else "llama.cpp binary: missing or not installed"
+        )
+        if msg:
+            line += f" — {msg}"
+        notes.append(line)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        notes.append(f"llama.cpp install check failed: {exc}")
+    try:
+        st = lm.get_llamacpp_server_status()
+        notes.append(
+            "llama.cpp server: "
+            f"running={st.get('running')}, port={st.get('port')}, "
+            f"model={st.get('model_name')!r}, pid={st.get('pid')}",
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        notes.append(f"llama.cpp server status failed: {exc}")
+    try:
+        if lm.is_llamacpp_server_transitioning():
+            notes.append(
+                "llama.cpp server is transitioning (start/stop in progress).",
+            )
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return notes
+
+
+def _slot_is_set(slot: Any) -> bool:
+    return bool(getattr(slot, "provider_id", None) and getattr(slot, "model", None))
+
+
+def _resolve_agent_effective_model_slot(
+    agent_cfg: AgentProfileConfig,
+    active_slot: Any | None,
+) -> tuple[Any | None, str]:
+    """Resolve which provider/model an agent will use for its default chat model."""
+    if agent_cfg.active_model is not None and _slot_is_set(agent_cfg.active_model):
+        return agent_cfg.active_model, "agent.active_model"
+
+    routing = agent_cfg.llm_routing
+    if getattr(routing, "enabled", False):
+        if routing.mode == "cloud_first":
+            if routing.cloud is not None and _slot_is_set(routing.cloud):
+                return routing.cloud, "agent.llm_routing.cloud"
+            if active_slot is not None and _slot_is_set(active_slot):
+                return active_slot, "providers.active_llm (cloud fallback)"
+            return None, "routing enabled but no cloud slot and no active LLM"
+        # local_first
+        if routing.local is not None and _slot_is_set(routing.local):
+            return routing.local, "agent.llm_routing.local"
+        return None, "routing enabled but local slot is not set"
+
+    if active_slot is not None and _slot_is_set(active_slot):
+        return active_slot, "providers.active_llm"
+    return None, "no agent.active_model and no active LLM"
+
+
+async def check_enabled_agents_model_connections(
+    cfg: Config,
+    *,
+    timeout: float,
+    deep: bool,
+) -> tuple[bool, list[str], list[str]]:
+    """Test each enabled agent's effective model connectivity (like UI 'test connection').
+
+    Returns (all_ok, per_agent_lines, extra_notes).
+    """
+    from ..providers.provider_manager import ProviderManager
+
+    mgr = ProviderManager.get_instance()
+    active_slot = mgr.get_active_model()
+    lines: list[str] = []
+    notes: list[str] = []
+    all_ok = True
+
+    for agent_id, ref in cfg.agents.profiles.items():
+        if not getattr(ref, "enabled", True):
+            continue
+        try:
+            ac = load_agent_config(agent_id)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            all_ok = False
+            lines.append(f"{agent_id}: FAIL — load_agent_config failed ({exc})")
+            continue
+
+        slot, source = _resolve_agent_effective_model_slot(ac, active_slot)
+        if slot is None:
+            all_ok = False
+            lines.append(f"{agent_id}: FAIL — no model resolved ({source})")
+            continue
+
+        pid = (getattr(slot, "provider_id", "") or "").strip()
+        model = (getattr(slot, "model", "") or "").strip()
+        if not pid or not model:
+            all_ok = False
+            lines.append(f"{agent_id}: FAIL — invalid model slot ({source})")
+            continue
+
+        provider = mgr.get_provider(pid)
+        if provider is None:
+            all_ok = False
+            lines.append(f"{agent_id}: FAIL — provider not found: {pid!r}")
+            continue
+        if not getattr(provider, "is_local", False):
+            if not (getattr(provider, "base_url", "") or "").strip():
+                all_ok = False
+                lines.append(f"{agent_id}: FAIL — {pid}: base_url is not set")
+                continue
+        if getattr(provider, "require_api_key", False) and not (
+            getattr(provider, "api_key", "") or ""
+        ).strip():
+            all_ok = False
+            lines.append(f"{agent_id}: FAIL — {pid}: API key is required but not set")
+            continue
+
+        if deep and pid == "copaw-local":
+            # Only add once (same underlying llama.cpp runtime).
+            if not any("llama.cpp" in n for n in notes):
+                notes.extend(copaw_local_llm_deep_notes())
+
+        if not getattr(provider, "support_connection_check", True):
+            lines.append(
+                f"{agent_id}: OK — {pid} / {model} (live check skipped for this provider)",
+            )
+            continue
+
+        try:
+            ok, msg = await provider.check_model_connection(model, timeout=timeout)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            ok, msg = False, str(exc)
+        if ok:
+            lines.append(f"{agent_id}: OK — {pid} / {model} (reachable)")
+            continue
+
+        all_ok = False
+        detail = f": {msg}" if msg else ""
+        body = f"{pid} / {model} unreachable{detail}"
+        if getattr(provider, "is_local", False) or pid in ("ollama", "lmstudio", "copaw-local"):
+            hint = active_llm_local_failure_hint(provider, pid)
+            if hint:
+                body = f"{body}\n{hint}"
+        lines.append(f"{agent_id}: FAIL — {body}")
+
+    if not lines:
+        return True, ["(no enabled agents)"], notes
+    return all_ok, lines, notes
+
+
+def console_static_diagnostic_notes() -> list[str]:
+    """Extra context for the web console bundle (paths, mtime, source-tree npm fix)."""
+    from datetime import datetime, timezone
+
+    from ..utils.console_static import (
+        CONSOLE_STATIC_ENV,
+        find_copaw_source_repo_root,
+        resolve_console_static_dir,
+    )
+
+    notes: list[str] = []
+    env_dir = (os.environ.get(CONSOLE_STATIC_ENV) or "").strip()
+    if env_dir:
+        notes.append(
+            f"{CONSOLE_STATIC_ENV} is set — the app serves console files from that "
+            f"path ({env_dir}), not from the package or repo defaults.",
+        )
+    static = Path(resolve_console_static_dir())
+    idx = static / "index.html"
+    if idx.is_file():
+        try:
+            mtime = datetime.fromtimestamp(
+                idx.stat().st_mtime,
+                tz=timezone.utc,
+            ).strftime("%Y-%m-%d %H:%M UTC")
+        except OSError:
+            mtime = "(unknown)"
+        notes.append(
+            f"resolved static dir: {static} — index.html present (mtime {mtime})",
+        )
+    else:
+        notes.append(
+            f"resolved static dir: {static} — index.html missing",
+        )
+
+    npm = shutil.which("npm")
+    notes.append(
+        "npm on PATH: "
+        + (npm if npm else "not found (install Node.js or fix PATH)"),
+    )
+
+    repo = find_copaw_source_repo_root()
+    if repo is not None:
+        notes.append(
+            f"source checkout detected at {repo} — bundle console into the package with "
+            "`copaw doctor fix -y --only rebuild-console-npm` "
+            "(`npm ci && npm run build` in console/, then copy to src/copaw/console/).",
+        )
+    else:
+        notes.append(
+            "source checkout not detected (normal for wheel installs) — use a git "
+            "checkout to run the npm bundle fix, or point COPAW_CONSOLE_STATIC_DIR at "
+            "a directory that contains index.html.",
+        )
+    return notes
+
+
+def api_target_mismatch_note(cfg: Config, cli_base: str) -> str | None:
+    """Warn when CLI --host/--port disagrees with persisted ``last_api``."""
+    host = cfg.last_api.host
+    port = cfg.last_api.port
+    if host is None and port is None:
+        return None
+    eff_host = host or "127.0.0.1"
+    eff_port = 8088 if port is None else port
+    expected = f"http://{eff_host}:{eff_port}".rstrip("/")
+    got = cli_base.rstrip("/")
+    if got == expected:
+        return None
+    return (
+        f"CLI targets {got!r} but config last_api is {eff_host!r}:{eff_port} — "
+        "use the same host/port as the running server, or update last_api in config."
+    )
+

--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Read-only diagnostics for `copaw doctor` (no config or disk mutations)."""
+"""Read-only diagnostics for `qwenpaw doctor` (no config or disk mutations)."""
 from __future__ import annotations
 
+# pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-return-statements
 import asyncio
+import importlib
 import importlib.util
 import json
 import os
@@ -15,7 +18,10 @@ from typing import Any
 from urllib.parse import urlparse
 
 from ..__version__ import __version__
-from ..agents.skills_manager import get_workspace_skills_dir, read_skill_manifest
+from ..agents.skills_manager import (
+    get_workspace_skills_dir,
+    read_skill_manifest,
+)
 from ..app.crons.models import JobsFile
 from ..config.config import (
     AgentProfileConfig,
@@ -41,18 +47,26 @@ from ..constant import (
     JOBS_FILE,
     MEMORY_DIR,
     PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV,
+    PROJECT_NAME,
     SECRET_DIR,
     WORKING_DIR,
+    EnvVarLoader,
 )
+from ..utils.logging import LOG_NAMESPACE
+from ..utils.system_info import summarize_python_environment
 from ..providers.provider import Provider
 
 
-# Log file opened on app startup (see ``copaw.app._app`` lifespan).
-COPAW_APP_LOG_NAME = "copaw.log"
+# Log file opened on app startup (see ``qwenpaw.app._app`` lifespan).
+APP_LOG_BASENAME = f"{LOG_NAMESPACE}.log"
+
+# Built-in local llama.cpp provider id; legacy configs may still use
+# copaw-local.
+_QWENPAW_LOCAL_PROVIDER_IDS = frozenset({"qwenpaw-local", "copaw-local"})
 
 
 def _resolve_existing_path_anchor(path: Path) -> Path | None:
-    """First existing path walking up from *path* (for ``stat`` / ``disk_usage``)."""
+    """First existing ancestor of *path* (for ``stat`` / ``disk_usage``)."""
     cur = path.expanduser()
     try:
         cur = cur.resolve(strict=False)
@@ -71,22 +85,23 @@ def _resolve_existing_path_anchor(path: Path) -> Path | None:
     return None
 
 
-def check_copaw_log_writable() -> tuple[bool, str]:
-    """``copaw app`` appends to ``WORKING_DIR / copaw.log`` during startup."""
-    log_path = WORKING_DIR / COPAW_APP_LOG_NAME
+def check_app_log_writable() -> tuple[bool, str]:
+    """``qwenpaw app`` appends to the app log under ``WORKING_DIR``."""
+    log_path = WORKING_DIR / APP_LOG_BASENAME
     try:
         with open(log_path, "a", encoding="utf-8"):
             pass
     except OSError as exc:
         return (
             False,
-            f"cannot append to {log_path} (required when starting `copaw app`): {exc}",
+            f"cannot append to {log_path} "
+            f"(required when starting `qwenpaw app`): {exc}",
         )
     return True, str(log_path)
 
 
 def check_agent_workspace_writable(cfg: Config) -> tuple[bool, str]:
-    """Existing agent workspace directories must be writable for runtime state."""
+    """Existing agent workspace dirs must be writable for runtime state."""
     problems: list[str] = []
     checked = 0
     for agent_id, ref in cfg.agents.profiles.items():
@@ -104,7 +119,7 @@ def check_agent_workspace_writable(cfg: Config) -> tuple[bool, str]:
 
 
 def startup_extra_volume_disk_notes(cfg: Config | None) -> list[str]:
-    """Low free space on volumes other than ``WORKING_DIR`` that hold persistence."""
+    """Low free space on volumes other than ``WORKING_DIR`` (persistence)."""
     notes: list[str] = []
     try:
         wd_dev = WORKING_DIR.stat().st_dev
@@ -138,41 +153,49 @@ def startup_extra_volume_disk_notes(cfg: Config | None) -> list[str]:
         free_gib = du.free / (1024**3)
         if free_gib < low_gib:
             notes.append(
-                f"persistence path on another volume ({anchor}): {free_gib:.2f} GiB free "
-                f"(below {low_gib} GiB) — writes may fail even if working_dir volume is healthy.",
+                f"persistence path on another volume ({anchor}): "
+                f"{free_gib:.2f} GiB free (below {low_gib} GiB) — "
+                "writes may fail even if working_dir volume is healthy.",
             )
     return notes
 
 
-def _active_python_environment_summary() -> str:
-    """Short label for the venv/conda context of this Python (CoPaw CLI)."""
-    ve = (os.environ.get("VIRTUAL_ENV") or "").strip()
-    if ve:
-        return f"{ve}"
-    cenv = (os.environ.get("CONDA_DEFAULT_ENV") or "").strip()
-    cpfx = (os.environ.get("CONDA_PREFIX") or "").strip()
-    if cenv and cpfx:
-        return f"conda {cenv} ({cpfx})"
-    base = getattr(sys, "base_prefix", sys.prefix)
-    if sys.prefix != base:
-        return f"venv (sys.prefix={sys.prefix})"
-    return "system interpreter (no virtualenv in effect)"
+def environment_summary_lines(
+    *,
+    server_python_environment: str | None = None,
+    server_python_note: str | None = None,
+) -> list[str]:
+    """One line per fact; safe to paste into bug reports.
 
-
-def environment_summary_lines() -> list[str]:
-    """One line per fact; safe to paste into bug reports."""
+    *server_python_environment* describes the **HTTP API process** (running
+    ``qwenpaw app``), when ``GET /api/version`` returned
+    ``python_environment``. Doctor's own interpreter uses
+    ``doctor_python_environment``.
+    """
     py_ver = sys.version.split()[0]
+    doctor_env = summarize_python_environment()
     lines = [
-        f"python: {py_ver}",
-        f"copaw: {__version__}",
+        f"python version: {py_ver}",
+        f"qwenpaw version: {__version__}",
         f"platform: {platform.system()} {platform.machine()}",
-        f"copaw_environment: {_active_python_environment_summary()}",
-        f"doctor_environment: {sys.executable}",
-        f"working_dir: {WORKING_DIR}",
+        f"doctor_python_environment: {doctor_env}",
     ]
-    copaw_wd = os.getenv("COPAW_WORKING_DIR")
-    if copaw_wd:
-        lines.append(f"COPAW_WORKING_DIR (env): {copaw_wd}")
+    if server_python_environment is not None:
+        lines.append(
+            f"qwenpaw_python_environment: {server_python_environment}",
+        )
+    else:
+        lines.append(
+            "qwenpaw_python_environment: "
+            + (server_python_note or "(unknown)"),
+        )
+    lines.append(f"working_dir: {WORKING_DIR}")
+    wd_qp = os.getenv("QWENPAW_WORKING_DIR")
+    wd_legacy = os.getenv("COPAW_WORKING_DIR")
+    if wd_qp:
+        lines.append(f"QWENPAW_WORKING_DIR (env): {wd_qp}")
+    elif wd_legacy:
+        lines.append(f"COPAW_WORKING_DIR (env, legacy): {wd_legacy}")
     lines.append(f"sqlite library: {sqlite3.sqlite_version}")
     try:
         ver_tuple = tuple(
@@ -191,7 +214,8 @@ def environment_summary_lines() -> list[str]:
         lines.append(f"disk free (working dir volume): {free_gib:.2f} GiB")
         if free_gib < 0.5:
             lines.append(
-                "Note: very low free space — risk of failed writes and corrupted state.",
+                "Note: very low free space — risk of failed writes and "
+                "corrupted state.",
             )
     except OSError:
         lines.append("disk free: (could not stat working dir volume)")
@@ -207,9 +231,9 @@ def load_raw_config_dict() -> dict[str, Any] | None:
 
 
 def scan_unknown_config_keys(raw: dict[str, Any]) -> list[str]:
-    """Shallow unknown keys vs current Pydantic models (read-only; never delete).
+    """Shallow unknown keys vs Pydantic models (read-only; never delete).
 
-    ``channels.*`` extras may still be valid (plugins); we flag with a note.
+    ``channels.*`` extras may still be valid (plugins); we add a note.
     """
     found: list[str] = []
 
@@ -265,8 +289,8 @@ def scan_unknown_config_keys(raw: dict[str, Any]) -> list[str]:
 def legacy_single_agent_workspace_note(cfg: Config) -> str | None:
     """Align with ``migrate_legacy_workspace_to_default_agent`` preconditions.
 
-    When this applies, ``copaw app`` may run an automatic migration; doctor only
-    informs — it does not migrate.
+    When this applies, ``qwenpaw app`` may run an automatic migration;
+    doctor only informs — it does not migrate.
     """
     profiles = cfg.agents.profiles
     if len(profiles) != 1 or "default" not in profiles:
@@ -280,14 +304,14 @@ def legacy_single_agent_workspace_note(cfg: Config) -> str | None:
     return (
         "Only `default` is listed and workspace "
         f"`{agent_json}` is missing — the same situation "
-        "`copaw app` uses to trigger legacy → multi-agent workspace migration. "
-        "Start `copaw app` once (or see docs / `copaw init`). "
+        "`qwenpaw app` uses to trigger legacy → multi-agent workspace "
+        "migration. Start `qwenpaw app` once (or see docs / `qwenpaw init`). "
         "Doctor does not change config or files."
     )
 
 
 def check_agent_profile_workspaces(cfg: Config) -> tuple[bool, str]:
-    """Each ``agents.profiles`` entry should have a directory and ``agent.json``."""
+    """Each profile needs a workspace dir and ``agent.json``."""
     problems: list[str] = []
     for agent_id, ref in cfg.agents.profiles.items():
         wd = Path(ref.workspace_dir).expanduser()
@@ -302,21 +326,23 @@ def check_agent_profile_workspaces(cfg: Config) -> tuple[bool, str]:
     if problems:
         return False, "\n".join(problems)
     n = len(cfg.agents.profiles)
-    return True, f"{n} agent profile(s); each workspace contains agent.json"
+    return (
+        True,
+        f"{n} agent profile(s); each workspace contains agent.json",
+    )
 
-
-# --- OpenClaw-inspired read-only checks (cron, security hints, memory, hygiene) ---
 
 _LARGE_PROMPT_BYTES = 350 * 1024
-# Disabled: long-lived lock carrier files (e.g. .skill.json.lock) often stay on
-# disk with old mtime while locks are still meaningful — too many false positives.
+# Disabled: long-lived lock carrier files (e.g. .skill.json.lock) often stay
+# on disk with old mtime while locks are still meaningful — too many false
+# positives.
 # _STALE_LOCK_SECS = 86400
 _TOOL_RESULT_MANY = 400
 _DIALOG_MANY = 200
 
 
 def check_cron_jobs_files(cfg: Config) -> tuple[bool, str]:
-    """Validate each agent workspace ``jobs.json`` and optional legacy root file."""
+    """Validate each workspace ``jobs.json`` and optional legacy root file."""
     problems: list[str] = []
     validated_paths: list[tuple[str, Path, int]] = []
 
@@ -350,10 +376,11 @@ def check_cron_jobs_files(cfg: Config) -> tuple[bool, str]:
     if problems:
         return False, "\n".join(problems)
     if not validated_paths:
-        return True, "no jobs.json under agent workspaces (OK if you do not use cron)"
-    summary = "; ".join(
-        f"{aid}: {n} job(s)" for aid, _p, n in validated_paths
-    )
+        return (
+            True,
+            "no jobs.json under agent workspaces (OK if you do not use cron)",
+        )
+    summary = "; ".join(f"{aid}: {n} job(s)" for aid, _p, n in validated_paths)
     return True, f"{len(validated_paths)} file(s) OK — {summary}"
 
 
@@ -372,7 +399,7 @@ def _ms_playwright_browser_cache_roots() -> list[Path]:
 
 
 def _playwright_chromium_bundle_present() -> bool:
-    """Best-effort: Playwright ``playwright install chromium`` cache directory."""
+    """Best-effort: ``playwright install chromium`` browser cache directory."""
     for root in _ms_playwright_browser_cache_roots():
         try:
             if not root.is_dir():
@@ -402,36 +429,42 @@ def browser_automation_notes(cfg: Config | None) -> list[str]:
         return notes
 
     try:
-        from playwright.async_api import async_playwright  # noqa: F401
+        importlib.import_module("playwright.async_api")
     except ImportError:
         notes.append(
-            "playwright is installed but async_api failed to import — reinstall "
-            "the playwright package for this Python.",
+            "playwright is installed but async_api failed to import — "
+            "reinstall the playwright package for this Python.",
         )
         return notes
 
-    use_default = os.environ.get("COPAW_BROWSER_USE_DEFAULT", "1").strip().lower()
+    use_default = (
+        EnvVarLoader.get_str("QWENPAW_BROWSER_USE_DEFAULT", "1")
+        .strip()
+        .lower()
+    )
     if use_default in ("0", "false", "no", "off"):
         notes.append(
-            "COPAW_BROWSER_USE_DEFAULT is off — browser_use will not prefer the "
-            "OS default Chrome/Edge path; bundled or scanned Chromium paths apply.",
+            "QWENPAW_BROWSER_USE_DEFAULT is off — browser_use will not "
+            "prefer the OS default Chrome/Edge path; bundled or scanned "
+            "Chromium paths apply.",
         )
 
     if is_running_in_container():
         notes.append(
             "Container environment: use headless browser_use unless you add "
             "display forwarding; install Chromium in the image or run "
-            f"'{sys.executable}' -m playwright install chromium if launches fail.",
+            f"'{sys.executable}' -m playwright install chromium "
+            "if launches fail.",
         )
 
     exe = get_playwright_chromium_executable_path()
     if not exe and sys.platform != "darwin":
         if not _playwright_chromium_bundle_present():
             notes.append(
-                "No system Chrome/Chromium path found and no Playwright chromium "
-                "cache detected — run "
-                f"'{sys.executable}' -m playwright install chromium' or install "
-                "Chrome/Edge, or set "
+                "No system Chrome/Chromium path found and no Playwright "
+                "chromium cache detected — run "
+                f"'{sys.executable}' -m playwright install chromium' or "
+                "install Chrome/Edge, or set "
                 f"{PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH_ENV}.",
             )
     elif not exe and sys.platform == "darwin":
@@ -439,15 +472,16 @@ def browser_automation_notes(cfg: Config | None) -> list[str]:
             notes.append(
                 "No Chrome/Edge/Chromium on PATH — browser_use falls back to "
                 "WebKit on macOS; install Chrome/Edge or run "
-                f"'{sys.executable}' -m playwright install chromium' if you need "
-                "Chromium specifically.",
+                f"'{sys.executable}' -m playwright install chromium' if you "
+                "need Chromium specifically.",
             )
 
     if sys.platform.startswith("linux") and not is_running_in_container():
         if not (os.environ.get("DISPLAY") or "").strip():
             notes.append(
-                "DISPLAY is unset — headed browser_use (visible window) may fail; "
-                "use the default headless mode or configure X11/Wayland.",
+                "DISPLAY is unset — headed browser_use (visible window) "
+                "may fail; use the default headless mode or configure "
+                "X11/Wayland.",
             )
 
     if cfg is not None:
@@ -457,13 +491,14 @@ def browser_automation_notes(cfg: Config | None) -> list[str]:
             try:
                 if ud.is_file():
                     notes.append(
-                        f"{agent_id}: {ud} exists as a file — remove or rename it "
-                        "so browser_use can use a profile directory.",
+                        f"{agent_id}: {ud} exists as a file — remove or "
+                        "rename it so browser_use can use a profile "
+                        "directory.",
                     )
                 elif ud.is_dir() and not os.access(ud, os.W_OK):
                     notes.append(
-                        f"{agent_id}: {ud} is not writable — persistent browser "
-                        "profiles may fail.",
+                        f"{agent_id}: {ud} is not writable — persistent "
+                        "browser profiles may fail.",
                     )
             except OSError:
                 pass
@@ -472,7 +507,7 @@ def browser_automation_notes(cfg: Config | None) -> list[str]:
 
 
 def security_baseline_notes(cfg: Config) -> list[str]:
-    """Non-fatal security posture hints (aligned with OpenClaw ``doctor:security``)."""
+    """Non-fatal security hints."""
     notes: list[str] = []
     if not cfg.security.tool_guard.enabled:
         notes.append(
@@ -512,11 +547,14 @@ def memory_embedding_notes(cfg: Config) -> list[str]:
             continue
         emb = ac.running.embedding_config
         ms = ac.running.memory_summary
-        if ms.force_memory_search and not _embedding_has_credentials(emb.api_key):
+        if ms.force_memory_search and not _embedding_has_credentials(
+            emb.api_key,
+        ):
             notes.append(
-                f"{agent_id}: running.memory_summary.force_memory_search is on "
-                "but no embedding API key is set in running.embedding_config.api_key "
-                "and no common OPENAI_/DASHSCOPE_/ANTHROPIC_ API key env was found.",
+                f"{agent_id}: running.memory_summary.force_memory_search "
+                "is on but no embedding API key is set in "
+                "running.embedding_config.api_key and no common "
+                "OPENAI_/DASHSCOPE_/ANTHROPIC_ API key env was found.",
             )
     return notes
 
@@ -560,8 +598,8 @@ def workspace_hygiene_notes(cfg: Config) -> list[str]:
                 continue
             if n > many:
                 notes.append(
-                    f"{agent_id}: {label}/ has {n} entries — cleanup or archival "
-                    "may improve performance.",
+                    f"{agent_id}: {label}/ has {n} entries — cleanup or "
+                    "archival may improve performance.",
                 )
         # Stale *.lock scan disabled — see _STALE_LOCK_SECS comment above.
         # stale = 0
@@ -578,7 +616,8 @@ def workspace_hygiene_notes(cfg: Config) -> list[str]:
         # if stale > 0:
         #     notes.append(
         #         f"{agent_id}: {stale}+ stale *.lock file(s) under workspace "
-        #         "(older than 24h) — possible crashed process; safe to inspect.",
+        #         "(older than 24h) — possible crashed process; "
+        #         "safe to inspect.",
         #     )
 
     if MEMORY_DIR.is_dir():
@@ -588,13 +627,13 @@ def workspace_hygiene_notes(cfg: Config) -> list[str]:
             mcount = 0
         if mcount > 5000:
             notes.append(
-                f"global memory tree {MEMORY_DIR} has many files ({mcount}+) — "
-                "expect slower indexing or backup size.",
+                f"global memory tree {MEMORY_DIR} has many files "
+                f"({mcount}+) — expect slower indexing or backup size.",
             )
     return notes
 
 
-# --- CoPaw-specific profile checks (agent.json, channels, MCP, skills, providers) ---
+# --- QwenPaw checks (agent.json, channels, MCP, skills, providers) ---
 
 
 def _read_workspace_agent_json(ref: AgentProfileRef) -> dict[str, Any] | None:
@@ -615,7 +654,7 @@ def _read_workspace_agent_json(ref: AgentProfileRef) -> dict[str, Any] | None:
 
 
 def check_agent_json_profiles(cfg: Config) -> tuple[bool, str]:
-    """Validate ``agent.json`` with ``AgentProfileConfig`` (read-only; no ``load_agent_config``)."""
+    """Validate ``agent.json`` with ``AgentProfileConfig`` (read-only)."""
     problems: list[str] = []
     n_ok = 0
     for agent_id, ref in cfg.agents.profiles.items():
@@ -640,11 +679,11 @@ def check_agent_json_profiles(cfg: Config) -> tuple[bool, str]:
 
 
 def check_enabled_agents_load_agent_config(cfg: Config) -> tuple[bool, str]:
-    """Dry-run :func:`~copaw.config.config.load_agent_config` for enabled profiles only.
+    """Dry-run :func:`~qwenpaw.config.config.load_agent_config` for enabled.
 
-    Matches agents started by ``MultiAgentManager.start_all_configured_agents``.
-    When ``agent.json`` is missing, we do **not** call ``load_agent_config`` (that
-    would write a fallback file on disk); we report FAIL for enabled agents instead.
+    Matches ``MultiAgentManager.start_all_configured_agents``. When
+    ``agent.json`` is missing, we do **not** call ``load_agent_config`` (that
+    would write a fallback on disk); we report FAIL for enabled agents.
     """
     problems: list[str] = []
     ok_n = 0
@@ -658,8 +697,9 @@ def check_enabled_agents_load_agent_config(cfg: Config) -> tuple[bool, str]:
         if not path.is_file():
             problems.append(
                 f"{agent_id}: enabled but missing {path} — at startup "
-                "`load_agent_config` would create a fallback agent.json on disk; "
-                "ensure the file exists or use `copaw doctor fix` where applicable.",
+                "`load_agent_config` would create a fallback agent.json on "
+                "disk; ensure the file exists or use `qwenpaw doctor fix` "
+                "where applicable.",
             )
             continue
         try:
@@ -697,7 +737,7 @@ def _effective_channels_mcp(
 
 
 def enabled_channel_notes(cfg: Config) -> list[str]:
-    """Static checks for built-in channels with ``enabled`` and empty credentials."""
+    """Static checks for enabled channels with missing credentials."""
     notes: list[str] = []
     for agent_id, ref in cfg.agents.profiles.items():
         raw = _read_workspace_agent_json(ref)
@@ -711,34 +751,48 @@ def enabled_channel_notes(cfg: Config) -> list[str]:
             if name == "console":
                 continue
             if name == "discord" and not (sub.bot_token or "").strip():
-                notes.append(f"{agent_id}: discord enabled but bot_token is empty")
+                notes.append(
+                    f"{agent_id}: discord enabled but bot_token is empty",
+                )
             elif name == "dingtalk":
-                if not (sub.client_id or "").strip() or not (
-                    sub.client_secret or ""
-                ).strip():
+                if (
+                    not (sub.client_id or "").strip()
+                    or not (sub.client_secret or "").strip()
+                ):
                     notes.append(
-                        f"{agent_id}: dingtalk enabled but client_id/client_secret incomplete",
+                        f"{agent_id}: dingtalk enabled but "
+                        "client_id/client_secret incomplete",
                     )
             elif name == "feishu":
-                if not (sub.app_id or "").strip() or not (
-                    sub.app_secret or ""
-                ).strip():
+                if (
+                    not (sub.app_id or "").strip()
+                    or not (sub.app_secret or "").strip()
+                ):
                     notes.append(
-                        f"{agent_id}: feishu enabled but app_id/app_secret incomplete",
+                        f"{agent_id}: feishu enabled but "
+                        "app_id/app_secret incomplete",
                     )
             elif name == "qq":
-                if not (sub.app_id or "").strip() or not (
-                    sub.client_secret or ""
-                ).strip():
+                if (
+                    not (sub.app_id or "").strip()
+                    or not (sub.client_secret or "").strip()
+                ):
                     notes.append(
-                        f"{agent_id}: qq enabled but app_id/client_secret incomplete",
+                        f"{agent_id}: qq enabled but "
+                        "app_id/client_secret incomplete",
                     )
             elif name == "telegram" and not (sub.bot_token or "").strip():
-                notes.append(f"{agent_id}: telegram enabled but bot_token is empty")
+                notes.append(
+                    f"{agent_id}: telegram enabled but bot_token is empty",
+                )
             elif name == "mattermost":
-                if not (sub.url or "").strip() or not (sub.bot_token or "").strip():
+                if (
+                    not (sub.url or "").strip()
+                    or not (sub.bot_token or "").strip()
+                ):
                     notes.append(
-                        f"{agent_id}: mattermost enabled but url/bot_token incomplete",
+                        f"{agent_id}: mattermost enabled but "
+                        "url/bot_token incomplete",
                     )
             elif name == "mqtt" and not (sub.host or "").strip():
                 notes.append(f"{agent_id}: mqtt enabled but host is empty")
@@ -749,7 +803,8 @@ def enabled_channel_notes(cfg: Config) -> list[str]:
                     or not (sub.access_token or "").strip()
                 ):
                     notes.append(
-                        f"{agent_id}: matrix enabled but homeserver/user_id/access_token incomplete",
+                        f"{agent_id}: matrix enabled but "
+                        "homeserver/user_id/access_token incomplete",
                     )
             elif name == "voice":
                 if (
@@ -758,12 +813,17 @@ def enabled_channel_notes(cfg: Config) -> list[str]:
                     or not (sub.phone_number or "").strip()
                 ):
                     notes.append(
-                        f"{agent_id}: voice enabled but Twilio fields incomplete",
+                        f"{agent_id}: voice enabled but Twilio fields "
+                        "incomplete",
                     )
             elif name == "wecom":
-                if not (sub.bot_id or "").strip() or not (sub.secret or "").strip():
+                if (
+                    not (sub.bot_id or "").strip()
+                    or not (sub.secret or "").strip()
+                ):
                     notes.append(
-                        f"{agent_id}: wecom enabled but bot_id/secret incomplete",
+                        f"{agent_id}: wecom enabled but "
+                        "bot_id/secret incomplete",
                     )
             elif name == "xiaoyi":
                 if (
@@ -772,7 +832,8 @@ def enabled_channel_notes(cfg: Config) -> list[str]:
                     or not (sub.agent_id or "").strip()
                 ):
                     notes.append(
-                        f"{agent_id}: xiaoyi enabled but ak/sk/agent_id incomplete",
+                        f"{agent_id}: xiaoyi enabled but "
+                        "ak/sk/agent_id incomplete",
                     )
             elif name == "weixin":
                 tok = (sub.bot_token or "").strip()
@@ -783,17 +844,20 @@ def enabled_channel_notes(cfg: Config) -> list[str]:
                     p = Path(fp).expanduser()
                     if not p.is_file():
                         notes.append(
-                            f"{agent_id}: weixin enabled but bot_token_file missing: {p}",
+                            f"{agent_id}: weixin enabled but "
+                            f"bot_token_file missing: {p}",
                         )
                 else:
                     notes.append(
-                        f"{agent_id}: weixin enabled but bot_token and bot_token_file unset",
+                        f"{agent_id}: weixin enabled but bot_token and "
+                        "bot_token_file unset",
                     )
             elif name == "imessage":
                 dbp = Path(sub.db_path).expanduser()
                 if not dbp.is_file():
                     notes.append(
-                        f"{agent_id}: imessage enabled but chat.db not found at {dbp}",
+                        f"{agent_id}: imessage enabled but chat.db not "
+                        f"found at {dbp}",
                     )
         extra = getattr(ch, "__pydantic_extra__", None) or {}
         for key, val in extra.items():
@@ -830,7 +894,8 @@ def _mcp_client_problems(mcp: MCPConfig | None, label: str) -> list[str]:
             exe = cmd0[0]
             if not shutil.which(exe):
                 problems.append(
-                    f"{label} MCP {cid!r}: stdio executable {exe!r} not found on PATH",
+                    f"{label} MCP {cid!r}: stdio executable {exe!r} "
+                    "not found on PATH",
                 )
         elif client.transport in ("streamable_http", "sse"):
             u = (client.url or "").strip()
@@ -840,13 +905,14 @@ def _mcp_client_problems(mcp: MCPConfig | None, label: str) -> list[str]:
                 )
             elif not _url_looks_httpish(u):
                 problems.append(
-                    f"{label} MCP {cid!r}: url does not look like http(s)://…",
+                    f"{label} MCP {cid!r}: url does not look like "
+                    "http(s)://…",
                 )
     return problems
 
 
 def mcp_client_notes(cfg: Config) -> list[str]:
-    """Enabled MCP clients: PATH / URL sanity (root + per-agent ``agent.json`` mcp)."""
+    """MCP client PATH / URL sanity (root + per-agent ``agent.json`` mcp)."""
     notes: list[str] = []
     notes.extend(_mcp_client_problems(cfg.mcp, "root"))
     for agent_id, ref in cfg.agents.profiles.items():
@@ -862,7 +928,7 @@ def mcp_client_notes(cfg: Config) -> list[str]:
 
 
 def skill_layout_notes(cfg: Config) -> list[str]:
-    """Enabled skills in skill.json vs on-disk directories under the workspace."""
+    """Enabled skills in skill.json vs on-disk workspace directories."""
     notes: list[str] = []
     for agent_id, ref in cfg.agents.profiles.items():
         wd = Path(ref.workspace_dir).expanduser()
@@ -881,13 +947,14 @@ def skill_layout_notes(cfg: Config) -> list[str]:
             d = root / str(sname)
             if not d.is_dir():
                 notes.append(
-                    f"{agent_id}: skill {sname!r} enabled in skill.json but directory missing: {d}",
+                    f"{agent_id}: skill {sname!r} enabled in skill.json but "
+                    f"directory missing: {d}",
                 )
     return notes
 
 
 def provider_overview_notes() -> list[str]:
-    """Custom providers with missing required fields (async provider registry)."""
+    """Custom providers missing required fields (async registry)."""
     from ..providers.provider_manager import ProviderManager
 
     async def _run() -> list[str]:
@@ -910,39 +977,46 @@ def provider_overview_notes() -> list[str]:
 
 
 def active_llm_local_failure_hint(provider: Provider, provider_id: str) -> str:
-    """Short hint when ``check_model_connection`` failed for a local-oriented provider."""
+    """Hint when ``check_model_connection`` failed (local provider)."""
     if provider_id == "ollama":
         base = (getattr(provider, "base_url", None) or "").strip()
         if not base:
-            base = (os.environ.get("OLLAMA_HOST") or "http://127.0.0.1:11434").strip()
+            base = (
+                os.environ.get("OLLAMA_HOST") or "http://127.0.0.1:11434"
+            ).strip()
         return (
-            f"Hint: start Ollama (e.g. `ollama serve`) and ensure the model is "
-            f"available (`ollama pull …`). OpenAI-compatible API is usually "
-            f"{base.rstrip('/')}/v1 ."
+            "Hint: start Ollama (e.g. `ollama serve`) and ensure the model "
+            "is available (`ollama pull …`). OpenAI-compatible API is "
+            f"usually {base.rstrip('/')}/v1 ."
         )
     if provider_id == "lmstudio":
-        base = (getattr(provider, "base_url", None) or "").strip() or "http://127.0.0.1:1234/v1"
+        base = (
+            getattr(provider, "base_url", None) or ""
+        ).strip() or "http://127.0.0.1:1234/v1"
         return (
-            f"Hint: open LM Studio, load a model, and enable the local server. "
+            "Hint: open LM Studio, load a model, and enable the local server. "
             f"Typical base URL: {base.rstrip('/')}"
         )
-    if provider_id == "copaw-local":
+    if provider_id in _QWENPAW_LOCAL_PROVIDER_IDS:
         return (
-            "Hint: CoPaw Local uses llama.cpp. Start the local server from the CoPaw "
-            "console or install the llama.cpp binary from there. "
-            "Run `copaw doctor --deep` to see llama.cpp install and server status."
+            f"Hint: {PROJECT_NAME} Local uses llama.cpp. Start the local "
+            f"server from the {PROJECT_NAME} console or install the llama.cpp "
+            "binary from there. Run `qwenpaw doctor --deep` to see llama.cpp "
+            "install and server status."
         )
     if getattr(provider, "is_local", False):
-        base = (getattr(provider, "base_url", None) or "").strip() or "your configured base_url"
+        base = (
+            getattr(provider, "base_url", None) or ""
+        ).strip() or "your configured base_url"
         return (
-            f"Hint: this provider is marked local — ensure the inference HTTP server "
-            f"is running and matches {base}."
+            "Hint: this provider is marked local — ensure the inference HTTP "
+            f"server is running and matches {base}."
         )
     return ""
 
 
-def copaw_local_llm_deep_notes() -> list[str]:
-    """Read-only llama.cpp install + server snapshot (for ``--deep`` + ``copaw-local``)."""
+def qwenpaw_local_llm_deep_notes() -> list[str]:
+    """Read-only llama.cpp install + server snapshot (``--deep`` / local)."""
     try:
         from ..local_models.manager import LocalModelManager
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -984,15 +1058,19 @@ def copaw_local_llm_deep_notes() -> list[str]:
 
 
 def _slot_is_set(slot: Any) -> bool:
-    return bool(getattr(slot, "provider_id", None) and getattr(slot, "model", None))
+    return bool(
+        getattr(slot, "provider_id", None) and getattr(slot, "model", None),
+    )
 
 
 def _resolve_agent_effective_model_slot(
     agent_cfg: AgentProfileConfig,
     active_slot: Any | None,
 ) -> tuple[Any | None, str]:
-    """Resolve which provider/model an agent will use for its default chat model."""
-    if agent_cfg.active_model is not None and _slot_is_set(agent_cfg.active_model):
+    """Resolve provider/model for the agent default chat model."""
+    if agent_cfg.active_model is not None and _slot_is_set(
+        agent_cfg.active_model,
+    ):
         return agent_cfg.active_model, "agent.active_model"
 
     routing = agent_cfg.llm_routing
@@ -1019,7 +1097,7 @@ async def check_enabled_agents_model_connections(
     timeout: float,
     deep: bool,
 ) -> tuple[bool, list[str], list[str]]:
-    """Test each enabled agent's effective model connectivity (like UI 'test connection').
+    """Test enabled agents' model connectivity (UI-style test).
 
     Returns (all_ok, per_agent_lines, extra_notes).
     """
@@ -1038,7 +1116,9 @@ async def check_enabled_agents_model_connections(
             ac = load_agent_config(agent_id)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             all_ok = False
-            lines.append(f"{agent_id}: FAIL — load_agent_config failed ({exc})")
+            lines.append(
+                f"{agent_id}: FAIL — load_agent_config failed ({exc})",
+            )
             continue
 
         slot, source = _resolve_agent_effective_model_slot(ac, active_slot)
@@ -1064,26 +1144,33 @@ async def check_enabled_agents_model_connections(
                 all_ok = False
                 lines.append(f"{agent_id}: FAIL — {pid}: base_url is not set")
                 continue
-        if getattr(provider, "require_api_key", False) and not (
-            getattr(provider, "api_key", "") or ""
-        ).strip():
+        if (
+            getattr(provider, "require_api_key", False)
+            and not (getattr(provider, "api_key", "") or "").strip()
+        ):
             all_ok = False
-            lines.append(f"{agent_id}: FAIL — {pid}: API key is required but not set")
+            lines.append(
+                f"{agent_id}: FAIL — {pid}: API key is required but not set",
+            )
             continue
 
-        if deep and pid == "copaw-local":
+        if deep and pid in _QWENPAW_LOCAL_PROVIDER_IDS:
             # Only add once (same underlying llama.cpp runtime).
             if not any("llama.cpp" in n for n in notes):
-                notes.extend(copaw_local_llm_deep_notes())
+                notes.extend(qwenpaw_local_llm_deep_notes())
 
         if not getattr(provider, "support_connection_check", True):
             lines.append(
-                f"{agent_id}: OK — {pid} / {model} (live check skipped for this provider)",
+                f"{agent_id}: OK — {pid} / {model} "
+                "(live check skipped for this provider)",
             )
             continue
 
         try:
-            ok, msg = await provider.check_model_connection(model, timeout=timeout)
+            ok, msg = await provider.check_model_connection(
+                model,
+                timeout=timeout,
+            )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             ok, msg = False, str(exc)
         if ok:
@@ -1093,7 +1180,11 @@ async def check_enabled_agents_model_connections(
         all_ok = False
         detail = f": {msg}" if msg else ""
         body = f"{pid} / {model} unreachable{detail}"
-        if getattr(provider, "is_local", False) or pid in ("ollama", "lmstudio", "copaw-local"):
+        if getattr(provider, "is_local", False) or pid in (
+            "ollama",
+            "lmstudio",
+            *_QWENPAW_LOCAL_PROVIDER_IDS,
+        ):
             hint = active_llm_local_failure_hint(provider, pid)
             if hint:
                 body = f"{body}\n{hint}"
@@ -1105,21 +1196,22 @@ async def check_enabled_agents_model_connections(
 
 
 def console_static_diagnostic_notes() -> list[str]:
-    """Extra context for the web console bundle (paths, mtime, source-tree npm fix)."""
+    """Web console bundle context (paths, mtime, npm rebuild hint)."""
     from datetime import datetime, timezone
 
     from ..utils.console_static import (
         CONSOLE_STATIC_ENV,
-        find_copaw_source_repo_root,
+        find_qwenpaw_source_repo_root,
         resolve_console_static_dir,
     )
 
     notes: list[str] = []
-    env_dir = (os.environ.get(CONSOLE_STATIC_ENV) or "").strip()
+    env_dir = EnvVarLoader.get_str("QWENPAW_CONSOLE_STATIC_DIR", "").strip()
     if env_dir:
         notes.append(
-            f"{CONSOLE_STATIC_ENV} is set — the app serves console files from that "
-            f"path ({env_dir}), not from the package or repo defaults.",
+            f"{CONSOLE_STATIC_ENV} is set — the app serves console files "
+            f"from that path ({env_dir}), not from the package or repo "
+            "defaults.",
         )
     static = Path(resolve_console_static_dir())
     idx = static / "index.html"
@@ -1132,7 +1224,8 @@ def console_static_diagnostic_notes() -> list[str]:
         except OSError:
             mtime = "(unknown)"
         notes.append(
-            f"resolved static dir: {static} — index.html present (mtime {mtime})",
+            f"resolved static dir: {static} — index.html present "
+            f"(mtime {mtime})",
         )
     else:
         notes.append(
@@ -1145,18 +1238,19 @@ def console_static_diagnostic_notes() -> list[str]:
         + (npm if npm else "not found (install Node.js or fix PATH)"),
     )
 
-    repo = find_copaw_source_repo_root()
+    repo = find_qwenpaw_source_repo_root()
     if repo is not None:
         notes.append(
-            f"source checkout detected at {repo} — bundle console into the package with "
-            "`copaw doctor fix -y --only rebuild-console-npm` "
-            "(`npm ci && npm run build` in console/, then copy to src/copaw/console/).",
+            f"source checkout detected at {repo} — if you changed the web "
+            "console under `console/`, you could rebuild the bundled UI with "
+            "`qwenpaw doctor fix -y --only rebuild-console-npm`.",
         )
     else:
         notes.append(
-            "source checkout not detected (normal for wheel installs) — use a git "
-            "checkout to run the npm bundle fix, or point COPAW_CONSOLE_STATIC_DIR at "
-            "a directory that contains index.html.",
+            "source checkout not detected (normal for wheel installs) — use "
+            "a git checkout to run the npm bundle fix, or point "
+            "QWENPAW_CONSOLE_STATIC_DIR (or legacy COPAW_CONSOLE_STATIC_DIR) "
+            "at a directory that contains index.html.",
         )
     return notes
 
@@ -1174,7 +1268,7 @@ def api_target_mismatch_note(cfg: Config, cli_base: str) -> str | None:
     if got == expected:
         return None
     return (
-        f"CLI targets {got!r} but config last_api is {eff_host!r}:{eff_port} — "
-        "use the same host/port as the running server, or update last_api in config."
+        f"CLI targets {got!r} but config last_api is "
+        f"{eff_host!r}:{eff_port} — use the same host/port as the running "
+        "server, or update last_api in config."
     )
-

--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -86,18 +86,39 @@ def _resolve_existing_path_anchor(path: Path) -> Path | None:
 
 
 def check_app_log_writable() -> tuple[bool, str]:
-    """``qwenpaw app`` appends to the app log under ``WORKING_DIR``."""
+    """Check log-path writability."""
     log_path = WORKING_DIR / APP_LOG_BASENAME
-    try:
-        with open(log_path, "a", encoding="utf-8"):
-            pass
-    except OSError as exc:
+    if log_path.exists():
+        if not log_path.is_file():
+            return (
+                False,
+                f"log path exists but is not a regular file: {log_path}",
+            )
+        if os.access(log_path, os.W_OK):
+            return True, f"{log_path} (existing file is writable)"
         return (
             False,
-            f"cannot append to {log_path} "
-            f"(required when starting `qwenpaw app`): {exc}",
+            f"cannot write to existing log file {log_path} "
+            "(required when starting `qwenpaw app`)",
         )
-    return True, str(log_path)
+
+    parent = log_path.parent
+    if not parent.is_dir():
+        return (
+            False,
+            f"log directory does not exist: {parent} "
+            "(required when starting `qwenpaw app`)",
+        )
+    if os.access(parent, os.W_OK | os.X_OK):
+        return (
+            True,
+            f"{log_path} (not present; parent directory appears writable)",
+        )
+    return (
+        False,
+        f"log file does not exist and parent directory is not writable: "
+        f"{parent}",
+    )
 
 
 def check_agent_workspace_writable(cfg: Config) -> tuple[bool, str]:
@@ -168,7 +189,7 @@ def environment_summary_lines(
     """One line per fact; safe to paste into bug reports.
 
     *server_python_environment* describes the **HTTP API process** (running
-    ``qwenpaw app``), when ``GET /api/version`` returned
+    ``qwenpaw app``), when ``GET /api/doctor/runtime`` returned
     ``python_environment``. Doctor's own interpreter uses
     ``doctor_python_environment``.
     """

--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -77,35 +77,57 @@ def _fetch_running_server_python(
     base: str,
     timeout: float,
 ) -> tuple[str | None, str | None, str | None]:
-    """Return env summary, python exe, and note from GET /api/version."""
-    url = f"{base.rstrip('/')}/api/version"
-    try:
-        resp = httpx.get(url, timeout=timeout)
-    except httpx.RequestError as exc:
-        return None, None, f"(not available: {exc})"
-    if resp.status_code != 200:
+    """Return env sum, python exe, and note from runtime diagnostics API."""
+    runtime_url = f"{base.rstrip('/')}/api/doctor/runtime"
+
+    def _extract_env_and_exe(
+        body: object,
+        source_url: str,
+    ) -> tuple[str | None, str | None, str | None]:
+        if not isinstance(body, dict):
+            return (
+                None,
+                None,
+                f"(not available: unexpected payload from {source_url})",
+            )
+        raw_env = body.get("python_environment")
+        raw_exe = body.get("python_executable")
+        env_s = raw_env.strip() if isinstance(raw_env, str) else ""
+        exe_s = raw_exe.strip() if isinstance(raw_exe, str) else ""
+        if env_s:
+            return env_s, exe_s or None, None
         return (
             None,
             None,
-            f"(not available: HTTP {resp.status_code} from {url})",
+            f"(not available: {source_url} did not report "
+            "python_environment)",
         )
+
     try:
-        body = resp.json()
-    except json.JSONDecodeError:
-        return None, None, "(not available: /api/version is not JSON)"
-    if not isinstance(body, dict):
-        return None, None, "(not available: unexpected /api/version payload)"
-    raw_env = body.get("python_environment")
-    raw_exe = body.get("python_executable")
-    env_s = raw_env.strip() if isinstance(raw_env, str) else ""
-    exe_s = raw_exe.strip() if isinstance(raw_exe, str) else ""
-    if env_s:
-        return env_s, exe_s or None, None
+        runtime_resp = httpx.get(runtime_url, timeout=timeout)
+    except httpx.RequestError as exc:
+        return None, None, f"(not available: {exc})"
+    if runtime_resp.status_code == 200:
+        try:
+            return _extract_env_and_exe(runtime_resp.json(), runtime_url)
+        except json.JSONDecodeError:
+            return (
+                None,
+                None,
+                "(not available: /api/doctor/runtime is not JSON)",
+            )
+    if runtime_resp.status_code in (401, 403):
+        return (
+            None,
+            None,
+            "(not available: /api/doctor/runtime requires authentication for "
+            "remote requests)",
+        )
+
     return (
         None,
         None,
-        "(running app did not report python_environment — update and "
-        "restart `qwenpaw app` so the listener picks up the new API)",
+        f"(not available: HTTP {runtime_resp.status_code} from {runtime_url})",
     )
 
 
@@ -650,7 +672,7 @@ def run_doctor_checks(
         if log_ok:
             click.echo(
                 click.style("OK", fg="green")
-                + f" — {PROJECT_NAME.lower()}.log appendable ({log_detail})",
+                + f" — {PROJECT_NAME.lower()}.log appendable",
             )
         else:
             failed = True

--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -1,0 +1,799 @@
+# -*- coding: utf-8 -*-
+"""`copaw doctor` — read-only checks; `copaw doctor fix` — conservative repairs with backup."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import click
+import httpx
+
+from ..__version__ import __version__
+from ..app.auth import has_registered_users, is_auth_enabled
+from ..config import load_config
+from ..config.utils import strict_validate_config_file
+from ..constant import WORKING_DIR
+from ..providers.provider import Provider
+from ..providers.provider_manager import ProviderManager
+from ..utils.console_static import CONSOLE_STATIC_ENV, resolve_console_static_dir
+from .doctor_checks import (
+    active_llm_local_failure_hint,
+    api_target_mismatch_note,
+    browser_automation_notes,
+    check_agent_json_profiles,
+    check_agent_profile_workspaces,
+    check_agent_workspace_writable,
+    check_copaw_log_writable,
+    check_cron_jobs_files,
+    check_enabled_agents_load_agent_config,
+    check_enabled_agents_model_connections,
+    console_static_diagnostic_notes,
+    enabled_channel_notes,
+    environment_summary_lines,
+    legacy_single_agent_workspace_note,
+    load_raw_config_dict,
+    mcp_client_notes,
+    memory_embedding_notes,
+    provider_overview_notes,
+    scan_unknown_config_keys,
+    security_baseline_notes,
+    skill_layout_notes,
+    copaw_local_llm_deep_notes,
+    startup_extra_volume_disk_notes,
+    workspace_hygiene_notes,
+)
+from .doctor_connectivity import collect_deep_channel_connectivity_notes
+from .doctor_registry import DoctorRunContext, run_extension_contributions
+from .http import resolve_base_url
+
+
+def _provider_is_configured(provider: Provider) -> tuple[bool, str]:
+    if provider.is_local:
+        return True, ""
+    if not (provider.base_url or "").strip():
+        return False, "base_url is not set"
+    if provider.require_api_key and not (provider.api_key or "").strip():
+        return False, "API key is required but not set"
+    return True, ""
+
+
+def _check_working_dir() -> tuple[bool, str]:
+    if not WORKING_DIR.is_dir():
+        return False, f"missing: {WORKING_DIR}"
+    if not os.access(WORKING_DIR, os.W_OK):
+        return False, f"not writable: {WORKING_DIR}"
+    return True, str(WORKING_DIR)
+
+
+def _check_console_static_files() -> tuple[bool, str]:
+    static_dir = resolve_console_static_dir()
+    index = Path(static_dir) / "index.html"
+    if index.is_file():
+        return True, f"{static_dir}"
+    return (
+        False,
+        f"index.html missing under {static_dir}\n"
+        "        Build: `npm ci && npm run build` in the `console/` directory, "
+        f"or set {CONSOLE_STATIC_ENV} to a directory that contains index.html.",
+    )
+
+
+def _check_web_auth(base: str) -> tuple[bool, str]:
+    if not is_auth_enabled():
+        return True, "disabled (default) — open the console without logging in"
+    if not has_registered_users():
+        return (
+            False,
+            "enabled but no account registered yet.\n"
+            f"        1) Start `copaw app`, open {base}/ in a browser.\n"
+            "        2) Complete registration (single user) on the login page.\n"
+            "        For automation, set COPAW_AUTH_USERNAME and "
+            "COPAW_AUTH_PASSWORD — the server creates the user on startup.",
+        )
+    return (
+        True,
+        f"enabled — open {base}/ and sign in; the console stores your session. "
+        "API clients must send Authorization: Bearer <token> from login.",
+    )
+
+
+def _classify_console_root_response(resp: httpx.Response) -> tuple[bool, str]:
+    ct = (resp.headers.get("content-type") or "").lower()
+    if "text/html" in ct:
+        return True, f"HTTP GET / returns HTML (HTTP {resp.status_code})"
+    text = (resp.text or "").lstrip()
+    if text.startswith("<!DOCTYPE") or text.startswith("<html"):
+        return True, f"HTTP GET / looks like HTML (HTTP {resp.status_code})"
+    if "application/json" in ct or text.startswith("{"):
+        try:
+            payload = resp.json()
+        except json.JSONDecodeError:
+            return False, "HTTP GET / returned JSON that is not parseable"
+        if isinstance(payload, dict):
+            msg = str(payload.get("message", ""))
+            if "Web Console is not available" in msg:
+                return (
+                    False,
+                    "server is running but the console bundle is not installed — "
+                    "build `console/` or set "
+                    f"{CONSOLE_STATIC_ENV}, then restart `copaw app`.",
+                )
+        return False, "HTTP GET / returned JSON instead of the console page"
+    return False, f"unexpected GET / response (content-type: {ct or 'unknown'})"
+
+
+async def _check_active_llm(
+    timeout: float,
+    deep: bool,
+) -> tuple[bool, str, list[str]]:
+    manager = ProviderManager.get_instance()
+    slot = manager.get_active_model()
+    if (
+        slot is None
+        or not (slot.provider_id or "").strip()
+        or not (slot.model or "").strip()
+    ):
+        return (
+            False,
+            "no active LLM slot — run `copaw models list` and configure "
+            "an active model",
+            [],
+        )
+    provider = manager.get_provider(slot.provider_id)
+    if provider is None:
+        return False, f"provider not found: {slot.provider_id!r}", []
+    ok, reason = _provider_is_configured(provider)
+    if not ok:
+        return False, f"{slot.provider_id}: {reason}", []
+
+    deep_notes: list[str] = []
+    if deep and (slot.provider_id or "").strip() == "copaw-local":
+        deep_notes = copaw_local_llm_deep_notes()
+
+    if not getattr(provider, "support_connection_check", True):
+        return (
+            True,
+            f"{slot.provider_id} / {slot.model} (live check skipped for "
+            f"this provider)",
+            deep_notes,
+        )
+    ping_ok, ping_msg = await provider.check_model_connection(
+        slot.model,
+        timeout=timeout,
+    )
+    if not ping_ok:
+        detail = f": {ping_msg}" if ping_msg else ""
+        body = f"{slot.provider_id} / {slot.model} unreachable{detail}"
+        if getattr(provider, "is_local", False) or slot.provider_id in (
+            "ollama",
+            "lmstudio",
+            "copaw-local",
+        ):
+            hint = active_llm_local_failure_hint(provider, slot.provider_id)
+            if hint:
+                body = f"{body}\n{hint}"
+        return False, body, deep_notes
+    return True, f"{slot.provider_id} / {slot.model} (reachable)", deep_notes
+
+
+def run_doctor_checks(
+    ctx: click.Context,
+    timeout: float,
+    llm_timeout: float,
+    deep: bool,
+) -> None:
+    """Run read-only ``copaw doctor`` checks (no disk mutations)."""
+    base = resolve_base_url(ctx, None).rstrip("/")
+    failed = False
+
+    click.echo("=== Environment ===")
+    for line in environment_summary_lines():
+        click.echo(f"  {line}")
+
+    click.echo("\n=== Config ===")
+    config_ok, detail = strict_validate_config_file()
+    if config_ok:
+        click.echo(click.style("OK", fg="green") + f" — {detail}")
+    else:
+        failed = True
+        click.echo(click.style("FAIL", fg="red") + f"\n{detail}", err=True)
+
+    raw_cfg = load_raw_config_dict()
+    if raw_cfg is not None:
+        unknown = scan_unknown_config_keys(raw_cfg)
+        if unknown:
+            click.echo("\n=== Config (unknown keys) ===")
+            click.echo(
+                click.style("Note:", fg="yellow")
+                + " keys present on disk that are not on the current schema "
+                "(informational only; doctor does not remove or rewrite them):",
+            )
+            for item in unknown:
+                click.echo(f"  - {item}")
+
+    if config_ok:
+        cfg = load_config()
+        legacy = legacy_single_agent_workspace_note(cfg)
+        if legacy:
+            click.echo("\n=== Multi-agent / workspace ===")
+            click.echo(click.style("Note:", fg="yellow") + f" {legacy}")
+
+        click.echo("\n=== Agents ===")
+        click.echo("Workspaces")
+        ws_ok, ws_detail = check_agent_profile_workspaces(cfg)
+        if ws_ok:
+            click.echo(click.style("OK", fg="green") + f" — {ws_detail}")
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red") + f" — {ws_detail}",
+                err=True,
+            )
+
+        click.echo("Profiles (agent.json)")
+        aj_ok, aj_detail = check_agent_json_profiles(cfg)
+        if aj_ok:
+            click.echo(click.style("OK", fg="green") + f" — {aj_detail}")
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red") + f" — {aj_detail}",
+                err=True,
+            )
+
+        click.echo("Config load (enabled)")
+        acl_ok, acl_detail = check_enabled_agents_load_agent_config(cfg)
+        if acl_ok:
+            click.echo(click.style("OK", fg="green") + f" — {acl_detail}")
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red") + f" — {acl_detail}",
+                err=True,
+            )
+
+        click.echo("\n=== Channels (enabled) ===")
+        ch_notes = enabled_channel_notes(cfg)
+        if ch_notes:
+            for line in ch_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green")
+                + " — no enabled-channel credential warnings",
+            )
+
+        click.echo("\n=== Doctor extensions ===")
+        ext_ctx = DoctorRunContext(
+            cfg=cfg,
+            raw_cfg=raw_cfg,
+            cli_base_url=base,
+            timeout=timeout,
+            deep=deep,
+        )
+        ext_results = run_extension_contributions(ext_ctx)
+        ext_nonempty = [(c, ls) for c, ls in ext_results if ls]
+        if not ext_nonempty:
+            click.echo(
+                click.style("OK", fg="green")
+                + " — no extension notes (register via copaw.doctor entry points "
+                "or register_doctor_contribution)",
+            )
+        else:
+            for contrib_id, lines in ext_nonempty:
+                click.echo(f"  [{contrib_id}]")
+                for line in lines:
+                    click.echo(
+                        click.style("Note:", fg="yellow") + f" {line}",
+                    )
+
+        if deep:
+            click.echo("\n=== Channels (connectivity, --deep) ===")
+            conn_notes = collect_deep_channel_connectivity_notes(cfg, timeout)
+            if conn_notes:
+                click.echo(
+                    click.style("Note:", fg="yellow")
+                    + " reachability issues (firewalled/offline is common):",
+                )
+                for line in conn_notes:
+                    click.echo(f"  - {line}")
+            else:
+                click.echo(
+                    click.style("OK", fg="green")
+                    + " — no connectivity warnings for enabled channels",
+                )
+
+        click.echo("\n=== MCP clients ===")
+        mcp_notes = mcp_client_notes(cfg)
+        if mcp_notes:
+            for line in mcp_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green") + " — no MCP client warnings",
+            )
+
+        click.echo("\n=== Skills ===")
+        sk_notes = skill_layout_notes(cfg)
+        if sk_notes:
+            for line in sk_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green") + " — no skill layout warnings",
+            )
+
+        click.echo("\n=== Browser (browser_use / Playwright) ===")
+        br_notes = browser_automation_notes(cfg)
+        if br_notes:
+            for line in br_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green")
+                + " — no browser automation warnings",
+            )
+
+        click.echo("\n=== Security (baseline) ===")
+        sec_notes = security_baseline_notes(cfg)
+        if sec_notes:
+            click.echo(
+                click.style("Note:", fg="yellow") + " review security posture:",
+            )
+            for line in sec_notes:
+                click.echo(f"  - {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green") + " — no baseline warnings",
+            )
+
+        click.echo("\n=== Memory / embedding ===")
+        mem_notes = memory_embedding_notes(cfg)
+        if mem_notes:
+            for line in mem_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green") + " — no embedding warnings",
+            )
+
+        click.echo("\n=== Workspace hygiene ===")
+        hy_notes = workspace_hygiene_notes(cfg)
+        if hy_notes:
+            for line in hy_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green") + " — no hygiene warnings",
+            )
+
+        click.echo("\n=== Cron (jobs.json) ===")
+        cj_ok, cj_detail = check_cron_jobs_files(cfg)
+        if cj_ok:
+            click.echo(click.style("OK", fg="green") + f" — {cj_detail}")
+        else:
+            failed = True
+            click.echo(click.style("FAIL", fg="red") + f" — {cj_detail}", err=True)
+    else:
+        click.echo("\n=== Agents ===")
+        click.echo("Workspaces")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("Profiles (agent.json)")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("Config load (enabled)")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Channels (enabled) ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Doctor extensions ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        if deep:
+            click.echo("\n=== Channels (connectivity, --deep) ===")
+            click.echo(
+                click.style("SKIP", fg="yellow")
+                + " — fix root config validation first",
+            )
+        click.echo("\n=== MCP clients ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Skills ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Browser (browser_use / Playwright) ===")
+        br_skip = browser_automation_notes(None)
+        if br_skip:
+            for line in br_skip:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green")
+                + " — no browser automation warnings",
+            )
+        click.echo("\n=== Security (baseline) ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Memory / embedding ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Workspace hygiene ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+        click.echo("\n=== Cron (jobs.json) ===")
+        click.echo(
+            click.style("SKIP", fg="yellow")
+            + " — fix root config validation first",
+        )
+
+    click.echo("\n=== Working directory ===")
+    wd_ok, detail = _check_working_dir()
+    if wd_ok:
+        click.echo(click.style("OK", fg="green") + f" — {detail}")
+    else:
+        failed = True
+        click.echo(click.style("FAIL", fg="red") + f" — {detail}", err=True)
+        click.echo(
+            "Hint: set COPAW_WORKING_DIR or run `copaw init`.",
+            err=True,
+        )
+
+    click.echo("\n=== Startup paths ===")
+    if not wd_ok:
+        click.echo(
+            click.style("SKIP", fg="yellow") + " — working directory not OK",
+        )
+    else:
+        log_ok, log_detail = check_copaw_log_writable()
+        if log_ok:
+            click.echo(
+                click.style("OK", fg="green")
+                + f" — copaw.log appendable ({log_detail})",
+            )
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red") + f"\n{log_detail}",
+                err=True,
+            )
+        if config_ok:
+            cfg_sp = load_config()
+            ws_w_ok, ws_w_detail = check_agent_workspace_writable(cfg_sp)
+            if ws_w_ok:
+                click.echo(
+                    click.style("OK", fg="green") + f" — {ws_w_detail}",
+                )
+            else:
+                failed = True
+                click.echo(
+                    click.style("FAIL", fg="red") + f"\n{ws_w_detail}",
+                    err=True,
+                )
+            vol_notes = startup_extra_volume_disk_notes(cfg_sp)
+        else:
+            click.echo(
+                click.style("SKIP", fg="yellow")
+                + " — agent workspace writability (fix root config validation first)",
+            )
+            vol_notes = startup_extra_volume_disk_notes(None)
+        for line in vol_notes:
+            click.echo(click.style("Note:", fg="yellow") + f" {line}")
+
+    click.echo("\n=== Console (static files) ===")
+    cs_ok, detail = _check_console_static_files()
+    if cs_ok:
+        click.echo(click.style("OK", fg="green") + f" — {detail}")
+    else:
+        failed = True
+        click.echo(click.style("FAIL", fg="red") + f"\n{detail}", err=True)
+    for line in console_static_diagnostic_notes():
+        click.echo(click.style("Note:", fg="yellow") + f" {line}")
+
+    click.echo("\n=== Web authentication ===")
+    auth_ok, detail = _check_web_auth(base)
+    if auth_ok:
+        click.echo(click.style("OK", fg="green") + f" — {detail}")
+    else:
+        failed = True
+        click.echo(click.style("FAIL", fg="red") + f"\n{detail}", err=True)
+
+    if config_ok:
+        click.echo("\n=== Providers (custom) ===")
+        try:
+            prov_notes = provider_overview_notes()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            prov_notes = [f"could not list providers: {exc}"]
+        if prov_notes:
+            for line in prov_notes:
+                click.echo(click.style("Note:", fg="yellow") + f" {line}")
+        else:
+            click.echo(
+                click.style("OK", fg="green")
+                + " — no custom provider configuration warnings",
+            )
+
+    click.echo("\n=== Active LLM ===")
+    llm_ok, llm_detail, llm_notes = asyncio.run(
+        _check_active_llm(llm_timeout, deep),
+    )
+    if llm_ok:
+        click.echo(click.style("OK", fg="green") + f" — {llm_detail}")
+    else:
+        failed = True
+        click.echo(click.style("FAIL", fg="red") + f" — {llm_detail}", err=True)
+    for line in llm_notes:
+        click.echo(click.style("Note:", fg="yellow") + f" {line}")
+
+    if config_ok:
+        click.echo("\n=== Models (per agent) ===")
+        aok, lines, extra_notes = asyncio.run(
+            check_enabled_agents_model_connections(
+                cfg,
+                timeout=llm_timeout,
+                deep=deep,
+            ),
+        )
+        if aok:
+            click.echo(click.style("OK", fg="green") + " — all enabled agents reachable")
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red") + " — some enabled agents unreachable",
+                err=True,
+            )
+        for ln in lines:
+            first, *rest_lines = ln.split("\n")
+            if " — " in first:
+                left, right = first.split(" — ", 1)
+                if ": OK" in left:
+                    first = click.style(left, fg="green") + " — " + right
+                elif ": FAIL" in left:
+                    first = click.style(left, fg="red") + " — " + right
+            merged = "\n".join([first, *rest_lines]) if rest_lines else first
+            click.echo(merged, err=": FAIL" in ln)
+        for ln in extra_notes:
+            click.echo(click.style("Note:", fg="yellow") + f" {ln}")
+
+    if config_ok:
+        mismatch = api_target_mismatch_note(cfg, base)
+        if mismatch:
+            click.echo("\n=== API target ===")
+            click.echo(click.style("Note:", fg="yellow") + f" {mismatch}")
+
+    click.echo("\n=== API ===")
+    health_url = f"{base}/api/agent/health"
+    version_url = f"{base}/api/version"
+    try:
+        health_resp = httpx.get(health_url, timeout=timeout)
+    except httpx.RequestError as exc:
+        failed = True
+        click.echo(
+            click.style("FAIL", fg="red")
+            + f" — health not reachable ({health_url})\n{exc}",
+            err=True,
+        )
+        click.echo(
+            f"Hint: start the server with `copaw app` (default {base}).",
+            err=True,
+        )
+    else:
+        if health_resp.status_code == 200:
+            click.echo(
+                click.style("OK", fg="green")
+                + f" — health ({health_url}, HTTP 200)",
+            )
+        else:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red")
+                + f" — health HTTP {health_resp.status_code} ({health_url})",
+                err=True,
+            )
+
+        try:
+            version_resp = httpx.get(version_url, timeout=timeout)
+        except httpx.RequestError as exc:
+            failed = True
+            click.echo(
+                click.style("FAIL", fg="red")
+                + f" — version not reachable ({version_url})\n{exc}",
+                err=True,
+            )
+        else:
+            if version_resp.status_code != 200:
+                failed = True
+                click.echo(
+                    click.style("FAIL", fg="red")
+                    + f" — version HTTP {version_resp.status_code} "
+                    f"({version_url})",
+                    err=True,
+                )
+            else:
+                try:
+                    body = version_resp.json()
+                except json.JSONDecodeError:
+                    body = None
+                server_ver = ""
+                if isinstance(body, dict) and "version" in body:
+                    server_ver = str(body.get("version", ""))
+                line = (
+                    click.style("OK", fg="green")
+                    + f" — version ({version_url}"
+                    + (f", server {server_ver!r}" if server_ver else "")
+                    + ")"
+                )
+                click.echo(line)
+                if server_ver and server_ver != __version__:
+                    click.echo(
+                        click.style(
+                            f"Note: CLI is {__version__!r}, server reports "
+                            f"{server_ver!r} (different installs or upgrade "
+                            f"pending).",
+                            fg="yellow",
+                        ),
+                    )
+
+        if health_resp.status_code == 200:
+            try:
+                root_resp = httpx.get(
+                    f"{base}/",
+                    timeout=timeout,
+                    follow_redirects=True,
+                )
+            except httpx.RequestError as exc:
+                failed = True
+                click.echo(
+                    click.style("FAIL", fg="red")
+                    + f" — could not GET / (console over HTTP): {exc}",
+                    err=True,
+                )
+            else:
+                root_ok, root_detail = _classify_console_root_response(root_resp)
+                if root_ok:
+                    click.echo(
+                        click.style("OK", fg="green")
+                        + f" — console over HTTP — {root_detail}",
+                    )
+                else:
+                    failed = True
+                    click.echo(
+                        click.style("FAIL", fg="red")
+                        + f" — console over HTTP — {root_detail}",
+                        err=True,
+                    )
+
+    click.echo("")
+    if failed:
+        sys.exit(1)
+
+
+@click.group(
+    "doctor",
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--timeout",
+    default=5.0,
+    type=float,
+    show_default=True,
+    help="HTTP timeout in seconds for API checks.",
+)
+@click.option(
+    "--llm-timeout",
+    default=15.0,
+    type=float,
+    show_default=True,
+    help="Timeout in seconds for the active LLM ping (streaming completion).",
+)
+@click.option(
+    "--deep",
+    is_flag=True,
+    help=(
+        "Run extra checks: enabled-channel reachability (non-fatal notes; "
+        "uses --timeout) and, when the active model is copaw-local, llama.cpp "
+        "install/server status notes."
+    ),
+)
+@click.pass_context
+def doctor_cmd(
+    ctx: click.Context,
+    timeout: float,
+    llm_timeout: float,
+    deep: bool,
+) -> None:
+    """Local sanity checks. Subcommand ``fix`` applies conservative repairs (with backup)."""
+    if ctx.invoked_subcommand is None:
+        run_doctor_checks(ctx, timeout, llm_timeout, deep)
+
+
+@doctor_cmd.command(
+    "fix",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="List planned operations only; do not modify files.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Apply changes without confirmation (still creates backups unless --no-backup).",
+)
+@click.option(
+    "--only",
+    default=None,
+    metavar="IDS",
+    help=(
+        "Comma-separated fix ids: ensure-working-dir, ensure-workspace-dirs, "
+        "reconcile-workspace-skills, seed-missing-agent-json, "
+        "reset-invalid-agent-json, write-empty-jobs-json, normalize-jobs-cron, "
+        "rebuild-console-npm. "
+        "Default: safe fixes only (first two). "
+        "reconcile-workspace-skills syncs each workspace skill.json with skills/ "
+        "(no --yes required)."
+    ),
+)
+@click.option(
+    "--no-backup",
+    is_flag=True,
+    help="Skip copying files to doctor-fix-backups/ (not recommended).",
+)
+@click.option(
+    "--backup-dir",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help="Must be inside the working directory; default is the working directory root.",
+)
+@click.pass_context
+def doctor_fix_cli(
+    ctx: click.Context,
+    dry_run: bool,
+    yes: bool,
+    only: str | None,
+    no_backup: bool,
+    backup_dir: Path | None,
+) -> None:
+    """Apply conservative filesystem fixes (default backup under doctor-fix-backups/)."""
+    from .doctor_fix_runner import run_doctor_fix
+
+    code = run_doctor_fix(
+        dry_run=dry_run,
+        yes=yes,
+        only=only,
+        no_backup=no_backup,
+        backup_dir=backup_dir,
+        working_dir=None,
+        echo=click.echo,
+        echo_err=lambda m: click.echo(click.style(m, fg="red"), err=True),
+        confirm_fn=(lambda m: click.confirm(m)) if not yes else None,
+    )
+    if code != 0:
+        sys.exit(code)

--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
-"""`copaw doctor` — read-only checks; `copaw doctor fix` — conservative repairs with backup."""
+"""`qwenpaw doctor` — read-only checks.
+
+`qwenpaw doctor fix` — conservative repairs with backup.
+"""
 from __future__ import annotations
 
+# pylint: disable=too-many-branches,too-many-statements
 import asyncio
 import json
 import os
@@ -15,10 +19,14 @@ from ..__version__ import __version__
 from ..app.auth import has_registered_users, is_auth_enabled
 from ..config import load_config
 from ..config.utils import strict_validate_config_file
-from ..constant import WORKING_DIR
+from ..constant import PROJECT_NAME, WORKING_DIR
 from ..providers.provider import Provider
 from ..providers.provider_manager import ProviderManager
-from ..utils.console_static import CONSOLE_STATIC_ENV, resolve_console_static_dir
+from ..utils.console_static import (
+    CONSOLE_STATIC_ENV,
+    resolve_console_static_dir,
+)
+from ..utils.system_info import summarize_python_environment
 from .doctor_checks import (
     active_llm_local_failure_hint,
     api_target_mismatch_note,
@@ -26,7 +34,7 @@ from .doctor_checks import (
     check_agent_json_profiles,
     check_agent_profile_workspaces,
     check_agent_workspace_writable,
-    check_copaw_log_writable,
+    check_app_log_writable,
     check_cron_jobs_files,
     check_enabled_agents_load_agent_config,
     check_enabled_agents_model_connections,
@@ -41,13 +49,92 @@ from .doctor_checks import (
     scan_unknown_config_keys,
     security_baseline_notes,
     skill_layout_notes,
-    copaw_local_llm_deep_notes,
+    qwenpaw_local_llm_deep_notes,
     startup_extra_volume_disk_notes,
     workspace_hygiene_notes,
 )
 from .doctor_connectivity import collect_deep_channel_connectivity_notes
 from .doctor_registry import DoctorRunContext, run_extension_contributions
 from .http import resolve_base_url
+
+
+def _doctor_fix_hint(message: str) -> None:
+    """One-line actionable hint after a FAIL (stderr)."""
+    click.echo(f"Hint: {message}", err=True)
+
+
+def _same_python_executable(a: str, b: str) -> bool:
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        try:
+            return Path(a).resolve() == Path(b).resolve()
+        except OSError:
+            return a == b
+
+
+def _fetch_running_server_python(
+    base: str,
+    timeout: float,
+) -> tuple[str | None, str | None, str | None]:
+    """Return env summary, python exe, and note from GET /api/version."""
+    url = f"{base.rstrip('/')}/api/version"
+    try:
+        resp = httpx.get(url, timeout=timeout)
+    except httpx.RequestError as exc:
+        return None, None, f"(not available: {exc})"
+    if resp.status_code != 200:
+        return (
+            None,
+            None,
+            f"(not available: HTTP {resp.status_code} from {url})",
+        )
+    try:
+        body = resp.json()
+    except json.JSONDecodeError:
+        return None, None, "(not available: /api/version is not JSON)"
+    if not isinstance(body, dict):
+        return None, None, "(not available: unexpected /api/version payload)"
+    raw_env = body.get("python_environment")
+    raw_exe = body.get("python_executable")
+    env_s = raw_env.strip() if isinstance(raw_env, str) else ""
+    exe_s = raw_exe.strip() if isinstance(raw_exe, str) else ""
+    if env_s:
+        return env_s, exe_s or None, None
+    return (
+        None,
+        None,
+        "(running app did not report python_environment — update and "
+        "restart `qwenpaw app` so the listener picks up the new API)",
+    )
+
+
+def _doctor_server_python_mismatch_note(
+    doctor_exe: str,
+    doctor_env: str,
+    server_env: str | None,
+    server_exe: str | None,
+) -> str | None:
+    """Warn when doctor CLI Python differs from the HTTP server (if known)."""
+    if server_env is None:
+        return None
+    if server_exe and doctor_exe:
+        if not _same_python_executable(doctor_exe, server_exe):
+            return (
+                "This `qwenpaw doctor` is not using the same Python "
+                "executable as the running `qwenpaw app` — diagnostics and "
+                "package versions may not match the server. doctor: "
+                f"{doctor_exe!r}; server: {server_exe!r}"
+            )
+        return None
+    if doctor_env.strip() != server_env.strip():
+        return (
+            "Doctor Python environment label differs from the running "
+            f"`qwenpaw app` (doctor: {doctor_env!r}; server: "
+            f"{server_env!r}). "
+            "Use the same venv when debugging if possible."
+        )
+    return None
 
 
 def _provider_is_configured(provider: Provider) -> tuple[bool, str]:
@@ -76,8 +163,10 @@ def _check_console_static_files() -> tuple[bool, str]:
     return (
         False,
         f"index.html missing under {static_dir}\n"
-        "        Build: `npm ci && npm run build` in the `console/` directory, "
-        f"or set {CONSOLE_STATIC_ENV} to a directory that contains index.html.",
+        "        Build: `npm ci && npm run build` in the `console/` "
+        "directory, "
+        f"or set {CONSOLE_STATIC_ENV} to a directory that contains "
+        "index.html.",
     )
 
 
@@ -88,15 +177,18 @@ def _check_web_auth(base: str) -> tuple[bool, str]:
         return (
             False,
             "enabled but no account registered yet.\n"
-            f"        1) Start `copaw app`, open {base}/ in a browser.\n"
-            "        2) Complete registration (single user) on the login page.\n"
-            "        For automation, set COPAW_AUTH_USERNAME and "
-            "COPAW_AUTH_PASSWORD — the server creates the user on startup.",
+            f"        1) Start `qwenpaw app`, open {base}/ in a browser.\n"
+            "        2) Complete registration (single user) on the login "
+            "page.\n"
+            "        For automation, set QWENPAW_AUTH_USERNAME and "
+            "QWENPAW_AUTH_PASSWORD (legacy COPAW_* names still work) — the "
+            "server creates the user on startup.",
         )
     return (
         True,
-        f"enabled — open {base}/ and sign in; the console stores your session. "
-        "API clients must send Authorization: Bearer <token> from login.",
+        f"enabled — open {base}/ and sign in; the console stores your "
+        "session. API clients must send Authorization: Bearer <token> "
+        "from login.",
     )
 
 
@@ -117,12 +209,16 @@ def _classify_console_root_response(resp: httpx.Response) -> tuple[bool, str]:
             if "Web Console is not available" in msg:
                 return (
                     False,
-                    "server is running but the console bundle is not installed — "
-                    "build `console/` or set "
-                    f"{CONSOLE_STATIC_ENV}, then restart `copaw app`.",
+                    "server is running but the console bundle is not "
+                    "installed — build `console/` or set "
+                    f"{CONSOLE_STATIC_ENV}, then restart "
+                    "`qwenpaw app`.",
                 )
         return False, "HTTP GET / returned JSON instead of the console page"
-    return False, f"unexpected GET / response (content-type: {ct or 'unknown'})"
+    return (
+        False,
+        f"unexpected GET / response (content-type: {ct or 'unknown'})",
+    )
 
 
 async def _check_active_llm(
@@ -138,7 +234,7 @@ async def _check_active_llm(
     ):
         return (
             False,
-            "no active LLM slot — run `copaw models list` and configure "
+            "no active LLM slot — run `qwenpaw models list` and configure "
             "an active model",
             [],
         )
@@ -150,8 +246,9 @@ async def _check_active_llm(
         return False, f"{slot.provider_id}: {reason}", []
 
     deep_notes: list[str] = []
-    if deep and (slot.provider_id or "").strip() == "copaw-local":
-        deep_notes = copaw_local_llm_deep_notes()
+    pid = (slot.provider_id or "").strip()
+    if deep and pid in ("qwenpaw-local", "copaw-local"):
+        deep_notes = qwenpaw_local_llm_deep_notes()
 
     if not getattr(provider, "support_connection_check", True):
         return (
@@ -170,6 +267,7 @@ async def _check_active_llm(
         if getattr(provider, "is_local", False) or slot.provider_id in (
             "ollama",
             "lmstudio",
+            "qwenpaw-local",
             "copaw-local",
         ):
             hint = active_llm_local_failure_hint(provider, slot.provider_id)
@@ -179,19 +277,91 @@ async def _check_active_llm(
     return True, f"{slot.provider_id} / {slot.model} (reachable)", deep_notes
 
 
+_DOCTOR_FIX_ONLY_HELP = (
+    "Comma-separated fix ids: ensure-working-dir, ensure-workspace-dirs, "
+    "validate-all-jobs-json, reconcile-workspace-skills, "
+    "seed-missing-agent-json, reset-invalid-agent-json, "
+    "write-empty-jobs-json, normalize-jobs-cron, rebuild-console-npm. "
+    "Default: safe fixes only (first two). "
+    "reconcile-workspace-skills syncs each workspace skill.json with skills/ "
+    "(no --yes required)."
+)
+
+
+def _run_doctor_fix_cli(
+    ctx: click.Context,
+    *,
+    dry_run: bool,
+    yes: bool,
+    non_interactive: bool,
+    only: str | None,
+    no_backup: bool,
+    backup_dir: Path | None,
+) -> None:
+    """Shared implementation for ``doctor fix``."""
+    from .doctor_fix_runner import run_doctor_fix
+
+    def echo_err(message: str) -> None:
+        click.echo(click.style(message, fg="red"), err=True)
+
+    cli_host, cli_port = _cli_api_host_port_from_ctx(ctx)
+    code = run_doctor_fix(
+        dry_run=dry_run,
+        yes=yes,
+        only=only,
+        no_backup=no_backup,
+        backup_dir=backup_dir,
+        working_dir=None,
+        echo=click.echo,
+        echo_err=echo_err,
+        confirm_fn=click.confirm,
+        cli_api_host=cli_host,
+        cli_api_port=cli_port,
+        non_interactive=non_interactive,
+    )
+    if code != 0:
+        sys.exit(code)
+
+
+def _cli_api_host_port_from_ctx(
+    ctx: click.Context,
+) -> tuple[str | None, int | None]:
+    """Read ``--host`` / ``--port`` from root CLI context (``main.cli``)."""
+    cur: click.Context | None = ctx
+    while cur.parent is not None:
+        cur = cur.parent
+    obj = cur.obj if cur is not None else None
+    if isinstance(obj, dict):
+        return obj.get("host"), obj.get("port")
+    return None, None
+
+
 def run_doctor_checks(
     ctx: click.Context,
     timeout: float,
     llm_timeout: float,
     deep: bool,
 ) -> None:
-    """Run read-only ``copaw doctor`` checks (no disk mutations)."""
+    """Run read-only ``qwenpaw doctor`` checks (no disk mutations)."""
     base = resolve_base_url(ctx, None).rstrip("/")
     failed = False
 
+    srv_env, srv_exe, srv_note = _fetch_running_server_python(base, timeout)
+
     click.echo("=== Environment ===")
-    for line in environment_summary_lines():
+    for line in environment_summary_lines(
+        server_python_environment=srv_env,
+        server_python_note=srv_note,
+    ):
         click.echo(f"  {line}")
+    mismatch = _doctor_server_python_mismatch_note(
+        sys.executable,
+        summarize_python_environment(),
+        srv_env,
+        srv_exe,
+    )
+    if mismatch:
+        click.echo(click.style("Note:", fg="yellow") + f" {mismatch}")
 
     click.echo("\n=== Config ===")
     config_ok, detail = strict_validate_config_file()
@@ -200,6 +370,11 @@ def run_doctor_checks(
     else:
         failed = True
         click.echo(click.style("FAIL", fg="red") + f"\n{detail}", err=True)
+        _doctor_fix_hint(
+            "fix the root `config.json` fields shown above. "
+            "For workspace repairs after it validates, see "
+            "`qwenpaw doctor fix --dry-run --help` and `--only`.",
+        )
 
     raw_cfg = load_raw_config_dict()
     if raw_cfg is not None:
@@ -209,10 +384,16 @@ def run_doctor_checks(
             click.echo(
                 click.style("Note:", fg="yellow")
                 + " keys present on disk that are not on the current schema "
-                "(informational only; doctor does not remove or rewrite them):",
+                + "(informational only; doctor does not remove or rewrite "
+                "them):",
             )
             for item in unknown:
                 click.echo(f"  - {item}")
+            _doctor_fix_hint(
+                "Fix: edit `config.json` manually to remove obsolete keys "
+                "(`qwenpaw doctor` and `doctor fix` do not strip unknown keys "
+                "yet).",
+            )
 
     if config_ok:
         cfg = load_config()
@@ -232,6 +413,12 @@ def run_doctor_checks(
                 click.style("FAIL", fg="red") + f" — {ws_detail}",
                 err=True,
             )
+            _doctor_fix_hint(
+                "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+                "--only ensure-working-dir,ensure-workspace-dirs`. Apply: run "
+                "the plan without `--dry-run` (add `-y` to skip the "
+                "confirmation prompt).",
+            )
 
         click.echo("Profiles (agent.json)")
         aj_ok, aj_detail = check_agent_json_profiles(cfg)
@@ -243,6 +430,12 @@ def run_doctor_checks(
                 click.style("FAIL", fg="red") + f" — {aj_detail}",
                 err=True,
             )
+            _doctor_fix_hint(
+                "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+                "--only seed-missing-agent-json,reset-invalid-agent-json`. "
+                "Apply: run the plan without `--dry-run` (risky writes need "
+                "adding `-y` to skip the confirmation prompt).",
+            )
 
         click.echo("Config load (enabled)")
         acl_ok, acl_detail = check_enabled_agents_load_agent_config(cfg)
@@ -253,6 +446,12 @@ def run_doctor_checks(
             click.echo(
                 click.style("FAIL", fg="red") + f" — {acl_detail}",
                 err=True,
+            )
+            _doctor_fix_hint(
+                "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+                "--only seed-missing-agent-json,reset-invalid-agent-json`. "
+                "Apply: run the plan without `--dry-run` (risky writes need "
+                "adding `-y` to skip the confirmation prompt).",
             )
 
         click.echo("\n=== Channels (enabled) ===")
@@ -279,8 +478,9 @@ def run_doctor_checks(
         if not ext_nonempty:
             click.echo(
                 click.style("OK", fg="green")
-                + " — no extension notes (register via copaw.doctor entry points "
-                "or register_doctor_contribution)",
+                + " — no extension notes (register via qwenpaw.doctor entry "
+                "points or register_doctor_contribution; legacy "
+                "copaw.doctor is still loaded)",
             )
         else:
             for contrib_id, lines in ext_nonempty:
@@ -341,7 +541,8 @@ def run_doctor_checks(
         sec_notes = security_baseline_notes(cfg)
         if sec_notes:
             click.echo(
-                click.style("Note:", fg="yellow") + " review security posture:",
+                click.style("Note:", fg="yellow")
+                + " review security posture:",
             )
             for line in sec_notes:
                 click.echo(f"  - {line}")
@@ -376,49 +577,41 @@ def run_doctor_checks(
             click.echo(click.style("OK", fg="green") + f" — {cj_detail}")
         else:
             failed = True
-            click.echo(click.style("FAIL", fg="red") + f" — {cj_detail}", err=True)
+            click.echo(
+                click.style("FAIL", fg="red") + f" — {cj_detail}",
+                err=True,
+            )
+            _doctor_fix_hint(
+                "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+                "--only validate-all-jobs-json` (read-only), or the same "
+                "command with `write-empty-jobs-json,normalize-jobs-cron` in "
+                "`--only`. "
+                "Apply: for those write ids, run the plan without `--dry-run` "
+                "(risky writes need adding `-y` to skip the confirmation "
+                "prompt).",
+            )
     else:
-        click.echo("\n=== Agents ===")
-        click.echo("Workspaces")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("Profiles (agent.json)")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("Config load (enabled)")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Channels (enabled) ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Doctor extensions ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
+        click.echo("\n=== Skipped (root config invalid) ===")
+        _skipped_when_cfg_invalid = (
+            "Agents (workspaces, profiles, enabled agent.json load), "
+            "Channels (enabled), Doctor extensions, MCP clients, Skills, "
+            "Security (baseline), Memory / embedding, Workspace hygiene, and "
+            "Cron (jobs.json)"
         )
         if deep:
-            click.echo("\n=== Channels (connectivity, --deep) ===")
-            click.echo(
-                click.style("SKIP", fg="yellow")
-                + " — fix root config validation first",
+            _skipped_when_cfg_invalid = (
+                "Agents (workspaces, profiles, enabled agent.json load), "
+                "Channels (enabled and --deep connectivity), "
+                "Doctor extensions, "
+                "MCP clients, Skills, Security (baseline), Memory / "
+                "embedding, "
+                "Workspace hygiene, and Cron (jobs.json)"
             )
-        click.echo("\n=== MCP clients ===")
         click.echo(
             click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Skills ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
+            + " — not run because root `config.json` failed validation above: "
+            + _skipped_when_cfg_invalid
+            + ". Fix the config file, then re-run `qwenpaw doctor`.",
         )
         click.echo("\n=== Browser (browser_use / Playwright) ===")
         br_skip = browser_automation_notes(None)
@@ -430,26 +623,6 @@ def run_doctor_checks(
                 click.style("OK", fg="green")
                 + " — no browser automation warnings",
             )
-        click.echo("\n=== Security (baseline) ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Memory / embedding ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Workspace hygiene ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
-        click.echo("\n=== Cron (jobs.json) ===")
-        click.echo(
-            click.style("SKIP", fg="yellow")
-            + " — fix root config validation first",
-        )
 
     click.echo("\n=== Working directory ===")
     wd_ok, detail = _check_working_dir()
@@ -458,9 +631,13 @@ def run_doctor_checks(
     else:
         failed = True
         click.echo(click.style("FAIL", fg="red") + f" — {detail}", err=True)
-        click.echo(
-            "Hint: set COPAW_WORKING_DIR or run `copaw init`.",
-            err=True,
+        _doctor_fix_hint(
+            "Fix: set `QWENPAW_WORKING_DIR` (or legacy `COPAW_WORKING_DIR`) "
+            "or run `qwenpaw init`. "
+            "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+            "--only ensure-working-dir` if the parent path exists and is "
+            "writable. Apply: run the plan `without --dry-run` (add `-y` to "
+            "skip the confirmation prompt).",
         )
 
     click.echo("\n=== Startup paths ===")
@@ -469,17 +646,24 @@ def run_doctor_checks(
             click.style("SKIP", fg="yellow") + " — working directory not OK",
         )
     else:
-        log_ok, log_detail = check_copaw_log_writable()
+        log_ok, log_detail = check_app_log_writable()
         if log_ok:
             click.echo(
                 click.style("OK", fg="green")
-                + f" — copaw.log appendable ({log_detail})",
+                + f" — {PROJECT_NAME.lower()}.log appendable ({log_detail})",
             )
         else:
             failed = True
             click.echo(
                 click.style("FAIL", fg="red") + f"\n{log_detail}",
                 err=True,
+            )
+            _doctor_fix_hint(
+                "Fix: ensure the data directory is writable. "
+                "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+                "--only ensure-working-dir` if the directory is missing and "
+                "the parent allows creating it. Apply: run the plan `without "
+                "--dry-run` (add `-y` to skip the confirmation prompt).",
             )
         if config_ok:
             cfg_sp = load_config()
@@ -494,11 +678,17 @@ def run_doctor_checks(
                     click.style("FAIL", fg="red") + f"\n{ws_w_detail}",
                     err=True,
                 )
+                _doctor_fix_hint(
+                    "fix filesystem permissions on the listed workspace paths "
+                    "(doctor fix does not chmod); ensure the right user owns "
+                    "the data dir.",
+                )
             vol_notes = startup_extra_volume_disk_notes(cfg_sp)
         else:
             click.echo(
                 click.style("SKIP", fg="yellow")
-                + " — agent workspace writability (fix root config validation first)",
+                + ' — agent workspace writability (see "Skipped (root config '
+                'invalid)" above)',
             )
             vol_notes = startup_extra_volume_disk_notes(None)
         for line in vol_notes:
@@ -511,6 +701,14 @@ def run_doctor_checks(
     else:
         failed = True
         click.echo(click.style("FAIL", fg="red") + f"\n{detail}", err=True)
+        _doctor_fix_hint(
+            f"Fix: build `console/` or set {CONSOLE_STATIC_ENV}. From a git "
+            "checkout — "
+            "Preview the plan (no writes): `qwenpaw doctor fix --dry-run "
+            "--only rebuild-console-npm`. "
+            "Apply: run `without --dry-run` and include `-y` (runs npm; "
+            "copies dist → bundled console).",
+        )
     for line in console_static_diagnostic_notes():
         click.echo(click.style("Note:", fg="yellow") + f" {line}")
 
@@ -534,7 +732,8 @@ def run_doctor_checks(
         else:
             click.echo(
                 click.style("OK", fg="green")
-                + " — no custom provider configuration warnings",
+                + " — no custom provider "
+                + "configuration warnings",
             )
 
     click.echo("\n=== Active LLM ===")
@@ -545,7 +744,14 @@ def run_doctor_checks(
         click.echo(click.style("OK", fg="green") + f" — {llm_detail}")
     else:
         failed = True
-        click.echo(click.style("FAIL", fg="red") + f" — {llm_detail}", err=True)
+        click.echo(
+            click.style("FAIL", fg="red") + f" — {llm_detail}",
+            err=True,
+        )
+        _doctor_fix_hint(
+            "`qwenpaw models list` / console model settings — not a "
+            "filesystem fix.",
+        )
     for line in llm_notes:
         click.echo(click.style("Note:", fg="yellow") + f" {line}")
 
@@ -559,11 +765,15 @@ def run_doctor_checks(
             ),
         )
         if aok:
-            click.echo(click.style("OK", fg="green") + " — all enabled agents reachable")
+            click.echo(
+                click.style("OK", fg="green")
+                + " — all enabled agents reachable",
+            )
         else:
             failed = True
             click.echo(
-                click.style("FAIL", fg="red") + " — some enabled agents unreachable",
+                click.style("FAIL", fg="red")
+                + " — some enabled agents unreachable",
                 err=True,
             )
         for ln in lines:
@@ -598,7 +808,7 @@ def run_doctor_checks(
             err=True,
         )
         click.echo(
-            f"Hint: start the server with `copaw app` (default {base}).",
+            f"Hint: start the server with `qwenpaw app` (default {base}).",
             err=True,
         )
     else:
@@ -673,7 +883,9 @@ def run_doctor_checks(
                     err=True,
                 )
             else:
-                root_ok, root_detail = _classify_console_root_response(root_resp)
+                root_ok, root_detail = _classify_console_root_response(
+                    root_resp,
+                )
                 if root_ok:
                     click.echo(
                         click.style("OK", fg="green")
@@ -709,15 +921,17 @@ def run_doctor_checks(
     default=15.0,
     type=float,
     show_default=True,
-    help="Timeout in seconds for the active LLM ping (streaming completion).",
+    help=(
+        "Timeout in seconds for the active LLM ping (streaming completion)."
+    ),
 )
 @click.option(
     "--deep",
     is_flag=True,
     help=(
         "Run extra checks: enabled-channel reachability (non-fatal notes; "
-        "uses --timeout) and, when the active model is copaw-local, llama.cpp "
-        "install/server status notes."
+        "uses --timeout) and, when the active model is qwenpaw-local, "
+        "llama.cpp install/server status notes."
     ),
 )
 @click.pass_context
@@ -727,7 +941,10 @@ def doctor_cmd(
     llm_timeout: float,
     deep: bool,
 ) -> None:
-    """Local sanity checks. Subcommand ``fix`` applies conservative repairs (with backup)."""
+    """Local sanity checks.
+
+    Subcommand ``fix`` applies conservative repairs (with backup).
+    """
     if ctx.invoked_subcommand is None:
         run_doctor_checks(ctx, timeout, llm_timeout, deep)
 
@@ -745,21 +962,25 @@ def doctor_cmd(
     "--yes",
     "-y",
     is_flag=True,
-    help="Apply changes without confirmation (still creates backups unless --no-backup).",
+    help=(
+        "Apply changes without confirmation (still creates backups unless "
+        "--no-backup)."
+    ),
+)
+@click.option(
+    "--non-interactive",
+    is_flag=True,
+    help=(
+        "Allow only safe, read-only validation, and workspace skill sync fix "
+        "ids; skip confirmation. Rejects risky ids (npm rebuild, agent.json "
+        "reset, jobs rewrites, etc.) even with -y."
+    ),
 )
 @click.option(
     "--only",
     default=None,
     metavar="IDS",
-    help=(
-        "Comma-separated fix ids: ensure-working-dir, ensure-workspace-dirs, "
-        "reconcile-workspace-skills, seed-missing-agent-json, "
-        "reset-invalid-agent-json, write-empty-jobs-json, normalize-jobs-cron, "
-        "rebuild-console-npm. "
-        "Default: safe fixes only (first two). "
-        "reconcile-workspace-skills syncs each workspace skill.json with skills/ "
-        "(no --yes required)."
-    ),
+    help=_DOCTOR_FIX_ONLY_HELP,
 )
 @click.option(
     "--no-backup",
@@ -770,30 +991,31 @@ def doctor_cmd(
     "--backup-dir",
     type=click.Path(path_type=Path, file_okay=False),
     default=None,
-    help="Must be inside the working directory; default is the working directory root.",
+    help=(
+        "Must be inside the working directory; default is the working "
+        "directory root."
+    ),
 )
 @click.pass_context
 def doctor_fix_cli(
     ctx: click.Context,
     dry_run: bool,
     yes: bool,
+    non_interactive: bool,
     only: str | None,
     no_backup: bool,
     backup_dir: Path | None,
 ) -> None:
-    """Apply conservative filesystem fixes (default backup under doctor-fix-backups/)."""
-    from .doctor_fix_runner import run_doctor_fix
+    """Apply conservative filesystem fixes.
 
-    code = run_doctor_fix(
+    Default backup under doctor-fix-backups/.
+    """
+    _run_doctor_fix_cli(
+        ctx,
         dry_run=dry_run,
         yes=yes,
+        non_interactive=non_interactive,
         only=only,
         no_backup=no_backup,
         backup_dir=backup_dir,
-        working_dir=None,
-        echo=click.echo,
-        echo_err=lambda m: click.echo(click.style(m, fg="red"), err=True),
-        confirm_fn=(lambda m: click.confirm(m)) if not yes else None,
     )
-    if code != 0:
-        sys.exit(code)

--- a/src/qwenpaw/cli/doctor_connectivity.py
+++ b/src/qwenpaw/cli/doctor_connectivity.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+"""Optional ``--deep`` network reachability checks for enabled channels.
+
+Failures are reported as non-fatal notes (firewalls and offline use are common).
+Built-in probes live here; custom channels can override
+:class:`~copaw.app.channels.base.BaseChannel`.doctor_connectivity_notes.
+"""
+from __future__ import annotations
+
+import socket
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+import httpx
+
+from ..app.channels.registry import get_channel_registry
+from ..config.config import (
+    ChannelConfig,
+    Config,
+    DingTalkConfig,
+    FeishuConfig,
+    MatrixConfig,
+    MattermostConfig,
+    MQTTConfig,
+    OneBotConfig,
+    QQConfig,
+    TelegramConfig,
+    VoiceChannelConfig,
+    WecomConfig,
+    XiaoYiConfig,
+    WeixinConfig,
+)
+from .doctor_checks import _effective_channels_mcp, _read_workspace_agent_json
+
+ChannelProbe = Callable[[str, Any, float], list[str]]
+
+
+def _tcp_check(host: str, port: int, timeout: float) -> str | None:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+    except OSError as exc:
+        return str(exc)
+    return None
+
+
+def _http_get_ok(url: str, timeout: float) -> str | None:
+    try:
+        resp = httpx.get(url, timeout=timeout, follow_redirects=True)
+        if resp.status_code >= 400:
+            return f"HTTP {resp.status_code}"
+    except httpx.RequestError as exc:
+        return str(exc)
+    return None
+
+
+def _probe_mqtt(agent_id: str, cfg: MQTTConfig, timeout: float) -> list[str]:
+    host = (cfg.host or "").strip()
+    if not host:
+        return []
+    port = int(cfg.port or 1883)
+    err = _tcp_check(host, port, timeout)
+    if err:
+        return [f"{agent_id}: mqtt: TCP {host}:{port} — {err}"]
+    return []
+
+
+def _probe_mattermost(agent_id: str, cfg: MattermostConfig, timeout: float) -> list[str]:
+    url = (cfg.url or "").strip().rstrip("/")
+    if not url:
+        return []
+    ping = f"{url}/api/v4/system/ping"
+    err = _http_get_ok(ping, timeout)
+    if err:
+        return [f"{agent_id}: mattermost: GET {ping!r} — {err}"]
+    return []
+
+
+def _probe_matrix(agent_id: str, cfg: MatrixConfig, timeout: float) -> list[str]:
+    hs = (cfg.homeserver or "").strip().rstrip("/")
+    if not hs:
+        return []
+    ver = f"{hs}/_matrix/client/versions"
+    err = _http_get_ok(ver, timeout)
+    if err:
+        return [f"{agent_id}: matrix: GET {ver!r} — {err}"]
+    return []
+
+
+def _probe_telegram(agent_id: str, _cfg: TelegramConfig, timeout: float) -> list[str]:
+    err = _http_get_ok("https://api.telegram.org", timeout)
+    if err:
+        return [f"{agent_id}: telegram: reach api.telegram.org — {err}"]
+    return []
+
+
+def _probe_discord(agent_id: str, _cfg: Any, timeout: float) -> list[str]:
+    err = _http_get_ok("https://discord.com/api/v10/gateway", timeout)
+    if err:
+        return [f"{agent_id}: discord: reach discord API — {err}"]
+    return []
+
+
+def _probe_onebot(agent_id: str, cfg: OneBotConfig, timeout: float) -> list[str]:
+    host = (cfg.ws_host or "127.0.0.1").strip()
+    port = int(cfg.ws_port or 6199)
+    if host in ("0.0.0.0", ""):
+        host = "127.0.0.1"
+    err = _tcp_check(host, port, timeout)
+    if err:
+        return [
+            f"{agent_id}: onebot: TCP {host}:{port} — {err} "
+            "(is the reverse WebSocket server running?)",
+        ]
+    return []
+
+
+def _probe_feishu(agent_id: str, cfg: FeishuConfig, timeout: float) -> list[str]:
+    base = (
+        "https://open.feishu.cn"
+        if getattr(cfg, "domain", "feishu") == "feishu"
+        else "https://open.larksuite.com"
+    )
+    err = _http_get_ok(base + "/", timeout)
+    if err:
+        return [f"{agent_id}: feishu: reach {base} — {err}"]
+    return []
+
+
+def _probe_dingtalk(agent_id: str, _cfg: DingTalkConfig, timeout: float) -> list[str]:
+    err = _http_get_ok("https://oapi.dingtalk.com/", timeout)
+    if err:
+        return [f"{agent_id}: dingtalk: reach oapi.dingtalk.com — {err}"]
+    return []
+
+
+def _probe_qq(agent_id: str, _cfg: QQConfig, timeout: float) -> list[str]:
+    err = _tcp_check("qq.com", 443, timeout)
+    if err:
+        return [f"{agent_id}: qq: TCP qq.com:443 — {err}"]
+    return []
+
+
+def _probe_wecom(agent_id: str, _cfg: WecomConfig, timeout: float) -> list[str]:
+    err = _tcp_check("qyapi.weixin.qq.com", 443, timeout)
+    if err:
+        return [f"{agent_id}: wecom: TCP qyapi.weixin.qq.com:443 — {err}"]
+    return []
+
+
+def _probe_voice(agent_id: str, _cfg: VoiceChannelConfig, timeout: float) -> list[str]:
+    err = _http_get_ok("https://api.twilio.com/", timeout)
+    if err:
+        return [f"{agent_id}: voice (Twilio): reach api.twilio.com — {err}"]
+    return []
+
+
+def _probe_xiaoyi(agent_id: str, cfg: XiaoYiConfig, timeout: float) -> list[str]:
+    raw = (cfg.ws_url or "").strip()
+    if not raw:
+        return []
+    parsed = urlparse(raw)
+    host = parsed.hostname
+    if not host:
+        return [f"{agent_id}: xiaoyi: could not parse host from ws_url"]
+    port = parsed.port or (443 if parsed.scheme in ("wss", "https") else 80)
+    err = _tcp_check(host, port, timeout)
+    if err:
+        return [f"{agent_id}: xiaoyi: TCP {host}:{port} — {err}"]
+    return []
+
+
+def _probe_weixin(agent_id: str, cfg: WeixinConfig, timeout: float) -> list[str]:
+    base = (cfg.base_url or "").strip().rstrip("/")
+    if base:
+        err = _http_get_ok(base + "/", timeout)
+        if err:
+            return [f"{agent_id}: weixin: GET {base!r} — {err}"]
+        return []
+    err = _http_get_ok("https://api.weixin.qq.com/", timeout)
+    if err:
+        return [f"{agent_id}: weixin: reach api.weixin.qq.com — {err}"]
+    return []
+
+
+_BUILTIN_PROBES: dict[str, ChannelProbe] = {
+    "mqtt": _probe_mqtt,
+    "mattermost": _probe_mattermost,
+    "matrix": _probe_matrix,
+    "telegram": _probe_telegram,
+    "discord": _probe_discord,
+    "onebot": _probe_onebot,
+    "feishu": _probe_feishu,
+    "dingtalk": _probe_dingtalk,
+    "qq": _probe_qq,
+    "wecom": _probe_wecom,
+    "voice": _probe_voice,
+    "xiaoyi": _probe_xiaoyi,
+    "weixin": _probe_weixin,
+}
+
+
+def _channel_enabled(sub: Any) -> bool:
+    return bool(getattr(sub, "enabled", False))
+
+
+def collect_deep_channel_connectivity_notes(cfg: Config, timeout: float) -> list[str]:
+    """Run reachability probes for each enabled channel (per agent profile)."""
+    notes: list[str] = []
+    reg = get_channel_registry()
+
+    for agent_id, ref in cfg.agents.profiles.items():
+        raw = _read_workspace_agent_json(ref)
+        ch, _ = _effective_channels_mcp(cfg, raw)
+
+        for name in ChannelConfig.model_fields:
+            sub = getattr(ch, name, None)
+            if sub is None or not _channel_enabled(sub):
+                continue
+            if name == "console":
+                continue
+            if name == "imessage":
+                continue
+
+            cls = reg.get(name)
+            custom_lines: list[str] = []
+            if cls is not None:
+                try:
+                    custom_lines = cls.doctor_connectivity_notes(
+                        agent_id,
+                        sub,
+                        timeout=timeout,
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    custom_lines = [
+                        f"{agent_id}: {name}: doctor_connectivity_notes error: {exc}",
+                    ]
+            if custom_lines:
+                notes.extend(custom_lines)
+                continue
+
+            probe = _BUILTIN_PROBES.get(name)
+            if probe is None:
+                continue
+            try:
+                notes.extend(probe(agent_id, sub, timeout))
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                notes.append(f"{agent_id}: {name}: connectivity probe error: {exc}")
+
+        extra = getattr(ch, "__pydantic_extra__", None) or {}
+        for key, val in extra.items():
+            en = False
+            if isinstance(val, dict):
+                en = bool(val.get("enabled"))
+            elif hasattr(val, "enabled"):
+                en = bool(getattr(val, "enabled"))
+            if not en:
+                continue
+            cls = reg.get(key)
+            if cls is None:
+                notes.append(
+                    f"{agent_id}: plugin channel {key!r} enabled — "
+                    "not in registry; add a BaseChannel subclass or skip --deep",
+                )
+                continue
+            try:
+                notes.extend(
+                    cls.doctor_connectivity_notes(agent_id, val, timeout=timeout),
+                )
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                notes.append(
+                    f"{agent_id}: {key}: doctor_connectivity_notes error: {exc}",
+                )
+
+    return notes

--- a/src/qwenpaw/cli/doctor_connectivity.py
+++ b/src/qwenpaw/cli/doctor_connectivity.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Optional ``--deep`` network reachability checks for enabled channels.
 
-Failures are reported as non-fatal notes (firewalls and offline use are common).
-Built-in probes live here; custom channels can override
-:class:`~copaw.app.channels.base.BaseChannel`.doctor_connectivity_notes.
+Failures are reported as non-fatal notes (firewalls and offline use are
+common). Built-in probes live here; custom channels can override
+:class:`~qwenpaw.app.channels.base.BaseChannel`.doctor_connectivity_notes.
 """
 from __future__ import annotations
 
@@ -65,7 +65,11 @@ def _probe_mqtt(agent_id: str, cfg: MQTTConfig, timeout: float) -> list[str]:
     return []
 
 
-def _probe_mattermost(agent_id: str, cfg: MattermostConfig, timeout: float) -> list[str]:
+def _probe_mattermost(
+    agent_id: str,
+    cfg: MattermostConfig,
+    timeout: float,
+) -> list[str]:
     url = (cfg.url or "").strip().rstrip("/")
     if not url:
         return []
@@ -76,7 +80,11 @@ def _probe_mattermost(agent_id: str, cfg: MattermostConfig, timeout: float) -> l
     return []
 
 
-def _probe_matrix(agent_id: str, cfg: MatrixConfig, timeout: float) -> list[str]:
+def _probe_matrix(
+    agent_id: str,
+    cfg: MatrixConfig,
+    timeout: float,
+) -> list[str]:
     hs = (cfg.homeserver or "").strip().rstrip("/")
     if not hs:
         return []
@@ -87,7 +95,11 @@ def _probe_matrix(agent_id: str, cfg: MatrixConfig, timeout: float) -> list[str]
     return []
 
 
-def _probe_telegram(agent_id: str, _cfg: TelegramConfig, timeout: float) -> list[str]:
+def _probe_telegram(
+    agent_id: str,
+    _cfg: TelegramConfig,
+    timeout: float,
+) -> list[str]:
     err = _http_get_ok("https://api.telegram.org", timeout)
     if err:
         return [f"{agent_id}: telegram: reach api.telegram.org — {err}"]
@@ -101,7 +113,11 @@ def _probe_discord(agent_id: str, _cfg: Any, timeout: float) -> list[str]:
     return []
 
 
-def _probe_onebot(agent_id: str, cfg: OneBotConfig, timeout: float) -> list[str]:
+def _probe_onebot(
+    agent_id: str,
+    cfg: OneBotConfig,
+    timeout: float,
+) -> list[str]:
     host = (cfg.ws_host or "127.0.0.1").strip()
     port = int(cfg.ws_port or 6199)
     if host in ("0.0.0.0", ""):
@@ -115,7 +131,11 @@ def _probe_onebot(agent_id: str, cfg: OneBotConfig, timeout: float) -> list[str]
     return []
 
 
-def _probe_feishu(agent_id: str, cfg: FeishuConfig, timeout: float) -> list[str]:
+def _probe_feishu(
+    agent_id: str,
+    cfg: FeishuConfig,
+    timeout: float,
+) -> list[str]:
     base = (
         "https://open.feishu.cn"
         if getattr(cfg, "domain", "feishu") == "feishu"
@@ -127,7 +147,11 @@ def _probe_feishu(agent_id: str, cfg: FeishuConfig, timeout: float) -> list[str]
     return []
 
 
-def _probe_dingtalk(agent_id: str, _cfg: DingTalkConfig, timeout: float) -> list[str]:
+def _probe_dingtalk(
+    agent_id: str,
+    _cfg: DingTalkConfig,
+    timeout: float,
+) -> list[str]:
     err = _http_get_ok("https://oapi.dingtalk.com/", timeout)
     if err:
         return [f"{agent_id}: dingtalk: reach oapi.dingtalk.com — {err}"]
@@ -141,21 +165,33 @@ def _probe_qq(agent_id: str, _cfg: QQConfig, timeout: float) -> list[str]:
     return []
 
 
-def _probe_wecom(agent_id: str, _cfg: WecomConfig, timeout: float) -> list[str]:
+def _probe_wecom(
+    agent_id: str,
+    _cfg: WecomConfig,
+    timeout: float,
+) -> list[str]:
     err = _tcp_check("qyapi.weixin.qq.com", 443, timeout)
     if err:
         return [f"{agent_id}: wecom: TCP qyapi.weixin.qq.com:443 — {err}"]
     return []
 
 
-def _probe_voice(agent_id: str, _cfg: VoiceChannelConfig, timeout: float) -> list[str]:
+def _probe_voice(
+    agent_id: str,
+    _cfg: VoiceChannelConfig,
+    timeout: float,
+) -> list[str]:
     err = _http_get_ok("https://api.twilio.com/", timeout)
     if err:
         return [f"{agent_id}: voice (Twilio): reach api.twilio.com — {err}"]
     return []
 
 
-def _probe_xiaoyi(agent_id: str, cfg: XiaoYiConfig, timeout: float) -> list[str]:
+def _probe_xiaoyi(
+    agent_id: str,
+    cfg: XiaoYiConfig,
+    timeout: float,
+) -> list[str]:
     raw = (cfg.ws_url or "").strip()
     if not raw:
         return []
@@ -170,7 +206,11 @@ def _probe_xiaoyi(agent_id: str, cfg: XiaoYiConfig, timeout: float) -> list[str]
     return []
 
 
-def _probe_weixin(agent_id: str, cfg: WeixinConfig, timeout: float) -> list[str]:
+def _probe_weixin(
+    agent_id: str,
+    cfg: WeixinConfig,
+    timeout: float,
+) -> list[str]:
     base = (cfg.base_url or "").strip().rstrip("/")
     if base:
         err = _http_get_ok(base + "/", timeout)
@@ -204,7 +244,11 @@ def _channel_enabled(sub: Any) -> bool:
     return bool(getattr(sub, "enabled", False))
 
 
-def collect_deep_channel_connectivity_notes(cfg: Config, timeout: float) -> list[str]:
+# pylint: disable-next=too-many-branches
+def collect_deep_channel_connectivity_notes(
+    cfg: Config,
+    timeout: float,
+) -> list[str]:
     """Run reachability probes for each enabled channel (per agent profile)."""
     notes: list[str] = []
     reg = get_channel_registry()
@@ -231,9 +275,12 @@ def collect_deep_channel_connectivity_notes(cfg: Config, timeout: float) -> list
                         sub,
                         timeout=timeout,
                     )
-                except Exception as exc:  # pylint: disable=broad-exception-caught
+                except (
+                    Exception
+                ) as exc:  # pylint: disable=broad-exception-caught
                     custom_lines = [
-                        f"{agent_id}: {name}: doctor_connectivity_notes error: {exc}",
+                        f"{agent_id}: {name}: "
+                        f"doctor_connectivity_notes error: {exc}",
                     ]
             if custom_lines:
                 notes.extend(custom_lines)
@@ -245,7 +292,9 @@ def collect_deep_channel_connectivity_notes(cfg: Config, timeout: float) -> list
             try:
                 notes.extend(probe(agent_id, sub, timeout))
             except Exception as exc:  # pylint: disable=broad-exception-caught
-                notes.append(f"{agent_id}: {name}: connectivity probe error: {exc}")
+                notes.append(
+                    f"{agent_id}: {name}: connectivity probe error: {exc}",
+                )
 
         extra = getattr(ch, "__pydantic_extra__", None) or {}
         for key, val in extra.items():
@@ -260,16 +309,22 @@ def collect_deep_channel_connectivity_notes(cfg: Config, timeout: float) -> list
             if cls is None:
                 notes.append(
                     f"{agent_id}: plugin channel {key!r} enabled — "
-                    "not in registry; add a BaseChannel subclass or skip --deep",
+                    "not in registry; add a BaseChannel subclass "
+                    "or skip --deep",
                 )
                 continue
             try:
                 notes.extend(
-                    cls.doctor_connectivity_notes(agent_id, val, timeout=timeout),
+                    cls.doctor_connectivity_notes(
+                        agent_id,
+                        val,
+                        timeout=timeout,
+                    ),
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 notes.append(
-                    f"{agent_id}: {key}: doctor_connectivity_notes error: {exc}",
+                    f"{agent_id}: {key}: doctor_connectivity_notes error: "
+                    f"{exc}",
                 )
 
     return notes

--- a/src/qwenpaw/cli/doctor_fix_runner.py
+++ b/src/qwenpaw/cli/doctor_fix_runner.py
@@ -1,15 +1,26 @@
 # -*- coding: utf-8 -*-
-"""Conservative filesystem repairs for ``copaw doctor fix`` (backup, allowlist, atomic write).
+"""Conservative filesystem repairs for ``qwenpaw doctor fix``.
 
-Includes ``reconcile-workspace-skills``, which calls the same
-``reconcile_workspace_manifest`` as the app (CLI-only, no server).
+Backup, allowlist, atomic write. Includes ``reconcile-workspace-skills``,
+which calls the same ``reconcile_workspace_manifest`` as the app (CLI-only,
+no server).
 
-``rebuild-console-npm`` runs ``npm ci && npm run build`` under ``console/`` in a
-source checkout and copies ``console/dist`` into ``src/copaw/console/`` (needs
-network for npm).
+``rebuild-console-npm`` runs ``npm ci && npm run build`` under ``console/``
+in a source checkout and copies ``console/dist`` into
+``src/qwenpaw/console/`` (needs network for npm).
+
+``validate-all-jobs-json`` reuses
+:func:`~qwenpaw.cli.doctor_checks.check_cron_jobs_files` (read-only); exits
+non-zero on FAIL (for CI).
+
+``doctor fix --non-interactive`` allows only :data:`NONINTERACTIVE_FIX_IDS`
+(safe + read-only validation + workspace skill reconcile); rejects risky ids
+even with ``-y``.
 """
 from __future__ import annotations
 
+# pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-return-statements
 import json
 import os
 import secrets
@@ -28,15 +39,28 @@ from ..agents.skills_manager import (
 )
 from ..app.crons.models import JobsFile, ScheduleSpec
 from ..config import load_config
-from ..config.config import AgentProfileConfig, build_fallback_agent_profile_config
-from ..config.utils import _normalize_working_dir_bound_paths, strict_validate_config_file
+from ..config.config import (
+    AgentProfileConfig,
+    build_fallback_agent_profile_config,
+)
+from ..config.utils import (
+    _normalize_working_dir_bound_paths,
+    read_last_api,
+    strict_validate_config_file,
+)
 from ..constant import JOBS_FILE, WORKING_DIR
-from ..utils.console_static import find_copaw_source_repo_root
+from ..utils.console_static import find_qwenpaw_source_repo_root
+from .doctor_checks import check_cron_jobs_files
 
 SAFE_FIX_IDS = frozenset({"ensure-working-dir", "ensure-workspace-dirs"})
-# Sync workspace ``skill.json`` with ``skills/`` (same as app reconcile); no --yes.
+# Read-only: validate every workspace + legacy jobs.json (no writes; no
+# --yes).
+READONLY_FIX_IDS = frozenset({"validate-all-jobs-json"})
+# Sync workspace ``skill.json`` with ``skills/`` (same as app reconcile);
+# no --yes.
 SYNC_FIX_IDS = frozenset({"reconcile-workspace-skills"})
-# Mutating fixes: require --yes (may create agent.json / jobs.json or rewrite jobs).
+# Mutating fixes: require --yes (may create agent.json / jobs.json or rewrite
+# jobs).
 RISKY_FIX_IDS = frozenset(
     {
         "seed-missing-agent-json",
@@ -46,7 +70,9 @@ RISKY_FIX_IDS = frozenset(
         "rebuild-console-npm",
     },
 )
-ALL_FIX_IDS = SAFE_FIX_IDS | SYNC_FIX_IDS | RISKY_FIX_IDS
+ALL_FIX_IDS = SAFE_FIX_IDS | READONLY_FIX_IDS | SYNC_FIX_IDS | RISKY_FIX_IDS
+# Subset allowed with ``doctor fix --non-interactive`` (CI / upgrade scripts).
+NONINTERACTIVE_FIX_IDS = SAFE_FIX_IDS | READONLY_FIX_IDS | SYNC_FIX_IDS
 
 BACKUP_SUBDIR = "doctor-fix-backups"
 
@@ -121,7 +147,7 @@ def _normalize_cron_fields_in_jobs_dict(data: dict[str, Any]) -> bool:
 
 
 def _workspace_agent_json_valid(path: Path) -> bool:
-    """Match :func:`copaw.cli.doctor_checks.check_agent_json_profiles` criteria."""
+    """Same validity criteria as ``check_agent_json_profiles``."""
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -170,18 +196,56 @@ def _backup_one_file(session_files: Path, path: Path, wd: Path) -> None:
         marker.write_text("", encoding="utf-8")
 
 
+def _effective_cli_api_host_port(
+    host_override: str | None,
+    port_override: int | None,
+) -> tuple[str, int]:
+    """Match ``main.cli`` host/port resolution for backup audit metadata."""
+    host, port = host_override, port_override
+    if host is None or port is None:
+        last = read_last_api()
+        if last:
+            host = host or last[0]
+            port = port or last[1]
+    return host or "127.0.0.1", port or 8088
+
+
 def _write_meta(
     session_dir: Path,
     argv: list[str],
     fix_ids: list[str],
     backed_paths: list[str],
+    *,
+    working_dir: str,
+    dry_run: bool,
+    yes: bool,
+    no_backup: bool,
+    non_interactive: bool,
+    cli_api_host: str | None,
+    cli_api_port: int | None,
 ) -> None:
+    cfg = load_config()
+    ch, cp = _effective_cli_api_host_port(cli_api_host, cli_api_port)
     meta = {
-        "copaw_version": __version__,
+        "qwenpaw_version": __version__,
         "utc": datetime.now(timezone.utc).isoformat(),
         "argv": argv,
         "fix_ids": fix_ids,
         "backed_up_files_relative": backed_paths,
+        "working_dir": working_dir,
+        "dry_run": dry_run,
+        "yes": yes,
+        "no_backup": no_backup,
+        "non_interactive": non_interactive,
+        "config_last_api": {
+            "host": cfg.last_api.host,
+            "port": cfg.last_api.port,
+        },
+        "cli_resolved_api": {
+            "host": ch,
+            "port": cp,
+            "base_url": f"http://{ch}:{cp}",
+        },
         "restore_hint": (
             "Copy files from the 'files/' subtree back to your working dir "
             "with the same relative paths."
@@ -207,7 +271,9 @@ def _parse_only(only: str | None) -> list[str]:
     ids = [x.strip() for x in only.split(",") if x.strip()]
     bad = [x for x in ids if x not in ALL_FIX_IDS]
     if bad:
-        raise ValueError(f"unknown fix id(s): {bad!r}; known: {sorted(ALL_FIX_IDS)}")
+        raise ValueError(
+            f"unknown fix id(s): {bad!r}; known: {sorted(ALL_FIX_IDS)}",
+        )
     return ids
 
 
@@ -216,16 +282,18 @@ def _plan_fixes(
     wd: Path,
     yes: bool,
     *,
+    dry_run: bool = False,
     no_backup: bool = False,
 ) -> tuple[list[str], list[PlannedFix]]:
     """Return (skip_messages, planned operations)."""
     if fix_ids:
         for fid in fix_ids:
-            if fid in RISKY_FIX_IDS and not yes:
+            if fid in RISKY_FIX_IDS and not yes and not dry_run:
                 raise ValueError(
-                    f"fix {fid!r} requires --yes after reviewing "
-                    "`copaw doctor fix --dry-run` (may modify files or run "
-                    "external tools such as npm).",
+                    f"fix {fid!r} requires --yes (-y) to apply "
+                    "(may modify files or run external tools such as npm). "
+                    "Use `qwenpaw doctor fix --dry-run --only ...` to preview "
+                    "the plan without -y.",
                 )
 
     needs_existing_wd = bool(
@@ -239,10 +307,14 @@ def _plan_fixes(
             "normalize-jobs-cron",
         },
     )
-    if needs_existing_wd and not wd.is_dir() and "ensure-working-dir" not in fix_ids:
+    if (
+        needs_existing_wd
+        and not wd.is_dir()
+        and "ensure-working-dir" not in fix_ids
+    ):
         raise ValueError(
             f"working directory {wd} does not exist; include "
-            "ensure-working-dir in --only or run `copaw doctor fix` without "
+            "ensure-working-dir in --only or run `qwenpaw doctor fix` without "
             "--only (safe fixes include it when needed).",
         )
 
@@ -254,7 +326,8 @@ def _plan_fixes(
             parent = wd.parent
             if not parent.is_dir():
                 raise ValueError(
-                    f"refusing to create {wd}: parent directory does not exist: {parent}",
+                    f"refusing to create {wd}: parent directory does not "
+                    f"exist: {parent}",
                 )
             if not os.access(parent, os.W_OK):
                 raise ValueError(
@@ -283,6 +356,18 @@ def _plan_fixes(
                 f"config-dependent fixes skipped: load_config failed: {exc}",
             )
             cfg = None
+
+    if "validate-all-jobs-json" in fix_ids:
+        if cfg is None:
+            skip_msgs.append(
+                "validate-all-jobs-json: skipped (root config invalid or "
+                "load_config failed)",
+            )
+        else:
+            ok, det = check_cron_jobs_files(cfg)
+            skip_msgs.append(
+                f"validate-all-jobs-json: {'OK' if ok else 'FAIL'} — {det}",
+            )
 
     if cfg is not None and "ensure-workspace-dirs" in fix_ids:
         for agent_id, ref in cfg.agents.profiles.items():
@@ -374,7 +459,8 @@ def _plan_fixes(
             planned.append(
                 PlannedFix(
                     "reset-invalid-agent-json",
-                    f"replace invalid {agent_json} with root config defaults (backup first)",
+                    f"replace invalid {agent_json} with root config defaults "
+                    "(backup first)",
                     (agent_json,),
                     _reset,
                 ),
@@ -382,7 +468,9 @@ def _plan_fixes(
 
     if cfg is not None and "write-empty-jobs-json" in fix_ids:
         empty = JobsFile(version=1, jobs=[])
-        body = json.dumps(empty.model_dump(), ensure_ascii=False, indent=2) + "\n"
+        body = (
+            json.dumps(empty.model_dump(), ensure_ascii=False, indent=2) + "\n"
+        )
         JobsFile.model_validate(json.loads(body))
 
         for agent_id in cfg.agents.profiles:
@@ -434,7 +522,8 @@ def _plan_fixes(
             planned.append(
                 PlannedFix(
                     "reconcile-workspace-skills",
-                    f"reconcile skill.json with skills/ for agent {agent_id!r} ({wsp})",
+                    f"reconcile skill.json with skills/ for agent "
+                    f"{agent_id!r} ({wsp})",
                     backup_paths,
                     _rec,
                 ),
@@ -487,7 +576,11 @@ def _plan_fixes(
                 + "\n"
             )
 
-            def _write_norm(jpath: Path = jp, text: str = body, root: Path = wd) -> None:
+            def _write_norm(
+                jpath: Path = jp,
+                text: str = body,
+                root: Path = wd,
+            ) -> None:
                 if not path_allowed_for_write(jpath, root):
                     raise RuntimeError(f"path not allowed: {jpath}")
                 _atomic_write_text(jpath, text)
@@ -502,21 +595,22 @@ def _plan_fixes(
             )
 
     if "rebuild-console-npm" in fix_ids:
-        repo = find_copaw_source_repo_root()
+        repo = find_qwenpaw_source_repo_root()
         if repo is None:
             skip_msgs.append(
-                "rebuild-console-npm: only in a CoPaw source checkout "
-                "(./console/package.json + ./console/package-lock.json + ./src/copaw/)",
+                "rebuild-console-npm: only in a QwenPaw source checkout "
+                "(./console/package.json + ./console/package-lock.json + "
+                "./src/qwenpaw/)",
             )
         elif not shutil.which("npm"):
             skip_msgs.append("rebuild-console-npm: npm not found on PATH")
         else:
             console = repo / "console"
             dist = console / "dist"
-            dst = repo / "src" / "copaw" / "console"
+            dst = repo / "src" / "qwenpaw" / "console"
             desc = (
-                f"npm ci + npm run build in {console}, then copy {dist} -> {dst} "
-                "(bundles web UI for editable installs)"
+                f"npm ci + npm run build in {console}, then copy {dist} -> "
+                f"{dst} (bundles web UI for editable installs)"
             )
 
             def _rebuild_console(
@@ -530,14 +624,15 @@ def _plan_fixes(
                     raise RuntimeError(f"missing console directory: {cdir}")
                 if not (cdir / "package-lock.json").is_file():
                     raise RuntimeError(
-                        f"missing {cdir / 'package-lock.json'} (npm ci needs a lockfile)",
+                        f"missing {cdir / 'package-lock.json'} "
+                        "(npm ci needs a lockfile)",
                     )
                 if (
                     not skip_prev_backup
                     and target.exists()
                     and any(target.iterdir())
                 ):
-                    bkp_root = r / ".copaw-doctor-fix-backups"
+                    bkp_root = r / ".qwenpaw-doctor-fix-backups"
                     sid = _utc_session_id()
                     bkp = bkp_root / sid
                     prev = bkp / "previous-console-bundle"
@@ -547,7 +642,7 @@ def _plan_fixes(
                     shutil.copytree(target, prev)
                     bkp.mkdir(parents=True, exist_ok=True)
                     meta = {
-                        "copaw_version": __version__,
+                        "qwenpaw_version": __version__,
                         "previous_bundle": str(prev),
                     }
                     (bkp / "meta.json").write_text(
@@ -566,9 +661,13 @@ def _plan_fixes(
                     check=True,
                     env=os.environ.copy(),
                 )
-                if not dist_dir.is_dir() or not (dist_dir / "index.html").is_file():
+                if (
+                    not dist_dir.is_dir()
+                    or not (dist_dir / "index.html").is_file()
+                ):
                     raise RuntimeError(
-                        f"after npm run build, expected {dist_dir / 'index.html'}",
+                        f"after npm run build, expected "
+                        f"{dist_dir / 'index.html'}",
                     )
                 if target.exists():
                     shutil.rmtree(target)
@@ -599,8 +698,14 @@ def run_doctor_fix(
     echo_err: Callable[[str], None],
     confirm_fn: Callable[[str], bool] | None,
     argv: list[str] | None = None,
+    cli_api_host: str | None = None,
+    cli_api_port: int | None = None,
+    non_interactive: bool = False,
 ) -> int:
-    """Run planned fixes. Returns 0 on success or user abort without writes; 1 on error."""
+    """Run planned fixes.
+
+    Returns 0 on success or user abort without writes; 1 on error.
+    """
     wd = _working_dir_resolved(working_dir or WORKING_DIR)
     argv = argv if argv is not None else sys.argv
 
@@ -610,11 +715,21 @@ def run_doctor_fix(
         echo_err(str(exc))
         return 1
 
+    if non_interactive:
+        disallowed = sorted(set(fix_ids) - NONINTERACTIVE_FIX_IDS)
+        if disallowed:
+            echo_err(
+                "--non-interactive allows only "
+                f"{sorted(NONINTERACTIVE_FIX_IDS)}; disallowed: {disallowed}",
+            )
+            return 1
+
     try:
         skip_msgs, planned = _plan_fixes(
             fix_ids,
             wd,
             yes=yes,
+            dry_run=dry_run,
             no_backup=no_backup,
         )
     except ValueError as exc:
@@ -624,7 +739,17 @@ def run_doctor_fix(
     for msg in skip_msgs:
         echo(f"  (note) {msg}")
 
+    validate_failed = any(
+        m.startswith("validate-all-jobs-json: FAIL") for m in skip_msgs
+    )
+
     if not planned:
+        if any(m.startswith("validate-all-jobs-json:") for m in skip_msgs):
+            echo(
+                "(read-only jobs.json validation complete; no file changes "
+                "planned.)",
+            )
+            return 1 if validate_failed else 0
         echo("Nothing to do (already satisfied).")
         return 0
 
@@ -634,7 +759,7 @@ def run_doctor_fix(
 
     if dry_run:
         echo("(dry-run: no files modified)")
-        return 0
+        return 1 if validate_failed else 0
 
     if no_backup:
         echo_err(
@@ -642,7 +767,8 @@ def run_doctor_fix(
             "something goes wrong.",
         )
 
-    if not yes:
+    skip_confirm = yes or non_interactive
+    if not skip_confirm:
         fn = confirm_fn or (lambda _m: False)
         if not fn("Apply these changes?"):
             echo("Aborted (no changes written).")
@@ -689,7 +815,9 @@ def run_doctor_fix(
         for p in rest_ops:
             for path in p.paths_to_backup:
                 if not path_allowed_for_write(path, wd):
-                    raise RuntimeError(f"refusing to touch disallowed path: {path}")
+                    raise RuntimeError(
+                        f"refusing to touch disallowed path: {path}",
+                    )
                 if session_files is not None and path.is_file():
                     _backup_one_file(session_files, path, wd)
                     backed_rels.append(str(_relative_under_wd(path, wd)))
@@ -702,8 +830,20 @@ def run_doctor_fix(
         return 1
 
     if session_dir is not None and session_files is not None:
-        _write_meta(session_dir, list(argv), all_applied_ids, backed_rels)
+        _write_meta(
+            session_dir,
+            list(argv),
+            all_applied_ids,
+            backed_rels,
+            working_dir=str(wd),
+            dry_run=dry_run,
+            yes=yes,
+            no_backup=no_backup,
+            non_interactive=non_interactive,
+            cli_api_host=cli_api_host,
+            cli_api_port=cli_api_port,
+        )
         echo(f"Backup session: {session_dir}")
 
     echo("Done.")
-    return 0
+    return 1 if validate_failed else 0

--- a/src/qwenpaw/cli/doctor_fix_runner.py
+++ b/src/qwenpaw/cli/doctor_fix_runner.py
@@ -1,0 +1,709 @@
+# -*- coding: utf-8 -*-
+"""Conservative filesystem repairs for ``copaw doctor fix`` (backup, allowlist, atomic write).
+
+Includes ``reconcile-workspace-skills``, which calls the same
+``reconcile_workspace_manifest`` as the app (CLI-only, no server).
+
+``rebuild-console-npm`` runs ``npm ci && npm run build`` under ``console/`` in a
+source checkout and copies ``console/dist`` into ``src/copaw/console/`` (needs
+network for npm).
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from ..__version__ import __version__
+from ..agents.skills_manager import (
+    get_workspace_skill_manifest_path,
+    reconcile_workspace_manifest,
+)
+from ..app.crons.models import JobsFile, ScheduleSpec
+from ..config import load_config
+from ..config.config import AgentProfileConfig, build_fallback_agent_profile_config
+from ..config.utils import _normalize_working_dir_bound_paths, strict_validate_config_file
+from ..constant import JOBS_FILE, WORKING_DIR
+from ..utils.console_static import find_copaw_source_repo_root
+
+SAFE_FIX_IDS = frozenset({"ensure-working-dir", "ensure-workspace-dirs"})
+# Sync workspace ``skill.json`` with ``skills/`` (same as app reconcile); no --yes.
+SYNC_FIX_IDS = frozenset({"reconcile-workspace-skills"})
+# Mutating fixes: require --yes (may create agent.json / jobs.json or rewrite jobs).
+RISKY_FIX_IDS = frozenset(
+    {
+        "seed-missing-agent-json",
+        "reset-invalid-agent-json",
+        "write-empty-jobs-json",
+        "normalize-jobs-cron",
+        "rebuild-console-npm",
+    },
+)
+ALL_FIX_IDS = SAFE_FIX_IDS | SYNC_FIX_IDS | RISKY_FIX_IDS
+
+BACKUP_SUBDIR = "doctor-fix-backups"
+
+
+def _utc_session_id() -> str:
+    return (
+        datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        + "-"
+        + secrets.token_hex(4)
+    )
+
+
+def _working_dir_resolved(working_dir: Path) -> Path:
+    return working_dir.expanduser().resolve()
+
+
+def workspace_under_working_dir(workspace: Path, wd: Path) -> bool:
+    try:
+        workspace.resolve().relative_to(wd.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def path_allowed_for_write(target: Path, wd: Path) -> bool:
+    """Allow writes only under ``WORKING_DIR`` (resolved)."""
+    try:
+        target.resolve().relative_to(wd.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _relative_under_wd(path: Path, wd: Path) -> Path:
+    return path.resolve().relative_to(wd.resolve())
+
+
+def _normalize_cron_fields_in_jobs_dict(data: dict[str, Any]) -> bool:
+    """Mutate *data* (``jobs.json`` root dict) so each job schedule matches
+    ``ScheduleSpec`` normalization. Compares against on-disk strings before
+    validation (``JobsFile`` validation already normalizes in memory).
+
+    Returns whether any ``cron`` or ``timezone`` field was updated.
+    """
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return False
+    changed = False
+    for j in jobs:
+        if not isinstance(j, dict):
+            continue
+        sch = j.get("schedule")
+        if not isinstance(sch, dict):
+            continue
+        cron = sch.get("cron")
+        if not isinstance(cron, str):
+            continue
+        tz_raw = sch.get("timezone", "UTC")
+        tz = tz_raw if isinstance(tz_raw, str) else "UTC"
+        jid = j.get("id", "?")
+        try:
+            ns = ScheduleSpec(type="cron", cron=cron, timezone=tz)
+        except ValueError:
+            raise ValueError(f"job {jid!r}: invalid cron {cron!r}") from None
+        if ns.cron != cron:
+            sch["cron"] = ns.cron
+            changed = True
+        if ns.timezone != tz:
+            sch["timezone"] = ns.timezone
+            changed = True
+    return changed
+
+
+def _workspace_agent_json_valid(path: Path) -> bool:
+    """Match :func:`copaw.cli.doctor_checks.check_agent_json_profiles` criteria."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(raw, dict):
+        return False
+    try:
+        raw = _normalize_working_dir_bound_paths(raw)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    try:
+        AgentProfileConfig.model_validate(raw)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+    return True
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = text.encode("utf-8")
+    tmp = path.with_name(f"{path.name}.tmp.{secrets.token_hex(8)}")
+    try:
+        tmp.write_bytes(data)
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        tmp.replace(path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def _backup_one_file(session_files: Path, path: Path, wd: Path) -> None:
+    rel = _relative_under_wd(path, wd)
+    dest = session_files / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_file():
+        shutil.copy2(path, dest)
+    else:
+        marker = dest.with_suffix(dest.suffix + ".MISSING")
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("", encoding="utf-8")
+
+
+def _write_meta(
+    session_dir: Path,
+    argv: list[str],
+    fix_ids: list[str],
+    backed_paths: list[str],
+) -> None:
+    meta = {
+        "copaw_version": __version__,
+        "utc": datetime.now(timezone.utc).isoformat(),
+        "argv": argv,
+        "fix_ids": fix_ids,
+        "backed_up_files_relative": backed_paths,
+        "restore_hint": (
+            "Copy files from the 'files/' subtree back to your working dir "
+            "with the same relative paths."
+        ),
+    }
+    (session_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+@dataclass(frozen=True)
+class PlannedFix:
+    fix_id: str
+    description: str
+    paths_to_backup: tuple[Path, ...]
+    apply_fn: Callable[[], None]
+
+
+def _parse_only(only: str | None) -> list[str]:
+    if not only or not only.strip():
+        return sorted(SAFE_FIX_IDS)
+    ids = [x.strip() for x in only.split(",") if x.strip()]
+    bad = [x for x in ids if x not in ALL_FIX_IDS]
+    if bad:
+        raise ValueError(f"unknown fix id(s): {bad!r}; known: {sorted(ALL_FIX_IDS)}")
+    return ids
+
+
+def _plan_fixes(
+    fix_ids: list[str],
+    wd: Path,
+    yes: bool,
+    *,
+    no_backup: bool = False,
+) -> tuple[list[str], list[PlannedFix]]:
+    """Return (skip_messages, planned operations)."""
+    if fix_ids:
+        for fid in fix_ids:
+            if fid in RISKY_FIX_IDS and not yes:
+                raise ValueError(
+                    f"fix {fid!r} requires --yes after reviewing "
+                    "`copaw doctor fix --dry-run` (may modify files or run "
+                    "external tools such as npm).",
+                )
+
+    needs_existing_wd = bool(
+        set(fix_ids)
+        & {
+            "ensure-workspace-dirs",
+            "seed-missing-agent-json",
+            "reset-invalid-agent-json",
+            "write-empty-jobs-json",
+            "reconcile-workspace-skills",
+            "normalize-jobs-cron",
+        },
+    )
+    if needs_existing_wd and not wd.is_dir() and "ensure-working-dir" not in fix_ids:
+        raise ValueError(
+            f"working directory {wd} does not exist; include "
+            "ensure-working-dir in --only or run `copaw doctor fix` without "
+            "--only (safe fixes include it when needed).",
+        )
+
+    skip_msgs: list[str] = []
+    planned: list[PlannedFix] = []
+
+    if "ensure-working-dir" in fix_ids:
+        if not wd.is_dir():
+            parent = wd.parent
+            if not parent.is_dir():
+                raise ValueError(
+                    f"refusing to create {wd}: parent directory does not exist: {parent}",
+                )
+            if not os.access(parent, os.W_OK):
+                raise ValueError(
+                    f"refusing to create {wd}: parent not writable: {parent}",
+                )
+
+            def _mk(wdir: Path = wd) -> None:
+                wdir.mkdir(mode=0o700, exist_ok=False)
+
+            planned.append(
+                PlannedFix(
+                    "ensure-working-dir",
+                    f"create working directory {wd}",
+                    (),
+                    _mk,
+                ),
+            )
+
+    config_ok, _cfg_msg = strict_validate_config_file()
+    cfg = None
+    if config_ok:
+        try:
+            cfg = load_config()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            skip_msgs.append(
+                f"config-dependent fixes skipped: load_config failed: {exc}",
+            )
+            cfg = None
+
+    if cfg is not None and "ensure-workspace-dirs" in fix_ids:
+        for agent_id, ref in cfg.agents.profiles.items():
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            if wsp.is_dir():
+                continue
+            desc = f"mkdir workspace for agent {agent_id!r}: {wsp}"
+
+            def _mk_ws(p: Path = wsp, root: Path = wd) -> None:
+                if not path_allowed_for_write(p, root):
+                    raise RuntimeError(f"path not allowed: {p}")
+                p.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+            planned.append(
+                PlannedFix(
+                    "ensure-workspace-dirs",
+                    desc,
+                    (),
+                    _mk_ws,
+                ),
+            )
+
+    if cfg is not None and "seed-missing-agent-json" in fix_ids:
+        for agent_id in cfg.agents.profiles:
+            ref = cfg.agents.profiles[agent_id]
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            agent_json = wsp / "agent.json"
+            if agent_json.exists():
+                continue
+            if not wsp.is_dir():
+                continue
+
+            profile = build_fallback_agent_profile_config(agent_id, cfg)
+            payload = profile.model_dump(exclude_none=True)
+            text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+            AgentProfileConfig.model_validate(json.loads(text))
+
+            def _seed(
+                aj: Path = agent_json,
+                body: str = text,
+                root: Path = wd,
+            ) -> None:
+                if aj.exists():
+                    return
+                if not path_allowed_for_write(aj, root):
+                    raise RuntimeError(f"path not allowed: {aj}")
+                _atomic_write_text(aj, body)
+
+            planned.append(
+                PlannedFix(
+                    "seed-missing-agent-json",
+                    f"write initial {agent_json} from root config defaults",
+                    (agent_json,),
+                    _seed,
+                ),
+            )
+
+    if cfg is not None and "reset-invalid-agent-json" in fix_ids:
+        for agent_id in cfg.agents.profiles:
+            ref = cfg.agents.profiles[agent_id]
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            if not wsp.is_dir():
+                continue
+            agent_json = wsp / "agent.json"
+            if not agent_json.is_file():
+                continue
+            if _workspace_agent_json_valid(agent_json):
+                continue
+            profile = build_fallback_agent_profile_config(agent_id, cfg)
+            payload = profile.model_dump(exclude_none=True)
+            text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+            AgentProfileConfig.model_validate(json.loads(text))
+
+            def _reset(
+                aj: Path = agent_json,
+                body: str = text,
+                root: Path = wd,
+            ) -> None:
+                if not path_allowed_for_write(aj, root):
+                    raise RuntimeError(f"path not allowed: {aj}")
+                _atomic_write_text(aj, body)
+
+            planned.append(
+                PlannedFix(
+                    "reset-invalid-agent-json",
+                    f"replace invalid {agent_json} with root config defaults (backup first)",
+                    (agent_json,),
+                    _reset,
+                ),
+            )
+
+    if cfg is not None and "write-empty-jobs-json" in fix_ids:
+        empty = JobsFile(version=1, jobs=[])
+        body = json.dumps(empty.model_dump(), ensure_ascii=False, indent=2) + "\n"
+        JobsFile.model_validate(json.loads(body))
+
+        for agent_id in cfg.agents.profiles:
+            ref = cfg.agents.profiles[agent_id]
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            jp = wsp / JOBS_FILE
+            if jp.exists():
+                continue
+            if not wsp.is_dir():
+                continue
+
+            def _jobs(
+                p: Path = jp,
+                b: str = body,
+                root: Path = wd,
+            ) -> None:
+                if p.exists():
+                    return
+                if not path_allowed_for_write(p, root):
+                    raise RuntimeError(f"path not allowed: {p}")
+                _atomic_write_text(p, b)
+
+            planned.append(
+                PlannedFix(
+                    "write-empty-jobs-json",
+                    f"write empty {jp} (version=1, jobs=[])",
+                    (jp,),
+                    _jobs,
+                ),
+            )
+
+    if cfg is not None and "reconcile-workspace-skills" in fix_ids:
+        for agent_id, ref in cfg.agents.profiles.items():
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            if not wsp.is_dir():
+                continue
+            mp = get_workspace_skill_manifest_path(wsp)
+            backup_paths: tuple[Path, ...] = (mp,) if mp.is_file() else ()
+
+            def _rec(ws: Path = wsp, root: Path = wd) -> None:
+                if not workspace_under_working_dir(ws, root):
+                    raise RuntimeError(f"path not allowed: {ws}")
+                reconcile_workspace_manifest(ws)
+
+            planned.append(
+                PlannedFix(
+                    "reconcile-workspace-skills",
+                    f"reconcile skill.json with skills/ for agent {agent_id!r} ({wsp})",
+                    backup_paths,
+                    _rec,
+                ),
+            )
+
+    if cfg is not None and "normalize-jobs-cron" in fix_ids:
+        for agent_id, ref in cfg.agents.profiles.items():
+            wsp = Path(ref.workspace_dir).expanduser()
+            if not workspace_under_working_dir(wsp, wd):
+                continue
+            if not wsp.is_dir():
+                continue
+            jp = wsp / JOBS_FILE
+            if not jp.is_file():
+                continue
+            try:
+                raw = json.loads(jp.read_text(encoding="utf-8"))
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                skip_msgs.append(
+                    f"{agent_id}: {jp.name} invalid or unreadable — "
+                    f"skip normalize-jobs-cron ({exc})",
+                )
+                continue
+            if not isinstance(raw, dict):
+                skip_msgs.append(
+                    f"{agent_id}: {jp.name} root must be a JSON object — "
+                    "skip normalize-jobs-cron",
+                )
+                continue
+            try:
+                if not _normalize_cron_fields_in_jobs_dict(raw):
+                    continue
+            except ValueError as exc:
+                skip_msgs.append(f"{agent_id}: {exc}")
+                continue
+            try:
+                jf = JobsFile.model_validate(raw)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                skip_msgs.append(
+                    f"{agent_id}: {jp.name} invalid after cron normalize — "
+                    f"skip ({exc})",
+                )
+                continue
+            body = (
+                json.dumps(
+                    jf.model_dump(mode="json"),
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n"
+            )
+
+            def _write_norm(jpath: Path = jp, text: str = body, root: Path = wd) -> None:
+                if not path_allowed_for_write(jpath, root):
+                    raise RuntimeError(f"path not allowed: {jpath}")
+                _atomic_write_text(jpath, text)
+
+            planned.append(
+                PlannedFix(
+                    "normalize-jobs-cron",
+                    f"normalize cron day-of-week fields in {jp}",
+                    (jp,),
+                    _write_norm,
+                ),
+            )
+
+    if "rebuild-console-npm" in fix_ids:
+        repo = find_copaw_source_repo_root()
+        if repo is None:
+            skip_msgs.append(
+                "rebuild-console-npm: only in a CoPaw source checkout "
+                "(./console/package.json + ./console/package-lock.json + ./src/copaw/)",
+            )
+        elif not shutil.which("npm"):
+            skip_msgs.append("rebuild-console-npm: npm not found on PATH")
+        else:
+            console = repo / "console"
+            dist = console / "dist"
+            dst = repo / "src" / "copaw" / "console"
+            desc = (
+                f"npm ci + npm run build in {console}, then copy {dist} -> {dst} "
+                "(bundles web UI for editable installs)"
+            )
+
+            def _rebuild_console(
+                r: Path = repo,
+                cdir: Path = console,
+                dist_dir: Path = dist,
+                target: Path = dst,
+                skip_prev_backup: bool = no_backup,
+            ) -> None:
+                if not cdir.is_dir():
+                    raise RuntimeError(f"missing console directory: {cdir}")
+                if not (cdir / "package-lock.json").is_file():
+                    raise RuntimeError(
+                        f"missing {cdir / 'package-lock.json'} (npm ci needs a lockfile)",
+                    )
+                if (
+                    not skip_prev_backup
+                    and target.exists()
+                    and any(target.iterdir())
+                ):
+                    bkp_root = r / ".copaw-doctor-fix-backups"
+                    sid = _utc_session_id()
+                    bkp = bkp_root / sid
+                    prev = bkp / "previous-console-bundle"
+                    prev.parent.mkdir(parents=True, exist_ok=True)
+                    if prev.exists():
+                        shutil.rmtree(prev)
+                    shutil.copytree(target, prev)
+                    bkp.mkdir(parents=True, exist_ok=True)
+                    meta = {
+                        "copaw_version": __version__,
+                        "previous_bundle": str(prev),
+                    }
+                    (bkp / "meta.json").write_text(
+                        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
+                        encoding="utf-8",
+                    )
+                subprocess.run(
+                    ["npm", "ci"],
+                    cwd=str(cdir),
+                    check=True,
+                    env=os.environ.copy(),
+                )
+                subprocess.run(
+                    ["npm", "run", "build"],
+                    cwd=str(cdir),
+                    check=True,
+                    env=os.environ.copy(),
+                )
+                if not dist_dir.is_dir() or not (dist_dir / "index.html").is_file():
+                    raise RuntimeError(
+                        f"after npm run build, expected {dist_dir / 'index.html'}",
+                    )
+                if target.exists():
+                    shutil.rmtree(target)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(dist_dir, target)
+
+            planned.append(
+                PlannedFix(
+                    "rebuild-console-npm",
+                    desc,
+                    (),
+                    _rebuild_console,
+                ),
+            )
+
+    return skip_msgs, planned
+
+
+def run_doctor_fix(
+    *,
+    dry_run: bool,
+    yes: bool,
+    only: str | None,
+    no_backup: bool,
+    backup_dir: Path | None,
+    working_dir: Path | None,
+    echo: Callable[[str], None],
+    echo_err: Callable[[str], None],
+    confirm_fn: Callable[[str], bool] | None,
+    argv: list[str] | None = None,
+) -> int:
+    """Run planned fixes. Returns 0 on success or user abort without writes; 1 on error."""
+    wd = _working_dir_resolved(working_dir or WORKING_DIR)
+    argv = argv if argv is not None else sys.argv
+
+    try:
+        fix_ids = _parse_only(only)
+    except ValueError as exc:
+        echo_err(str(exc))
+        return 1
+
+    try:
+        skip_msgs, planned = _plan_fixes(
+            fix_ids,
+            wd,
+            yes=yes,
+            no_backup=no_backup,
+        )
+    except ValueError as exc:
+        echo_err(str(exc))
+        return 1
+
+    for msg in skip_msgs:
+        echo(f"  (note) {msg}")
+
+    if not planned:
+        echo("Nothing to do (already satisfied).")
+        return 0
+
+    echo("Planned operations:")
+    for p in planned:
+        echo(f"  [{p.fix_id}] {p.description}")
+
+    if dry_run:
+        echo("(dry-run: no files modified)")
+        return 0
+
+    if no_backup:
+        echo_err(
+            "WARNING: --no-backup — no copies under doctor-fix-backups if "
+            "something goes wrong.",
+        )
+
+    if not yes:
+        fn = confirm_fn or (lambda _m: False)
+        if not fn("Apply these changes?"):
+            echo("Aborted (no changes written).")
+            return 0
+
+    mkdir_wd_ops = [p for p in planned if p.fix_id == "ensure-working-dir"]
+    rest_ops = [p for p in planned if p.fix_id != "ensure-working-dir"]
+
+    try:
+        for p in mkdir_wd_ops:
+            p.apply_fn()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        echo_err(f"Stopped after error: {exc}")
+        return 1
+
+    wd = _working_dir_resolved(working_dir or WORKING_DIR)
+    if not wd.is_dir():
+        echo_err(f"working directory still missing after fixes: {wd}")
+        return 1
+
+    session_dir: Path | None = None
+    session_files: Path | None = None
+    backed_rels: list[str] = []
+
+    if not no_backup:
+        base = _working_dir_resolved(backup_dir) if backup_dir else wd
+        if not base.is_dir():
+            echo_err(f"backup base directory missing: {base}")
+            return 1
+        try:
+            base.relative_to(wd)
+        except ValueError:
+            if backup_dir is not None:
+                echo_err("--backup-dir must be inside the working directory.")
+                return 1
+
+        session_dir = base / BACKUP_SUBDIR / _utc_session_id()
+        session_files = session_dir / "files"
+        session_dir.mkdir(parents=True, exist_ok=True)
+
+    all_applied_ids: list[str] = [p.fix_id for p in mkdir_wd_ops]
+
+    try:
+        for p in rest_ops:
+            for path in p.paths_to_backup:
+                if not path_allowed_for_write(path, wd):
+                    raise RuntimeError(f"refusing to touch disallowed path: {path}")
+                if session_files is not None and path.is_file():
+                    _backup_one_file(session_files, path, wd)
+                    backed_rels.append(str(_relative_under_wd(path, wd)))
+            p.apply_fn()
+            all_applied_ids.append(p.fix_id)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        echo_err(f"Stopped after error (no further operations): {exc}")
+        if session_dir is not None:
+            echo_err(f"Partial backup may be under: {session_dir}")
+        return 1
+
+    if session_dir is not None and session_files is not None:
+        _write_meta(session_dir, list(argv), all_applied_ids, backed_rels)
+        echo(f"Backup session: {session_dir}")
+
+    echo("Done.")
+    return 0

--- a/src/qwenpaw/cli/doctor_registry.py
+++ b/src/qwenpaw/cli/doctor_registry.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Extensible hooks for `copaw doctor` (entry points + programmatic registration).
+
+Plugins can expose a setuptools entry point in group ``copaw.doctor``::
+
+    [project.entry-points."copaw.doctor"]
+    my_pkg = "my_pkg.doctor:doctor_notes"
+
+The callable must accept :class:`DoctorRunContext` and return a list of
+informational strings (empty if nothing to report).
+
+Alternatively, call :func:`register_doctor_contribution` at import time
+(e.g. from a channel package).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from importlib.metadata import entry_points as metadata_entry_points
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from ..config.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DoctorRunContext:
+    """Context passed to doctor extension callables."""
+
+    cfg: "Config"
+    raw_cfg: dict[str, Any] | None
+    cli_base_url: str
+    timeout: float
+    deep: bool
+
+
+DoctorNotesFn = Callable[[DoctorRunContext], list[str]]
+
+_manual: dict[str, DoctorNotesFn] = {}
+_eps_cached: list[tuple[str, DoctorNotesFn]] | None = None
+
+
+def register_doctor_contribution(contrib_id: str, fn: DoctorNotesFn) -> None:
+    """Register a doctor extension (id should be unique, e.g. ``myplugin.cron``)."""
+    _manual[contrib_id] = fn
+
+
+def reset_doctor_registry_state() -> None:
+    """Clear manual registrations and entry-point cache (for tests)."""
+    _manual.clear()
+    global _eps_cached
+    _eps_cached = None
+
+
+def _load_entry_point_functions() -> list[tuple[str, DoctorNotesFn]]:
+    out: list[tuple[str, DoctorNotesFn]] = []
+    try:
+        eps = metadata_entry_points(group="copaw.doctor")
+    except TypeError:
+        eps = metadata_entry_points().select(group="copaw.doctor")
+    for ep in eps:
+        try:
+            fn = ep.load()
+        except Exception:
+            logger.exception('copaw.doctor entry point "%s" failed to load', ep.name)
+            continue
+        if not callable(fn):
+            logger.warning(
+                'copaw.doctor entry point "%s" is not callable; skipped',
+                ep.name,
+            )
+            continue
+        out.append((ep.name, fn))
+    return out
+
+
+def _resolved_eps() -> list[tuple[str, DoctorNotesFn]]:
+    global _eps_cached
+    if _eps_cached is None:
+        _eps_cached = _load_entry_point_functions()
+    return _eps_cached
+
+
+def run_extension_contributions(ctx: DoctorRunContext) -> list[tuple[str, list[str]]]:
+    """Run manual registrations first (sorted by id), then setuptools entry points."""
+    results: list[tuple[str, list[str]]] = []
+
+    for cid in sorted(_manual):
+        fn = _manual[cid]
+        try:
+            raw = fn(ctx)
+            lines = list(raw) if raw is not None else []
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            lines = [f"(extension error) {exc}"]
+        results.append((cid, lines))
+
+    for name, fn in sorted(_resolved_eps(), key=lambda x: x[0]):
+        try:
+            raw = fn(ctx)
+            lines = list(raw) if raw is not None else []
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            lines = [f"(entry point {name!r} error) {exc}"]
+        results.append((f"ep:{name}", lines))
+
+    return results

--- a/src/qwenpaw/cli/doctor_registry.py
+++ b/src/qwenpaw/cli/doctor_registry.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
-"""Extensible hooks for `copaw doctor` (entry points + programmatic registration).
+"""Extensible hooks for `qwenpaw doctor`
+(entry points + programmatic registration).
 
-Plugins can expose a setuptools entry point in group ``copaw.doctor``::
+Plugins can expose a setuptools entry point in group ``qwenpaw.doctor``::
 
-    [project.entry-points."copaw.doctor"]
+    [project.entry-points."qwenpaw.doctor"]
     my_pkg = "my_pkg.doctor:doctor_notes"
+
+The group ``copaw.doctor`` is still discovered when present (legacy plugins).
 
 The callable must accept :class:`DoctorRunContext` and return a list of
 informational strings (empty if nothing to report).
@@ -43,7 +46,7 @@ _eps_cached: list[tuple[str, DoctorNotesFn]] | None = None
 
 
 def register_doctor_contribution(contrib_id: str, fn: DoctorNotesFn) -> None:
-    """Register a doctor extension (id should be unique, e.g. ``myplugin.cron``)."""
+    """Register an extension (id should be unique, e.g. ``myplugin.cron``)."""
     _manual[contrib_id] = fn
 
 
@@ -54,25 +57,38 @@ def reset_doctor_registry_state() -> None:
     _eps_cached = None
 
 
+def _entry_points_for_group(group: str):
+    try:
+        return metadata_entry_points(group=group)
+    except TypeError:
+        return metadata_entry_points().select(group=group)
+
+
 def _load_entry_point_functions() -> list[tuple[str, DoctorNotesFn]]:
     out: list[tuple[str, DoctorNotesFn]] = []
-    try:
-        eps = metadata_entry_points(group="copaw.doctor")
-    except TypeError:
-        eps = metadata_entry_points().select(group="copaw.doctor")
-    for ep in eps:
-        try:
-            fn = ep.load()
-        except Exception:
-            logger.exception('copaw.doctor entry point "%s" failed to load', ep.name)
-            continue
-        if not callable(fn):
-            logger.warning(
-                'copaw.doctor entry point "%s" is not callable; skipped',
-                ep.name,
-            )
-            continue
-        out.append((ep.name, fn))
+    seen: set[str] = set()
+    for group in ("qwenpaw.doctor", "copaw.doctor"):
+        for ep in _entry_points_for_group(group):
+            if ep.name in seen:
+                continue
+            try:
+                fn = ep.load()
+            except Exception:
+                logger.exception(
+                    '%s entry point "%s" failed to load',
+                    group,
+                    ep.name,
+                )
+                continue
+            if not callable(fn):
+                logger.warning(
+                    '%s entry point "%s" is not callable; skipped',
+                    group,
+                    ep.name,
+                )
+                continue
+            seen.add(ep.name)
+            out.append((ep.name, fn))
     return out
 
 
@@ -83,8 +99,10 @@ def _resolved_eps() -> list[tuple[str, DoctorNotesFn]]:
     return _eps_cached
 
 
-def run_extension_contributions(ctx: DoctorRunContext) -> list[tuple[str, list[str]]]:
-    """Run manual registrations first (sorted by id), then setuptools entry points."""
+def run_extension_contributions(
+    ctx: DoctorRunContext,
+) -> list[tuple[str, list[str]]]:
+    """Run manual registrations first, then setuptools entry points."""
     results: list[tuple[str, list[str]]] = []
 
     for cid in sorted(_manual):

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -141,6 +141,7 @@ class LazyGroup(click.Group):
             ".plugin_commands",
         ),
         "task": ("qwenpaw.cli.task_cmd", "task_cmd", ".task_cmd"),
+        "doctor": ("copaw.cli.doctor_cmd", "doctor_cmd", ".doctor_cmd"),
     },
 )
 @click.version_option(version=__version__, prog_name="QwenPaw")

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -141,7 +141,7 @@ class LazyGroup(click.Group):
             ".plugin_commands",
         ),
         "task": ("qwenpaw.cli.task_cmd", "task_cmd", ".task_cmd"),
-        "doctor": ("copaw.cli.doctor_cmd", "doctor_cmd", ".doctor_cmd"),
+        "doctor": ("qwenpaw.cli.doctor_cmd", "doctor_cmd", ".doctor_cmd"),
     },
 )
 @click.version_option(version=__version__, prog_name="QwenPaw")

--- a/src/qwenpaw/config/__init__.py
+++ b/src/qwenpaw/config/__init__.py
@@ -20,6 +20,7 @@ from .utils import (
     is_running_in_container,
     load_config,
     save_config,
+    strict_validate_config_file,
     update_last_dispatch,
 )
 
@@ -42,5 +43,6 @@ __all__ = [
     "is_running_in_container",
     "load_config",
     "save_config",
+    "strict_validate_config_file",
     "update_last_dispatch",
 ]

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1177,9 +1177,11 @@ def build_fallback_agent_profile_config(
     agent_id: str,
     config: "Config",
 ) -> AgentProfileConfig:
-    """Build the same profile as when ``agent.json`` is missing (no disk read/write).
+    """Build the same profile as when ``agent.json``
+    is missing (no disk read/write).
 
-    Used by :func:`load_agent_config` and ``copaw doctor fix`` so defaults stay in sync.
+    Used by :func:`load_agent_config` and ``qwenpaw doctor fix``
+    so defaults stay in sync.
     """
     if agent_id not in config.agents.profiles:
         raise ValueError(f"Agent '{agent_id}' not found in config")
@@ -1198,9 +1200,7 @@ def build_fallback_agent_profile_config(
         ),
         mcp=config.mcp if hasattr(config, "mcp") and config.mcp else None,
         tools=(
-            config.tools
-            if hasattr(config, "tools") and config.tools
-            else None
+            config.tools if hasattr(config, "tools") and config.tools else None
         ),
         security=(
             config.security
@@ -1214,7 +1214,8 @@ def build_fallback_agent_profile_config(
         ),
         llm_routing=(
             config.agents.llm_routing
-            if hasattr(config.agents, "llm_routing") and config.agents.llm_routing
+            if hasattr(config.agents, "llm_routing")
+            and config.agents.llm_routing
             else AgentsLLMRoutingConfig()
         ),
         system_prompt_files=(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1173,6 +1173,59 @@ ChannelConfigUnion = Union[
 # Agent configuration utility functions
 
 
+def build_fallback_agent_profile_config(
+    agent_id: str,
+    config: "Config",
+) -> AgentProfileConfig:
+    """Build the same profile as when ``agent.json`` is missing (no disk read/write).
+
+    Used by :func:`load_agent_config` and ``copaw doctor fix`` so defaults stay in sync.
+    """
+    if agent_id not in config.agents.profiles:
+        raise ValueError(f"Agent '{agent_id}' not found in config")
+
+    agent_ref = config.agents.profiles[agent_id]
+    workspace_dir = Path(agent_ref.workspace_dir).expanduser()
+    return AgentProfileConfig(
+        id=agent_id,
+        name=agent_id.title(),
+        description=f"{agent_id} agent",
+        workspace_dir=str(workspace_dir),
+        channels=(
+            config.channels
+            if hasattr(config, "channels") and config.channels
+            else None
+        ),
+        mcp=config.mcp if hasattr(config, "mcp") and config.mcp else None,
+        tools=(
+            config.tools
+            if hasattr(config, "tools") and config.tools
+            else None
+        ),
+        security=(
+            config.security
+            if hasattr(config, "security") and config.security
+            else None
+        ),
+        running=(
+            config.agents.running
+            if hasattr(config.agents, "running") and config.agents.running
+            else AgentsRunningConfig()
+        ),
+        llm_routing=(
+            config.agents.llm_routing
+            if hasattr(config.agents, "llm_routing") and config.agents.llm_routing
+            else AgentsLLMRoutingConfig()
+        ),
+        system_prompt_files=(
+            config.agents.system_prompt_files
+            if hasattr(config.agents, "system_prompt_files")
+            and config.agents.system_prompt_files
+            else ["AGENTS.md", "SOUL.md", "PROFILE.md"]
+        ),
+    )
+
+
 def load_agent_config(agent_id: str) -> AgentProfileConfig:
     """Load agent's complete configuration from workspace/agent.json.
 
@@ -1200,49 +1253,7 @@ def load_agent_config(agent_id: str) -> AgentProfileConfig:
     agent_config_path = workspace_dir / "agent.json"
 
     if not agent_config_path.exists():
-        # Fallback: Try to use root config fields for backward compatibility
-        # This allows downgrade scenarios where agent.json doesn't exist yet
-        fallback_config = AgentProfileConfig(
-            id=agent_id,
-            name=agent_id.title(),
-            description=f"{agent_id} agent",
-            workspace_dir=str(workspace_dir),
-            # Inherit from root config if available (for backward compat)
-            channels=(
-                config.channels
-                if hasattr(config, "channels") and config.channels
-                else None
-            ),
-            mcp=config.mcp if hasattr(config, "mcp") and config.mcp else None,
-            tools=(
-                config.tools
-                if hasattr(config, "tools") and config.tools
-                else None
-            ),
-            security=(
-                config.security
-                if hasattr(config, "security") and config.security
-                else None
-            ),
-            # Use agent-specific configs with proper defaults
-            running=(
-                config.agents.running
-                if hasattr(config.agents, "running") and config.agents.running
-                else AgentsRunningConfig()
-            ),
-            llm_routing=(
-                config.agents.llm_routing
-                if hasattr(config.agents, "llm_routing")
-                and config.agents.llm_routing
-                else AgentsLLMRoutingConfig()
-            ),
-            system_prompt_files=(
-                config.agents.system_prompt_files
-                if hasattr(config.agents, "system_prompt_files")
-                and config.agents.system_prompt_files
-                else ["AGENTS.md", "SOUL.md", "PROFILE.md"]
-            ),
-        )
+        fallback_config = build_fallback_agent_profile_config(agent_id, config)
         # Save for future use
         save_agent_config(agent_id, fallback_config)
         return fallback_config

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -530,6 +530,42 @@ def load_config(config_path: Optional[Path] = None) -> Config:
         return Config()
 
 
+def strict_validate_config_file(config_path: Optional[Path] = None) -> tuple[bool, str]:
+    """Validate *config_path* strictly for diagnostics (no auto-repair).
+
+    Returns:
+        ``(True, summary)`` if the file is missing (defaults OK), readable, and valid.
+        ``(False, error)`` if the file is unreadable or fails :class:`Config` validation.
+    """
+    if config_path is None:
+        config_path = get_config_path()
+    if not config_path.is_file():
+        return True, f"(no file) defaults — {config_path}"
+
+    data = _read_config_data(config_path)
+    if data is None:
+        return False, f"unreadable or invalid JSON — {config_path}"
+
+    data = _normalize_working_dir_bound_paths(data)
+    if "last_api_host" in data or "last_api_port" in data:
+        la = data.setdefault("last_api", {})
+        if "host" not in la and "last_api_host" in data:
+            la["host"] = data.get("last_api_host")
+        if "port" not in la and "last_api_port" in data:
+            la["port"] = data.get("last_api_port")
+
+    try:
+        Config.model_validate(data)
+    except ValidationError as exc:
+        lines = [f"{config_path}:"]
+        for err in exc.errors():
+            loc = ".".join(str(x) for x in err.get("loc", ()))
+            msg = err.get("msg", "")
+            lines.append(f"  {loc}: {msg}")
+        return False, "\n".join(lines)
+    return True, str(config_path)
+
+
 def save_config(config: Config, config_path: Optional[Path] = None) -> None:
     """Save the config to the file."""
     if config_path is None:

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -530,12 +530,16 @@ def load_config(config_path: Optional[Path] = None) -> Config:
         return Config()
 
 
-def strict_validate_config_file(config_path: Optional[Path] = None) -> tuple[bool, str]:
+def strict_validate_config_file(
+    config_path: Optional[Path] = None,
+) -> tuple[bool, str]:
     """Validate *config_path* strictly for diagnostics (no auto-repair).
 
     Returns:
-        ``(True, summary)`` if the file is missing (defaults OK), readable, and valid.
-        ``(False, error)`` if the file is unreadable or fails :class:`Config` validation.
+        ``(True, summary)`` if the file is missing (defaults OK),
+        readable, and valid.
+        ``(False, error)`` if the file is unreadable or
+        fails :class:`Config` validation.
     """
     if config_path is None:
         config_path = get_config_path()

--- a/src/qwenpaw/utils/console_static.py
+++ b/src/qwenpaw/utils/console_static.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-CONSOLE_STATIC_ENV = "COPAW_CONSOLE_STATIC_DIR"
+from ..constant import EnvVarLoader
+
+# Primary env key (``COPAW_CONSOLE_STATIC_DIR`` is accepted as a legacy
+# fallback via :class:`~qwenpaw.constant.EnvVarLoader`).
+CONSOLE_STATIC_ENV = "QWENPAW_CONSOLE_STATIC_DIR"
 
 
 def resolve_console_static_dir() -> str:
     """Return the directory expected to contain ``index.html`` for the console.
 
-    Resolution order matches :mod:`copaw.app._app`: env override, package
-    ``copaw/console``, repo ``console/dist``, then cwd fallbacks.
+    Resolution order matches :mod:`qwenpaw.app._app`: env override, package
+    ``qwenpaw/console``, repo ``console/dist``, then cwd fallbacks.
     """
-    if os.environ.get(CONSOLE_STATIC_ENV):
-        return os.environ[CONSOLE_STATIC_ENV]
+    static_dir = EnvVarLoader.get_str("QWENPAW_CONSOLE_STATIC_DIR")
+    if static_dir:
+        return static_dir
 
     pkg_dir = Path(__file__).resolve().parent.parent
     candidate = pkg_dir / "console"
@@ -36,24 +41,26 @@ def resolve_console_static_dir() -> str:
     return str(cwd / "console" / "dist")
 
 
-def find_copaw_source_repo_root() -> Path | None:
-    """Return the git checkout root if this Python is running from CoPaw source.
+def find_qwenpaw_source_repo_root() -> Path | None:
+    """Return the git checkout root if this Python
+    is running from QwenPaw source.
 
-    Looks upward from :mod:`copaw` for ``console/package.json``,
-    ``console/package-lock.json``, and ``src/copaw/`` (bundled static target).
+    Looks upward from :mod:`qwenpaw` for ``console/package.json``,
+    ``console/package-lock.json``, and ``src/qwenpaw/``
+    (bundled static target).
     Returns ``None`` for a normal pip/wheel install.
     """
     try:
-        import copaw  # noqa: PLC0415 — avoid import cycle at module load
+        import qwenpaw  # noqa: PLC0415 — avoid import cycle at module load
     except Exception:  # pylint: disable=broad-exception-caught
         return None
-    cur = Path(copaw.__file__).resolve().parent
+    cur = Path(qwenpaw.__file__).resolve().parent
     for _ in range(20):
         con = cur / "console"
         if (
             (con / "package.json").is_file()
             and (con / "package-lock.json").is_file()
-            and (cur / "src" / "copaw").is_dir()
+            and (cur / "src" / "qwenpaw").is_dir()
         ):
             return cur
         if cur.parent == cur:

--- a/src/qwenpaw/utils/console_static.py
+++ b/src/qwenpaw/utils/console_static.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Resolve the web console static assets directory (shared by app and CLI)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+CONSOLE_STATIC_ENV = "COPAW_CONSOLE_STATIC_DIR"
+
+
+def resolve_console_static_dir() -> str:
+    """Return the directory expected to contain ``index.html`` for the console.
+
+    Resolution order matches :mod:`copaw.app._app`: env override, package
+    ``copaw/console``, repo ``console/dist``, then cwd fallbacks.
+    """
+    if os.environ.get(CONSOLE_STATIC_ENV):
+        return os.environ[CONSOLE_STATIC_ENV]
+
+    pkg_dir = Path(__file__).resolve().parent.parent
+    candidate = pkg_dir / "console"
+    if candidate.is_dir() and (candidate / "index.html").is_file():
+        return str(candidate)
+
+    repo_dir = pkg_dir.parent.parent
+    candidate = repo_dir / "console" / "dist"
+    if candidate.is_dir() and (candidate / "index.html").is_file():
+        return str(candidate)
+
+    cwd = Path(os.getcwd())
+    for subdir in ("console/dist", "console_dist"):
+        candidate = cwd / subdir
+        if candidate.is_dir() and (candidate / "index.html").is_file():
+            return str(candidate)
+
+    return str(cwd / "console" / "dist")
+
+
+def find_copaw_source_repo_root() -> Path | None:
+    """Return the git checkout root if this Python is running from CoPaw source.
+
+    Looks upward from :mod:`copaw` for ``console/package.json``,
+    ``console/package-lock.json``, and ``src/copaw/`` (bundled static target).
+    Returns ``None`` for a normal pip/wheel install.
+    """
+    try:
+        import copaw  # noqa: PLC0415 — avoid import cycle at module load
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    cur = Path(copaw.__file__).resolve().parent
+    for _ in range(20):
+        con = cur / "console"
+        if (
+            (con / "package.json").is_file()
+            and (con / "package-lock.json").is_file()
+            and (cur / "src" / "copaw").is_dir()
+        ):
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return None

--- a/src/qwenpaw/utils/system_info.py
+++ b/src/qwenpaw/utils/system_info.py
@@ -8,6 +8,8 @@ import os
 import platform
 import re
 import subprocess
+import sys
+from collections.abc import Mapping
 from typing import Any
 
 _BYTES_PER_GB = float(1024**3)
@@ -15,6 +17,28 @@ _CUDA_VERSION_PATTERNS = (
     re.compile(r"CUDA Version:\s*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE),
     re.compile(r"release\s+([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE),
 )
+
+
+def summarize_python_environment(
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Short label for the venv/conda context of current ``sys.executable``.
+
+    When *environ* is omitted, uses :data:`os.environ`. Passing a mapping is
+    mainly for tests.
+    """
+    env = os.environ if environ is None else environ
+    ve = (env.get("VIRTUAL_ENV") or "").strip()
+    if ve:
+        return ve
+    cenv = (env.get("CONDA_DEFAULT_ENV") or "").strip()
+    cpfx = (env.get("CONDA_PREFIX") or "").strip()
+    if cenv and cpfx:
+        return f"conda {cenv} ({cpfx})"
+    base = getattr(sys, "base_prefix", sys.prefix)
+    if sys.prefix != base:
+        return f"venv (sys.prefix={sys.prefix})"
+    return "system interpreter (no virtualenv in effect)"
 
 
 def get_os_name() -> str:

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -88,6 +88,91 @@ qwenpaw daemon version
 qwenpaw daemon logs -n 50
 ```
 
+### qwenpaw doctor
+
+Read-only diagnostics for your install: root `config.json` validation,
+workspaces, `agent.json`, channels, MCP, static console bundle, API
+reachability, active LLM / per-agent model checks, and more. **`doctor` by
+itself does not repair files** — use the separate **`doctor fix`** subcommand
+when you intend to change disk (that path creates backups by default).
+
+```bash
+qwenpaw doctor                      # Default checks
+qwenpaw doctor --deep               # Extra: enabled-channel probes + local llama notes
+qwenpaw doctor --port 8088          # Force API target (see note below)
+qwenpaw doctor fix --dry-run        # Preview planned fixes (no writes)
+qwenpaw doctor fix -y --only …      # Apply allowlisted fixes (see --help)
+```
+
+| Option          | Applies to | Purpose                                                               |
+| --------------- | ---------- | --------------------------------------------------------------------- |
+| `--timeout`     | `doctor`   | HTTP timeout for API / connectivity checks (default 5s)               |
+| `--llm-timeout` | `doctor`   | Timeout for model “ping” checks (default 15s)                         |
+| `--deep`        | `doctor`   | Outbound probes for enabled channels; extra notes for `qwenpaw-local` |
+
+**Which host/port does `doctor` hit?** Global `qwenpaw --host` / `--port`
+apply to every subcommand, including `doctor`. If you omit them, the CLI
+fills missing values from **`last_api` in `config.json`** (updated when
+`qwenpaw app` last ran). Only when `last_api` is absent do you get
+`127.0.0.1:8088`. If checks target the wrong port, pass `--port` explicitly or
+update `last_api`.
+
+**Side effects:** `doctor` may open the app log in append mode to verify
+writability (this can create an empty log file if missing). Model checks send
+minimal real requests to your configured providers (possible usage / billing).
+
+**`doctor fix`** applies conservative repairs under the working directory
+only.
+
+#### Recommended workflow (preview before apply)
+
+```bash
+qwenpaw doctor fix --dry-run
+# Narrow to the exact ids you want
+qwenpaw doctor fix --dry-run --only ensure-working-dir,ensure-workspace-dirs
+
+# Apply after you confirm the plan
+qwenpaw doctor fix --only ensure-working-dir,ensure-workspace-dirs
+```
+
+- `--dry-run` prints planned operations and does not write files.
+- Read-only validations in the plan (such as jobs.json validation) can still
+  return non-zero exit codes on FAIL (useful for CI gates).
+
+#### Fix ids at a glance
+
+Pass comma-separated ids with `--only`.
+
+- Common safe examples:
+  - `ensure-working-dir` - create working directory if missing
+  - `ensure-workspace-dirs` - create missing agent workspace directories
+- For the full list of fix ids and risk semantics, run:
+  - `qwenpaw doctor fix --help`
+- When `qwenpaw doctor` detects issues, output includes matching fix hints,
+  including suggested `doctor fix --dry-run --only ...` commands.
+
+#### Applying risky ids safely
+
+```bash
+qwenpaw doctor fix --dry-run --only seed-missing-agent-json,reset-invalid-agent-json
+qwenpaw doctor fix -y --only seed-missing-agent-json,reset-invalid-agent-json
+```
+
+- Risky ids require `-y` only when applying (without `--dry-run`).
+- `--non-interactive` allows only safe + read-only + skill-sync ids and still
+  rejects risky ids even with `-y`.
+
+#### Backups and restore
+
+By default, `doctor fix` writes backups to:
+
+- `doctor-fix-backups/<timestamp>/files/`
+
+Restore by copying files from the `files/` subtree back into your working
+directory using the same relative paths.
+
+> Avoid `--no-backup` unless you are sure you do not need rollback.
+
 ---
 
 ## Models & environment variables

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -117,10 +117,6 @@ fills missing values from **`last_api` in `config.json`** (updated when
 `127.0.0.1:8088`. If checks target the wrong port, pass `--port` explicitly or
 update `last_api`.
 
-**Side effects:** `doctor` may open the app log in append mode to verify
-writability (this can create an empty log file if missing). Model checks send
-minimal real requests to your configured providers (possible usage / billing).
-
 **`doctor fix`** applies conservative repairs under the working directory
 only.
 

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -81,6 +81,84 @@ qwenpaw daemon version
 qwenpaw daemon logs -n 50
 ```
 
+### qwenpaw doctor
+
+对当前安装做**只读**检查：根目录 `config.json` 校验、工作区、`agent.json`、
+频道、MCP、控制台静态资源、HTTP API 可达性、活跃模型与各 Agent 模型连通性
+等。**单独运行 `doctor` 不会修复磁盘**；需要改文件时请使用子命令
+**`qwenpaw doctor fix`**（默认会在 `doctor-fix-backups/` 下备份后再写）。
+
+```bash
+qwenpaw doctor                      # 默认检查
+qwenpaw doctor --deep               # 额外：已启用频道出站探测 + 本地 llama 提示
+qwenpaw doctor --port 8088          # 强制指定 API 端口（见下文说明）
+qwenpaw doctor fix --dry-run        # 仅打印计划，不写盘
+qwenpaw doctor fix -y --only …      # 应用白名单内的修复项（详见 --help）
+```
+
+| 选项            | 作用对象 | 说明                                               |
+| --------------- | -------- | -------------------------------------------------- |
+| `--timeout`     | `doctor` | API / 连通性相关 HTTP 超时（默认 5 秒）            |
+| `--llm-timeout` | `doctor` | 模型连通性检测超时（默认 15 秒）                   |
+| `--deep`        | `doctor` | 对已启用频道做出站探测；`qwenpaw-local` 时附加说明 |
+
+**`doctor` 连的是哪个 host/port？** 根命令上的 `qwenpaw --host` /
+`--port` 对所有子命令生效（含 `doctor`）。若未指定，CLI 会用
+**`config.json` 里持久化的 `last_api`**（一般在 `qwenpaw app` 启动时写入）
+补全缺省项；**仅当没有 `last_api` 时**才回落到 `127.0.0.1:8088`。若发现
+检查打到了错误端口，可显式加 `--port`，或改配置里的 `last_api`。
+
+**`doctor fix`** 只会在工作目录范围内做保守修复。
+
+#### 推荐流程（先预览，再执行）
+
+```bash
+qwenpaw doctor fix --dry-run
+# 缩小到你明确想执行的修复项
+qwenpaw doctor fix --dry-run --only ensure-working-dir,ensure-workspace-dirs
+
+# 确认计划无误后再执行
+qwenpaw doctor fix --only ensure-working-dir,ensure-workspace-dirs
+```
+
+- `--dry-run` 仅打印计划，不写盘。
+- 若计划里包含只读校验（如 jobs.json 校验），FAIL 时仍会返回非 0 退出码
+  （便于 CI 使用）。
+
+#### 修复项（fix ids）
+
+可通过 `--only` 传入逗号分隔的 id。
+
+- 常见安示例：
+  - `ensure-working-dir`：工作目录不存在时创建
+  - `ensure-workspace-dirs`：创建缺失的 agent workspace 目录
+- 完整 fix ids 列表与风险说明请查看：
+  - `qwenpaw doctor fix --help`
+- 当 `qwenpaw doctor` 检测到问题时，输出里会给出对应的修复提示（含建议
+  的 `doctor fix --dry-run --only ...` 命令）。
+
+#### 修复项的安全执行方式
+
+示例：
+
+```bash
+qwenpaw doctor fix --dry-run --only seed-missing-agent-json,reset-invalid-agent-json
+qwenpaw doctor fix -y --only seed-missing-agent-json,reset-invalid-agent-json
+```
+
+- `-y` 仅在真实执行（不带 `--dry-run`）时生效。
+- `--non-interactive` 只允许安全 + 只读 + 技能同步类修复项
+
+#### 备份与恢复
+
+默认会写备份到：
+
+- `doctor-fix-backups/<时间戳>/files/`
+
+恢复时，将 `files/` 子树中的文件按相同相对路径复制回工作目录即可。
+
+> 除非你非常确定不需要回滚，否则不建议使用 `--no-backup`。
+
 ---
 
 ## 模型与环境变量

--- a/website/public/docs/intro.en.md
+++ b/website/public/docs/intro.en.md
@@ -109,6 +109,6 @@ Each concept is explained in detail in its corresponding chapter.
    - [Magic Commands](./commands) — Use special commands to quickly control conversation state (like `/new` for new conversation, `/clear` to clear history, `/stop` to stop tasks, `/restart` to restart service, etc.) without waiting for AI to understand;
    - [Security](./security) — Configure tool protection, file protection, skill security scanning, and other security mechanisms;
    - [Heartbeat](./heartbeat) — Set up scheduled check-ins or digests (optional);
-   - [Scheduled tasks](./console#scheduled-tasks) or [CLI](./cli) — Manage scheduled tasks, clean working directory, etc.;
+   - [Scheduled tasks](./console#scheduled-tasks) or [CLI](./cli) — Scheduled tasks, `qwenpaw doctor` diagnostics, `qwenpaw doctor fix`, and more;
    - [Multi-Agent](./multi-agent) — Multi-agent configuration, management, and collaboration (v0.1.0+ feature);
    - [Config & working directory](./config) — Working directory and config file details.

--- a/website/public/docs/intro.zh.md
+++ b/website/public/docs/intro.zh.md
@@ -86,6 +86,6 @@ QwenPaw 由 [AgentScope 团队](https://github.com/agentscope-ai) 基于
    - [魔法命令](./commands) — 使用特殊命令快速控制对话状态（如 `/new` 开启新对话、`/clear` 清空历史、`/stop` 停止任务、`/restart` 重启服务等），无需等待 AI 理解；
    - [安全](./security) — 配置工具防护、文件防护、技能安全扫描等安全机制；
    - [心跳](./heartbeat) — 配置定时自检或摘要（可选）；
-   - [定时任务](./console#定时任务) 或 [CLI](./cli) — 管理定时任务、清空工作目录等；
+   - [定时任务](./console#定时任务) 或 [CLI](./cli) — 管理定时任务、`qwenpaw doctor` 诊断与 `qwenpaw doctor fix`、清空工作目录等；
    - [多智能体](./multi-agent) — 多智能体配置、管理与协作（v0.1.0+ 新功能）；
    - [配置与工作目录](./config) — 工作目录与配置文件说明。


### PR DESCRIPTION
## Description

This PR introduces the `qwenpaw doctor` cli command, including:
- read-only diagnostic checks for config validity, workspace/profile health, channel/MCP/static-console readiness, API reachability, and model connectivity
- optional deep checks for channel connectivity and additional local-runtime notes
- `qwenpaw doctor fix` with allowlisted repair actions, dry-run planning, risky-action gating, and backup-first execution
- supporting connectivity/registry/fix-runner modules and user-facing doctor hints
- website documentation updates for `doctor` / `doctor fix` usage and operational guidance
The goal is to provide a safer, more actionable troubleshooting flow for local setup and runtime issues.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
