### PR TITLE
feat(WeChat): support quoted message handling and audio file sending

### DIFF
--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -672,6 +672,19 @@ class WeixinChannel(BaseChannel):
                 else:
                     text_parts.append(f"[unsupported type: {item_type}]")
 
+                # Handle quoted (replied-to) message if present.
+                # When a user replies to a message in WeChat, the item
+                # contains a ``ref_msg`` field whose ``message_item``
+                # mirrors the structure of a normal item (type 1-5).
+                ref_msg = item.get("ref_msg")
+                if ref_msg:
+                    await self._process_quoted_ref_msg(
+                        ref_msg,
+                        text_parts,
+                        content_parts,
+                        client,
+                    )
+
             text = "\n".join(text_parts).strip()
             if text:
                 content_parts.insert(
@@ -761,6 +774,141 @@ class WeixinChannel(BaseChannel):
 
         except Exception:
             logger.exception("weixin _on_message failed")
+
+    async def _process_quoted_ref_msg(
+        self,
+        ref_msg: Dict[str, Any],
+        text_parts: List[str],
+        content_parts: List[Any],
+        client: ILinkClient,
+    ) -> None:
+        """Process a quoted (replied-to) message from ``ref_msg``.
+
+        Extracts text and media from the referenced message and prepends
+        quoted text to *text_parts* / appends media to *content_parts*,
+        following the same pattern used by the WeCom and Feishu channels.
+
+        Args:
+            ref_msg: The ``ref_msg`` dict from an inbound item.
+            text_parts: Mutable list of text strings to prepend quoted text.
+            content_parts: Mutable list of content parts to append media.
+            client: The ILinkClient used for downloading media.
+        """
+        quoted_item = ref_msg.get("message_item") or {}
+        quoted_type = quoted_item.get("type", 0)
+
+        if quoted_type == 1:
+            # Quoted text
+            quoted_text = (
+                (quoted_item.get("text_item") or {}).get("text", "").strip()
+            )
+            if quoted_text:
+                text_parts.insert(0, f"[quoted message: {quoted_text}]")
+
+        elif quoted_type == 2:
+            # Quoted image
+            img_item = quoted_item.get("image_item") or {}
+            media = img_item.get("media") or {}
+            encrypt_query_param = media.get("encrypt_query_param", "")
+            aeskey_hex = img_item.get("aeskey", "")
+            if aeskey_hex:
+                aes_key = _b64.b64encode(
+                    bytes.fromhex(aeskey_hex),
+                ).decode()
+            else:
+                aes_key = media.get("aes_key", "")
+            if encrypt_query_param:
+                path = await self._download_media(
+                    client,
+                    "",
+                    aes_key,
+                    "image.jpg",
+                    encrypt_query_param=encrypt_query_param,
+                )
+                if path:
+                    content_parts.append(
+                        ImageContent(
+                            type=ContentType.IMAGE,
+                            image_url=path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted image: download failed]")
+            else:
+                text_parts.insert(0, "[quoted image: no url]")
+
+        elif quoted_type == 3:
+            # Quoted voice — use ASR transcription
+            voice_item = quoted_item.get("voice_item") or {}
+            asr_text = (
+                voice_item.get("text_item", {}).get("text", "").strip()
+                if isinstance(voice_item.get("text_item"), dict)
+                else voice_item.get("text", "").strip()
+            )
+            if asr_text:
+                text_parts.insert(0, f"[quoted voice: {asr_text}]")
+            else:
+                text_parts.insert(0, "[quoted voice: no transcription]")
+
+        elif quoted_type == 4:
+            # Quoted file
+            file_item = quoted_item.get("file_item") or {}
+            filename = file_item.get("file_name", "file.bin") or "file.bin"
+            media = file_item.get("media") or {}
+            encrypt_query_param = media.get("encrypt_query_param", "")
+            aes_key = media.get("aes_key", "")
+            if encrypt_query_param:
+                path = await self._download_media(
+                    client,
+                    "",
+                    aes_key,
+                    filename,
+                    encrypt_query_param=encrypt_query_param,
+                )
+                if path:
+                    content_parts.append(
+                        FileContent(
+                            type=ContentType.FILE,
+                            file_url=path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted file: download failed]")
+            else:
+                text_parts.insert(0, "[quoted file: no url]")
+
+        elif quoted_type == 5:
+            # Quoted video
+            video_item = quoted_item.get("video_item") or {}
+            media = video_item.get("media") or {}
+            encrypt_query_param = media.get("encrypt_query_param", "")
+            aes_key = media.get("aes_key", "")
+            if encrypt_query_param:
+                path = await self._download_media(
+                    client,
+                    "",
+                    aes_key,
+                    "video.mp4",
+                    encrypt_query_param=encrypt_query_param,
+                )
+                if path:
+                    content_parts.append(
+                        VideoContent(
+                            type=ContentType.VIDEO,
+                            video_url=path,
+                        ),
+                    )
+                else:
+                    text_parts.insert(0, "[quoted video: download failed]")
+            else:
+                text_parts.insert(0, "[quoted video: no url]")
+
+        else:
+            if quoted_type:
+                text_parts.insert(
+                    0,
+                    f"[quoted message: unsupported type {quoted_type}]",
+                )
 
     # ------------------------------------------------------------------
     # Media download helper
@@ -984,6 +1132,18 @@ class WeixinChannel(BaseChannel):
                         context_token,
                         video_url,
                         ContentType.VIDEO,
+                    )
+            elif t == ContentType.AUDIO:
+                # Send audio as file (WeChat has no dedicated audio send)
+                audio_url = getattr(p, "data", None) or (
+                    p.get("data") if isinstance(p, dict) else None
+                )
+                if audio_url and not audio_url.startswith("data:"):
+                    await self._send_media_file(
+                        to_user_id,
+                        context_token,
+                        audio_url,
+                        ContentType.FILE,
                     )
 
         body = "\n".join(text_parts).strip()


### PR DESCRIPTION
## Description

Two improvements for the WeChat (iLink) channel:

- Quoted message support: When a user replies to a message in WeChat, the inbound item contains a ref_msg field. Added _process_quoted_ref_msg method to extract referenced content (text, image, voice, file, video) from ref_msg.message_item and prepend quoted text / append media to content parts, following the same pattern as WeCom and Feishu channels.

- Audio file sending: Added ContentType.AUDIO handling in send_content_parts. Since WeChat has no dedicated audio message API, audio files are sent as regular file attachments via send_file.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
