### PR TITLE
fix(console): sort token usage by-date table in descending order

### DIFF
--- a/console/src/pages/Settings/TokenUsage/index.tsx
+++ b/console/src/pages/Settings/TokenUsage/index.tsx
@@ -68,11 +68,13 @@ function TokenUsagePage() {
 
   const byDateDataSource: ByDateRow[] = useMemo(() => {
     if (!data?.by_date) return [];
-    return Object.entries(data.by_date).map(([dt, stats]) => ({
-      ...stats,
-      key: dt,
-      date: dt,
-    }));
+    return Object.entries(data.by_date)
+      .map(([dt, stats]) => ({
+        ...stats,
+        key: dt,
+        date: dt,
+      }))
+      .sort((a, b) => b.date.localeCompare(a.date));
   }, [data?.by_date]);
 
   const byModelColumns: ColumnsType<ByModelRow> = useMemo(


### PR DESCRIPTION
## Description

The Token Usage page's "by date" table currently renders rows in the order returned by the backend (ascending by date), forcing users to scroll to the bottom to see the most recent day. This PR sorts the by-date rows in descending order so the latest date appears first.

**Related Issue:** Fixes agentscope-ai/QwenPaw#3368

**Security Considerations:** None. Frontend-only display sort.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open Settings → Token Usage.
2. Confirm the "By Date" table now lists the most recent date at the top.

## Local Verification Evidence

```bash
npx prettier --check console/src/pages/Settings/TokenUsage/index.tsx
# All matched files use Prettier code style!
```

## Additional Notes

Single-line change in `byDateDataSource` memo — added `.sort((a, b) => b.date.localeCompare(a.date))`. Dates are ISO `YYYY-MM-DD` strings, so lexicographic comparison is equivalent to chronological.