### PR TITLE
feat(acp): add ACP server — expose QwenPaw as ACP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pillow>=10.0.0",
     # anyio 4.13.0: _deliver_cancellation busy-loop / getpid storm (QwenPaw#2632)
     "anyio>=4.0.0,<4.13.0",
+    "agent-client-protocol>=0.9.0",
 ]
 
 [tool.setuptools.dynamic]

--- a/src/qwenpaw/agents/acp/__init__.py
+++ b/src/qwenpaw/agents/acp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Minimal ACP exports."""
+"""ACP client and server exports."""
 
 from .core import (
     ACPAgentConfig,
@@ -12,6 +12,7 @@ from .core import (
     PermissionResolution,
     SuspendedPermission,
 )
+from .server import QwenPawACPAgent, run_qwenpaw_agent
 from .service import ACPService, get_acp_service, init_acp_service
 
 __all__ = [
@@ -23,8 +24,10 @@ __all__ = [
     "ACPSessionError",
     "ACPTransportError",
     "ACPService",
+    "QwenPawACPAgent",
     "get_acp_service",
     "init_acp_service",
     "PermissionResolution",
+    "run_qwenpaw_agent",
     "SuspendedPermission",
 ]

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -57,8 +57,16 @@ from acp.schema import (
     SseMcpServer,
     TextContentBlock,
 )
+from agentscope.message import Msg
+from agentscope_runtime.engine.schemas.agent_schemas import (
+    AgentRequest,
+    Message,
+)
 
 from ...__version__ import __version__
+from ...constant import WORKING_DIR
+from ...providers.models import ModelSlotConfig
+from ...providers.provider_manager import ProviderManager
 
 logger = logging.getLogger(__name__)
 
@@ -342,7 +350,6 @@ class QwenPawACPAgent(Agent):
         self._cancel_events: dict[str, asyncio.Event] = {}
         self._workspace: Any | None = None
         self._workspace_ready = False
-        self._session_mode: str = self.MODE_DEFAULT
 
     def on_connect(self, conn: Client) -> None:
         self._conn = conn
@@ -356,7 +363,7 @@ class QwenPawACPAgent(Agent):
         if self._agent_id is not None:
             return self._agent_id
 
-        from ...config import load_config
+        from ...config.utils import load_config
 
         config = load_config()
         agents_cfg = getattr(config, "agents", None)
@@ -373,15 +380,17 @@ class QwenPawACPAgent(Agent):
         """Return the effective workspace directory."""
         if self._workspace_dir is not None:
             return self._workspace_dir
-
-        from ...constant import WORKING_DIR
-
         return WORKING_DIR / "workspaces" / agent_id
 
     async def _ensure_workspace(self) -> Any:
         """Boot a full ``Workspace`` (once) and return its runner."""
         if self._workspace is not None and self._workspace_ready:
-            return self._workspace.runner
+            runner = self._workspace.runner
+            if runner is None:
+                raise RuntimeError(
+                    "Workspace runner is not available after startup",
+                )
+            return runner
 
         from ...app.workspace.workspace import Workspace
 
@@ -395,8 +404,12 @@ class QwenPawACPAgent(Agent):
         await workspace.start()
 
         runner = workspace.runner
-        if runner is not None:
-            await runner.init_handler()
+        if runner is None:
+            raise RuntimeError(
+                "Workspace started but runner is not available. "
+                "Check agent configuration and workspace setup.",
+            )
+        await runner.init_handler()
 
         self._workspace = workspace
         self._workspace_ready = True
@@ -464,7 +477,7 @@ class QwenPawACPAgent(Agent):
         self._sessions[session_id] = {
             "cwd": cwd,
             "user_id": f"acp_{session_id[:8]}",
-            "mcp_servers": mcp_servers,
+            "mode": self.MODE_DEFAULT,
         }
         logger.info(
             "ACP new_session: id=%s cwd=%s",
@@ -473,7 +486,7 @@ class QwenPawACPAgent(Agent):
         )
         return NewSessionResponse(
             session_id=session_id,
-            config_options=self._build_config_options(),
+            config_options=self._build_config_options(session_id),
         )
 
     async def load_session(  # pylint: disable=unused-argument
@@ -488,7 +501,7 @@ class QwenPawACPAgent(Agent):
         self._sessions[session_id] = {
             "cwd": cwd,
             "user_id": f"acp_{session_id[:8]}",
-            "mcp_servers": mcp_servers,
+            "mode": self.MODE_DEFAULT,
         }
         logger.info(
             "ACP load_session: id=%s cwd=%s",
@@ -526,12 +539,6 @@ class QwenPawACPAgent(Agent):
         cancel_event = asyncio.Event()
         self._cancel_events[session_id] = cancel_event
 
-        from agentscope.message import Msg
-        from agentscope_runtime.engine.schemas.agent_schemas import (
-            AgentRequest,
-            Message,
-        )
-
         msgs = [
             Msg(
                 name="user",
@@ -540,8 +547,9 @@ class QwenPawACPAgent(Agent):
             ),
         ]
 
+        session_mode = session_info.get("mode", self.MODE_DEFAULT)
         request_context: dict[str, str] = {}
-        if self._session_mode == self.MODE_BYPASS:
+        if session_mode == self.MODE_BYPASS:
             request_context["_headless_tool_guard"] = "false"
 
         request = AgentRequest(
@@ -647,7 +655,7 @@ class QwenPawACPAgent(Agent):
             self._sessions[session_id] = {
                 "cwd": cwd,
                 "user_id": f"acp_{session_id[:8]}",
-                "mcp_servers": mcp_servers,
+                "mode": self.MODE_DEFAULT,
             }
         else:
             self._sessions[session_id]["cwd"] = cwd
@@ -672,6 +680,11 @@ class QwenPawACPAgent(Agent):
                 model_id,
             )
             return None
+        logger.info(
+            "Model switched to %s for agent %s",
+            model_id,
+            self._resolve_agent_id(),
+        )
         return SetSessionModelResponse()
 
     async def set_config_option(  # pylint: disable=unused-argument
@@ -694,9 +707,17 @@ class QwenPawACPAgent(Agent):
                     f"Must be '{self.MODE_DEFAULT}' or "
                     f"'{self.MODE_BYPASS}'.",
                 )
-            self._session_mode = str(value)
+            str_value = str(value)
+            if str_value == self.MODE_BYPASS:
+                logger.warning(
+                    "Tool guard DISABLED for session %s — all tool "
+                    "calls will bypass security checks.",
+                    session_id,
+                )
+            if session_id in self._sessions:
+                self._sessions[session_id]["mode"] = str_value
             return SetSessionConfigOptionResponse(
-                config_options=self._build_config_options(),
+                config_options=self._build_config_options(session_id),
             )
         return None
 
@@ -739,8 +760,8 @@ class QwenPawACPAgent(Agent):
     ) -> dict[str, Any] | None:
         """Retrieve and clear token usage recorded for *session_id*.
 
