### PR TITLE
feat(security): add shell evasion guard

### DIFF
--- a/src/qwenpaw/security/tool_guard/engine.py
+++ b/src/qwenpaw/security/tool_guard/engine.py
@@ -25,6 +25,7 @@ from ...constant import EnvVarLoader
 from .guardians import BaseToolGuardian
 from .guardians.file_guardian import FilePathToolGuardian
 from .guardians.rule_guardian import RuleBasedToolGuardian
+from .guardians.shell_evasion_guardian import ShellEvasionGuardian
 from .models import ToolGuardResult
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,13 @@ class ToolGuardEngine:
         except Exception as exc:  # pragma: no cover
             logger.warning(
                 "Failed to initialise RuleBasedToolGuardian: %s",
+                exc,
+            )
+        try:
+            guardians.append(ShellEvasionGuardian())
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "Failed to initialise ShellEvasionGuardian: %s",
                 exc,
             )
         return guardians

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -21,7 +21,7 @@ from ..models import GuardFinding, GuardSeverity, GuardThreatCategory
 from . import BaseToolGuardian
 
 # ── Command substitution patterns ────────────────────────────────────
-# Checked against unquoted (outside single-quote) content.
+# Checked against content outside single quotes.
 _COMMAND_SUBSTITUTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"<\("), "process substitution <()"),
     (re.compile(r">\("), "process substitution >()"),
@@ -31,7 +31,6 @@ _COMMAND_SUBSTITUTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "Zsh equals expansion (=cmd)",
     ),
     (re.compile(r"\$\("), "$() command substitution"),
-    (re.compile(r"\$\{"), "${} parameter substitution"),
     (re.compile(r"\$\["), "$[] legacy arithmetic expansion"),
     (re.compile(r"~\["), "Zsh-style parameter expansion"),
     (re.compile(r"\(e:"), "Zsh-style glob qualifiers"),
@@ -52,9 +51,6 @@ _LOCALE_QUOTE_RE = re.compile(r'\$"[^"]*"')
 _EMPTY_SPECIAL_QUOTE_DASH_RE = re.compile(r"\$['\"]{2}\s*-")
 _EMPTY_QUOTE_DASH_RE = re.compile(r"(?:^|\s)(?:''|\"\")+\s*-")
 _EMPTY_PAIR_QUOTED_DASH_RE = re.compile(r"""(?:""|'')+['"]- """)
-_CONSECUTIVE_QUOTES_RE = re.compile(r"(?:^|\s)['\"]{ 3,}")
-
-
 # =====================================================================
 # Quote-state tracker
 # =====================================================================
@@ -97,18 +93,18 @@ class _QuoteState:
             self.in_double = not self.in_double
 
 
-def _extract_unquoted(command: str) -> str:
-    """Return *command* with all single- and double-quoted content removed.
+def _extract_outside_single_quotes(command: str) -> str:
+    """Return *command* with only single-quoted content removed.
 
-    Backslash escaping outside single quotes is respected.  The result
-    contains only characters that the shell would interpret as unquoted.
+    Keep double-quoted content because shell still expands command
+    substitutions inside double quotes.
     """
     state = _QuoteState()
     parts: list[str] = []
     for ch in command:
-        was_quoted = state.in_any_quote
+        was_single = state.in_single
         state.feed(ch)
-        if not was_quoted and not state.in_any_quote and not state.escaped:
+        if not was_single and not state.in_single:
             parts.append(ch)
     return "".join(parts)
 
@@ -128,14 +124,15 @@ def _check_command_substitution(
     Also detects unescaped backticks (outside quotes) which are the
     legacy command substitution syntax.
     """
-    # Backtick check: unescaped ` outside quotes
+    # Backtick check: unescaped ` outside single quotes.
+    # Backticks inside double quotes are still command substitution.
     state = _QuoteState()
     for i, ch in enumerate(command):
         if state.escaped:
             state.feed(ch)
             continue
         state.feed(ch)
