### PR TITLE
feat(routing): add local model routing strategies

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -36,8 +36,10 @@ except ImportError:  # pragma: no cover - compatibility fallback
 from .utils.message_request_normalizer import (
     normalize_messages_for_model_request,
 )
+from ..config.config import AgentsLLMRoutingConfig
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
+from ..providers.models import ModelSlotConfig
 from ..providers.retry_chat_model import (
     RetryChatModel,
     RetryConfig,
@@ -111,6 +113,8 @@ def _normalize_messages_for_formatter(
         issubclass(base_formatter_class, GeminiChatFormatter)
     )
     supports_multimodal = _supports_multimodal_for_current_model()
+    if getattr(formatter_instance, "_qwenpaw_routing_preserve_media", False):
+        supports_multimodal = True
     if getattr(formatter_instance, "_qwenpaw_force_strip_media", False):
         supports_multimodal = False
     normalized_msgs = normalize_messages_for_model_request(
@@ -798,6 +802,113 @@ def _strip_top_level_message_name(
     return messages
 
 
+def _has_configured_slot(slot: ModelSlotConfig | None) -> bool:
+    return bool(slot and slot.provider_id and slot.model)
+
+
+def _create_model_instance_for_provider(
+    model_slot: ModelSlotConfig,
+    *,
+    manager: ProviderManager,
+) -> Tuple[ChatModelBase, Type[ChatModelBase]]:
+    provider = manager.get_provider(model_slot.provider_id)
+    if provider is None:
+        raise ProviderError(
+            message=f"Provider '{model_slot.provider_id}' not found.",
+        )
+
+    model = provider.get_chat_model_instance(model_slot.model)
+    return model, provider.get_chat_model_cls()
+
+
+def _wrap_model_with_retry(
+    provider_id: str,
+    model: ChatModelBase,
+    *,
+    retry_config: RetryConfig | None = None,
+    rate_limit_config: RateLimitConfig | None = None,
+) -> ChatModelBase:
+    wrapped_model = TokenRecordingModelWrapper(provider_id, model)
+    return RetryChatModel(
+        wrapped_model,
+        retry_config=retry_config,
+        rate_limit_config=rate_limit_config,
+    )
+
+
+def _create_routing_endpoint(
+    model_slot: ModelSlotConfig,
+    *,
+    manager: ProviderManager,
+    retry_config: RetryConfig | None = None,
+    rate_limit_config: RateLimitConfig | None = None,
+):
+    from .routing_chat_model import RoutingEndpoint
+
+    provider_id = model_slot.provider_id
+    model, chat_model_class = _create_model_instance_for_provider(
+        model_slot,
+        manager=manager,
+    )
+    formatter = _create_formatter_instance(chat_model_class)
+    wrapped_model = _wrap_model_with_retry(
+        provider_id,
+        model,
+        retry_config=retry_config,
+        rate_limit_config=rate_limit_config,
+    )
+
+    return RoutingEndpoint(
+        provider_id=provider_id,
+        model_name=model_slot.model,
+        model=wrapped_model,
+        formatter=formatter,
+        formatter_family=_get_formatter_for_chat_model(chat_model_class),
+    )
+
+
+def _create_routing_model_and_formatter(
+    local_slot: ModelSlotConfig,
+    cloud_slot: ModelSlotConfig,
+    routing_cfg: AgentsLLMRoutingConfig,
+    *,
+    manager: ProviderManager,
+    retry_config: RetryConfig | None = None,
+    rate_limit_config: RateLimitConfig | None = None,
+) -> Tuple[ChatModelBase, FormatterBase]:
+    from .routing_chat_model import RoutingChatModel
+
+    local_endpoint = _create_routing_endpoint(
+        local_slot,
+        manager=manager,
+        retry_config=retry_config,
+        rate_limit_config=rate_limit_config,
+    )
+    cloud_endpoint = _create_routing_endpoint(
+        cloud_slot,
+        manager=manager,
+        retry_config=retry_config,
+        rate_limit_config=rate_limit_config,
+    )
+
+    if local_endpoint.formatter_family is not cloud_endpoint.formatter_family:
+        raise ValueError(
+            "LLM routing requires local and cloud slots to share the same "
+            "formatter family.",
+        )
+
+    model: ChatModelBase = RoutingChatModel(
+        local_endpoint=local_endpoint,
+        cloud_endpoint=cloud_endpoint,
+        routing_cfg=routing_cfg,
+    )
+    formatter = _create_formatter_from_family(
+        local_endpoint.formatter_family,
+    )
+    setattr(formatter, "_qwenpaw_routing_preserve_media", True)
+    return model, formatter
+
+
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
 ) -> Tuple[ChatModelBase, FormatterBase]:
@@ -818,6 +929,7 @@ def create_model_and_formatter(
     """
     from ..app.agent_context import get_current_agent_id
     from ..config.config import load_agent_config
+    from ..config.utils import load_config
 
     # Determine agent_id (parameter > context > None)
     if agent_id is None:
@@ -827,13 +939,16 @@ def create_model_and_formatter(
             pass
 
     # Try to get agent-specific model first
+    manager = ProviderManager.get_instance()
     model_slot = None
+    routing_cfg = None
     retry_config = None
     rate_limit_config = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
             model_slot = agent_config.active_model
+            routing_cfg = agent_config.llm_routing
             retry_config = RetryConfig(
                 enabled=agent_config.running.llm_retry_enabled,
                 max_retries=agent_config.running.llm_max_retries,
@@ -850,22 +965,52 @@ def create_model_and_formatter(
         except Exception:
             pass
 
+    if routing_cfg is None:
+        routing_cfg = load_config().agents.llm_routing
+
+    if routing_cfg.enabled:
+        if not _has_configured_slot(routing_cfg.local):
+            raise ValueError(
+                "LLM routing is enabled but the local slot is not configured.",
+            )
+
+        cloud_slot = (
+            routing_cfg.cloud
+            if _has_configured_slot(routing_cfg.cloud)
+            else (
+                model_slot
+                if _has_configured_slot(model_slot)
+                else manager.get_active_model()
+            )
+        )
+        if not _has_configured_slot(cloud_slot):
+            raise ValueError(
+                "LLM routing is enabled but the cloud slot could not be "
+                "resolved from routing config, agent config, or active model.",
+            )
+
+        assert cloud_slot is not None
+        return _create_routing_model_and_formatter(
+            routing_cfg.local,
+            cloud_slot,
+            routing_cfg,
+            manager=manager,
+            retry_config=retry_config,
+            rate_limit_config=rate_limit_config,
+        )
+
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:
         # Use agent-specific model
-        manager = ProviderManager.get_instance()
-        provider = manager.get_provider(model_slot.provider_id)
-        if provider is None:
-            raise ProviderError(
-                message=f"Provider '{model_slot.provider_id}' not found.",
-            )
-
-        model = provider.get_chat_model_instance(model_slot.model)
+        model, chat_model_class = _create_model_instance_for_provider(
+            model_slot,
+            manager=manager,
+        )
         provider_id = model_slot.provider_id
     else:
         # Fallback to global active model
         model = ProviderManager.get_active_chat_model()
-        global_model = ProviderManager.get_instance().get_active_model()
+        global_model = manager.get_active_model()
         if not global_model:
             raise ProviderError(
                 message=(
@@ -875,14 +1020,20 @@ def create_model_and_formatter(
                 ),
             )
         provider_id = global_model.provider_id
+        provider = manager.get_provider(provider_id)
+        if provider is None:
+            raise ProviderError(
+                message=f"Provider '{provider_id}' not found.",
+            )
+        chat_model_class = provider.get_chat_model_cls()
 
     # Create the formatter based on the real model class
-    formatter = _create_formatter_instance(model.__class__)
+    formatter = _create_formatter_instance(chat_model_class)
 
     # Wrap with retry logic for transient LLM API errors
-    wrapped_model = TokenRecordingModelWrapper(provider_id, model)
-    wrapped_model = RetryChatModel(
-        wrapped_model,
+    wrapped_model = _wrap_model_with_retry(
+        provider_id,
+        model,
         retry_config=retry_config,
         rate_limit_config=rate_limit_config,
     )
@@ -905,6 +1056,12 @@ def _create_formatter_instance(
         Formatter instance with file block support
     """
     base_formatter_class = _get_formatter_for_chat_model(chat_model_class)
+    return _create_formatter_from_family(base_formatter_class)
+
+
+def _create_formatter_from_family(
+    base_formatter_class: Type[FormatterBase],
+) -> FormatterBase:
     formatter_class = _create_file_block_support_formatter(
         base_formatter_class,
     )

--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -359,37 +359,71 @@ def build_bootstrap_guidance(
     )
 
 
-def _get_active_model_info():
-    """Resolve the active model's ModelInfo and model name.
-
-    Tries agent-specific model first, then falls back to global.
-
-    Returns:
-        A ``(ModelInfo, model_name)`` tuple.  Both elements are *None*
-        when the active model cannot be resolved.
-    """
+def _resolve_active_and_routing_config():
+    """Resolve active slot and routing config for the current request."""
     try:
         from ..app.agent_context import get_current_agent_id
         from ..config.config import load_agent_config
+        from ..config.utils import load_config
         from ..providers.provider_manager import ProviderManager
 
         manager = ProviderManager.get_instance()
 
-        # Try to get agent-specific model first
         active = None
+        routing_cfg = None
         try:
             agent_id = get_current_agent_id()
             agent_config = load_agent_config(agent_id)
-            if agent_config.active_model:
+            if getattr(agent_config, "active_model", None):
                 active = agent_config.active_model
+            routing_cfg = getattr(agent_config, "llm_routing", None)
         except Exception:
             pass
 
-        # Fallback to global active model
+        if routing_cfg is None:
+            routing_cfg = load_config().agents.llm_routing
+
         if not active:
             active = manager.get_active_model()
 
-        if not active:
+        return manager, active, routing_cfg
+    except Exception:
+        return None, None, None
+
+
+def _resolve_multimodal_slot():
+    """Resolve the slot whose multimodal capability matters for this request.
+
+    When routing is enabled, multimodal user input is intentionally sent to the
+    cloud slot, so multimodal capability checks should key off that slot rather
+    than the active local/default slot.
+    """
+    manager, active, routing_cfg = _resolve_active_and_routing_config()
+    if manager is None:
+        return None, None
+
+    if (
+        routing_cfg is not None
+        and routing_cfg.enabled
+        and routing_cfg.cloud
+        and routing_cfg.cloud.provider_id
+        and routing_cfg.cloud.model
+    ):
+        return manager, routing_cfg.cloud
+
+    return manager, active
+
+
+def _get_active_model_info():
+    """Resolve the effective ModelInfo and model name for the current request.
+
+    Returns:
+        A ``(ModelInfo, model_name)`` tuple.  Both elements are *None*
+        when the effective model cannot be resolved.
+    """
+    try:
+        manager, active = _resolve_multimodal_slot()
+        if manager is None or not active:
             return None, None
 
         provider = manager.get_provider(active.provider_id)
@@ -405,11 +439,23 @@ def _get_active_model_info():
 
 
 def get_active_model_supports_multimodal() -> bool:
-    """Check if the current active model supports multimodal input."""
+    """Check if the effective model path supports multimodal input.
+
+    In routing mode this reflects the cloud slot, because non-text inputs are
+    intentionally routed there. Unknown capability is treated as allowed so the
+    agent does not proactively strip media or disable media tools.
+    """
     model_info, _ = _get_active_model_info()
     if model_info is None:
         return False
-    return bool(model_info.supports_multimodal)
+    if model_info.supports_multimodal is not None:
+        return bool(model_info.supports_multimodal)
+    if (
+        model_info.supports_image is not None
+        or model_info.supports_video is not None
+    ):
+        return bool(model_info.supports_image or model_info.supports_video)
+    return True
 
 
 def build_multimodal_hint() -> str:

--- a/src/qwenpaw/agents/routing_chat_model.py
+++ b/src/qwenpaw/agents/routing_chat_model.py
@@ -27,7 +27,7 @@ class RoutingDecision:
 
 
 class RoutingPolicy:
-    """Select a route using the configured default mode."""
+    """Select a route using deterministic request-shape heuristics first."""
 
     def __init__(self, cfg: AgentsLLMRoutingConfig):
         self.cfg = cfg
@@ -38,8 +38,36 @@ class RoutingPolicy:
         text: str = "",
         channel: str = "",
         tools_available: bool = True,
+        tool_choice: Literal["auto", "none", "required"] | str | None = None,
+        structured_output_requested: bool = False,
+        has_non_text_user_content: bool = False,
+        has_recent_tool_context: bool = False,
     ) -> RoutingDecision:
         del text, channel, tools_available
+
+        if structured_output_requested:
+            return RoutingDecision(
+                route="cloud",
+                reasons=["structured_output"],
+            )
+
+        if has_non_text_user_content:
+            return RoutingDecision(
+                route="cloud",
+                reasons=["user_content:non_text"],
+            )
+
+        if tool_choice == "required":
+            return RoutingDecision(
+                route="cloud",
+                reasons=["tool_choice:required"],
+            )
+
+        if has_recent_tool_context:
+            return RoutingDecision(
+                route="cloud",
+                reasons=["recent_tool_context"],
+            )
 
         if getattr(self.cfg, "mode", "local_first") == "cloud_first":
             return RoutingDecision(
@@ -89,15 +117,14 @@ class RoutingChatModel(ChatModelBase):
         structured_model: Type[BaseModel] | None = None,
         **kwargs: Any,
     ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
-        text = " ".join(
-            message["content"]
-            for message in messages
-            if message.get("role") == "user"
-            and isinstance(message.get("content"), str)
-        )
+        text = _collect_user_text(messages)
         decision = self.policy.decide(
             text=text,
             tools_available=tools is not None,
+            tool_choice=tool_choice,
+            structured_output_requested=structured_model is not None,
+            has_non_text_user_content=_has_non_text_user_content(messages),
+            has_recent_tool_context=_has_recent_tool_context(messages),
         )
         endpoint = (
             self.local_endpoint
@@ -120,3 +147,72 @@ class RoutingChatModel(ChatModelBase):
             structured_model=structured_model,
             **kwargs,
         )
+
+
+def _collect_user_text(messages: list[dict]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        parts.extend(_extract_text_segments(message.get("content")))
+    return " ".join(part for part in parts if part).strip()
+
+
+def _extract_text_segments(content: Any) -> list[str]:
+    if isinstance(content, str):
+        return [content]
+
+    if not isinstance(content, list):
+        return []
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text" and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return parts
+
+
+def _has_non_text_user_content(messages: list[dict]) -> bool:
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if content in (None, ""):
+            continue
+        if isinstance(content, str):
+            continue
+        if isinstance(content, list):
+            if any(_is_non_text_block(block) for block in content):
+                return True
+            continue
+        return True
+    return False
+
+
+def _has_recent_tool_context(messages: list[dict]) -> bool:
+    for message in reversed(messages):
+        role = message.get("role")
+        if role == "user":
+            return False
+        if role == "tool":
+            return True
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            return True
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") in {"tool_use", "tool_result"}:
+                return True
+    return False
+
+
+def _is_non_text_block(block: Any) -> bool:
+    if not isinstance(block, dict):
+        return True
+    return block.get("type") != "text"

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -193,6 +193,34 @@ def test_force_strip_media_flag_overrides_multimodal_support(
     assert normalized[0].content[0]["text"] == MEDIA_UNSUPPORTED_PLACEHOLDER
 
 
+def test_routing_formatter_preserves_media_even_if_active_model_is_text_only(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: False,
+    )
+
+    original = _media_messages()
+    formatter_instance = SimpleNamespace(
+        _qwenpaw_routing_preserve_media=True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        original,
+        OpenAIChatFormatter,
+        formatter_instance,
+    )
+
+    assert normalized[0].content[0]["type"] == "image"
+    assert normalized[2].content[0]["output"][0]["type"] == "image"
+
+
 def test_formatter_flags_returned_correctly() -> None:
     """Test that formatter family flags are returned correctly."""
     msgs = [Msg(name="user", role="user", content="Hello")]

--- a/tests/unit/agents/test_prompt_multimodal_routing.py
+++ b/tests/unit/agents/test_prompt_multimodal_routing.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+from qwenpaw.agents import prompt
+import qwenpaw.app.agent_context as agent_context_module
+import qwenpaw.config.config as config_module
+import qwenpaw.config.utils as config_utils
+from qwenpaw.providers.models import ModelSlotConfig
+from qwenpaw.providers.provider import ModelInfo
+import qwenpaw.providers.provider_manager as provider_manager_module
+
+
+class FakeProvider:
+    def __init__(self, *models: ModelInfo) -> None:
+        self.models = list(models)
+        self.extra_models = []
+
+
+class FakeManager:
+    def __init__(
+        self,
+        *,
+        providers: dict[str, FakeProvider],
+        active_model: ModelSlotConfig | None = None,
+    ) -> None:
+        self.providers = providers
+        self.active_model = active_model
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+def test_routing_cloud_slot_drives_multimodal_capability(
+    monkeypatch,
+) -> None:
+    local_model = ModelInfo(
+        id="local-model",
+        name="Local",
+        supports_multimodal=False,
+        supports_image=False,
+        supports_video=False,
+    )
+    cloud_model = ModelInfo(
+        id="cloud-model",
+        name="Cloud",
+        supports_multimodal=True,
+        supports_image=True,
+        supports_video=True,
+    )
+    manager = FakeManager(
+        providers={
+            "local": FakeProvider(local_model),
+            "cloud": FakeProvider(cloud_model),
+        },
+        active_model=ModelSlotConfig(provider_id="local", model="local-model"),
+    )
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="local", model="local-model"),
+        llm_routing=SimpleNamespace(
+            enabled=True,
+            local=ModelSlotConfig(provider_id="local", model="local-model"),
+            cloud=ModelSlotConfig(provider_id="cloud", model="cloud-model"),
+        ),
+    )
+
+    monkeypatch.setattr(
+        provider_manager_module.ProviderManager,
+        "get_instance",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        agent_context_module,
+        "get_current_agent_id",
+        lambda: "agent-1",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=agent_config.llm_routing),
+        ),
+    )
+
+    assert prompt.get_active_model_supports_multimodal() is True
+    assert prompt.build_multimodal_hint() == ""
+
+
+def test_unknown_multimodal_capability_is_treated_as_allowed(
+    monkeypatch,
+) -> None:
+    manager = FakeManager(
+        providers={
+            "cloud": FakeProvider(
+                ModelInfo(
+                    id="cloud-model",
+                    name="Cloud",
+                    supports_multimodal=None,
+                    supports_image=None,
+                    supports_video=None,
+                ),
+            ),
+        },
+        active_model=ModelSlotConfig(provider_id="cloud", model="cloud-model"),
+    )
+
+    monkeypatch.setattr(
+        provider_manager_module.ProviderManager,
+        "get_instance",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        agent_context_module,
+        "get_current_agent_id",
+        lambda: "agent-1",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda agent_id: SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="cloud",
+                model="cloud-model",
+            ),
+            llm_routing=SimpleNamespace(enabled=False, local=None, cloud=None),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=SimpleNamespace(
+                    enabled=False,
+                    local=None,
+                    cloud=None,
+                ),
+            ),
+        ),
+    )
+
+    assert prompt.get_active_model_supports_multimodal() is True