-        Returns a ``_meta``-shaped dict with ``usage`` and ``durationMs``
-        keys, matching the format used by QwenCode, or ``None`` if no
+        Returns a ``_meta``-shaped dict with ``usage`` keys,
+        matching the format used by QwenCode, or ``None`` if no
         usage was recorded.
         """
         try:
@@ -763,18 +784,30 @@ class QwenPawACPAgent(Agent):
             },
         }
 
+    def _get_session_mode(self, session_id: str) -> str:
+        """Return the current mode for *session_id*."""
+        info = self._sessions.get(session_id)
+        if info is not None:
+            return info.get("mode", self.MODE_DEFAULT)
+        return self.MODE_DEFAULT
+
     def _build_config_options(
         self,
+        session_id: str,
     ) -> list[SessionConfigOptionSelect]:
         """Return the current set of session config options."""
+        current_mode = self._get_session_mode(session_id)
         return [
             SessionConfigOptionSelect(
                 type="select",
                 id=self.MODE_CONFIG_ID,
                 name="Session Mode",
                 category="mode",
-                description=("Controls tool guard and permission behavior"),
-                current_value=self._session_mode,
+                description=(
+                    "Controls tool guard and permission behavior. "
+                    "'Bypass Permissions' disables all security checks."
+                ),
+                current_value=current_mode,
                 options=[
                     SessionConfigSelectOption(
                         value=self.MODE_DEFAULT,
@@ -784,7 +817,7 @@ class QwenPawACPAgent(Agent):
                     SessionConfigSelectOption(
                         value=self.MODE_BYPASS,
                         name="Bypass Permissions",
-                        description=("Skip tool guard checks"),
+                        description=("Skip all tool guard security checks"),
                     ),
                 ],
             ),
@@ -794,14 +827,18 @@ class QwenPawACPAgent(Agent):
         self,
         model_spec: str,
     ) -> None:
-        """Switch the active model via ``ProviderManager``.
+        """Switch the active model for the current agent.
+
+        Validates the provider/model pair exists, then writes the
+        choice into ``agent.json`` so ``create_model_and_formatter``
+        picks it up on the next ``prompt()`` call.  The global
+        ``ProviderManager`` state is **not** modified — the change
+        is scoped to this agent only.
 
         *model_spec* should be ``"provider_id:model_id"``.
         Falls back to treating the whole string as *model_id* with
-        an empty provider search.
+        an automatic provider search.
         """
-        from ...providers.provider_manager import ProviderManager
-
         if ":" in model_spec:
             provider_id, model_id = model_spec.split(":", 1)
         else:
@@ -810,9 +847,17 @@ class QwenPawACPAgent(Agent):
         manager = ProviderManager.get_instance()
 
         if provider_id:
-            await manager.activate_model(provider_id, model_id)
+            provider = manager.get_provider(provider_id)
+            if not provider:
+                raise ValueError(
+                    f"Provider {provider_id!r} not found",
+                )
+            if not provider.has_model(model_id):
+                raise ValueError(
+                    f"Model {model_id!r} not found in "
+                    f"provider {provider_id!r}",
+                )
         else:
-            # Search all providers for this model_id.
             all_infos = await manager.list_provider_info()
             matched = False
             for pinfo in all_infos:
@@ -820,13 +865,26 @@ class QwenPawACPAgent(Agent):
                     pinfo.extra_models,
                 )
                 if any(m.id == model_id for m in all_models):
-                    await manager.activate_model(pinfo.id, model_id)
+                    provider_id = pinfo.id
                     matched = True
                     break
             if not matched:
                 raise ValueError(
                     f"Model {model_id!r} not found in any provider",
                 )