-        if ch == "`" and not state.in_any_quote and not state.escaped:
+        if ch == "`" and not state.in_single and not state.escaped:
             snippet_start = max(0, i - 20)
             snippet_end = min(len(command), i + 20)
             return _finding(
@@ -277,10 +274,19 @@ def _check_backslash_escaped_operators(
     split on re-parsing, enabling arbitrary file reads that bypass path
     validation.
     """
+    find_exec_terminator_re = re.compile(
+        r"-(?:exec|execdir)\b[\s\S]*\{\}\s*\\;$",
+    )
     state = _QuoteState()
     for i, ch in enumerate(command):
         if state.escaped:
             if not state.in_double and ch in _SHELL_OPERATORS:
+                # find ... -exec ... {} \; is normal shell syntax.
+                if ch == ";":
+                    prefix = command[: i + 1]
+                    if find_exec_terminator_re.search(prefix):
+                        state.feed(ch)
+                        continue
                 return _finding(
                     "SHELL_EVASION_BACKSLASH_OPERATOR",
                     GuardSeverity.HIGH,
@@ -299,6 +305,11 @@ def _check_newlines(command: str) -> GuardFinding | None:
     """bashSecurity #7: detect newlines and carriage returns that could
     separate hidden commands.
     """
+    # Heredoc intentionally relies on multiline input and should not be
+    # treated as hidden-command splitting.
+    if _looks_like_heredoc(command):
+        return None
+
     # Carriage return outside double quotes (misparsing concern)
     state = _QuoteState()
     for ch in command:
@@ -324,7 +335,7 @@ def _check_newlines(command: str) -> GuardFinding | None:
         state.feed(ch)
         if ch in ("\n", "\r") and not state.in_any_quote:
             rest = command[i + 1 :]
-            if rest.lstrip() and not rest.lstrip()[0:1] == "":
+            if rest.lstrip():
                 return _finding(
                     "SHELL_EVASION_NEWLINE",
                     GuardSeverity.HIGH,
@@ -334,6 +345,25 @@ def _check_newlines(command: str) -> GuardFinding | None:
                 )
 
     return None
+
+
+def _looks_like_heredoc(command: str) -> bool:
+    """Return True when command appears to include a complete heredoc."""
+    opener_re = re.compile(
+        r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1",
+    )
+    lines = command.splitlines()
+    if len(lines) < 2:
+        return False
+    for i, line in enumerate(lines):
+        m = opener_re.search(line)
+        if not m:
+            continue
+        delim = m.group(2)
+        for next_line in lines[i + 1 :]:
+            if next_line.strip() == delim:
+                return True
+    return False
 
 
 def _check_comment_quote_desync(command: str) -> GuardFinding | None:
@@ -456,8 +486,7 @@ def _finding(
 # Guardian class
 # =====================================================================
 
-# All checks, executed in order. Short-circuit on first finding to keep
-# the approval dialog focused on the primary concern.
+# All checks, executed in order, collecting all matched findings.
 _ShellCheckFn = Callable[..., GuardFinding | None]
 _CHECKS: tuple[_ShellCheckFn, ...] = (
     _check_command_substitution,
@@ -493,8 +522,8 @@ class ShellEvasionGuardian(BaseToolGuardian):
         if not isinstance(command, str) or not command.strip():
             return []
 
-        # Pre-compute unquoted content for checks that need it.
-        unquoted = _extract_unquoted(command)
+        # Pre-compute content outside single quotes for checks that need it.
+        outside_single_quotes = _extract_outside_single_quotes(command)
 
         findings: list[GuardFinding] = []
         for check in _CHECKS:
@@ -502,7 +531,7 @@ class ShellEvasionGuardian(BaseToolGuardian):
             # others take only the raw command.
             try:
                 if check is _check_command_substitution:
-                    result = check(command, unquoted)
+                    result = check(command, outside_single_quotes)
                 else:
                     result = check(command)
             except Exception:

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -181,7 +181,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
         return _finding(
             "SHELL_EVASION_OBFUSCATED_FLAGS",
             GuardSeverity.HIGH,
-            "Command contains locale quoting ($\"...\") which can hide characters",
+            'Command contains locale quoting ($"...") which can hide characters',
             command,
         )
 
@@ -358,7 +358,9 @@ def _check_comment_quote_desync(command: str) -> GuardFinding | None:
                     "Command contains quote characters inside a # comment"
                     " which can desync quote tracking",
                     command,
-                    matched=command[i : (line_end if line_end != -1 else i + 40)],
+                    matched=command[
+                        i : (line_end if line_end != -1 else i + 40)
+                    ],
                 )
             # Skip rest of comment line
             if line_end == -1:
@@ -398,7 +400,9 @@ def _check_quoted_newline(command: str) -> GuardFinding | None:
                     " #-prefixed line, which can hide arguments from"
                     " line-based permission checks",
                     command,
-                    matched=command[max(0, i - 10) : min(len(command), line_end + 10)],
+                    matched=command[
+                        max(0, i - 10) : min(len(command), line_end + 10)
+                    ],
                 )
 
     return None

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 import re
 import uuid
+import logging
 from typing import Any, Callable
 
 from ..models import GuardFinding, GuardSeverity, GuardThreatCategory
 from . import BaseToolGuardian
+
+logger = logging.getLogger(__name__)
 
 # ── Command substitution patterns ────────────────────────────────────
 # Checked against content outside single quotes.
@@ -50,7 +53,6 @@ _ANSI_C_QUOTE_RE = re.compile(r"\$'[^']*'")
 _LOCALE_QUOTE_RE = re.compile(r'\$"[^"]*"')
 _EMPTY_SPECIAL_QUOTE_DASH_RE = re.compile(r"\$['\"]{2}\s*-")
 _EMPTY_QUOTE_DASH_RE = re.compile(r"(?:^|\s)(?:''|\"\")+\s*-")
-_EMPTY_PAIR_QUOTED_DASH_RE = re.compile(r"""(?:""|'')+['"]- """)
 # =====================================================================
 # Quote-state tracker
 # =====================================================================
@@ -58,10 +60,6 @@ _EMPTY_PAIR_QUOTED_DASH_RE = re.compile(r"""(?:""|'')+['"]- """)
 
 class _QuoteState:
     """Tracks shell quoting context character-by-character.
-
-    Mirrors the logic in Claude Code's ``extractQuotedContent`` and the
-    quote trackers used by ``validateObfuscatedFlags``,
-    ``hasBackslashEscapedWhitespace``, etc.
     """
 
     __slots__ = ("in_single", "in_double", "escaped")
@@ -534,7 +532,13 @@ class ShellEvasionGuardian(BaseToolGuardian):
                     result = check(command, outside_single_quotes)
                 else:
                     result = check(command)
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "ShellEvasionGuardian check failed: %s: %s",
+                    getattr(check, "__name__", str(check)),
+                    exc,
+                    exc_info=True,
+                )
                 continue
             if result is not None:
                 findings.append(result)

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -59,8 +59,7 @@ _EMPTY_QUOTE_DASH_RE = re.compile(r"(?:^|\s)(?:''|\"\")+\s*-")
 
 
 class _QuoteState:
-    """Tracks shell quoting context character-by-character.
-    """
+    """Tracks shell quoting context character-by-character."""
 
     __slots__ = ("in_single", "in_double", "escaped")
 

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from typing import Any
+from typing import Any, Callable
 
 from ..models import GuardFinding, GuardSeverity, GuardThreatCategory
 from . import BaseToolGuardian
@@ -173,7 +173,8 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
         return _finding(
             "SHELL_EVASION_OBFUSCATED_FLAGS",
             GuardSeverity.HIGH,
-            "Command contains ANSI-C quoting ($'...') which can hide characters",
+            "Command contains ANSI-C quoting ($'...') "
+            "which can hide characters",
             command,
         )
 
@@ -181,7 +182,8 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
         return _finding(
             "SHELL_EVASION_OBFUSCATED_FLAGS",
             GuardSeverity.HIGH,
-            'Command contains locale quoting ($"...") which can hide characters',
+            'Command contains locale quoting ($"...") '
+            "which can hide characters",
             command,
         )
 
@@ -189,7 +191,8 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
         return _finding(
             "SHELL_EVASION_OBFUSCATED_FLAGS",
             GuardSeverity.HIGH,
-            "Command contains empty special quotes before dash (potential bypass)",
+            "Command contains empty special quotes before dash "
+            "(potential bypass)",
             command,
         )
 
@@ -197,7 +200,8 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
         return _finding(
             "SHELL_EVASION_OBFUSCATED_FLAGS",
             GuardSeverity.HIGH,
-            "Command contains empty quotes before dash (potential flag bypass)",
+            "Command contains empty quotes before dash "
+            "(potential flag bypass)",
             command,
         )
 
@@ -224,7 +228,8 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
                     return _finding(
                         "SHELL_EVASION_OBFUSCATED_FLAGS",
                         GuardSeverity.HIGH,
-                        "Command contains quoted flag name (potential obfuscation)",
+                        "Command contains quoted flag name "
+                        "(potential obfuscation)",
                         command,
                         matched=command[i : j + 1],
                     )
@@ -453,7 +458,8 @@ def _finding(
 
 # All checks, executed in order. Short-circuit on first finding to keep
 # the approval dialog focused on the primary concern.
-_CHECKS = [
+_ShellCheckFn = Callable[..., GuardFinding | None]
+_CHECKS: tuple[_ShellCheckFn, ...] = (
     _check_command_substitution,
     _check_obfuscated_flags,
     _check_backslash_escaped_whitespace,
@@ -461,7 +467,7 @@ _CHECKS = [
     _check_newlines,
     _check_comment_quote_desync,
     _check_quoted_newline,
-]
+)
 
 
 class ShellEvasionGuardian(BaseToolGuardian):

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+"""Quote-aware shell evasion and obfuscation detection guardian.
+
+The checks detect obfuscation/evasion techniques that attempt to hide
+malicious intent from simpler regex-only detection:
+
+- Command substitution patterns ($(), ``, ${}, =(), <(), etc.)
+- ANSI-C quoting ($'...') and locale quoting ($"...") flag obfuscation
+- Backslash-escaped whitespace and shell operators
+- Newlines / carriage returns that split hidden commands
+- Comment-quote desync attacks
+- Quoted newline + comment-line stripping attacks
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from ..models import GuardFinding, GuardSeverity, GuardThreatCategory
+from . import BaseToolGuardian
+
+# ── Command substitution patterns ────────────────────────────────────
+# Checked against unquoted (outside single-quote) content.
+_COMMAND_SUBSTITUTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"<\("), "process substitution <()"),
+    (re.compile(r">\("), "process substitution >()"),
+    (re.compile(r"=\("), "Zsh process substitution =()"),
+    (
+        re.compile(r"(?:^|[\s;&|])=[a-zA-Z_]"),
+        "Zsh equals expansion (=cmd)",
+    ),
+    (re.compile(r"\$\("), "$() command substitution"),
+    (re.compile(r"\$\{"), "${} parameter substitution"),
+    (re.compile(r"\$\["), "$[] legacy arithmetic expansion"),
+    (re.compile(r"~\["), "Zsh-style parameter expansion"),
+    (re.compile(r"\(e:"), "Zsh-style glob qualifiers"),
+    (re.compile(r"\(\+"), "Zsh glob qualifier with command execution"),
+    (
+        re.compile(r"\}\s*always\s*\{"),
+        "Zsh always block (try/always construct)",
+    ),
+    (re.compile(r"<#"), "PowerShell comment syntax"),
+]
+
+# Shell operators whose preceding backslash indicates evasion.
+_SHELL_OPERATORS = frozenset(";|&<>")
+
+# ANSI-C quoting: $'...' or locale quoting: $"..."
+_ANSI_C_QUOTE_RE = re.compile(r"\$'[^']*'")
+_LOCALE_QUOTE_RE = re.compile(r'\$"[^"]*"')
+_EMPTY_SPECIAL_QUOTE_DASH_RE = re.compile(r"\$['\"]{2}\s*-")
+_EMPTY_QUOTE_DASH_RE = re.compile(r"(?:^|\s)(?:''|\"\")+\s*-")
+_EMPTY_PAIR_QUOTED_DASH_RE = re.compile(r"""(?:""|'')+['"]- """)
+_CONSECUTIVE_QUOTES_RE = re.compile(r"(?:^|\s)['\"]{ 3,}")
+
+
+# =====================================================================
+# Quote-state tracker
+# =====================================================================
+
+
+class _QuoteState:
+    """Tracks shell quoting context character-by-character.
+
+    Mirrors the logic in Claude Code's ``extractQuotedContent`` and the
+    quote trackers used by ``validateObfuscatedFlags``,
+    ``hasBackslashEscapedWhitespace``, etc.
+    """
+
+    __slots__ = ("in_single", "in_double", "escaped")
+
+    def __init__(self) -> None:
+        self.in_single = False
+        self.in_double = False
+        self.escaped = False
+
+    @property
+    def in_any_quote(self) -> bool:
+        return self.in_single or self.in_double
+
+    def feed(self, char: str) -> None:
+        """Advance the state machine by one character."""
+        if self.escaped:
+            self.escaped = False
+            return
+
+        if char == "\\" and not self.in_single:
+            self.escaped = True
+            return
+
+        if char == "'" and not self.in_double:
+            self.in_single = not self.in_single
+            return
+
+        if char == '"' and not self.in_single:
+            self.in_double = not self.in_double
+
+
+def _extract_unquoted(command: str) -> str:
+    """Return *command* with all single- and double-quoted content removed.
+
+    Backslash escaping outside single quotes is respected.  The result
+    contains only characters that the shell would interpret as unquoted.
+    """
+    state = _QuoteState()
+    parts: list[str] = []
+    for ch in command:
+        was_quoted = state.in_any_quote
+        state.feed(ch)
+        if not was_quoted and not state.in_any_quote and not state.escaped:
+            parts.append(ch)
+    return "".join(parts)
+
+
+# =====================================================================
+# Individual check functions
+# =====================================================================
+# Each returns a GuardFinding or None.
+
+
+def _check_command_substitution(
+    command: str,
+    unquoted: str,
+) -> GuardFinding | None:
+    """bashSecurity #8: detect command substitution patterns.
+
+    Also detects unescaped backticks (outside quotes) which are the
+    legacy command substitution syntax.
+    """
+    # Backtick check: unescaped ` outside quotes
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            state.feed(ch)
+            continue
+        state.feed(ch)
+        if ch == "`" and not state.in_any_quote and not state.escaped:
+            snippet_start = max(0, i - 20)
+            snippet_end = min(len(command), i + 20)
+            return _finding(
+                "SHELL_EVASION_COMMAND_SUBSTITUTION",
+                GuardSeverity.HIGH,
+                "Command contains backtick (`) command substitution",
+                command,
+                matched=command[snippet_start:snippet_end],
+                snippet=command[snippet_start:snippet_end],
+            )
+
+    # Other patterns checked against unquoted content
+    for pattern, label in _COMMAND_SUBSTITUTION_PATTERNS:
+        m = pattern.search(unquoted)
+        if m:
+            return _finding(
+                "SHELL_EVASION_COMMAND_SUBSTITUTION",
+                GuardSeverity.HIGH,
+                f"Command contains {label}",
+                command,
+                matched=m.group(0),
+                pattern=pattern.pattern,
+            )
+    return None
+
+
+def _check_obfuscated_flags(command: str) -> GuardFinding | None:
+    """bashSecurity #4: detect ANSI-C / locale quoting and empty-quote
+    flag obfuscation.
+
+    These quoting mechanisms can hide flag characters (e.g. ``$'\\x2d exec'``
+    hides ``-exec``) and bypass regex-based flag detection.
+    """
+    if _ANSI_C_QUOTE_RE.search(command):
+        return _finding(
+            "SHELL_EVASION_OBFUSCATED_FLAGS",
+            GuardSeverity.HIGH,
+            "Command contains ANSI-C quoting ($'...') which can hide characters",
+            command,
+        )
+
+    if _LOCALE_QUOTE_RE.search(command):
+        return _finding(
+            "SHELL_EVASION_OBFUSCATED_FLAGS",
+            GuardSeverity.HIGH,
+            "Command contains locale quoting ($\"...\") which can hide characters",
+            command,
+        )
+
+    if _EMPTY_SPECIAL_QUOTE_DASH_RE.search(command):
+        return _finding(
+            "SHELL_EVASION_OBFUSCATED_FLAGS",
+            GuardSeverity.HIGH,
+            "Command contains empty special quotes before dash (potential bypass)",
+            command,
+        )
+
+    if _EMPTY_QUOTE_DASH_RE.search(command):
+        return _finding(
+            "SHELL_EVASION_OBFUSCATED_FLAGS",
+            GuardSeverity.HIGH,
+            "Command contains empty quotes before dash (potential flag bypass)",
+            command,
+        )
+
+    # Quoted flag content: whitespace + quote + dash-letter inside quote
+    state = _QuoteState()
+    prev_char = ""
+    for i, ch in enumerate(command):
+        if state.escaped:
+            state.feed(ch)
+            prev_char = ch
+            continue
+
+        if not state.in_any_quote and prev_char in (" ", "\t"):
+            if ch in ("'", '"'):
+                # Peek inside the quote to see if it starts with a dash
+                quote_char = ch
+                j = i + 1
+                inside = []
+                while j < len(command) and command[j] != quote_char:
+                    inside.append(command[j])
+                    j += 1
+                content = "".join(inside)
+                if re.match(r"^-+[a-zA-Z0-9$`]", content):
+                    return _finding(
+                        "SHELL_EVASION_OBFUSCATED_FLAGS",
+                        GuardSeverity.HIGH,
+                        "Command contains quoted flag name (potential obfuscation)",
+                        command,
+                        matched=command[i : j + 1],
+                    )
+
+        state.feed(ch)
+        prev_char = ch
+
+    return None
+
+
+def _check_backslash_escaped_whitespace(
+    command: str,
+) -> GuardFinding | None:
+    """bashSecurity #15: detect backslash-escaped space/tab outside quotes.
+
+    ``echo\\ test`` is a single token in bash (command named "echo test"),
+    but parsers may decode the escape and produce two separate tokens.
+    This enables path traversal and command hiding.
+    """
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            if not state.in_double and ch in (" ", "\t"):
+                return _finding(
+                    "SHELL_EVASION_BACKSLASH_WHITESPACE",
+                    GuardSeverity.HIGH,
+                    "Command contains backslash-escaped whitespace"
+                    " that could alter command parsing",
+                    command,
+                    matched=command[max(0, i - 1) : i + 1],
+                )
+            state.feed(ch)
+            continue
+        state.feed(ch)
+    return None
+
+
+def _check_backslash_escaped_operators(
+    command: str,
+) -> GuardFinding | None:
+    r"""bashSecurity #21: detect ``\;``, ``\|``, ``\&``, ``\<``, ``\>``
+    outside quotes.
+
+    splitCommand normalises ``\;`` to bare ``;`` which causes a false
+    split on re-parsing, enabling arbitrary file reads that bypass path
+    validation.
+    """
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            if not state.in_double and ch in _SHELL_OPERATORS:
+                return _finding(
+                    "SHELL_EVASION_BACKSLASH_OPERATOR",
+                    GuardSeverity.HIGH,
+                    f"Command contains backslash before shell operator"
+                    f" (\\{ch}) which can hide command structure",
+                    command,
+                    matched=command[max(0, i - 1) : i + 1],
+                )
+            state.feed(ch)
+            continue
+        state.feed(ch)
+    return None
+
+
+def _check_newlines(command: str) -> GuardFinding | None:
+    """bashSecurity #7: detect newlines and carriage returns that could
+    separate hidden commands.
+    """
+    # Carriage return outside double quotes (misparsing concern)
+    state = _QuoteState()
+    for ch in command:
+        if state.escaped:
+            state.feed(ch)
+            continue
+        state.feed(ch)
+        if ch == "\r" and not state.in_double:
+            return _finding(
+                "SHELL_EVASION_NEWLINE",
+                GuardSeverity.HIGH,
+                "Command contains carriage return (\\r) which shell-quote"
+                " and bash tokenize differently",
+                command,
+            )
+
+    # Newline outside quotes followed by non-whitespace (hidden command)
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            state.feed(ch)
+            continue
+        state.feed(ch)
+        if ch in ("\n", "\r") and not state.in_any_quote:
+            rest = command[i + 1 :]
+            if rest.lstrip() and not rest.lstrip()[0:1] == "":
+                return _finding(
+                    "SHELL_EVASION_NEWLINE",
+                    GuardSeverity.HIGH,
+                    "Command contains newlines that could separate"
+                    " multiple commands",
+                    command,
+                )
+
+    return None
+
+
+def _check_comment_quote_desync(command: str) -> GuardFinding | None:
+    """bashSecurity #22: detect quote characters inside ``#`` comments.
+
+    Everything after an unquoted ``#`` is a comment in bash, but quote
+    trackers don't handle comments — a ``'`` or ``"`` in a comment
+    desyncs quote state tracking for subsequent lines.
+    """
+    if "#" not in command:
+        return None
+
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            state.feed(ch)
+            continue
+        state.feed(ch)
+
+        if ch == "#" and not state.in_any_quote:
+            line_end = command.find("\n", i)
+            comment = command[i + 1 : line_end if line_end != -1 else None]
+            if re.search(r"['\"]", comment):
+                return _finding(
+                    "SHELL_EVASION_COMMENT_QUOTE_DESYNC",
+                    GuardSeverity.HIGH,
+                    "Command contains quote characters inside a # comment"
+                    " which can desync quote tracking",
+                    command,
+                    matched=command[i : (line_end if line_end != -1 else i + 40)],
+                )
+            # Skip rest of comment line
+            if line_end == -1:
+                break
+
+    return None
+
+
+def _check_quoted_newline(command: str) -> GuardFinding | None:
+    """bashSecurity #23: detect newlines inside quoted strings where the
+    next line starts with ``#``.
+
+    Line-based processing (like stripCommentLines) drops ``#``-prefixed
+    lines without tracking quote state, hiding arguments from path
+    validation.
+    """
+    if "\n" not in command or "#" not in command:
+        return None
+
+    state = _QuoteState()
+    for i, ch in enumerate(command):
+        if state.escaped:
+            state.feed(ch)
+            continue
+        state.feed(ch)
+
+        if ch == "\n" and state.in_any_quote:
+            line_start = i + 1
+            next_nl = command.find("\n", line_start)
+            line_end = next_nl if next_nl != -1 else len(command)
+            next_line = command[line_start:line_end]
+            if next_line.strip().startswith("#"):
+                return _finding(
+                    "SHELL_EVASION_QUOTED_NEWLINE",
+                    GuardSeverity.HIGH,
+                    "Command contains a quoted newline followed by a"
+                    " #-prefixed line, which can hide arguments from"
+                    " line-based permission checks",
+                    command,
+                    matched=command[max(0, i - 10) : min(len(command), line_end + 10)],
+                )
+
+    return None
+
+
+# =====================================================================
+# Finding factory
+# =====================================================================
+
+
+def _finding(
+    rule_id: str,
+    severity: GuardSeverity,
+    description: str,
+    command: str,
+    *,
+    matched: str | None = None,
+    pattern: str | None = None,
+    snippet: str | None = None,
+) -> GuardFinding:
+    return GuardFinding(
+        id=f"GUARD-{uuid.uuid4().hex}",
+        rule_id=rule_id,
+        category=GuardThreatCategory.CODE_EXECUTION,
+        severity=severity,
+        title=f"[{severity.value}] {description}",
+        description=(
+            f"ShellEvasionGuardian: {description}\n\n"
+            "This pattern is commonly used to bypass shell command"
+            " security checks."
+        ),
+        tool_name="execute_shell_command",
+        param_name="command",
+        matched_value=matched,
+        matched_pattern=pattern,
+        snippet=snippet or command[:120],
+        remediation=(
+            "Review the command carefully. If the pattern is"
+            " intentional, approve manually."
+        ),
+        guardian="shell_evasion_guardian",
+    )
+
+
+# =====================================================================
+# Guardian class
+# =====================================================================
+
+# All checks, executed in order. Short-circuit on first finding to keep
+# the approval dialog focused on the primary concern.
+_CHECKS = [
+    _check_command_substitution,
+    _check_obfuscated_flags,
+    _check_backslash_escaped_whitespace,
+    _check_backslash_escaped_operators,
+    _check_newlines,
+    _check_comment_quote_desync,
+    _check_quoted_newline,
+]
+
+
+class ShellEvasionGuardian(BaseToolGuardian):
+    """Quote-aware shell evasion / obfuscation detection.
+
+    Detects command substitution, flag obfuscation, backslash-escaped
+    whitespace/operators, hidden newlines, comment-quote desync, and
+    quoted-newline attacks.  Only fires for ``execute_shell_command``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="shell_evasion_guardian")
+
+    def guard(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> list[GuardFinding]:
+        if tool_name != "execute_shell_command":
+            return []
+
+        command = params.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return []
+
+        # Pre-compute unquoted content for checks that need it.
+        unquoted = _extract_unquoted(command)
+
+        findings: list[GuardFinding] = []
+        for check in _CHECKS:
+            # Checks that need unquoted content have 2-arg signature;
+            # others take only the raw command.
+            try:
+                if check is _check_command_substitution:
+                    result = check(command, unquoted)
+                else:
+                    result = check(command)
+            except Exception:
+                continue
+            if result is not None:
+                findings.append(result)
+
+        return findings


### PR DESCRIPTION
## Description

Adds **`ShellEvasionGuardian`**, a quote-aware pre-execution check for `execute_shell_command` that flags common shell obfuscation / evasion patterns (for example command substitution, ANSI-C / locale quoting and empty-quote flag tricks, backslash-escaped whitespace and shell operators, suspicious newlines / `\r`, `#`-comment quote desync, and quoted-newline + `#`-line patterns). Findings are produced through the existing **Tool Guard** pipeline (`ToolGuardEngine` runs this guardian alongside the default rule- and file-path guardians).

**Related Issue:** N/A (replace with `Fixes #…` / `Relates to #…` if you have one)

**Security Considerations:** Defense-in-depth only: scanning happens **before** the shell tool runs; severity and approval behavior follow existing Tool Guard / approval UX. This does not replace OS-level sandboxing or channel auth; misclassification remains possible for unusual but legitimate commands, so users may still need to review or approve per existing flows.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass *(please run and tick if you did)*
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Ensure Tool Guard is enabled (default / `QWENPAW_TOOL_GUARD_ENABLED` / config as usual).
2. Trigger an agent (or any path that calls `ToolGuardEngine.guard`) with tool **`execute_shell_command`** and a `command` string that should match one of the guardian checks, for example:
   - `echo $(whoami)` → command substitution finding
   - `echo $'-n'` → obfuscated-flag style finding
   - `echo\ hello` → backslash-escaped whitespace
   - `true \; false` → backslash before operator
   - A command containing an unquoted newline between two tokens → newline finding
3. Confirm the aggregated guard result includes findings from **`shell_evasion_guardian`** and that the existing approval / blocked-tool UX still behaves as before for other guardians.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed (mypy, black, flake8, pylint, prettier, etc.)

pytest