### PR TITLE
fix(provider): serialize models in get_info() to prevent pydantic class-identity crash

### DIFF
--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -211,7 +211,7 @@ class Provider(ProviderInfo, ABC):
                 ModelInfo.model_validate(
                     model.model_dump()
                     if isinstance(model, BaseModel)
-                    else model
+                    else model,
                 )
                 for model in config["extra_models"]
             ]

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -205,10 +205,14 @@ class Provider(ProviderInfo, ABC):
         ):
             self.generate_kwargs = config["generate_kwargs"]
         if "extra_models" in config and config["extra_models"] is not None:
+            # Always go through model_validate with dict data to
+            # avoid class-identity issues from dual module loading.
             self.extra_models = [
-                model
-                if isinstance(model, ModelInfo)
-                else ModelInfo.model_validate(model)
+                ModelInfo.model_validate(
+                    model.model_dump()
+                    if isinstance(model, BaseModel)
+                    else model
+                )
                 for model in config["extra_models"]
             ]
 
@@ -313,14 +317,19 @@ class Provider(ProviderInfo, ABC):
             if mock_secret and self.api_key
             else self.api_key
         )
+        # Serialize models/extra_models to plain dicts so that
+        # ProviderInfo constructs fresh ModelInfo instances using
+        # the class in its own module scope.  This avoids pydantic
+        # class-identity mismatches when the same module is loaded
+        # via two different import paths (e.g. PYTHONPATH + pip install).
         return ProviderInfo(
             id=self.id,
             name=self.name,
             base_url=self.base_url,
             api_key=api_key,
             chat_model=self.chat_model,
-            models=self.models,
-            extra_models=self.extra_models,
+            models=[m.model_dump() for m in self.models],
+            extra_models=[m.model_dump() for m in self.extra_models],
             api_key_prefix=self.api_key_prefix,
             is_local=self.is_local,
             is_custom=self.is_custom,

--- a/tests/unit/providers/test_provider_class_identity.py
+++ b/tests/unit/providers/test_provider_class_identity.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Tests for ModelInfo class-identity resilience (issues #3301 / #3375).
+
+When the same module is loaded via two different import paths (e.g.
+PYTHONPATH=src/ combined with a pip-installed package), Python creates
+two distinct class objects for ModelInfo.  Pydantic v2 treats them as
+incompatible types, causing ValidationError on ProviderInfo construction
+and Provider.update_config().
+
+These tests simulate that scenario by fabricating a "foreign" ModelInfo
+class and verifying that Provider.get_info() and update_config() still
+succeed.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import List
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from qwenpaw.providers.provider import ModelInfo, Provider, ProviderInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers: create a "foreign" ModelInfo that shares the same schema but is
+# a different Python class — exactly what happens under dual module loading.
+# ---------------------------------------------------------------------------
+
+_FOREIGN_SRC = """\
+from pydantic import BaseModel, Field
+
+class ModelInfo(BaseModel):
+    id: str = Field(..., description="Model identifier used in API calls")
+    name: str = Field(..., description="Human-readable model name")
+    supports_multimodal: bool | None = None
+    supports_image: bool | None = None
+    supports_video: bool | None = None
+    probe_source: str | None = None
+    generate_kwargs: dict = Field(default_factory=dict)
+"""
+
+
+def _make_foreign_model_info(model_id: str, name: str):
+    """Create a ModelInfo instance whose class is *not* the canonical one."""
+    ns: dict = {}
+    exec(_FOREIGN_SRC, ns)  # noqa: S102
+    ForeignModelInfo = ns["ModelInfo"]
+
+    # Sanity: the two classes must be distinct
+    assert ForeignModelInfo is not ModelInfo
+    instance = ForeignModelInfo(id=model_id, name=name)
+    assert not isinstance(instance, ModelInfo)
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# A minimal concrete Provider for testing (Provider is abstract).
+# ---------------------------------------------------------------------------
+
+class _StubProvider(Provider):
+    async def check_connection(self, timeout=5):
+        return True, "ok"
+
+    async def fetch_models(self, timeout=5):
+        return []
+
+    async def check_model_connection(self, model_id, timeout=5):
+        return True, "ok"
+
+    def get_chat_model_instance(self, model_id):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetInfoClassIdentity:
+    """Provider.get_info() must tolerate foreign ModelInfo instances."""
+
+    @pytest.mark.asyncio
+    async def test_get_info_with_foreign_models(self):
+        """get_info() should not raise even when self.models contains
+        ModelInfo instances from a different class identity."""
+        foreign = _make_foreign_model_info("qwen-test", "Qwen Test")
+
+        provider = _StubProvider(
+            id="test-provider",
+            name="Test",
+            # Use canonical ModelInfo for construction, then swap
+            models=[ModelInfo(id="qwen-test", name="Qwen Test")],
+        )
+        # Simulate class-identity mismatch by replacing with foreign instance
+        provider.models = [foreign]
+
+        # Before the fix this would raise ValidationError
+        info = await provider.get_info()
+        assert isinstance(info, ProviderInfo)
+        assert len(info.models) == 1
+        assert info.models[0].id == "qwen-test"
+        # The returned ModelInfo must be the canonical class
+        assert isinstance(info.models[0], ModelInfo)
+
+    @pytest.mark.asyncio
+    async def test_get_info_with_foreign_extra_models(self):
+        """get_info() should not raise even when self.extra_models contains
+        ModelInfo instances from a different class identity."""
+        foreign = _make_foreign_model_info("glm-5", "GLM 5")
+
+        provider = _StubProvider(
+            id="test-provider",
+            name="Test",
+        )
+        provider.extra_models = [foreign]
+
+        info = await provider.get_info()
+        assert isinstance(info, ProviderInfo)
+        assert len(info.extra_models) == 1
+        assert info.extra_models[0].id == "glm-5"
+        assert isinstance(info.extra_models[0], ModelInfo)
+
+
+class TestUpdateConfigClassIdentity:
+    """Provider.update_config() must tolerate foreign ModelInfo instances."""
+
+    def test_update_config_with_foreign_model_instances(self):
+        """update_config() with foreign ModelInfo instances in extra_models
+        should succeed by serializing through dicts."""
+        foreign = _make_foreign_model_info("qwen3.5-plus", "Qwen 3.5 Plus")
+
+        provider = _StubProvider(id="test-provider", name="Test")
+        provider.update_config({"extra_models": [foreign]})
+
+        assert len(provider.extra_models) == 1
+        assert provider.extra_models[0].id == "qwen3.5-plus"
+        # Must be canonical ModelInfo, not foreign
+        assert isinstance(provider.extra_models[0], ModelInfo)
+
+    def test_update_config_with_dict_models(self):
+        """update_config() with plain dicts should still work normally."""
+        provider = _StubProvider(id="test-provider", name="Test")
+        provider.update_config({
+            "extra_models": [
+                {"id": "model-a", "name": "Model A"},
+                {"id": "model-b", "name": "Model B"},
+            ]
+        })
+
+        assert len(provider.extra_models) == 2
+        assert all(isinstance(m, ModelInfo) for m in provider.extra_models)
+
+    def test_update_config_with_canonical_model_instances(self):
+        """update_config() with canonical ModelInfo instances must still work."""
+        canonical = ModelInfo(id="model-c", name="Model C")
+
+        provider = _StubProvider(id="test-provider", name="Test")
+        provider.update_config({"extra_models": [canonical]})
+
+        assert len(provider.extra_models) == 1
+        assert provider.extra_models[0].id == "model-c"
+        assert isinstance(provider.extra_models[0], ModelInfo)
+
+
+class TestProviderInfoDirectConstruction:
+    """ProviderInfo construction must handle foreign ModelInfo in fields."""
+
+    def test_provider_info_rejects_foreign_model_directly(self):
+        """Without the get_info() dict-serialization fix, directly passing
+        a foreign ModelInfo to ProviderInfo would fail — confirm that the
+        failure mode exists so the fix is meaningful."""
+        foreign = _make_foreign_model_info("test-model", "Test")
+        with pytest.raises(ValidationError):
+            ProviderInfo(
+                id="p",
+                name="P",
+                extra_models=[foreign],
+            )
+
+    def test_provider_info_accepts_dicts(self):
+        """ProviderInfo must accept plain dicts for models/extra_models."""
+        info = ProviderInfo(
+            id="p",
+            name="P",
+            models=[{"id": "m1", "name": "M1"}],
+            extra_models=[{"id": "m2", "name": "M2"}],
+        )
+        assert info.models[0].id == "m1"
+        assert info.extra_models[0].id == "m2"

--- a/tests/unit/providers/test_provider_class_identity.py
+++ b/tests/unit/providers/test_provider_class_identity.py
@@ -14,11 +14,8 @@ succeed.
 
 from __future__ import annotations
 
-import types
-from typing import List
-
 import pytest
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import ValidationError
 
 from qwenpaw.providers.provider import ModelInfo, Provider, ProviderInfo
 
@@ -59,6 +56,7 @@ def _make_foreign_model_info(model_id: str, name: str):
 # A minimal concrete Provider for testing (Provider is abstract).
 # ---------------------------------------------------------------------------
 
+
 class _StubProvider(Provider):
     async def check_connection(self, timeout=5):
         return True, "ok"
@@ -76,6 +74,7 @@ class _StubProvider(Provider):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestGetInfoClassIdentity:
     """Provider.get_info() must tolerate foreign ModelInfo instances."""
@@ -141,18 +140,21 @@ class TestUpdateConfigClassIdentity:
     def test_update_config_with_dict_models(self):
         """update_config() with plain dicts should still work normally."""
         provider = _StubProvider(id="test-provider", name="Test")
-        provider.update_config({
-            "extra_models": [
-                {"id": "model-a", "name": "Model A"},
-                {"id": "model-b", "name": "Model B"},
-            ]
-        })
+        provider.update_config(
+            {
+                "extra_models": [
+                    {"id": "model-a", "name": "Model A"},
+                    {"id": "model-b", "name": "Model B"},
+                ],
+            },
+        )
 
         assert len(provider.extra_models) == 2
         assert all(isinstance(m, ModelInfo) for m in provider.extra_models)
 
     def test_update_config_with_canonical_model_instances(self):
-        """update_config() with canonical ModelInfo instances must still work."""
+        """update_config() with canonical ModelInfo instances
+        must still work."""
         canonical = ModelInfo(id="model-c", name="Model C")
 
         provider = _StubProvider(id="test-provider", name="Test")


### PR DESCRIPTION
## Problem

`Provider.get_info()` 返回 `ProviderInfo` 时直接传入 `self.models` 和 `self.extra_models` 的 `ModelInfo` 实例。当同一模块通过两条 Python import 路径加载（如 `PYTHONPATH=src/` + pip install），内存中会存在两个 `ModelInfo` 类。pydantic v2 在构造 `ProviderInfo` 时做 `isinstance()` 检查，发现 class-A 的实例不是 class-B 的 `ModelInfo`，直接抛 `ValidationError`。

用户表现：每次通过 UI 添加模型后调用 provider API 就报错：
```
1 validation error for ProviderInfo
extra_models.0
  Input should be a valid dictionary or instance of ModelInfo
```

与 #3375 同根因（双重模块加载导致 pydantic 类身份冲突），但触发路径不同：#3375 是 gunicorn 启动时 builtin models 崩溃，本 issue 是运行时 API 响应中 extra_models 崩溃。

## Fix

两处改动，都在 `provider.py`：

1. **`get_info()`** — `models` 和 `extra_models` 先 `model_dump()` 序列化为 plain dict 再传给 `ProviderInfo`，让 pydantic 用当前作用域的 `ModelInfo` 类构造新实例
2. **`update_config()`** — 对 `extra_models` 中的 pydantic BaseModel 实例统一先 `model_dump()` 再 `model_validate()`，避免 `isinstance` 在双重加载下误判

## Validation

```
# 7 个专项测试（模拟 foreign ModelInfo 类身份冲突）
pytest tests/unit/providers/test_provider_class_identity.py → 7 passed

# 全量单元测试
pytest tests/unit/ → 524 passed

# gunicorn 双 worker 真实启动 + curl 验证
gunicorn qwenpaw.app._app:app --worker-class uvicorn.workers.UvicornWorker --workers 2
curl /api/models → HTTP 200, 23 providers, 零 ValidationError
```

Closes #3301