+
+        from ...config.config import (
+            load_agent_config,
+            save_agent_config,
+        )
+
+        agent_id = self._resolve_agent_id()
+        agent_config = load_agent_config(agent_id)
+        agent_config.active_model = ModelSlotConfig(
+            provider_id=provider_id,
+            model=model_id,
+        )
+        save_agent_config(agent_id, agent_config)
 
 
 async def run_qwenpaw_agent(

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -34,6 +34,7 @@ from acp import (
 from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
+    AgentMessageChunk,
     AudioContentBlock,
     ClientCapabilities,
     CloseSessionResponse,
@@ -88,10 +89,42 @@ def _extract_text(
     return "\n".join(parts)
 
 
-def _msg_to_updates(
+class _StreamTracker:
+    """Track cumulative text/thinking to emit only incremental deltas."""
+
+    def __init__(self) -> None:
+        self._prev_text: str = ""
+        self._prev_thinking: str = ""
+
+    def delta_text(self, cumulative: str) -> str:
+        """Return only the new portion of the text."""
+        if cumulative.startswith(self._prev_text):
+            delta = cumulative[len(self._prev_text) :]
+        else:
+            delta = cumulative
+        self._prev_text = cumulative
+        return delta
+
+    def delta_thinking(self, cumulative: str) -> str:
+        """Return only the new portion of the thinking."""
+        if cumulative.startswith(self._prev_thinking):
+            delta = cumulative[len(self._prev_thinking) :]
+        else:
+            delta = cumulative
+        self._prev_thinking = cumulative
+        return delta
+
+
+def _msg_to_updates(  # pylint: disable=too-many-branches
     msg: Any,
-) -> list[Any]:  # pylint: disable=too-many-branches
-    """Convert a QwenPaw Msg into ACP session update(s)."""
+    tracker: _StreamTracker | None = None,
+) -> list[Any]:
+    """Convert a QwenPaw Msg into ACP session update(s).
+
+    When *tracker* is provided, text and thinking content blocks are
+    emitted as **incremental** deltas rather than cumulative snapshots,
+    matching the ACP standard used by QwenCode and Qoder.
+    """
     updates: list[Any] = []
     metadata = getattr(msg, "metadata", {}) or {}
     content = getattr(msg, "content", None)
@@ -140,14 +173,17 @@ def _msg_to_updates(
         return updates
 
     if isinstance(content, list):
-        _content_blocks_to_updates(content, updates)
+        _content_blocks_to_updates(content, updates, tracker)
 
     if not updates:
         text = _get_msg_text(msg)
         if text:
-            updates.append(
-                update_agent_message(text_block(text)),
-            )
+            if tracker:
+                text = tracker.delta_text(text)
+            if text:
+                updates.append(
+                    update_agent_message(text_block(text)),
+                )
 
     return updates
 
@@ -155,42 +191,74 @@ def _msg_to_updates(
 def _content_blocks_to_updates(
     content: list[Any],
     updates: list[Any],
+    tracker: _StreamTracker | None = None,
 ) -> None:
     """Map Msg content blocks to ACP updates."""
     for block in content:
-        if not isinstance(block, dict):
-            continue
-        block_type = block.get("type", "text")
-        if block_type == "tool_use":
+        block_type, block_data = _normalise_block(block)
+        if block_type == "thinking":
+            _emit_thinking(block_data, tracker, updates)
+        elif block_type == "text":
+            _emit_text(block_data, tracker, updates)
+        elif block_type == "tool_use":
             updates.append(
                 start_tool_call(
-                    str(block.get("id") or uuid4().hex[:8]),
-                    str(block.get("name") or "tool"),
+                    str(block_data.get("id") or uuid4().hex[:8]),
+                    str(block_data.get("name") or "tool"),
                     status="in_progress",
                 ),
             )
         elif block_type == "tool_result":
             updates.append(
                 update_tool_call(
-                    str(block.get("id") or uuid4().hex[:8]),
+                    str(block_data.get("id") or uuid4().hex[:8]),
                     status="completed",
                     content=[
                         tool_content(
                             text_block(
-                                str(block.get("output", "")),
+                                str(block_data.get("output", "")),
                             ),
                         ),
                     ],
                 ),
             )
-        elif block_type == "text":
-            text = block.get("text", "")
-            if text:
-                updates.append(
-                    update_agent_message(
-                        text_block(text),
-                    ),
-                )
+
+
+def _normalise_block(block: Any) -> tuple[str, dict[str, Any]]:
+    """Return ``(block_type, data_dict)`` for both dict and object blocks."""
+    if isinstance(block, dict):
+        return block.get("type", "text"), block
+    btype = getattr(block, "type", "text") or "text"
+    data: dict[str, Any] = {}
+    for attr in ("text", "thinking", "id", "name", "output"):
+        val = getattr(block, attr, None)
+        if val is not None:
+            data[attr] = val
+    return btype, data
+
+
+def _emit_thinking(
+    data: dict[str, Any],
+    tracker: _StreamTracker | None,
+    updates: list[Any],
+) -> None:
+    thinking = data.get("thinking", "")
+    if tracker:
+        thinking = tracker.delta_thinking(thinking)
+    if thinking:
+        updates.append(update_agent_thought(text_block(thinking)))
+
+
+def _emit_text(
+    data: dict[str, Any],
+    tracker: _StreamTracker | None,
+    updates: list[Any],
+) -> None:
+    text = data.get("text", "")
+    if tracker:
+        text = tracker.delta_text(text)
+    if text:
+        updates.append(update_agent_message(text_block(text)))
 
 
 def _get_msg_text(msg: Any) -> str:
@@ -446,6 +514,8 @@ class QwenPawACPAgent(Agent):
             request_context=request_context or None,
         )
 
+        tracker = _StreamTracker()
+
         try:
             async for msg, _is_last in runner.query_handler(
                 msgs,
@@ -458,7 +528,7 @@ class QwenPawACPAgent(Agent):
                     )
                     break
 
-                updates = _msg_to_updates(msg)
+                updates = _msg_to_updates(msg, tracker)
                 for upd in updates:
                     await self._conn.session_update(
                         session_id=session_id,
@@ -471,6 +541,18 @@ class QwenPawACPAgent(Agent):
             )
         finally:
             self._cancel_events.pop(session_id, None)
+
+        # Emit a final empty chunk with usage metadata (like QwenCode)
+        usage_meta = self._pop_session_usage(session_id)
+        if usage_meta:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    sessionUpdate="agent_message_chunk",
+                    content=text_block(""),
+                    field_meta=usage_meta,
+                ),
+            )
 
         return PromptResponse(stop_reason="end_turn")
 
@@ -592,6 +674,36 @@ class QwenPawACPAgent(Agent):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _pop_session_usage(
+        session_id: str,
+    ) -> dict[str, Any] | None:
+        """Retrieve and clear token usage recorded for *session_id*.
+
+        Returns a ``_meta``-shaped dict with ``usage`` and ``durationMs``
+        keys, matching the format used by QwenCode, or ``None`` if no
+        usage was recorded.
+        """
+        try:
+            from ...token_usage.model_wrapper import (
+                TokenRecordingModelWrapper,
+            )
+
+            raw = TokenRecordingModelWrapper.pop_usage_for_session(
+                session_id,
+            )
+        except Exception:  # noqa: BLE001
+            return None
+        if not raw:
+            return None
+        return {
+            "usage": {
+                "inputTokens": raw.get("prompt_tokens", 0),
+                "outputTokens": raw.get("completion_tokens", 0),
+                "totalTokens": raw.get("total_tokens", 0),
+            },
+        }
 
     def _build_config_options(
         self,

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -1,0 +1,669 @@
+# -*- coding: utf-8 -*-
+"""QwenPaw ACP Agent server.
+
+Exposes QwenPaw as an ACP-compliant agent that external clients
+(Zed, OpenCode, etc.) can connect to via stdio JSON-RPC.
+
+Uses the full ``Workspace`` lifecycle so the ACP agent has exactly
+the same capabilities as the web console (MCP tools, memory,
+sub-agent delegation, etc.).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from acp import (
+    Agent,
+    InitializeResponse,
+    LoadSessionResponse,
+    NewSessionResponse,
+    PromptResponse,
+    SetSessionModelResponse,
+    run_agent,
+    start_tool_call,
+    text_block,
+    tool_content,
+    update_agent_message,
+    update_agent_thought,
+    update_tool_call,
+)
+from acp.interfaces import Client
+from acp.schema import (
+    AgentCapabilities,
+    AudioContentBlock,
+    ClientCapabilities,
+    CloseSessionResponse,
+    EmbeddedResourceContentBlock,
+    HttpMcpServer,
+    ImageContentBlock,
+    Implementation,
+    ListSessionsResponse,
+    McpServerStdio,
+    ResourceContentBlock,
+    ResumeSessionResponse,
+    SessionCapabilities,
+    SessionCloseCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
+    SessionInfo,
+    SessionListCapabilities,
+    SessionResumeCapabilities,
+    SetSessionConfigOptionResponse,
+    SseMcpServer,
+    TextContentBlock,
+)
+
+from ...__version__ import __version__
+
+logger = logging.getLogger(__name__)
+
+
+PromptBlocks = list[
+    TextContentBlock
+    | ImageContentBlock
+    | AudioContentBlock
+    | ResourceContentBlock
+    | EmbeddedResourceContentBlock
+]
+
+
+def _extract_text(
+    blocks: PromptBlocks,
+) -> str:
+    """Pull plain text from ACP prompt content blocks."""
+    parts: list[str] = []
+    for block in blocks:
+        if isinstance(block, dict):
+            text = block.get("text", "")
+        elif isinstance(block, TextContentBlock):
+            text = block.text
+        else:
+            text = getattr(block, "text", "")
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+def _msg_to_updates(
+    msg: Any,
+) -> list[Any]:  # pylint: disable=too-many-branches
+    """Convert a QwenPaw Msg into ACP session update(s)."""
+    updates: list[Any] = []
+    metadata = getattr(msg, "metadata", {}) or {}
+    content = getattr(msg, "content", None)
+    role = getattr(msg, "role", "assistant")
+
+    if role == "system":
+        text = _get_msg_text(msg)
+        if text:
+            updates.append(
+                update_agent_thought(text_block(text)),
+            )
+        return updates
+
+    tool_calls = metadata.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            updates.append(
+                start_tool_call(
+                    str(tc.get("id") or uuid4().hex[:8]),
+                    str(tc.get("name") or "tool"),
+                    status="in_progress",
+                ),
+            )
+        return updates
+
+    tool_responses = metadata.get("tool_responses")
+    if isinstance(tool_responses, list):
+        for tr in tool_responses:
+            if not isinstance(tr, dict):
+                continue
+            updates.append(
+                update_tool_call(
+                    str(tr.get("id") or uuid4().hex[:8]),
+                    status="completed",
+                    content=[
+                        tool_content(
+                            text_block(
+                                str(tr.get("output", "")),
+                            ),
+                        ),
+                    ],
+                ),
+            )
+        return updates
+
+    if isinstance(content, list):
+        _content_blocks_to_updates(content, updates)
+
+    if not updates:
+        text = _get_msg_text(msg)
+        if text:
+            updates.append(
+                update_agent_message(text_block(text)),
+            )
+
+    return updates
+
+
+def _content_blocks_to_updates(
+    content: list[Any],
+    updates: list[Any],
+) -> None:
+    """Map Msg content blocks to ACP updates."""
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type", "text")
+        if block_type == "tool_use":
+            updates.append(
+                start_tool_call(
+                    str(block.get("id") or uuid4().hex[:8]),
+                    str(block.get("name") or "tool"),
+                    status="in_progress",
+                ),
+            )
+        elif block_type == "tool_result":
+            updates.append(
+                update_tool_call(
+                    str(block.get("id") or uuid4().hex[:8]),
+                    status="completed",
+                    content=[
+                        tool_content(
+                            text_block(
+                                str(block.get("output", "")),
+                            ),
+                        ),
+                    ],
+                ),
+            )
+        elif block_type == "text":
+            text = block.get("text", "")
+            if text:
+                updates.append(
+                    update_agent_message(
+                        text_block(text),
+                    ),
+                )
+
+
+def _get_msg_text(msg: Any) -> str:
+    """Extract plain text from a Msg."""
+    get_text = getattr(msg, "get_text_content", None)
+    if callable(get_text):
+        return get_text() or ""
+    content = getattr(msg, "content", "")
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+class QwenPawACPAgent(Agent):
+    """ACP Agent backed by a full ``Workspace``.
+
+    Instead of creating a bare ``AgentRunner``, this class boots a
+    complete ``Workspace`` — the same lifecycle the web console uses —
+    so MCP tools, memory, chat persistence, sub-agent calls, etc. are
+    all available.
+    """
+
+    _conn: Client
+
+    MODE_CONFIG_ID = "mode"
+    MODE_DEFAULT = "default"
+    MODE_BYPASS = "bypassPermissions"
+
+    def __init__(
+        self,
+        agent_id: str | None = None,
+        workspace_dir: Path | None = None,
+    ):
+        self._agent_id = agent_id
+        self._workspace_dir = workspace_dir
+        self._sessions: dict[str, dict[str, Any]] = {}
+        self._cancel_events: dict[str, asyncio.Event] = {}
+        self._workspace: Any | None = None
+        self._workspace_ready = False
+        self._session_mode: str = self.MODE_DEFAULT
+
+    def on_connect(self, conn: Client) -> None:
+        self._conn = conn
+
+    # ------------------------------------------------------------------
+    # Workspace bootstrap (mirrors the web-app lifespan)
+    # ------------------------------------------------------------------
+
+    def _resolve_agent_id(self) -> str:
+        """Return the effective agent id."""
+        if self._agent_id is not None:
+            return self._agent_id
+
+        from ...config import load_config
+
+        config = load_config()
+        agents_cfg = getattr(config, "agents", None)
+        if agents_cfg is not None:
+            aid = getattr(agents_cfg, "active_agent", None)
+            if aid:
+                return aid
+        return "default"
+
+    def _resolve_workspace_dir(
+        self,
+        agent_id: str,
+    ) -> Path:
+        """Return the effective workspace directory."""
+        if self._workspace_dir is not None:
+            return self._workspace_dir
+
+        from ...constant import WORKING_DIR
+
+        return WORKING_DIR / "workspaces" / agent_id
+
+    async def _ensure_workspace(self) -> Any:
+        """Boot a full ``Workspace`` (once) and return its runner."""
+        if self._workspace is not None and self._workspace_ready:
+            return self._workspace.runner
+
+        from ...app.workspace.workspace import Workspace
+
+        agent_id = self._resolve_agent_id()
+        workspace_dir = self._resolve_workspace_dir(agent_id)
+
+        workspace = Workspace(
+            agent_id=agent_id,
+            workspace_dir=str(workspace_dir),
+        )
+        await workspace.start()
+
+        runner = workspace.runner
+        if runner is not None:
+            await runner.init_handler()
+
+        self._workspace = workspace
+        self._workspace_ready = True
+        logger.info(
+            "QwenPaw ACP Agent workspace started: agent_id=%s workspace=%s",
+            agent_id,
+            workspace_dir,
+        )
+        return runner
+
+    async def _shutdown_workspace(self) -> None:
+        """Gracefully stop the workspace."""
+        if self._workspace is not None:
+            try:
+                await self._workspace.stop(final=True)
+            except Exception:
+                logger.exception(
+                    "Error stopping ACP workspace",
+                )
+            self._workspace = None
+            self._workspace_ready = False
+
+    # ------------------------------------------------------------------
+    # ACP protocol methods
+    # ------------------------------------------------------------------
+
+    async def initialize(  # pylint: disable=unused-argument
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        logger.info(
+            "ACP initialize: version=%d client=%s",
+            protocol_version,
+            client_info,
+        )
+        return InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(
+                load_session=True,
+                session_capabilities=SessionCapabilities(
+                    close=SessionCloseCapabilities(),
+                    list=SessionListCapabilities(),
+                    resume=SessionResumeCapabilities(),
+                ),
+            ),
+            agent_info=Implementation(
+                name="qwenpaw",
+                title="QwenPaw",
+                version=__version__,
+            ),
+        )
+
+    async def new_session(  # pylint: disable=unused-argument
+        self,
+        cwd: str,
+        mcp_servers: (
+            list[HttpMcpServer | SseMcpServer | McpServerStdio] | None
+        ) = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        session_id = uuid4().hex
+        self._sessions[session_id] = {
+            "cwd": cwd,
+            "user_id": f"acp_{session_id[:8]}",
+            "mcp_servers": mcp_servers,
+        }
+        logger.info(
+            "ACP new_session: id=%s cwd=%s",
+            session_id,
+            cwd,
+        )
+        return NewSessionResponse(
+            session_id=session_id,
+            config_options=self._build_config_options(),
+        )
+
+    async def load_session(  # pylint: disable=unused-argument
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: (
+            list[HttpMcpServer | SseMcpServer | McpServerStdio] | None
+        ) = None,
+        **kwargs: Any,
+    ) -> LoadSessionResponse | None:
+        self._sessions[session_id] = {
+            "cwd": cwd,
+            "user_id": f"acp_{session_id[:8]}",
+            "mcp_servers": mcp_servers,
+        }
+        logger.info(
+            "ACP load_session: id=%s cwd=%s",
+            session_id,
+            cwd,
+        )
+        return LoadSessionResponse()
+
+    async def prompt(  # pylint: disable=too-many-locals,unused-argument
+        self,
+        prompt: PromptBlocks,
+        session_id: str,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> PromptResponse:
+        logger.info(
+            "ACP prompt: session=%s",
+            session_id,
+        )
+
+        text = _extract_text(prompt)
+        if not text:
+            return PromptResponse(stop_reason="end_turn")
+
+        runner = await self._ensure_workspace()
+        session_info = self._sessions.get(
+            session_id,
+            {},
+        )
+        user_id = session_info.get(
+            "user_id",
+            f"acp_{session_id[:8]}",
+        )
+
+        cancel_event = asyncio.Event()
+        self._cancel_events[session_id] = cancel_event
+
+        from agentscope.message import Msg
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            AgentRequest,
+            Message,
+        )
+
+        msgs = [
+            Msg(
+                name="user",
+                role="user",
+                content=text,
+            ),
+        ]
+
+        request_context: dict[str, str] = {}
+        if self._session_mode == self.MODE_BYPASS:
+            request_context["_headless_tool_guard"] = "false"
+
+        request = AgentRequest(
+            input=[
+                Message(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": text},
+                    ],
+                ),
+            ],
+            session_id=session_id,
+            user_id=user_id,
+            request_context=request_context or None,
+        )
+
+        try:
+            async for msg, _is_last in runner.query_handler(
+                msgs,
+                request=request,
+            ):
+                if cancel_event.is_set():
+                    logger.info(
+                        "ACP prompt cancelled: session=%s",
+                        session_id,
+                    )
+                    break
+
+                updates = _msg_to_updates(msg)
+                for upd in updates:
+                    await self._conn.session_update(
+                        session_id=session_id,
+                        update=upd,
+                    )
+        except Exception:
+            logger.exception(
+                "ACP prompt error: session=%s",
+                session_id,
+            )
+        finally:
+            self._cancel_events.pop(session_id, None)
+
+        return PromptResponse(stop_reason="end_turn")
+
+    async def close_session(  # pylint: disable=unused-argument
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> CloseSessionResponse | None:
+        logger.info("ACP close_session: session=%s", session_id)
+        self._sessions.pop(session_id, None)
+        self._cancel_events.pop(session_id, None)
+        return CloseSessionResponse()
+
+    async def list_sessions(  # pylint: disable=unused-argument
+        self,
+        cursor: str | None = None,
+        cwd: str | None = None,
+        **kwargs: Any,
+    ) -> ListSessionsResponse:
+        logger.info("ACP list_sessions: cwd=%s", cwd)
+        sessions: list[SessionInfo] = []
+        for sid, info in self._sessions.items():
+            sess_cwd = info.get("cwd", "")
+            if cwd is not None and sess_cwd != cwd:
+                continue
+            sessions.append(
+                SessionInfo(
+                    session_id=sid,
+                    cwd=sess_cwd,
+                    title=f"ACP session {sid[:8]}",
+                ),
+            )
+        return ListSessionsResponse(sessions=sessions)
+
+    async def resume_session(  # pylint: disable=unused-argument
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: (
+            list[HttpMcpServer | SseMcpServer | McpServerStdio] | None
+        ) = None,
+        **kwargs: Any,
+    ) -> ResumeSessionResponse:
+        logger.info(
+            "ACP resume_session: id=%s cwd=%s",
+            session_id,
+            cwd,
+        )
+        if session_id not in self._sessions:
+            self._sessions[session_id] = {
+                "cwd": cwd,
+                "user_id": f"acp_{session_id[:8]}",
+                "mcp_servers": mcp_servers,
+            }
+        else:
+            self._sessions[session_id]["cwd"] = cwd
+        return ResumeSessionResponse()
+
+    async def set_session_model(  # pylint: disable=unused-argument
+        self,
+        model_id: str,
+        session_id: str,
+        **kwargs: Any,
+    ) -> SetSessionModelResponse | None:
+        logger.info(
+            "ACP set_session_model: session=%s model=%s",
+            session_id,
+            model_id,
+        )
+        try:
+            await self._switch_model(model_id)
+        except Exception:
+            logger.exception(
+                "Failed to switch model to %s",
+                model_id,
+            )
+            return None
+        return SetSessionModelResponse()
+
+    async def set_config_option(  # pylint: disable=unused-argument
+        self,
+        config_id: str,
+        session_id: str,
+        value: str | bool,
+        **kwargs: Any,
+    ) -> SetSessionConfigOptionResponse | None:
+        logger.info(
+            "ACP set_config_option: session=%s config=%s value=%s",
+            session_id,
+            config_id,
+            value,
+        )
+        if config_id == self.MODE_CONFIG_ID:
+            if value in (self.MODE_DEFAULT, self.MODE_BYPASS):
+                self._session_mode = str(value)
+            return SetSessionConfigOptionResponse(
+                config_options=self._build_config_options(),
+            )
+        return None
+
+    async def cancel(  # pylint: disable=unused-argument
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> None:
+        logger.info(
+            "ACP cancel: session=%s",
+            session_id,
+        )
+        event = self._cancel_events.get(session_id)
+        if event is not None:
+            event.set()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_config_options(
+        self,
+    ) -> list[SessionConfigOptionSelect]:
+        """Return the current set of session config options."""
+        return [
+            SessionConfigOptionSelect(
+                type="select",
+                id=self.MODE_CONFIG_ID,
+                name="Session Mode",
+                category="mode",
+                description=("Controls tool guard and permission behavior"),
+                current_value=self._session_mode,
+                options=[
+                    SessionConfigSelectOption(
+                        value=self.MODE_DEFAULT,
+                        name="Default",
+                        description=("Normal mode with Tool Guard enabled"),
+                    ),
+                    SessionConfigSelectOption(
+                        value=self.MODE_BYPASS,
+                        name="Bypass Permissions",
+                        description=("Skip tool guard checks"),
+                    ),
+                ],
+            ),
+        ]
+
+    async def _switch_model(
+        self,
+        model_spec: str,
+    ) -> None:
+        """Switch the active model via ``ProviderManager``.
+
+        *model_spec* should be ``"provider_id:model_id"``.
+        Falls back to treating the whole string as *model_id* with
+        an empty provider search.
+        """
+        from ...providers.provider_manager import ProviderManager
+
+        if ":" in model_spec:
+            provider_id, model_id = model_spec.split(":", 1)
+        else:
+            provider_id, model_id = "", model_spec
+
+        manager = ProviderManager.get_instance()
+
+        if provider_id:
+            await manager.activate_model(provider_id, model_id)
+        else:
+            # Search all providers for this model_id.
+            all_infos = await manager.list_provider_info()
+            matched = False
+            for pinfo in all_infos:
+                all_models = list(pinfo.models) + list(
+                    pinfo.extra_models,
+                )
+                if any(m.id == model_id for m in all_models):
+                    await manager.activate_model(pinfo.id, model_id)
+                    matched = True
+                    break
+            if not matched:
+                raise ValueError(
+                    f"Model {model_id!r} not found in any provider",
+                )
+
+
+async def run_qwenpaw_agent(
+    agent_id: str | None = None,
+    workspace_dir: Path | None = None,
+) -> None:
+    """Entry point: run QwenPaw as an ACP agent over stdio."""
+    agent = QwenPawACPAgent(
+        agent_id=agent_id,
+        workspace_dir=workspace_dir,
+    )
+    try:
+        await run_agent(agent)
+    finally:
+        await agent._shutdown_workspace()  # pylint: disable=protected-access

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -578,6 +578,12 @@ class QwenPawACPAgent(Agent):
                         session_id=session_id,
                         update=upd,
                     )
+
+                # After each message, check for new usage data.
+                # Each LLM invocation writes usage; poll here so
+                # multi-step prompts (with tool calls) report usage
+                # per LLM call, matching QwenCode behaviour.
+                await self._emit_usage_if_available(session_id)
         except Exception:
             logger.exception(
                 "ACP prompt error: session=%s",
@@ -586,17 +592,9 @@ class QwenPawACPAgent(Agent):
         finally:
             self._cancel_events.pop(session_id, None)
 
-        # Emit a final empty chunk with usage metadata (like QwenCode)
-        usage_meta = self._pop_session_usage(session_id)
-        if usage_meta:
-            await self._conn.session_update(
-                session_id=session_id,
-                update=AgentMessageChunk(
-                    sessionUpdate="agent_message_chunk",
-                    content=text_block(""),
-                    field_meta=usage_meta,
-                ),
-            )
+        # Final sweep: catch any usage that arrived after the last
+        # streamed message (e.g., single-turn prompts with no tools).
+        await self._emit_usage_if_available(session_id)
 
         return PromptResponse(stop_reason="end_turn")
 
@@ -718,6 +716,22 @@ class QwenPawACPAgent(Agent):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    async def _emit_usage_if_available(
+        self,
+        session_id: str,
+    ) -> None:
+        """Send a usage chunk if new usage data is available."""
+        usage_meta = self._pop_session_usage(session_id)
+        if usage_meta:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    sessionUpdate="agent_message_chunk",
+                    content=text_block(""),
+                    field_meta=usage_meta,
+                ),
+            )
 
     @staticmethod
     def _pop_session_usage(

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -90,11 +90,18 @@ def _extract_text(
 
 
 class _StreamTracker:
-    """Track cumulative text/thinking to emit only incremental deltas."""
+    """Convert agentscope's snapshot-style messages to ACP event stream.
+
+    agentscope emits cumulative snapshots (each message contains the full
+    state so far).  ACP expects an event stream (each update is a delta).
+    This tracker maintains the necessary state to perform that conversion
+    for text, thinking, and tool-call events.
+    """
 
     def __init__(self) -> None:
         self._prev_text: str = ""
         self._prev_thinking: str = ""
+        self._seen_tool_ids: set[str] = set()
 
     def delta_text(self, cumulative: str) -> str:
         """Return only the new portion of the text."""
@@ -114,6 +121,13 @@ class _StreamTracker:
         self._prev_thinking = cumulative
         return delta
 
+    def is_new_tool_call(self, tool_id: str) -> bool:
+        """Return True only the first time *tool_id* is seen."""
+        if tool_id in self._seen_tool_ids:
+            return False
+        self._seen_tool_ids.add(tool_id)
+        return True
+
 
 def _msg_to_updates(  # pylint: disable=too-many-branches
     msg: Any,
@@ -131,11 +145,14 @@ def _msg_to_updates(  # pylint: disable=too-many-branches
     role = getattr(msg, "role", "assistant")
 
     if role == "system":
-        text = _get_msg_text(msg)
-        if text:
-            updates.append(
-                update_agent_thought(text_block(text)),
-            )
+        if isinstance(content, list):
+            _content_blocks_to_updates(content, updates, tracker)
+        if not updates:
+            text = _get_msg_text(msg)
+            if text:
+                updates.append(
+                    update_agent_thought(text_block(text)),
+                )
         return updates
 
     tool_calls = metadata.get("tool_calls")
@@ -143,13 +160,15 @@ def _msg_to_updates(  # pylint: disable=too-many-branches
         for tc in tool_calls:
             if not isinstance(tc, dict):
                 continue
-            updates.append(
-                start_tool_call(
-                    str(tc.get("id") or uuid4().hex[:8]),
-                    str(tc.get("name") or "tool"),
-                    status="in_progress",
-                ),
-            )
+            tc_id = str(tc.get("id") or uuid4().hex[:8])
+            if not tracker or tracker.is_new_tool_call(tc_id):
+                updates.append(
+                    start_tool_call(
+                        tc_id,
+                        str(tc.get("name") or "tool"),
+                        status="in_progress",
+                    ),
+                )
         return updates
 
     tool_responses = metadata.get("tool_responses")
@@ -164,7 +183,9 @@ def _msg_to_updates(  # pylint: disable=too-many-branches
                     content=[
                         tool_content(
                             text_block(
-                                str(tr.get("output", "")),
+                                _extract_tool_output(
+                                    tr.get("output", ""),
+                                ),
                             ),
                         ),
                     ],
@@ -201,13 +222,15 @@ def _content_blocks_to_updates(
         elif block_type == "text":
             _emit_text(block_data, tracker, updates)
         elif block_type == "tool_use":
-            updates.append(
-                start_tool_call(
-                    str(block_data.get("id") or uuid4().hex[:8]),
-                    str(block_data.get("name") or "tool"),
-                    status="in_progress",
-                ),
-            )
+            tc_id = str(block_data.get("id") or uuid4().hex[:8])
+            if not tracker or tracker.is_new_tool_call(tc_id):
+                updates.append(
+                    start_tool_call(
+                        tc_id,
+                        str(block_data.get("name") or "tool"),
+                        status="in_progress",
+                    ),
+                )
         elif block_type == "tool_result":
             updates.append(
                 update_tool_call(
@@ -216,12 +239,33 @@ def _content_blocks_to_updates(
                     content=[
                         tool_content(
                             text_block(
-                                str(block_data.get("output", "")),
+                                _extract_tool_output(
+                                    block_data.get("output", ""),
+                                ),
                             ),
                         ),
                     ],
                 ),
             )
+
+
+def _extract_tool_output(output: Any) -> str:
+    """Extract plain text from a tool output value.
+
+    The output may be a string, a list of content blocks, or another
+    structure — normalise everything to a flat string.
+    """
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        parts = []
+        for item in output:
+            if isinstance(item, dict):
+                parts.append(item.get("text", str(item)))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    return str(output)
 
 
 def _normalise_block(block: Any) -> tuple[str, dict[str, Any]]:

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -564,8 +564,13 @@ class QwenPawACPAgent(Agent):
             value,
         )
         if config_id == self.MODE_CONFIG_ID:
-            if value in (self.MODE_DEFAULT, self.MODE_BYPASS):
-                self._session_mode = str(value)
+            if value not in (self.MODE_DEFAULT, self.MODE_BYPASS):
+                raise ValueError(
+                    f"Invalid mode value: {value!r}. "
+                    f"Must be '{self.MODE_DEFAULT}' or "
+                    f"'{self.MODE_BYPASS}'.",
+                )
+            self._session_mode = str(value)
             return SetSessionConfigOptionResponse(
                 config_options=self._build_config_options(),
             )
@@ -664,6 +669,6 @@ async def run_qwenpaw_agent(
         workspace_dir=workspace_dir,
     )
     try:
-        await run_agent(agent)
+        await run_agent(agent, use_unstable_protocol=True)
     finally:
         await agent._shutdown_workspace()  # pylint: disable=protected-access

--- a/src/qwenpaw/cli/acp_cmd.py
+++ b/src/qwenpaw/cli/acp_cmd.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""``qwenpaw acp`` — run QwenPaw as an ACP agent over stdio."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import click
+
+
+@click.command("acp")
+@click.option(
+    "--agent",
+    default=None,
+    help="Agent ID to use (defaults to active agent)",
+)
+@click.option(
+    "--workspace",
+    default=None,
+    type=click.Path(exists=False),
+    help="Workspace directory override",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Enable debug logging to stderr",
+)
+def acp_cmd(
+    agent: str | None,
+    workspace: str | None,
+    debug: bool,
+) -> None:
+    """Start QwenPaw as an ACP agent (stdio)."""
+    from pathlib import Path
+
+    level = logging.DEBUG if debug else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    workspace_dir = Path(workspace) if workspace else None
+
+    from ..agents.acp.server import run_qwenpaw_agent
+
+    asyncio.run(
+        run_qwenpaw_agent(
+            agent_id=agent,
+            workspace_dir=workspace_dir,
+        ),
+    )

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -96,6 +96,7 @@ class LazyGroup(click.Group):
     cls=LazyGroup,
     context_settings={"help_option_names": ["-h", "--help"]},
     lazy_subcommands={
+        "acp": ("qwenpaw.cli.acp_cmd", "acp_cmd", ".acp_cmd"),
         "app": ("qwenpaw.cli.app_cmd", "app_cmd", ".app_cmd"),
         "channels": (
             "qwenpaw.cli.channels_cmd",

--- a/website/public/docs/acp-server.en.md
+++ b/website/public/docs/acp-server.en.md
@@ -26,18 +26,18 @@ The process communicates over stdin/stdout using the ACP JSON-RPC protocol. stde
 
 ## Supported ACP Methods
 
-| Method | Description |
-|---|---|
-| `initialize` | Handshake — returns agent capabilities and version info |
-| `new_session` | Create a new conversation session |
-| `load_session` | Load/attach to an existing session by ID |
-| `resume_session` | Resume a previously closed session |
-| `list_sessions` | List active sessions, optionally filtered by `cwd` |
-| `close_session` | Close and clean up a session |
-| `prompt` | Send a user message and stream back agent responses |
+| Method              | Description                                                  |
+| ------------------- | ------------------------------------------------------------ |
+| `initialize`        | Handshake — returns agent capabilities and version info      |
+| `new_session`       | Create a new conversation session                            |
+| `load_session`      | Load/attach to an existing session by ID                     |
+| `resume_session`    | Resume a previously closed session                           |
+| `list_sessions`     | List active sessions, optionally filtered by `cwd`           |
+| `close_session`     | Close and clean up a session                                 |
+| `prompt`            | Send a user message and stream back agent responses          |
 | `set_session_model` | Switch the active LLM model (format: `provider_id:model_id`) |
-| `set_config_option` | Toggle session config options (e.g. Tool Guard on/off) |
-| `cancel` | Cancel an in-progress prompt |
+| `set_config_option` | Toggle session config options (e.g. Tool Guard on/off)       |
+| `cancel`            | Cancel an in-progress prompt                                 |
 
 ---
 
@@ -45,12 +45,12 @@ The process communicates over stdin/stdout using the ACP JSON-RPC protocol. stde
 
 During a `prompt` call, the agent streams real-time updates back to the client via `session_update` notifications:
 
-| Update Type | When |
-|---|---|
-| `agent_message_chunk` | Agent text response (streaming) |
+| Update Type           | When                                       |
+| --------------------- | ------------------------------------------ |
+| `agent_message_chunk` | Agent text response (streaming)            |
 | `agent_thought_chunk` | Agent internal reasoning / system messages |
-| `tool_call` | Tool invocation started |
-| `tool_call_update` | Tool execution completed with output |
+| `tool_call`           | Tool invocation started                    |
+| `tool_call_update`    | Tool execution completed with output       |
 
 ---
 
@@ -75,9 +75,9 @@ The agent declares the following capabilities during `initialize`:
 
 When a new session is created, the agent returns config options that the client can change via `set_config_option`:
 
-| Config ID | Type | Category | Default | Options |
-|---|---|---|---|---|
-| `mode` | select | `mode` | `default` | `default` — Normal mode with Tool Guard enabled; `bypassPermissions` — Skip tool guard checks |
+| Config ID | Type   | Category | Default   | Options                                                                                       |
+| --------- | ------ | -------- | --------- | --------------------------------------------------------------------------------------------- |
+| `mode`    | select | `mode`   | `default` | `default` — Normal mode with Tool Guard enabled; `bypassPermissions` — Skip tool guard checks |
 
 ---
 

--- a/website/public/docs/acp-server.en.md
+++ b/website/public/docs/acp-server.en.md
@@ -1,0 +1,90 @@
+# ACP Server — QwenPaw as an ACP Agent
+
+This module exposes QwenPaw as an [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) compliant agent server over stdio JSON-RPC. External clients — such as [Zed](https://zed.dev), [OpenCode](https://github.com/nicholasgasior/opencode), or any ACP-compatible editor — can connect to QwenPaw via the `qwenpaw acp` CLI command and interact with it programmatically.
+
+---
+
+## Quick Start
+
+```bash
+# Start QwenPaw as an ACP agent
+qwenpaw acp
+
+# Use a specific agent profile
+qwenpaw acp --agent mybot
+
+# Use a custom workspace directory
+qwenpaw acp --workspace /path/to/workspace
+
+# Enable debug logging to stderr
+qwenpaw acp --debug
+```
+
+The process communicates over stdin/stdout using the ACP JSON-RPC protocol. stderr is used for logging.
+
+---
+
+## Supported ACP Methods
+
+| Method | Description |
+|---|---|
+| `initialize` | Handshake — returns agent capabilities and version info |
+| `new_session` | Create a new conversation session |
+| `load_session` | Load/attach to an existing session by ID |
+| `resume_session` | Resume a previously closed session |
+| `list_sessions` | List active sessions, optionally filtered by `cwd` |
+| `close_session` | Close and clean up a session |
+| `prompt` | Send a user message and stream back agent responses |
+| `set_session_model` | Switch the active LLM model (format: `provider_id:model_id`) |
+| `set_config_option` | Toggle session config options (e.g. Tool Guard on/off) |
+| `cancel` | Cancel an in-progress prompt |
+
+---
+
+## Streaming Updates
+
+During a `prompt` call, the agent streams real-time updates back to the client via `session_update` notifications:
+
+| Update Type | When |
+|---|---|
+| `agent_message_chunk` | Agent text response (streaming) |
+| `agent_thought_chunk` | Agent internal reasoning / system messages |
+| `tool_call` | Tool invocation started |
+| `tool_call_update` | Tool execution completed with output |
+
+---
+
+## Capabilities Declared
+
+The agent declares the following capabilities during `initialize`:
+
+```json
+{
+  "load_session": true,
+  "session_capabilities": {
+    "close": {},
+    "list": {},
+    "resume": {}
+  }
+}
+```
+
+---
+
+## Session Config Options
+
+When a new session is created, the agent returns config options that the client can change via `set_config_option`:
+
+| Config ID | Type | Category | Default | Options |
+|---|---|---|---|---|
+| `mode` | select | `mode` | `default` | `default` — Normal mode with Tool Guard enabled; `bypassPermissions` — Skip tool guard checks |
+
+---
+
+## Configuration
+
+The ACP agent resolves its configuration in the following order:
+
+1. **CLI arguments** — `--agent` and `--workspace` take highest priority
+2. **WORKING_DIR config** — reads `agents.active_agent` from the `config.json` inside `WORKING_DIR` (default `~/.qwenpaw`, or `~/.copaw` for legacy installations; overridable via `QWENPAW_WORKING_DIR` env var)
+3. **Defaults** — falls back to agent ID `"default"` and workspace directory `WORKING_DIR/workspaces/default/`

--- a/website/public/docs/acp-server.zh.md
+++ b/website/public/docs/acp-server.zh.md
@@ -26,18 +26,18 @@ qwenpaw acp --debug
 
 ## 支持的 ACP 方法
 
-| 方法 | 说明 |
-|---|---|
-| `initialize` | 握手——返回智能体能力和版本信息 |
-| `new_session` | 创建新的会话 |
-| `load_session` | 按 ID 加载/接入已有会话 |
-| `resume_session` | 恢复之前关闭的会话 |
-| `list_sessions` | 列出活跃会话，可按 `cwd` 过滤 |
-| `close_session` | 关闭并清理会话 |
-| `prompt` | 发送用户消息，流式返回智能体响应 |
+| 方法                | 说明                                              |
+| ------------------- | ------------------------------------------------- |
+| `initialize`        | 握手——返回智能体能力和版本信息                    |
+| `new_session`       | 创建新的会话                                      |
+| `load_session`      | 按 ID 加载/接入已有会话                           |
+| `resume_session`    | 恢复之前关闭的会话                                |
+| `list_sessions`     | 列出活跃会话，可按 `cwd` 过滤                     |
+| `close_session`     | 关闭并清理会话                                    |
+| `prompt`            | 发送用户消息，流式返回智能体响应                  |
 | `set_session_model` | 切换活跃 LLM 模型（格式：`provider_id:model_id`） |
-| `set_config_option` | 切换会话配置选项（如 Tool Guard 开关） |
-| `cancel` | 取消正在进行的 prompt |
+| `set_config_option` | 切换会话配置选项（如 Tool Guard 开关）            |
+| `cancel`            | 取消正在进行的 prompt                             |
 
 ---
 
@@ -45,12 +45,12 @@ qwenpaw acp --debug
 
 在 `prompt` 调用过程中，智能体通过 `session_update` 通知向客户端实时推送更新：
 
-| 更新类型 | 触发时机 |
-|---|---|
-| `agent_message_chunk` | 智能体文本响应（流式） |
+| 更新类型              | 触发时机                |
+| --------------------- | ----------------------- |
+| `agent_message_chunk` | 智能体文本响应（流式）  |
 | `agent_thought_chunk` | 智能体内部推理/系统消息 |
-| `tool_call` | 工具调用开始 |
-| `tool_call_update` | 工具执行完成并返回结果 |
+| `tool_call`           | 工具调用开始            |
+| `tool_call_update`    | 工具执行完成并返回结果  |
 
 ---
 
@@ -75,9 +75,9 @@ qwenpaw acp --debug
 
 创建新会话时，智能体会返回可通过 `set_config_option` 切换的配置选项：
 
-| 配置 ID | 类型 | 类别 | 默认值 | 可选值 |
-|---|---|---|---|---|
-| `mode` | select | `mode` | `default` | `default` — 正常模式，启用 Tool Guard；`bypassPermissions` — 跳过工具安全检查 |
+| 配置 ID | 类型   | 类别   | 默认值    | 可选值                                                                        |
+| ------- | ------ | ------ | --------- | ----------------------------------------------------------------------------- |
+| `mode`  | select | `mode` | `default` | `default` — 正常模式，启用 Tool Guard；`bypassPermissions` — 跳过工具安全检查 |
 
 ---
 

--- a/website/public/docs/acp-server.zh.md
+++ b/website/public/docs/acp-server.zh.md
@@ -1,0 +1,90 @@
+# ACP Server — 将 QwenPaw 作为 ACP 智能体运行
+
+本模块将 QwenPaw 暴露为一个符合 [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) 规范的智能体服务器，通过 stdio JSON-RPC 通信。外部客户端（如 [Zed](https://zed.dev)、[OpenCode](https://github.com/nicholasgasior/opencode) 或任何兼容 ACP 的编辑器）可以通过 `qwenpaw acp` CLI 命令连接 QwenPaw 并以编程方式与之交互。
+
+---
+
+## 快速开始
+
+```bash
+# 启动 QwenPaw 作为 ACP 智能体
+qwenpaw acp
+
+# 使用指定的智能体配置
+qwenpaw acp --agent mybot
+
+# 使用自定义工作区目录
+qwenpaw acp --workspace /path/to/workspace
+
+# 启用调试日志（输出到 stderr）
+qwenpaw acp --debug
+```
+
+进程通过 stdin/stdout 使用 ACP JSON-RPC 协议通信，stderr 用于日志输出。
+
+---
+
+## 支持的 ACP 方法
+
+| 方法 | 说明 |
+|---|---|
+| `initialize` | 握手——返回智能体能力和版本信息 |
+| `new_session` | 创建新的会话 |
+| `load_session` | 按 ID 加载/接入已有会话 |
+| `resume_session` | 恢复之前关闭的会话 |
+| `list_sessions` | 列出活跃会话，可按 `cwd` 过滤 |
+| `close_session` | 关闭并清理会话 |
+| `prompt` | 发送用户消息，流式返回智能体响应 |
+| `set_session_model` | 切换活跃 LLM 模型（格式：`provider_id:model_id`） |
+| `set_config_option` | 切换会话配置选项（如 Tool Guard 开关） |
+| `cancel` | 取消正在进行的 prompt |
+
+---
+
+## 流式更新
+
+在 `prompt` 调用过程中，智能体通过 `session_update` 通知向客户端实时推送更新：
+
+| 更新类型 | 触发时机 |
+|---|---|
+| `agent_message_chunk` | 智能体文本响应（流式） |
+| `agent_thought_chunk` | 智能体内部推理/系统消息 |
+| `tool_call` | 工具调用开始 |
+| `tool_call_update` | 工具执行完成并返回结果 |
+
+---
+
+## 声明的能力
+
+智能体在 `initialize` 阶段声明以下能力：
+
+```json
+{
+  "load_session": true,
+  "session_capabilities": {
+    "close": {},
+    "list": {},
+    "resume": {}
+  }
+}
+```
+
+---
+
+## 会话配置选项
+
+创建新会话时，智能体会返回可通过 `set_config_option` 切换的配置选项：
+
+| 配置 ID | 类型 | 类别 | 默认值 | 可选值 |
+|---|---|---|---|---|
+| `mode` | select | `mode` | `default` | `default` — 正常模式，启用 Tool Guard；`bypassPermissions` — 跳过工具安全检查 |
+
+---
+
+## 配置
+
+ACP 智能体按以下优先级解析配置：
+
+1. **CLI 参数** — `--agent` 和 `--workspace` 优先级最高
+2. **WORKING_DIR 配置** — 从 `WORKING_DIR` 内的 `config.json` 中读取 `agents.active_agent`（默认 `~/.qwenpaw`，旧版安装为 `~/.copaw`；可通过 `QWENPAW_WORKING_DIR` 环境变量覆盖）
+3. **默认值** — 回退到智能体 ID `"default"` 和工作区目录 `WORKING_DIR/workspaces/default/`


### PR DESCRIPTION
## Description

Add ACP (Agent Client Protocol) server support, allowing external clients such as Zed, OpenCode, or any ACP-compatible editor to connect to QwenPaw via `qwenpaw acp` and interact with a full workspace over stdio JSON-RPC.

`QwenPawACPAgent` boots a complete `Workspace` — the same lifecycle the web console uses — so the ACP agent has exactly the same capabilities (MCP tools, memory, chat persistence, sub-agent delegation, etc.).

Supported ACP methods: `initialize`, `new_session`, `load_session`, `resume_session`, `list_sessions`, `close_session`, `prompt` (with streaming session updates), `set_session_model`, `set_config_option`, and `cancel`.

Session mode config option (`select` type, `mode` category) allows clients to toggle between `default` (Tool Guard enabled) and `bypassPermissions` (skip guard checks), aligned with the ACP ecosystem convention (same approach as Claude Agent ACP).

All protocol-level functionality is implemented using the official [ACP Python SDK](https://github.com/agentclientprotocol/python-sdk) (`agent-client-protocol>=0.9.0`). The only custom code is the QwenPaw-specific business logic: Msg-to-ACP-update mapping, workspace lifecycle, session tracking, and model switching.

**Related Issue:** Relates to #1059, Relates to #3134

**Security Considerations:** Runs locally via stdio; inherits workspace-level permissions. No network exposure. Tool Guard is enabled by default and can be toggled per-session via ACP `set_config_option`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Suggested verification steps:

1. Run `qwenpaw acp` to start the ACP agent server over stdio.
2. Connect an ACP client (e.g. Zed, OpenCode, or `acpx`) and verify `initialize` returns agent capabilities.
3. Create a new session and confirm `configOptions` includes the `mode` select option with `default` and `bypassPermissions` values.
4. Send a `prompt` request and verify streaming updates (`agent_message_chunk`, `tool_call`, `tool_call_update`) are received.
5. Switch session mode to `bypassPermissions` via `set_config_option` and confirm tool calls bypass guard checks.
6. Test `set_session_model` with format `provider_id:model_id`.
7. Test session lifecycle: `new_session` → `list_sessions` → `close_session` → `resume_session` → `load_session`.
8. Test `cancel` during an in-progress prompt.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed (all hooks green)

pytest tests/ -v -x
# 1823 passed, 3 skipped in 54.86s
```

## Additional Notes

- The ACP Server reuses the full `Workspace` lifecycle, so all existing QwenPaw features (MCP tools, memory, chat persistence, sub-agent delegation, skills) work identically to the web console.
- Session mode config option uses `select` type with `mode` category, `default` and `bypassPermissions` values — same naming convention as Claude Agent ACP.