--- a/tests/unit/agents/test_routing_chat_model.py
+++ b/tests/unit/agents/test_routing_chat_model.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from qwenpaw.agents.routing_chat_model import RoutingChatModel, RoutingEndpoint
+from qwenpaw.config.config import AgentsLLMRoutingConfig
+
+
+class DummyStructuredOutput(BaseModel):
+    value: str
+
+
+class DummyFormatter:
+    pass
+
+
+class DummyModel:
+    def __init__(self, provider_id: str, model_name: str):
+        self.provider_id = provider_id
+        self.model_name = model_name
+        self.stream = True
+
+    async def __call__(self, *args, **kwargs):
+        return SimpleNamespace(
+            provider_id=self.provider_id,
+            model_name=self.model_name,
+            args=args,
+            kwargs=kwargs,
+        )
+
+
+def _endpoint(provider_id: str, model_name: str) -> RoutingEndpoint:
+    return RoutingEndpoint(
+        provider_id=provider_id,
+        model_name=model_name,
+        model=DummyModel(provider_id, model_name),
+        formatter=DummyFormatter(),
+        formatter_family=DummyFormatter,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_local_first_uses_local_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[],
+    )
+
+    assert response.provider_id == "local-provider"
+    assert response.model_name == "local-model"
+
+
+@pytest.mark.asyncio
+async def test_cloud_first_uses_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="cloud_first"),
+    )
+
+    response = await model(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[],
+    )
+
+    assert response.provider_id == "cloud-provider"
+    assert response.model_name == "cloud-model"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_forces_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[{"role": "user", "content": "extract a schema"}],
+        tools=[],
+        structured_model=DummyStructuredOutput,
+    )
+
+    assert response.provider_id == "cloud-provider"
+    assert response.model_name == "cloud-model"
+
+
+@pytest.mark.asyncio
+async def test_non_text_user_content_forces_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is in this image"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "file:///tmp/demo.png",
+                        },
+                    },
+                ],
+            },
+        ],
+        tools=[],
+    )
+
+    assert response.provider_id == "cloud-provider"
+    assert response.model_name == "cloud-model"
+
+
+@pytest.mark.asyncio
+async def test_text_blocks_do_not_force_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "text", "text": "world"},
+                ],
+            },
+        ],
+        tools=[],
+    )
+
+    assert response.provider_id == "local-provider"
+    assert response.model_name == "local-model"
+
+
+@pytest.mark.asyncio
+async def test_required_tool_choice_forces_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[{"role": "user", "content": "use a tool"}],
+        tools=[{"name": "search"}],
+        tool_choice="required",
+    )
+
+    assert response.provider_id == "cloud-provider"
+    assert response.model_name == "cloud-model"
+
+
+@pytest.mark.asyncio
+async def test_recent_tool_context_forces_cloud_route() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[
+            {"role": "assistant", "tool_calls": [{"id": "call-1"}]},
+            {"role": "tool", "content": "tool result"},
+        ],
+        tools=[],
+    )
+
+    assert response.provider_id == "cloud-provider"
+    assert response.model_name == "cloud-model"
+
+
+@pytest.mark.asyncio
+async def test_old_tool_context_does_not_pin_new_user_turn_to_cloud() -> None:
+    model = RoutingChatModel(
+        local_endpoint=_endpoint("local-provider", "local-model"),
+        cloud_endpoint=_endpoint("cloud-provider", "cloud-model"),
+        routing_cfg=AgentsLLMRoutingConfig(enabled=True, mode="local_first"),
+    )
+
+    response = await model(
+        messages=[
+            {"role": "assistant", "tool_calls": [{"id": "call-1"}]},
+            {"role": "tool", "content": "tool result"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "new question"},
+        ],
+        tools=[],
+    )
+
+    assert response.provider_id == "local-provider"
+    assert response.model_name == "local-model"

