### PR TITLE
feat(skills): improve skill selection UI

### DIFF
--- a/console/src/pages/Agent/Skills/components/PoolTransferModal.tsx
+++ b/console/src/pages/Agent/Skills/components/PoolTransferModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Button, Modal } from "@agentscope-ai/design";
+import { Button, Modal, Tooltip } from "@agentscope-ai/design";
 import { CheckOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { PoolSkillSpec, SkillSpec } from "../../../../api/types";
+import { isSkillBuiltin } from "@/utils/skill";
 import styles from "../index.module.less";
 
 interface PoolTransferModalProps {
@@ -52,6 +53,9 @@ export function PoolTransferModal({
     : setPoolSkillNames;
   const items = isUpload ? skills : poolSkills;
   const hasSelection = selectedNames.length > 0;
+  const builtinNames = items
+    .filter((item) => isSkillBuiltin(item.source))
+    .map((item) => item.name);
 
   return (
     <Modal
@@ -86,18 +90,28 @@ export function PoolTransferModal({
           <div className={styles.bulkActions}>
             <Button
               size="small"
-              onClick={() => setSelectedNames([])}
-              className={styles.bulkActionButton}
-            >
-              {t("skills.clearSelection")}
-            </Button>
-            <Button
-              size="small"
               type="primary"
               onClick={() => setSelectedNames(items.map((s) => s.name))}
               className={styles.bulkActionButton}
             >
               {t("skills.selectAll")}
+            </Button>
+            {!isUpload && (
+              <Button
+                size="small"
+                onClick={() => setSelectedNames(builtinNames)}
+                disabled={builtinNames.length === 0}
+                className={styles.bulkActionButton}
+              >
+                {t("agent.selectBuiltin")}
+              </Button>
+            )}
+            <Button
+              size="small"
+              onClick={() => setSelectedNames([])}
+              className={styles.bulkActionButton}
+            >
+              {t("skills.clearSelection")}
             </Button>
           </div>
         </div>
@@ -108,7 +122,7 @@ export function PoolTransferModal({
             return (
               <div
                 key={skill.name}
-                className={`${styles.pickerCard} ${
+                className={`${styles.pickerCard} ${styles.compactPickerCard} ${
                   selected ? styles.pickerCardSelected : ""
                 }`}
                 onClick={() =>
@@ -126,11 +140,13 @@ export function PoolTransferModal({
                     <CheckOutlined />
                   </span>
                 )}
-                <div
-                  className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
-                >
-                  {skill.name}
-                </div>
+                <Tooltip title={skill.name}>
+                  <div
+                    className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
+                  >
+                    {skill.name}
+                  </div>
+                </Tooltip>
               </div>
             );
           })}

--- a/console/src/pages/Agent/Skills/index.module.less
+++ b/console/src/pages/Agent/Skills/index.module.less
@@ -755,6 +755,7 @@
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.15s ease;
+  min-width: 0;
 
   &:hover {
     border-color: #ff7f16;
@@ -787,10 +788,15 @@
 }
 
 .pickerCardTitle {
+  display: block;
+  width: 100%;
   font-size: 14px;
   font-weight: 500;
   color: #1a1a1a;
-  word-break: break-all;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pickerCardMeta {
@@ -810,6 +816,7 @@
   padding: 8px 10px;
   display: flex;
   align-items: center;
+  min-width: 0;
 }
 
 .compactPickerCheck {
@@ -823,6 +830,7 @@
 .compactPickerTitle {
   font-size: 12px;
   line-height: 1.25;
+  width: 100%;
   padding-right: 18px;
 }
 

--- a/console/src/pages/Settings/SkillPool/components/BroadcastModal.tsx
+++ b/console/src/pages/Settings/SkillPool/components/BroadcastModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button, Modal } from "@agentscope-ai/design";
+import { Button, Modal, Tooltip } from "@agentscope-ai/design";
 import { CheckOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type {
@@ -72,6 +72,7 @@ export function BroadcastModal({
             <div className={styles.bulkActions}>
               <Button
                 size="small"
+                type="primary"
                 onClick={() => setSelectedSkillNames(skills.map((s) => s.name))}
               >
                 {t("agent.selectAll")}
@@ -113,11 +114,13 @@ export function BroadcastModal({
                     <CheckOutlined />
                   </span>
                 )}
-                <div
-                  className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
-                >
-                  {skill.name}
-                </div>
+                <Tooltip title={skill.name}>
+                  <div
+                    className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
+                  >
+                    {skill.name}
+                  </div>
+                </Tooltip>
               </div>
             );
           })}
@@ -130,6 +133,7 @@ export function BroadcastModal({
             <div className={styles.bulkActions}>
               <Button
                 size="small"
+                type="primary"
                 onClick={() =>
                   setSelectedWorkspaceIds(workspaces.map((ws) => ws.agent_id))
                 }
@@ -169,17 +173,27 @@ export function BroadcastModal({
                     <CheckOutlined />
                   </span>
                 )}
-                <div
-                  className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
-                >
-                  {getAgentDisplayName(
+                <Tooltip
+                  title={getAgentDisplayName(
                     {
                       id: workspace.agent_id,
                       name: workspace.agent_name ?? "",
                     },
                     t,
                   )}
-                </div>
+                >
+                  <div
+                    className={`${styles.pickerCardTitle} ${styles.compactPickerTitle}`}
+                  >
+                    {getAgentDisplayName(
+                      {
+                        id: workspace.agent_id,
+                        name: workspace.agent_name ?? "",
+                      },
+                      t,
+                    )}
+                  </div>
+                </Tooltip>
               </div>
             );
           })}

--- a/console/src/pages/Settings/SkillPool/components/ImportBuiltinModal.tsx
+++ b/console/src/pages/Settings/SkillPool/components/ImportBuiltinModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button, Modal } from "@agentscope-ai/design";
+import { Button, Modal, Tooltip } from "@agentscope-ai/design";
 import { CheckOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { BuiltinImportSpec } from "../../../../api/types";
@@ -52,6 +52,7 @@ export function ImportBuiltinModal({
         <div className={styles.bulkActions}>
           <Button
             size="small"
+            type="primary"
             onClick={() => setSelectedNames(sources.map((item) => item.name))}
           >
             {t("agent.selectAll")}
@@ -82,7 +83,9 @@ export function ImportBuiltinModal({
                     <CheckOutlined />
                   </span>
                 )}
-                <div className={styles.pickerCardTitle}>{item.name}</div>
+                <Tooltip title={item.name}>
+                  <div className={styles.pickerCardTitle}>{item.name}</div>
+                </Tooltip>
                 <div className={styles.pickerCardMeta}>
                   {t("skillPool.sourceVersion")}: {item.version_text || "-"}
                 </div>


### PR DESCRIPTION
## Description

This PR makes:
- Long skill names easier to read with ellipsis and tooltips, aligns button order and styles across dialogs
- Fixes picker card layout so selection states look consistent between load, sync, broadcast, and import flows.

Fix: #3270 4-5. 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
