### PR TITLE
fix(mission): Detect active mission before agent creation to enable tool guard bypass

### DIFF
--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -488,6 +488,14 @@ class AgentRunner(Runner):
             if isinstance(mission_result, dict):
                 mission_info = mission_result
 
+            # Active mission: auto-detect follow-up messages
+            # (e.g., user confirms PRD without typing /mission again)
+            if mission_info is None:
+                mission_info = detect_active_mission_phase(
+                    _ws,
+                    session_id=session_id,
+                )
+
             # Mission Mode: bypass tool guard
             # (workers can't respond to /approve)
             if mission_info is not None:
@@ -495,6 +503,36 @@ class AgentRunner(Runner):
                 logger.info(
                     "Mission Mode: bypassing tool guard for session %s",
                     session_id,
+                )
+                # Inject context reminder for active mission
+                loop_dir = mission_info.get("loop_dir", "")
+                phase = mission_info.get("mission_phase", 1)
+                if phase == 1:
+                    refresher = (
+                        f"[Mission active — dir: `{loop_dir}`]\n"
+                        f"You are in Mission Phase 1 (PRD review). "
+                        f"The user's message follows.\n"
+                        f"If the user is confirming the PRD, update "
+                        f"`{loop_dir}/loop_config.json` setting "
+                        f"`current_phase` to `execution_confirmed`.\n"
+                        f"If the user requests changes, modify "
+                        f"prd.json.\n---\n"
+                    )
+                elif phase == 2:
+                    refresher = (
+                        f"[Mission active — dir: `{loop_dir}`]\n"
+                        f"You are in Mission Phase 2 (execution). "
+                        f"The user's follow-up message follows.\n"
+                        f"Continue the worker → verifier pipeline. "
+                        f"Check prd.json progress and dispatch workers "
+                        f"for remaining stories.\n---\n"
+                    )
+                else:
+                    refresher = f"[Mission active — dir: `{loop_dir}`]\n---\n"
+                original = query or ""
+                self._rewrite_last_message_text(
+                    msgs,
+                    refresher + original,
                 )
 
             agent = QwenPawAgent(
@@ -546,47 +584,6 @@ class AgentRunner(Runner):
                     f"ChatManager is None! Cannot auto-register chat for "
                     f"session_id={session_id}",
                 )
-
-            # Active mission: auto-route follow-up messages
-            if mission_info is None:
-                mission_info = detect_active_mission_phase(
-                    _ws,
-                    session_id=session_id,
-                )
-                if mission_info is not None:
-                    loop_dir = mission_info["loop_dir"]
-                    phase = mission_info.get("mission_phase", 1)
-
-                    if phase == 1:
-                        refresher = (
-                            f"[Mission active — dir: `{loop_dir}`]\n"
-                            f"You are in Mission Phase 1 (PRD review). "
-                            f"The user's message follows.\n"
-                            f"If the user is confirming the PRD, update "
-                            f"`{loop_dir}/loop_config.json` setting "
-                            f"`current_phase` to `execution_confirmed`.\n"
-                            f"If the user requests changes, modify "
-                            f"prd.json.\n---\n"
-                        )
-                    elif phase == 2:
-                        refresher = (
-                            f"[Mission active — dir: `{loop_dir}`]\n"
-                            f"You are in Mission Phase 2 (execution). "
-                            f"The user's follow-up message follows.\n"
-                            f"Continue the worker → verifier pipeline. "
-                            f"Check prd.json progress and dispatch workers "
-                            f"for remaining stories.\n---\n"
-                        )
-                    else:
-                        refresher = (
-                            f"[Mission active — dir: `{loop_dir}`]\n---\n"
-                        )
-
-                    original = query or ""
-                    self._rewrite_last_message_text(
-                        msgs,
-                        refresher + original,
-                    )
 
             # Skill info (/<name> without input) is display-only
             if mission_info is None:


### PR DESCRIPTION
## Description

Fixes a timing issue in Mission Mode where tool guard bypass was not applied during Phase 2 execution, causing pending approvals to accumulate and interfere with subsequent user inputs.

**Root Cause:**
When a user confirms the PRD to enter Phase 2 (without typing `/mission` again), the active mission detection (`detect_active_mission_phase`) was called **after** agent creation. This meant the agent was created without `_headless_tool_guard = "false"`, causing tool calls to trigger the guard and create pending approvals that would persist after mission completion.

**Solution:**
Move `detect_active_mission_phase` before agent creation to ensure `_headless_tool_guard = "false"` is set in `request_context` for both explicit `/mission` commands and Phase 2 follow-ups.

**Related Issue:** Fixes internal issue where users received "Tool denied" errors after mission completion

**Security Considerations:** None - this is a timing fix that ensures the existing bypass mechanism works correctly

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

### How to Test

1. Start a mission: `/mission write a test file`
2. Wait for PRD generation (Phase 1)
3. Confirm the PRD by typing "agree" or similar (without `/mission`)
4. Verify Phase 2 executes without approval prompts
5. After mission completes, verify tool guard is re-enabled

### Expected Behavior

**Before fix:**
- Phase 2 would trigger tool approvals
- Pending approvals would accumulate
- After mission exit, user input would be misinterpreted as "denial"

**After fix:**
- Phase 2 correctly bypasses tool guard
- No pending approvals accumulate
- After mission exit, tool guard properly re-enables

## Local Verification Evidence

```bash
# Run pre-commit checks
pre-commit run --all-files
# Expected: All hooks pass
