### PR TITLE
fix(desktop): isolate packaged Python from user site-packages to prevent dependency conflicts

### DIFF
--- a/scripts/pack/README.md
+++ b/scripts/pack/README.md
@@ -49,10 +49,10 @@ If the .app crashes on double-click, run it from Terminal to see the full error 
 ```bash
 # From repo root; force packed env only (no system conda / PYTHONPATH). Adjust path if needed.
 APP_ENV="$(pwd)/dist/QwenPaw.app/Contents/Resources/env"
-PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
+PYTHONNOUSERSITE=1 PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
 ```
 
-All stdout/stderr (including Python tracebacks) will appear in the terminal. Use this to debug startup errors or to run with `--log-level debug`.
+The `PYTHONNOUSERSITE=1` prevents Python from loading packages from `~/.local/lib/pythonX.Y/site-packages`, which can conflict with the packaged environment. All stdout/stderr (including Python tracebacks) will appear in the terminal. Use this to debug startup errors or to run with `--log-level debug`.
 
 When you **double-click** the .app and nothing appears, the launcher writes stderr/stdout to `~/.qwenpaw/desktop.log`. Inspect that file for errors.
 

--- a/scripts/pack/README_zh.md
+++ b/scripts/pack/README_zh.md
@@ -47,10 +47,10 @@ CREATE_ZIP=1 bash ./scripts/pack/build_macos.sh   # 同时生成 .zip
 ```bash
 # 在仓库根目录执行，强制只用打包环境（不用系统 conda / PYTHONPATH）。路径按需改。
 APP_ENV="$(pwd)/dist/QwenPaw.app/Contents/Resources/env"
-PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
+PYTHONNOUSERSITE=1 PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
 ```
 
-所有标准输出和错误（包括 Python traceback）都会打在终端里；可加 `--log-level debug` 查看更详细日志。
+`PYTHONNOUSERSITE=1` 可防止 Python 加载 `~/.local/lib/pythonX.Y/site-packages` 中的包，避免与打包环境冲突。所有标准输出和错误（包括 Python traceback）都会打在终端里；可加 `--log-level debug` 查看更详细日志。
 
 若**双击** .app 没有任何窗口出现，启动器会把 stderr/stdout 写入 `~/.qwenpaw/desktop.log`，可打开该文件查看报错。
 

--- a/scripts/pack/build_macos.sh
+++ b/scripts/pack/build_macos.sh
@@ -63,6 +63,7 @@ ENV_DIR="$(cd "$(dirname "$0")/../Resources/env" && pwd)"
 LOG="$HOME/.qwenpaw/desktop.log"
 unset PYTHONPATH
 export PYTHONHOME="$ENV_DIR"
+export PYTHONNOUSERSITE=1
 export QWENPAW_DESKTOP_APP=1
 
 # Preserve system PATH for accessing system commands (e.g. imsg, brew)

--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -158,6 +158,9 @@ $LauncherBat = Join-Path $EnvRoot "QwenPaw Desktop.bat"
 @echo off
 cd /d "%~dp0"
 
+REM Isolate packaged Python from user site-packages to prevent conflicts
+set "PYTHONNOUSERSITE=1"
+
 REM Preserve system PATH for accessing system commands
 REM Prepend packaged env to PATH so packaged Python takes precedence
 set "PATH=%~dp0;%~dp0Scripts;%PATH%"
@@ -191,6 +194,9 @@ $DebugBat = Join-Path $EnvRoot "QwenPaw Desktop (Debug).bat"
 @echo off
 cd /d "%~dp0"
 
+REM Isolate packaged Python from user site-packages to prevent conflicts
+set "PYTHONNOUSERSITE=1"
+
 REM Preserve system PATH for accessing system commands
 REM Prepend packaged env to PATH so packaged Python takes precedence
 set "PATH=%~dp0;%~dp0Scripts;%PATH%"
@@ -218,6 +224,7 @@ echo ====================================
 echo Working Directory: %cd%
 echo Python: "%~dp0python.exe"
 echo PATH: %PATH%
+echo PYTHONNOUSERSITE: %PYTHONNOUSERSITE%
 echo Log Level: %QWENPAW_LOG_LEVEL%
 echo SSL_CERT_FILE: %SSL_CERT_FILE%
 echo REQUESTS_CA_BUNDLE: %REQUESTS_CA_BUNDLE%

--- a/website/public/docs/desktop.en.md
+++ b/website/public/docs/desktop.en.md
@@ -182,9 +182,9 @@ If the app crashes or you need to see detailed logs:
 # Navigate to the application directory
 cd /Applications  # or wherever your QwenPaw.app is located
 
-# Set environment variables and launch
+# Set environment variables and launch (isolate packaged env, avoid conflicts)
 APP_ENV="$(pwd)/QwenPaw.app/Contents/Resources/env"
-PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
+PYTHONNOUSERSITE=1 PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
 ```
 
 **Advantages of terminal launch:**

--- a/website/public/docs/desktop.zh.md
+++ b/website/public/docs/desktop.zh.md
@@ -182,9 +182,9 @@ xattr -cr /Applications/QwenPaw.app
 # 切换到应用目录
 cd /Applications  # 或您的 QwenPaw.app 所在目录
 
-# 设置环境变量并启动
+# 设置环境变量并启动（隔离打包环境，避免冲突）
 APP_ENV="$(pwd)/QwenPaw.app/Contents/Resources/env"
-PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
+PYTHONNOUSERSITE=1 PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
 ```
 
 **终端启动的优势：**


### PR DESCRIPTION
## Description

Fix a critical issue where the packaged QwenPaw desktop app loads incompatible packages from user's local site-packages directory, causing import errors and startup failures.

**Problem:**
- macOS/Windows launchers did not set `PYTHONNOUSERSITE=1`
- Python loads packages from `~/.local/lib/pythonX.Y/site-packages` (macOS) or `%APPDATA%\Python` (Windows) even when `PYTHONPATH` and `PYTHONHOME` are set
- User-installed packages with different versions can shadow packaged dependencies
- Example: User's old `protobuf < 4.x` without `runtime_version` causes `ImportError` in `a2a.grpc.a2a_pb2`

**Solution:**
- Set `PYTHONNOUSERSITE=1` in both macOS launcher script and Windows .bat files
- This completely disables Python's user site-packages directory
- Ensures the packaged environment is fully isolated from system/user Python installations

**Related Issue:** Fixes user-reported startup error with protobuf version conflicts

**Security Considerations:** Improves isolation of packaged environment, reducing supply chain risks from user-installed packages

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

**Before this fix:**
```bash
# User with old protobuf in ~/.local/ gets:
APP_ENV="dist/QwenPaw.app/Contents/Resources/env"
PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
# ImportError: cannot import name 'runtime_version' from 'google.protobuf'
```

**After this fix:**
```bash
# PYTHONNOUSERSITE=1 ensures isolation:
APP_ENV="dist/QwenPaw.app/Contents/Resources/env"
PYTHONNOUSERSITE=1 PYTHONPATH= PYTHONHOME="$APP_ENV" "$APP_ENV/bin/python" -m qwenpaw desktop
# Works correctly - packaged protobuf is used
```

**Verification:**
```bash
# Check sys.path does NOT include ~/.local/
PYTHONNOUSERSITE=1 "$APP_ENV/bin/python" -c "import sys; print('\n'.join(sys.path))"
```

## Local Verification Evidence

```bash
pre-commit run --all-files
# All checks passed

# Manual verification:
# 1. Built new QwenPaw.app with updated launcher
# 2. Verified PYTHONNOUSERSITE=1 in launcher script
# 3. Tested that user packages