### PR TITLE
style: Navigation bar distinguishes agent area styles

### DIFF
--- a/console/src/components/AgentSelector/index.module.less
+++ b/console/src/components/AgentSelector/index.module.less
@@ -4,7 +4,7 @@
   flex-direction: column;
   gap: 2px;
   padding: 8px 12px;
-  background: rgba(43, 18, 0, 0.02);
+  background: #fff;
   border: 1px solid rgba(26, 23, 22, 0.06);
   border-radius: 8px;
   box-sizing: border-box;

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -236,9 +236,9 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     },
   ];
 
-  // ── Menu items ────────────────────────────────────────────────────────────
+  // ── Menu items — agent-scoped (Chat + Control + Workspace) ──────────────
 
-  const menuItems: MenuProps["items"] = [
+  const agentMenuItems: MenuProps["items"] = [
     {
       key: "chat",
       label: collapsed ? null : t("nav.chat"),
@@ -301,6 +301,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
         },
       ],
     },
+  ];
+
+  // ── Menu items — global settings ──────────────────────────────────────
+
+  const settingsMenuItems: MenuProps["items"] = [
     {
       key: "settings-group",
       label: collapsed ? null : t("nav.settings"),
@@ -353,10 +358,6 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
         collapsed ? ` ${styles.siderCollapsed}` : ""
       }${isDark ? ` ${styles.siderDark}` : ""}`}
     >
-      <div className={styles.agentSelectorContainer}>
-        <AgentSelector collapsed={collapsed} />
-      </div>
-
       {collapsed ? (
         <nav className={styles.collapsedNav}>
           {collapsedNavItems.map((item) => {
@@ -384,18 +385,40 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
           })}
         </nav>
       ) : (
-        <Menu
-          mode="inline"
-          selectedKeys={[selectedKey]}
-          openKeys={DEFAULT_OPEN_KEYS}
-          onClick={({ key }) => {
-            const path = KEY_TO_PATH[String(key)];
-            if (path) navigate(path);
-          }}
-          items={menuItems}
-          theme={isDark ? "dark" : "light"}
-          className={styles.sideMenu}
-        />
+        <>
+          {/* Agent-scoped section: selector + Chat + Control + Workspace */}
+          <div className={styles.agentScopedSection}>
+            <div className={styles.agentSelectorContainer}>
+              <AgentSelector collapsed={collapsed} />
+            </div>
+            <Menu
+              mode="inline"
+              selectedKeys={[selectedKey]}
+              openKeys={DEFAULT_OPEN_KEYS}
+              onClick={({ key }) => {
+                const path = KEY_TO_PATH[String(key)];
+                if (path) navigate(path);
+              }}
+              items={agentMenuItems}
+              theme={isDark ? "dark" : "light"}
+              className={styles.sideMenu}
+            />
+          </div>
+
+          {/* Global settings section */}
+          <Menu
+            mode="inline"
+            selectedKeys={[selectedKey]}
+            openKeys={DEFAULT_OPEN_KEYS}
+            onClick={({ key }) => {
+              const path = KEY_TO_PATH[String(key)];
+              if (path) navigate(path);
+            }}
+            items={settingsMenuItems}
+            theme={isDark ? "dark" : "light"}
+            className={styles.sideMenu}
+          />
+        </>
       )}
 
       {authEnabled && !collapsed && (

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -56,13 +56,25 @@
   -ms-overflow-style: none;
   /* IE and Edge */
 
+  // Agent-scoped section: selector + Chat + Control + Workspace
+  .agentScopedSection {
+    background: rgba(43, 18, 0, 0.02);
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    padding: 4px;
+
+    :global {
+      .qwenpaw-menu {
+        background: transparent !important;
+      }
+    }
+  }
   // AgentSelector container - fixed at top
   .agentSelectorContainer {
     position: sticky;
     top: 0;
     z-index: 10;
-    background: #f9f8f4;
-    margin-bottom: 12px;
+    margin-bottom: 4px;
   }
 
   // Menu takes remaining space
@@ -129,7 +141,6 @@
 
   :global {
     .qwenpaw-menu {
-      background: #f9f8f4 !important;
       border-inline-end: 0 !important;
     }
 
@@ -197,9 +208,10 @@
   background: #1a1a1a !important;
   border-right-color: rgba(255, 255, 255, 0.08) !important;
 
-  // AgentSelector container - fixed at top (dark mode)
-  .agentSelectorContainer {
-    background: #1a1a1a;
+  // Agent-scoped section (dark mode)
+  .agentScopedSection {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
   }
 
   :global {


### PR DESCRIPTION
## Description

Navigation bar distinguishes agent area styles
<img width="1554" height="1229" alt="左边菜单" src="https://github.com/user-attachments/assets/fb6c083f-f9fb-4bb0-bd57-d964cdbbb786" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
