### PR TITLE
style(console): bump prettier from 3.0.x to 3.8.x for natual indention in conditional branches and styles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,9 +112,9 @@ repos:
           --disable=C0116,  # Disable missing function or method docstring for quick dev
         ]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.0.0'
+    rev: ''
     hooks:
       - id: prettier
-        additional_dependencies: [ 'prettier@3.0.0' ]
+        additional_dependencies: [ 'prettier@3.8.3' ]
         files: \.(tsx?)$
         exclude: '(?x)(^web/|^console/|/dist/|.*/skills/.*|^scripts/pack/)'

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -45,7 +45,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
         "less": "^4.5.1",
-        "prettier": "3.0.0",
+        "prettier": "^3.8.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5"
@@ -12175,9 +12175,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/console/package.json
+++ b/console/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "less": "^4.5.1",
-    "prettier": "3.0.0",
+    "prettier": "^3.8.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/console/src/components/MarkdownCopy/MarkdownCopy.tsx
+++ b/console/src/components/MarkdownCopy/MarkdownCopy.tsx
@@ -79,8 +79,8 @@ export function MarkdownCopy({
       localShowMarkdown && !(editable && !textareaProps.disabled)
         ? content
         : editable
-        ? editContent
-        : content;
+          ? editContent
+          : content;
 
     if (!contentToCopy) return;
 

--- a/console/src/components/MarkdownCopy/index.module.less
+++ b/console/src/components/MarkdownCopy/index.module.less
@@ -61,8 +61,8 @@
         background: transparent;
         padding: 0;
         margin: 0;
-        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
-          monospace;
+        font-family:
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
         font-size: 13px;
         line-height: 1.6;
         white-space: pre-wrap;

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -93,8 +93,9 @@ export default function Header() {
         const versions = versionsWithTime.map((v) => v.version);
         const latest = versions[0] ?? data?.info?.version ?? "";
 
-        const releaseTime = versionsWithTime.find((v) => v.version === latest)
-          ?.uploadTime;
+        const releaseTime = versionsWithTime.find(
+          (v) => v.version === latest,
+        )?.uploadTime;
         const isOldEnough =
           !!releaseTime &&
           new Date(releaseTime) <= new Date(Date.now() - ONE_HOUR_MS);
@@ -117,8 +118,8 @@ export default function Header() {
     const lang = i18n.language?.startsWith("zh")
       ? "zh"
       : i18n.language?.startsWith("ru")
-      ? "ru"
-      : "en";
+        ? "ru"
+        : "en";
     const faqLang = lang === "zh" ? "zh" : "en";
     const url = `https://qwenpaw.agentscope.io/docs/faq.${faqLang}.md`;
     fetch(url, { cache: "no-cache" })
@@ -130,7 +131,7 @@ export default function Header() {
         setUpdateMarkdown(
           match && lang !== "ru"
             ? match[0].trim()
-            : UPDATE_MD[lang] ?? UPDATE_MD.en,
+            : (UPDATE_MD[lang] ?? UPDATE_MD.en),
         );
       })
       .catch(() => {

--- a/console/src/layouts/constants.ts
+++ b/console/src/layouts/constants.ts
@@ -106,8 +106,8 @@ export const compareVersions = (a: string, b: string): number => {
         preLabel === "a" || preLabel === "alpha"
           ? -3
           : preLabel === "b" || preLabel === "beta"
-          ? -2
-          : -1; // rc or c
+            ? -2
+            : -1; // rc or c
       preNum = preMatch[3] ? Number(preMatch[3]) : 0;
     }
 

--- a/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
+++ b/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
@@ -98,8 +98,8 @@ export function ACPDrawer({
         isCreateMode
           ? t("acp.createTitle")
           : activeKey
-          ? `${t("acp.editTitle")}: ${activeKey}`
-          : t("acp.editTitle")
+            ? `${t("acp.editTitle")}: ${activeKey}`
+            : t("acp.editTitle")
       }
       open={open}
       onClose={onClose}

--- a/console/src/pages/Agent/Skills/components/ImportHubModal.tsx
+++ b/console/src/pages/Agent/Skills/components/ImportHubModal.tsx
@@ -82,8 +82,8 @@ export function ImportHubModal({
   const inputStateClass = validation.ok
     ? styles.valid
     : validation.messageKey
-    ? styles.invalid
-    : "";
+      ? styles.invalid
+      : "";
 
   const activeMarketData = skillMarkets.find((m) => m.key === activeMarket);
 

--- a/console/src/pages/Agent/Skills/index.module.less
+++ b/console/src/pages/Agent/Skills/index.module.less
@@ -564,7 +564,8 @@
   padding: 40px 32px;
   border: 1px solid #e7ebf3;
   border-radius: 20px;
-  background: radial-gradient(
+  background:
+    radial-gradient(
       circle at top left,
       rgba(97, 92, 237, 0.08),
       transparent 34%
@@ -1106,7 +1107,8 @@
 
   .emptyState {
     border-color: rgba(255, 255, 255, 0.1);
-    background: radial-gradient(
+    background:
+      radial-gradient(
         circle at top left,
         rgba(97, 92, 237, 0.18),
         transparent 34%

--- a/console/src/pages/Agent/Skills/useSkillsPage.tsx
+++ b/console/src/pages/Agent/Skills/useSkillsPage.tsx
@@ -479,13 +479,13 @@ export function useSkillsPage() {
         const title = allBuiltinUpgrades
           ? t("skills.builtinUpgradeTitle")
           : allLanguageSwitch
-          ? t("skills.languageSwitchTitle")
-          : t("skillPool.overwriteConfirm");
+            ? t("skills.languageSwitchTitle")
+            : t("skillPool.overwriteConfirm");
         const subtitle = allBuiltinUpgrades
           ? t("skillPool.builtinOverwriteTargetsContent")
           : allLanguageSwitch
-          ? t("skills.languageSwitchContent")
-          : t("skills.overwriteExistingList");
+            ? t("skills.languageSwitchContent")
+            : t("skills.overwriteExistingList");
         const confirmed = await confirmOverwrite(
           title,
           <div style={{ display: "grid", gap: 8 }}>

--- a/console/src/pages/Agent/Workspace/index.module.less
+++ b/console/src/pages/Agent/Workspace/index.module.less
@@ -263,8 +263,8 @@
         background: transparent;
         padding: 0;
         margin: 0;
-        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
-          monospace;
+        font-family:
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
         font-size: 13px;
         line-height: 1.6;
         white-space: pre-wrap;

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -54,9 +54,8 @@ function SessionsPage() {
     let filtered: Session[] = sessions;
 
     if (filterUserId) {
-      filtered = filtered.filter(
-        (session: Session) =>
-          session.user_id?.toLowerCase().includes(filterUserId.toLowerCase()),
+      filtered = filtered.filter((session: Session) =>
+        session.user_id?.toLowerCase().includes(filterUserId.toLowerCase()),
       );
     }
 

--- a/console/src/pages/Settings/Agents/components/SortableAgentRow.tsx
+++ b/console/src/pages/Settings/Agents/components/SortableAgentRow.tsx
@@ -14,8 +14,7 @@ const SortableHandleContext = createContext<SortableHandleContextValue | null>(
   null,
 );
 
-interface SortableAgentRowProps
-  extends React.HTMLAttributes<HTMLTableRowElement> {
+interface SortableAgentRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   "data-row-key": string;
 }
 

--- a/console/src/pages/Settings/Backups/restore/RestoreBackupModal.tsx
+++ b/console/src/pages/Settings/Backups/restore/RestoreBackupModal.tsx
@@ -149,8 +149,8 @@ export default function RestoreBackupModal({
       const agent_ids = isFull
         ? allBackupAgentIds
         : includeAgents
-        ? selectedAgents
-        : [];
+          ? selectedAgents
+          : [];
 
       await api.restoreBackup(backup.id, {
         mode: restoreMode,

--- a/console/src/pages/Settings/Debug/index.module.less
+++ b/console/src/pages/Settings/Debug/index.module.less
@@ -73,8 +73,9 @@
   padding: 12px;
   min-height: 120px;
   background: rgba(0, 0, 0, 0.02);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
   font-size: 12px;
   line-height: 1.5;
   white-space: pre-wrap;

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -75,23 +75,23 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
   const statusLabel = isAvailable
     ? t("models.providerAvailable")
     : isConfigured
-    ? t("models.providerNoModels")
-    : t("models.providerNotConfigured");
+      ? t("models.providerNoModels")
+      : t("models.providerNotConfigured");
   const statusType = isAvailable
     ? "enabled"
     : isConfigured
-    ? "partial"
-    : "disabled";
+      ? "partial"
+      : "disabled";
   const statusDotColor = isAvailable
     ? "rgba(20, 184, 166, 1)"
     : isConfigured
-    ? "#faad14"
-    : "#d9d9d9";
+      ? "#faad14"
+      : "#d9d9d9";
   const statusDotShadow = isAvailable
     ? "0 0 0 2px rgba(82, 196, 26, 0.2)"
     : isConfigured
-    ? "0 0 0 2px rgba(250, 173, 20, 0.2)"
-    : "none";
+      ? "0 0 0 2px rgba(250, 173, 20, 0.2)"
+      : "none";
 
   return (
     <Card hoverable className={styles.providerCard}>
@@ -115,8 +115,8 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
               statusType === "enabled"
                 ? styles.enabled
                 : statusType === "partial"
-                ? styles.partial
-                : styles.disabled
+                  ? styles.partial
+                  : styles.disabled
             }`}
           >
             {statusLabel}

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -9,8 +9,10 @@ import { useTranslation } from "react-i18next";
 import { getLocalizedTestConnectionMessage } from "./testConnectionMessage";
 import styles from "../../index.module.less";
 
-interface ProviderConfigFormValues
-  extends Omit<ProviderConfigRequest, "generate_kwargs"> {
+interface ProviderConfigFormValues extends Omit<
+  ProviderConfigRequest,
+  "generate_kwargs"
+> {
   generate_kwargs_text?: string;
 }
 

--- a/console/src/pages/Settings/Models/components/modals/local-models/LocalRuntimePanel.tsx
+++ b/console/src/pages/Settings/Models/components/modals/local-models/LocalRuntimePanel.tsx
@@ -44,19 +44,19 @@ export const LocalRuntimePanel = memo(function LocalRuntimePanel({
         label: t("models.localRuntimeUpdateAvailable"),
       }
     : installed
-    ? {
-        className: styles.localStatusBadgeInstalled,
-        label: t("models.localRuntimeInstalled"),
-      }
-    : !installable
-    ? {
-        className: styles.localStatusBadgeDead,
-        label: t("models.localRuntimeUnsupported"),
-      }
-    : {
-        className: styles.localStatusBadgeMuted,
-        label: t("models.localRuntimeMissing"),
-      };
+      ? {
+          className: styles.localStatusBadgeInstalled,
+          label: t("models.localRuntimeInstalled"),
+        }
+      : !installable
+        ? {
+            className: styles.localStatusBadgeDead,
+            label: t("models.localRuntimeUnsupported"),
+          }
+        : {
+            className: styles.localStatusBadgeMuted,
+            label: t("models.localRuntimeMissing"),
+          };
   const runBadge =
     serverStatus?.message && !serverStatus.available
       ? {
@@ -64,14 +64,14 @@ export const LocalRuntimePanel = memo(function LocalRuntimePanel({
           label: t("models.localServerIdle"),
         }
       : isRunning
-      ? {
-          className: styles.localStatusBadgeRunning,
-          label: t("models.localServerOnline"),
-        }
-      : {
-          className: styles.localStatusBadgeDead,
-          label: t("models.localServerIdle"),
-        };
+        ? {
+            className: styles.localStatusBadgeRunning,
+            label: t("models.localServerOnline"),
+          }
+        : {
+            className: styles.localStatusBadgeDead,
+            label: t("models.localServerIdle"),
+          };
   const progressPercent = getProgressPercent(progress);
   const progressText = isDownloading ? formatProgressText(progress) : null;
   const canTriggerUpdate = hasUpdate && !isDownloading;

--- a/console/src/pages/Settings/SkillPool/useSkillPool.tsx
+++ b/console/src/pages/Settings/SkillPool/useSkillPool.tsx
@@ -131,8 +131,8 @@ export function useSkillPool() {
     () =>
       Boolean(
         builtinNotice?.has_updates &&
-          builtinNotice.fingerprint &&
-          builtinNotice.fingerprint !== builtinNoticeAck,
+        builtinNotice.fingerprint &&
+        builtinNotice.fingerprint !== builtinNoticeAck,
       ),
     [builtinNotice, builtinNoticeAck],
   );
@@ -445,13 +445,13 @@ export function useSkillPool() {
         const title = allBuiltinUpgrades
           ? t("skills.builtinUpgradeTitle")
           : allLanguageSwitch
-          ? t("skills.languageSwitchTitle")
-          : t("skillPool.overwriteConfirm");
+            ? t("skills.languageSwitchTitle")
+            : t("skillPool.overwriteConfirm");
         const subtitle = allBuiltinUpgrades
           ? t("skillPool.builtinOverwriteTargetsContent")
           : allLanguageSwitch
-          ? t("skills.languageSwitchContent")
-          : t("skillPool.overwriteTargetsContent");
+            ? t("skills.languageSwitchContent")
+            : t("skillPool.overwriteTargetsContent");
         const confirmed = await confirmOverwrite(
           title,
           <div style={{ display: "grid", gap: 8 }}>
@@ -720,8 +720,8 @@ export function useSkillPool() {
         savedAsNew
           ? `${t("common.create")}: ${result.name}`
           : mode === "edit"
-          ? t("common.save")
-          : t("common.create"),
+            ? t("common.save")
+            : t("common.create"),
       );
       closeDrawer();
       invalidateSkillCache({ pool: true });

--- a/console/src/utils/lazyWithRetry.ts
+++ b/console/src/utils/lazyWithRetry.ts
@@ -116,10 +116,10 @@ export function lazyImportWithRetry(
   const globKey = PAGE_MODULES[base]
     ? base
     : PAGE_MODULES[`${base}/index.tsx`]
-    ? `${base}/index.tsx`
-    : PAGE_MODULES[`${base}/index.ts`]
-    ? `${base}/index.ts`
-    : base;
+      ? `${base}/index.tsx`
+      : PAGE_MODULES[`${base}/index.ts`]
+        ? `${base}/index.ts`
+        : base;
   const factory = PAGE_MODULES[globKey];
   if (!factory) {
     throw new Error(

--- a/website/src/pages/Home/components/Hero.tsx
+++ b/website/src/pages/Home/components/Hero.tsx
@@ -65,8 +65,8 @@ export function Hero() {
   const mascotSrc = !showIdle
     ? "https://img.alicdn.com/imgextra/i4/O1CN01nMDfdp23mXcSGecsm_!!6000000007298-1-tps-120-120.gif"
     : isHovered || !idlePlayedOnce
-    ? "https://img.alicdn.com/imgextra/i1/O1CN016cb70x1KlwOGcvRgb_!!6000000001205-1-tps-120-120.gif"
-    : "https://img.alicdn.com/imgextra/i1/O1CN01UzhqBc1tym2X8dhl6_!!6000000005971-2-tps-120-120.png";
+      ? "https://img.alicdn.com/imgextra/i1/O1CN016cb70x1KlwOGcvRgb_!!6000000001205-1-tps-120-120.gif"
+      : "https://img.alicdn.com/imgextra/i1/O1CN01UzhqBc1tym2X8dhl6_!!6000000005971-2-tps-120-120.png";
 
   return (
     <>


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

- The current prettier version 3.0.0 is out of date, which was released in Jul 2023
- bump prettier from 3.0.x to 3.8.x for more natual indention

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
