### PR TITLE
feat: provider sort

### DIFF
--- a/console/src/pages/Agent/MCP/index.module.less
+++ b/console/src/pages/Agent/MCP/index.module.less
@@ -1,4 +1,14 @@
 .mcpPage {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .pageHeader {

--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -180,7 +180,9 @@ function MCPPage() {
           <p>{t("common.loading")}</p>
         </div>
       ) : clients.length === 0 ? (
-        <Empty description={t("mcp.emptyState")} />
+        <div className={styles.emptyState}>
+          <Empty description={t("mcp.emptyState")} />
+        </div>
       ) : (
         <div className={styles.mcpGrid}>
           {clients.map((client) => (

--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -34,6 +34,36 @@ function ModelsPage() {
       if (p.is_local) local.push(p);
       else regular.push(p);
     }
+
+    // Sort providers: custom/available first, then configured, then the rest.
+    // This mirrors the isConfigured logic in RemoteProviderCard.
+    const sortPriority = (provider: ProviderInfo): number => {
+      let isConfigured = false;
+      if (provider.id === "qwenpaw-local") {
+        isConfigured = true;
+      } else if (provider.is_custom && provider.base_url) {
+        isConfigured = true;
+      } else if (provider.require_api_key === false) {
+        isConfigured = true;
+      } else if (provider.require_api_key && provider.api_key) {
+        isConfigured = true;
+      }
+
+      const hasModels =
+        provider.models.length + provider.extra_models.length > 0;
+      const isAvailable = isConfigured && hasModels;
+
+      // Lower number = higher priority (shown first)
+      if (provider.is_custom && isAvailable) return 0;
+      if (provider.is_custom && isConfigured) return 1;
+      if (provider.is_custom) return 2;
+      if (isAvailable) return 3;
+      if (isConfigured) return 4;
+      return 5;
+    };
+
+    regular.sort((a, b) => sortPriority(a) - sortPriority(b));
+
     // Fuzzy search filter: match provider name (case-insensitive)
     const query = searchQuery.trim().toLowerCase();
     if (!query) {

--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -54,12 +54,13 @@ function ModelsPage() {
       const isAvailable = isConfigured && hasModels;
 
       // Lower number = higher priority (shown first)
-      if (provider.is_custom && isAvailable) return 0;
-      if (provider.is_custom && isConfigured) return 1;
+      // Available providers (configured + has models) always come first,
+      // then custom providers, then configured-only, then unconfigured.
+      if (isAvailable && provider.is_custom) return 0;
+      if (isAvailable) return 1;
       if (provider.is_custom) return 2;
-      if (isAvailable) return 3;
-      if (isConfigured) return 4;
-      return 5;
+      if (isConfigured) return 3;
+      return 4;
     };
 
     regular.sort((a, b) => sortPriority(a) - sortPriority(b));


### PR DESCRIPTION
## Description

Add priority sorting logic to the list, with the following sorting rules (priority from high to low):

Priority | Type Description

Custom + Available: A configured custom Provider with a model.

1 Built-in + Available: A configured built-in Provider with a model.

2 Custom (Other): A custom Provider (not fully configured).

3 Configured (No Model): A configured Provider without a model.

4 Not Configured: An unconfigured Provider.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

Fixes #3410