--- a/tests/unit/agents/test_routing_model_factory.py
+++ b/tests/unit/agents/test_routing_model_factory.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+from agentscope.model import OpenAIChatModel
+
+from qwenpaw.agents import model_factory
+from qwenpaw.agents.routing_chat_model import RoutingChatModel
+import qwenpaw.config.config as config_module
+import qwenpaw.config.utils as config_utils
+from qwenpaw.config.config import AgentsLLMRoutingConfig
+from qwenpaw.providers.models import ModelSlotConfig
+
+
+class FakeProvider:
+    def __init__(self, provider_id: str) -> None:
+        self.id = provider_id
+
+    def get_chat_model_cls(self):
+        return OpenAIChatModel
+
+
+class FakeManager:
+    def __init__(
+        self,
+        *,
+        providers: dict[str, FakeProvider],
+        active_model: ModelSlotConfig | None = None,
+    ) -> None:
+        self.providers = providers
+        self.active_model = active_model
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+class FakeChatModel:
+    def __init__(self, provider_id: str, model_name: str):
+        self.provider_id = provider_id
+        self.model_name = model_name
+        self.stream = True
+
+    async def __call__(self, *args, **kwargs):
+        return SimpleNamespace(
+            provider_id=self.provider_id,
+            model_name=self.model_name,
+            args=args,
+            kwargs=kwargs,
+        )
+
+
+def _patch_config_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agent_config,
+    global_routing_cfg: AgentsLLMRoutingConfig | None = None,
+) -> None:
+    if global_routing_cfg is None:
+        global_routing_cfg = AgentsLLMRoutingConfig(enabled=False)
+
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(llm_routing=global_routing_cfg),
+        ),
+    )
+
+
+def _patch_common_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    manager: FakeManager,
+) -> list[tuple[str, str]]:
+    created: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_active_chat_model",
+        lambda: FakeChatModel("global-provider", "global-model"),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "TokenRecordingModelWrapper",
+        lambda provider_id, model: model,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "RetryChatModel",
+        lambda model, retry_config=None, rate_limit_config=None: model,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda chat_model_class: SimpleNamespace(
+            formatter_for=chat_model_class.__name__,
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_from_family",
+        lambda formatter_family: SimpleNamespace(
+            formatter_for=formatter_family.__name__,
+        ),
+    )
+
+    def fake_create_model_instance_for_provider(
+        model_slot: ModelSlotConfig,
+        *,
+        manager: FakeManager,
+    ):
+        del manager
+        created.append((model_slot.provider_id, model_slot.model))
+        return (
+            FakeChatModel(
+                provider_id=model_slot.provider_id,
+                model_name=model_slot.model,
+            ),
+            OpenAIChatModel,
+        )
+
+    monkeypatch.setattr(
+        model_factory,
+        "_create_model_instance_for_provider",
+        fake_create_model_instance_for_provider,
+    )
+    return created
+
+
+def _running_config():
+    return SimpleNamespace(
+        llm_retry_enabled=False,
+        llm_max_retries=0,
+        llm_backoff_base=0.1,
+        llm_backoff_cap=1.0,
+        llm_max_concurrent=1,
+        llm_max_qpm=0,
+        llm_rate_limit_pause=0.0,
+        llm_rate_limit_jitter=0.0,
+        llm_acquire_timeout=1.0,
+    )
+
+
+def test_routing_uses_agent_active_cloud_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="local_first",
+        local=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+        cloud=None,
+    )
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={
+            "ollama": FakeProvider("ollama"),
+            "openai": FakeProvider("openai"),
+        },
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+    )
+    created = _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    model, formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert isinstance(model, RoutingChatModel)
+    assert model.local_endpoint.provider_id == "ollama"
+    assert model.local_endpoint.model_name == "qwen2.5:7b"
+    assert model.cloud_endpoint.provider_id == "openai"
+    assert model.cloud_endpoint.model_name == "gpt-5"
+    assert formatter.formatter_for == "OpenAIChatFormatter"
+    assert getattr(formatter, "_qwenpaw_routing_preserve_media", False) is True
+    assert created == [
+        ("ollama", "qwen2.5:7b"),
+        ("openai", "gpt-5"),
+    ]
+
+
+def test_create_model_and_formatter_uses_explicit_cloud_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="cloud_first",
+        local=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+        cloud=ModelSlotConfig(
+            provider_id="openai",
+            model="gpt-5",
+        ),
+    )
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={
+            "ollama": FakeProvider("ollama"),
+            "openai": FakeProvider("openai"),
+        },
+        active_model=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+    )
+    created = _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    model, _ = model_factory.create_model_and_formatter(agent_id="agent-1")
+
+    assert isinstance(model, RoutingChatModel)
+    assert model.local_endpoint.provider_id == "ollama"
+    assert model.cloud_endpoint.provider_id == "openai"
+    assert model.routing_cfg.mode == "cloud_first"
+    assert created == [
+        ("ollama", "qwen2.5:7b"),
+        ("openai", "gpt-5"),
+    ]
+
+
+def test_routing_enabled_requires_local_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(enabled=True)
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={"openai": FakeProvider("openai")},
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+    )
+    _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    with pytest.raises(ValueError, match="local slot is not configured"):
+        model_factory.create_model_and_formatter(agent_id="agent-1")
+
+
+def test_routing_enabled_requires_resolved_cloud_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        local=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+    )
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={"ollama": FakeProvider("ollama")},
+        active_model=None,
+    )
+    _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    with pytest.raises(ValueError, match="cloud slot could not be resolved"):
+        model_factory.create_model_and_formatter(agent_id="agent-1")
+
+
+def test_routing_enabled_formatter_mismatch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LocalFormatter:
+        __name__ = "LocalFormatter"
+
+    class CloudFormatter:
+        __name__ = "CloudFormatter"
+
+    routing_cfg = AgentsLLMRoutingConfig(
+        enabled=True,
+        local=ModelSlotConfig(provider_id="ollama", model="qwen2.5:7b"),
+        cloud=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+    )
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={
+            "ollama": FakeProvider("ollama"),
+            "openai": FakeProvider("openai"),
+        },
+        active_model=ModelSlotConfig(provider_id="openai", model="gpt-5"),
+    )
+    _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    def fake_create_routing_endpoint(
+        model_slot,
+        manager,
+        retry_config=None,
+        rate_limit_config=None,
+    ):
+        del manager, retry_config, rate_limit_config
+        return SimpleNamespace(
+            provider_id=model_slot.provider_id,
+            model_name=model_slot.model,
+            formatter_family=(
+                LocalFormatter
+                if model_slot.provider_id == "ollama"
+                else CloudFormatter
+            ),
+        )
+
+    monkeypatch.setattr(
+        model_factory,
+        "_create_routing_endpoint",
+        fake_create_routing_endpoint,
+    )
+
+    with pytest.raises(ValueError, match="same formatter family"):
+        model_factory.create_model_and_formatter(agent_id="agent-1")
+
+
+def test_routing_disabled_uses_manager_active_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_cfg = AgentsLLMRoutingConfig(enabled=False)
+    agent_config = SimpleNamespace(
+        active_model=ModelSlotConfig(),
+        llm_routing=routing_cfg,
+        running=_running_config(),
+    )
+    manager = FakeManager(
+        providers={"global-provider": FakeProvider("global-provider")},
+        active_model=ModelSlotConfig(
+            provider_id="global-provider",
+            model="global-model",
+        ),
+    )
+    _patch_common_mocks(monkeypatch, manager=manager)
+    _patch_config_loaders(monkeypatch, agent_config=agent_config)
+
+    model, formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert isinstance(model, FakeChatModel)
+    assert model.provider_id == "global-provider"
+    assert model.model_name == "global-model"
+    assert formatter.formatter_for == "OpenAIChatModel"


### PR DESCRIPTION
## Summary
- wire `llm_routing` into the current QwenPaw runtime path
- add deterministic local/cloud routing for structured output, non-text user content, required tools, and recent tool context
- make multimodal prompt/message handling routing-aware so media is preserved for cloud-bound requests

## Validation
- `python3 -m compileall src/qwenpaw/agents/model_factory.py src/qwenpaw/agents/routing_chat_model.py src/qwenpaw/agents/prompt.py`

Split out from #3443 so routing/runtime changes can be reviewed separately from the Settings UI.