### PR TITLE
fix: prevent message history navigation when suggestion popup is open

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -316,16 +316,8 @@ function useMessageHistoryNavigation(
     return null;
   };
 
-  const isSuggestionPopupOpen = (textarea: HTMLTextAreaElement): boolean => {
-    if (!textarea.value.startsWith("/")) return false;
-    const doc = textarea.ownerDocument;
-    const menuItems = Array.from(
-      doc.querySelectorAll('[role="menuitemcheckbox"], [role="menuitem"]'),
-    );
-    return menuItems.some((item) =>
-      (item.textContent || "").trim().startsWith("/"),
-    );
-  };
+  const isSuggestionPopupOpen = (textarea: HTMLTextAreaElement): boolean =>
+    textarea.value.startsWith("/");
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -316,6 +316,17 @@ function useMessageHistoryNavigation(
     return null;
   };
 
+  const isSuggestionPopupOpen = (textarea: HTMLTextAreaElement): boolean => {
+    if (!textarea.value.startsWith("/")) return false;
+    const doc = textarea.ownerDocument;
+    const menuItems = Array.from(
+      doc.querySelectorAll('[role="menuitemcheckbox"], [role="menuitem"]'),
+    );
+    return menuItems.some((item) =>
+      (item.textContent || "").trim().startsWith("/"),
+    );
+  };
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!isChatActive()) return;
@@ -336,6 +347,8 @@ function useMessageHistoryNavigation(
       const userMessages = getUserMessagesWithText();
 
       if (e.key === "ArrowUp") {
+        if (isSuggestionPopupOpen(textarea)) return;
+
         const cursorPosition = textarea.selectionStart || 0;
         const textBeforeCursor = textarea.value.substring(0, cursorPosition);
         const lineBreaks = textBeforeCursor.split("\n").length - 1;


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** 
- Fixes #3274


## Summary
- Prevent `ArrowUp` key from navigating message history when the `/` suggestion popup is open
- Added `isSuggestionPopupOpen()` helper to detect if suggestion popup is active by checking textarea value and menu items
## Problem
When typing `/` in the chat input, a suggestion popup appears. However, pressing `ArrowUp` would incorrectly trigger message history navigation instead of navigating within the popup suggestions.
## Solution
Check if the suggestion popup is open before allowing message history navigation. The popup is detected by:
1. Textarea value starts with `/`
2. There are menu items (role="menuitemcheckbox" or role="menuitem") that start with `/`
## Testing
Manual testing confirmed:
- `/` triggers suggestion popup
- `ArrowUp` while popup is open → no message history navigation
- `ArrowUp` when popup is closed → message history navigation works as expected

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
