### PR TITLE
fix(WeChat): prevent typing task leak and reduce CPU/memory usage

### DIFF
--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -715,11 +715,12 @@ class WeixinChannel(BaseChannel):
                 self._user_context_tokens[from_user_id] = context_token
                 self._save_context_tokens()
 
-            # Start typing indicator for this user
+            # Start "typing..." indicator immediately and keep refreshing
+            # until send_content_parts finishes the reply.
             if from_user_id and context_token:
 
-                async def _start_typing_async():
-                    # Stop any existing typing indicator to prevent task leak
+                async def _start_typing_on_receive():
+                    # Stop any existing typing indicator first
                     with self._typing_stop_lock:
                         old_stop = self._typing_stop_funcs.pop(
                             from_user_id,
@@ -737,7 +738,7 @@ class WeixinChannel(BaseChannel):
 
                 if self._loop and self._loop.is_running():
                     asyncio.run_coroutine_threadsafe(
-                        _start_typing_async(),
+                        _start_typing_on_receive(),
                         self._loop,
                     )
 
@@ -887,6 +888,13 @@ class WeixinChannel(BaseChannel):
                 file_path[:60],
             )
 
+    def _stop_typing_for_user(self, user_id: str) -> None:
+        """Stop typing indicator and remove from tracking dict."""
+        with self._typing_stop_lock:
+            stop_func = self._typing_stop_funcs.pop(user_id, None)
+        if stop_func:
+            stop_func()
+
     async def send_content_parts(
         self,
         to_handle: str,
@@ -909,28 +917,6 @@ class WeixinChannel(BaseChannel):
         if not to_user_id:
             logger.warning("weixin send_content_parts: no to_user_id")
             return
-
-        # Stop any existing typing indicator before starting a new one
-        # (prevents multiple typing loops running simultaneously)
-        with self._typing_stop_lock:
-            old_stop = self._typing_stop_funcs.pop(to_user_id, None)
-        if old_stop:
-            old_stop()
-
-        # Start typing indicator for this reply
-        # (like Telegram/Mattermost: restart typing for each send)
-        stop_typing = None
-        if to_user_id and context_token:
-            try:
-                stop_typing = await self.start_typing(
-                    to_user_id,
-                    context_token,
-                )
-                # Store stop function for cleanup
-                with self._typing_stop_lock:
-                    self._typing_stop_funcs[to_user_id] = stop_typing
-            except Exception as e:
-                logger.warning(f"weixin start_typing failed: {e}")
 
         prefix = m.get("bot_prefix", "") or self.bot_prefix or ""
         text_parts: List[str] = []
@@ -991,16 +977,37 @@ class WeixinChannel(BaseChannel):
             body = prefix + "  " + body
 
         if not body:
-            if stop_typing:
-                stop_typing()
             return
 
         for chunk in split_text(body):
             await self._send_text_direct(to_user_id, chunk, context_token)
 
-        # Stop typing indicator after sending all messages
-        if stop_typing:
-            stop_typing()
+    async def _on_process_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Stop typing indicator after all reply messages have been sent."""
+        user_id = (
+            (send_meta or {}).get("weixin_from_user_id")
+            or self._parse_user_id_from_handle(to_handle)
+            or ""
+        )
+        if user_id:
+            self._stop_typing_for_user(user_id)
+
+    async def _on_consume_error(
+        self,
+        request: Any,
+        to_handle: str,
+        err_text: str,
+    ) -> None:
+        """Stop typing and send error message."""
+        user_id = self._parse_user_id_from_handle(to_handle) or ""
+        if user_id:
+            self._stop_typing_for_user(user_id)
+        await super()._on_consume_error(request, to_handle, err_text)
 
     async def send(
         self,
@@ -1126,8 +1133,7 @@ class WeixinChannel(BaseChannel):
         logger.info(f"weixin start_typing called for user_id={user_id}")
         ticket = await self._get_typing_ticket(user_id, context_token)
         if not ticket:
-            logger.warning(f"weixin start_typing: no ticket for {user_id}")
-            # Return empty function if no ticket
+            logger.debug("weixin start_typing: no ticket for %s", user_id)
             return lambda: None
 
         stop_event = asyncio.Event()
@@ -1135,92 +1141,71 @@ class WeixinChannel(BaseChannel):
 
         async def refresh_typing():
             """Refresh typing indicator every 5 seconds."""
-            logger.info(f"weixin refresh_typing task started for {user_id}")
+            logger.debug("weixin refresh_typing started for %s", user_id)
             while not stop_event.is_set():
-                try:
-                    await self._client.sendtyping(user_id, ticket, status=1)
-                    logger.info(
-                        "weixin refresh_typing: sent typing status "
-                        f"for {user_id}",
+                client = self._client
+                if client is None:
+                    logger.debug(
+                        "weixin refresh_typing: client gone, exiting "
+                        "for %s",
+                        user_id,
                     )
-                except Exception as e:
-                    logger.warning(f"weixin sendtyping refresh failed: {e}")
-                # Wait for 5 seconds or until stop
+                    break
+                try:
+                    await client.sendtyping(user_id, ticket, status=1)
+                except Exception as exc:
+                    logger.debug(
+                        "weixin sendtyping refresh failed: %s",
+                        exc,
+                    )
                 try:
                     await asyncio.wait_for(
                         stop_event.wait(),
                         timeout=5.0,
                     )
                 except asyncio.TimeoutError:
-                    pass  # Timeout, continue refreshing
-                # If wait_for completes without timeout, stop_event was set,
-                # so loop will exit
-            logger.info(f"weixin refresh_typing task stopped for {user_id}")
+                    pass
+            logger.debug("weixin refresh_typing stopped for %s", user_id)
 
-        # Start refresh task in background
-        task = None
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = self._loop
-
-        logger.info(
-            f"weixin start_typing: loop={loop}, "
-            f"is_running={loop.is_running() if loop else False}",
-        )
-        if loop and loop.is_running():
-            task = asyncio.create_task(refresh_typing())
-            logger.info(f"weixin start_typing: refresh task created: {task}")
-        else:
-            logger.warning(
-                "weixin start_typing: no event loop "
-                "available for refresh task",
-            )
+        # Create the background refresh task.
+        # The reference is held by the stop() closure via stop_event;
+        # we do not need to store it separately.
+        asyncio.create_task(refresh_typing())
 
         # Send initial typing status
-        try:
-            logger.info(
-                f"weixin sending initial typing status for {user_id} "
-                f"with ticket={ticket[:20]}...",
-            )
-            await self._client.sendtyping(user_id, ticket, status=1)
-            logger.info(
-                "weixin initial typing status sent successfully "
-                f"for {user_id}",
-            )
-        except Exception as e:
-            logger.warning(f"weixin sendtyping initial failed: {e}")
+        client = self._client
+        if client:
+            try:
+                await client.sendtyping(user_id, ticket, status=1)
+            except Exception as exc:
+                logger.debug("weixin sendtyping initial failed: %s", exc)
 
         def stop(send_cancel: bool = True):
-            """Stop typing indicator.
-
-            Args:
-                send_cancel: If True, send explicit cancel (status=2) to
-                    immediately hide typing indicator. Set to False to let
-                    it timeout naturally.
-            """
+            """Stop the typing indicator and cancel the refresh task."""
             nonlocal stop_called
             if stop_called:
                 return
             stop_called = True
             stop_event.set()
 
-            # Send cancel status to immediately hide typing indicator
             if send_cancel:
+                client = self._client
+                if client:
 
-                async def _cancel():
+                    async def _cancel():
+                        try:
+                            await client.sendtyping(
+                                user_id,
+                                ticket,
+                                status=2,
+                            )
+                        except Exception:
+                            pass
+
                     try:
-                        await self._client.sendtyping(
-                            user_id,
-                            ticket,
-                            status=2,
-                        )
-                    except Exception as e:
-                        logger.debug(f"weixin sendtyping cancel failed: {e}")
-
-                # Run cancel in background
-                if loop and loop.is_running():
-                    asyncio.create_task(_cancel())
+                        asyncio.ensure_future(_cancel())
+                    except RuntimeError:
+                        pass
 
         return stop
 
@@ -1295,6 +1280,17 @@ class WeixinChannel(BaseChannel):
         if self._poll_thread:
             self._poll_thread.join(timeout=10)
         self._poll_thread = None
+
+        # Stop all active typing indicators before closing the client
+        with self._typing_stop_lock:
+            stop_funcs = list(self._typing_stop_funcs.values())
+            self._typing_stop_funcs.clear()
+        for func in stop_funcs:
+            try:
+                func()
+            except Exception:
+                pass
+
         if self._client:
             await self._client.stop()
         self._client = None


### PR DESCRIPTION
## Description

Fix WeChat channel typing indicator task leak that causes high CPU/memory usage and channel instability.

- Start typing on message receive, stop after all replies via _on_process_completed hook (instead of per-message - - --stop/restart in send_content_parts)
- Override _on_consume_error to also stop typing on errors
- Fix refresh_typing task leak: exit loop when self._client is None
- Add _stop_typing_for_user helper for consistent cleanup
- Clean up all active typing tasks on channel stop
- Reduce typing log verbosity from INFO to DEBUG

**Related Issue:** Fixes #3044 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
