### PR TITLE
feat: prefer qwenpaw.log over copaw.log in debug log endpoint

### DIFF
--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
 from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
-from ...constant import WORKING_DIR
+from ...constant import PROJECT_NAME, WORKING_DIR
 from ..agent_context import get_agent_for_request
 
 
@@ -240,8 +240,15 @@ async def get_backend_debug_logs(
         description="Number of trailing log lines to return",
     ),
 ) -> dict:
-    """Return the tail of WORKING_DIR/copaw.log for the debug UI."""
-    log_path = (WORKING_DIR / "copaw.log").resolve()
+    """Return the tail of the project log file for the debug UI.
+
+    Prefers WORKING_DIR/qwenpaw.log when it exists; falls back to
+    WORKING_DIR/copaw.log for legacy installations.
+    """
+    # Prefer qwenpaw.log if it exists; otherwise fall back to copaw.log
+    qwen_log_path = WORKING_DIR / f"{PROJECT_NAME.lower()}.log"
+    copa_log_path = (WORKING_DIR / "copaw.log").resolve()
+    log_path = qwen_log_path if qwen_log_path.exists() else copa_log_path
     try:
         st = log_path.stat()
         return {

--- a/tests/unit/routers/test_console_debug_logs.py
+++ b/tests/unit/routers/test_console_debug_logs.py
@@ -39,7 +39,8 @@ def _patch_working_dir(tmp_path: Path):
 
 
 async def test_prefers_qwenpaw_log_when_present(
-    api_client, tmp_path: Path
+    api_client,
+    tmp_path: Path,
 ):
     """When qwenpaw.log exists, the endpoint should read from it."""
     qwen_log = tmp_path / "qwenpaw.log"
@@ -48,7 +49,8 @@ async def test_prefers_qwenpaw_log_when_present(
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     assert resp.status_code == 200
@@ -59,7 +61,8 @@ async def test_prefers_qwenpaw_log_when_present(
 
 
 async def test_qwenpaw_log_returns_correct_metadata(
-    api_client, tmp_path: Path
+    api_client,
+    tmp_path: Path,
 ):
     """Metadata fields (size, lines) are populated from qwenpaw.log."""
     qwen_log = tmp_path / "qwenpaw.log"
@@ -69,7 +72,8 @@ async def test_qwenpaw_log_returns_correct_metadata(
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     data = resp.json()
@@ -89,7 +93,8 @@ async def test_falls_back_to_copaw_log(api_client, tmp_path: Path):
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     assert resp.status_code == 200
@@ -107,7 +112,8 @@ async def test_copaw_log_metadata(api_client, tmp_path: Path):
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     data = resp.json()
@@ -119,13 +125,15 @@ async def test_copaw_log_metadata(api_client, tmp_path: Path):
 
 
 async def test_returns_not_found_when_no_log_exists(
-    api_client, tmp_path: Path
+    api_client,
+    tmp_path: Path,
 ):
     """When neither log file exists, exists=False is returned."""
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     assert resp.status_code == 200
@@ -141,7 +149,8 @@ async def test_not_found_path_is_copaw_fallback(api_client, tmp_path: Path):
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     data = resp.json()
@@ -152,7 +161,8 @@ async def test_not_found_path_is_copaw_fallback(api_client, tmp_path: Path):
 
 
 async def test_qwenpaw_log_wins_when_both_exist(
-    api_client, tmp_path: Path
+    api_client,
+    tmp_path: Path,
 ):
     """qwenpaw.log must win even when copaw.log also exists."""
     (tmp_path / "qwenpaw.log").write_text("from qwenpaw\n", encoding="utf-8")
@@ -161,7 +171,8 @@ async def test_qwenpaw_log_wins_when_both_exist(
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 20}
+                "/api/console/debug/backend-logs",
+                params={"lines": 20},
             )
 
     data = resp.json()
@@ -178,7 +189,8 @@ async def test_lines_param_too_small_rejected(api_client, tmp_path: Path):
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 5}
+                "/api/console/debug/backend-logs",
+                params={"lines": 5},
             )
     assert resp.status_code == 422
 
@@ -188,6 +200,7 @@ async def test_lines_param_too_large_rejected(api_client, tmp_path: Path):
     with _patch_working_dir(tmp_path):
         async with api_client:
             resp = await api_client.get(
-                "/api/console/debug/backend-logs", params={"lines": 9999}
+                "/api/console/debug/backend-logs",
+                params={"lines": 9999},
             )
     assert resp.status_code == 422

--- a/tests/unit/routers/test_console_debug_logs.py
+++ b/tests/unit/routers/test_console_debug_logs.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Unit tests for get_backend_debug_logs in the console router.
+
+Verifies that the endpoint prefers WORKING_DIR/qwenpaw.log when the file
+exists, and falls back to WORKING_DIR/copaw.log for legacy installations.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.routers.console import router
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+
+@pytest.fixture
+def api_client():
+    """Async test client for the console router."""
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _patch_working_dir(tmp_path: Path):
+    """Patch WORKING_DIR in the console router module to *tmp_path*."""
+    return patch("qwenpaw.app.routers.console.WORKING_DIR", tmp_path)
+
+
+# ── tests: qwenpaw.log present ───────────────────────────────────────
+
+
+async def test_prefers_qwenpaw_log_when_present(
+    api_client, tmp_path: Path
+):
+    """When qwenpaw.log exists, the endpoint should read from it."""
+    qwen_log = tmp_path / "qwenpaw.log"
+    qwen_log.write_text("line from qwenpaw\n", encoding="utf-8")
+
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exists"] is True
+    assert "qwenpaw.log" in data["path"]
+    assert "line from qwenpaw" in data["content"]
+
+
+async def test_qwenpaw_log_returns_correct_metadata(
+    api_client, tmp_path: Path
+):
+    """Metadata fields (size, lines) are populated from qwenpaw.log."""
+    qwen_log = tmp_path / "qwenpaw.log"
+    content = "alpha\nbeta\ngamma\n"
+    qwen_log.write_text(content, encoding="utf-8")
+
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    data = resp.json()
+    assert data["size"] == qwen_log.stat().st_size
+    assert data["lines"] == 20
+    assert data["updated_at"] is not None
+
+
+# ── tests: qwenpaw.log absent, copaw.log present ─────────────────────
+
+
+async def test_falls_back_to_copaw_log(api_client, tmp_path: Path):
+    """When qwenpaw.log is absent, the endpoint falls back to copaw.log."""
+    copa_log = tmp_path / "copaw.log"
+    copa_log.write_text("line from copaw\n", encoding="utf-8")
+
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exists"] is True
+    assert "copaw.log" in data["path"]
+    assert "line from copaw" in data["content"]
+
+
+async def test_copaw_log_metadata(api_client, tmp_path: Path):
+    """Metadata is read from copaw.log when qwenpaw.log is absent."""
+    copa_log = tmp_path / "copaw.log"
+    copa_log.write_text("x\ny\nz\n", encoding="utf-8")
+
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    data = resp.json()
+    assert data["size"] == copa_log.stat().st_size
+    assert data["updated_at"] is not None
+
+
+# ── tests: neither log present ────────────────────────────────────────
+
+
+async def test_returns_not_found_when_no_log_exists(
+    api_client, tmp_path: Path
+):
+    """When neither log file exists, exists=False is returned."""
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exists"] is False
+    assert data["content"] == ""
+    assert data["size"] == 0
+    assert data["updated_at"] is None
+
+
+async def test_not_found_path_is_copaw_fallback(api_client, tmp_path: Path):
+    """When no log file exists, the reported path is the copaw.log fallback."""
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    data = resp.json()
+    assert "copaw.log" in data["path"]
+
+
+# ── tests: qwenpaw.log takes priority over copaw.log ─────────────────
+
+
+async def test_qwenpaw_log_wins_when_both_exist(
+    api_client, tmp_path: Path
+):
+    """qwenpaw.log must win even when copaw.log also exists."""
+    (tmp_path / "qwenpaw.log").write_text("from qwenpaw\n", encoding="utf-8")
+    (tmp_path / "copaw.log").write_text("from copaw\n", encoding="utf-8")
+
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 20}
+            )
+
+    data = resp.json()
+    assert "qwenpaw.log" in data["path"]
+    assert "from qwenpaw" in data["content"]
+    assert "from copaw" not in data["content"]
+
+
+# ── tests: query parameter validation ────────────────────────────────
+
+
+async def test_lines_param_too_small_rejected(api_client, tmp_path: Path):
+    """lines < 20 should return 422."""
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 5}
+            )
+    assert resp.status_code == 422
+
+
+async def test_lines_param_too_large_rejected(api_client, tmp_path: Path):
+    """lines > MAX_DEBUG_LOG_LINES should return 422."""
+    with _patch_working_dir(tmp_path):
+        async with api_client:
+            resp = await api_client.get(
+                "/api/console/debug/backend-logs", params={"lines": 9999}
+            )
+    assert resp.status_code == 422


### PR DESCRIPTION
This pull request updates the backend debug log endpoint to prefer the new `qwenpaw.log` file over the legacy `copaw.log` for log retrieval, improving compatibility with newer installations while maintaining backward compatibility. Comprehensive unit tests are also added to verify the correct log file selection and response behavior under various scenarios.

**Log file selection logic:**

* The debug logs endpoint in `console.py` now checks for `qwenpaw.log` in `WORKING_DIR` and uses it if present; otherwise, it falls back to `copaw.log` for legacy support. (`src/qwenpaw/app/routers/console.py`, [[1]](diffhunk://#diff-e23201e08c24e0b075ef6da80877b4e0cee74919a53c352027cb9e39d7e88813L16-R16) [[2]](diffhunk://#diff-e23201e08c24e0b075ef6da80877b4e0cee74919a53c352027cb9e39d7e88813L243-R251)

**Testing improvements:**

* A new test suite (`test_console_debug_logs.py`) is added to verify:
  - The endpoint prefers `qwenpaw.log` when available.
  - Correct fallback to `copaw.log` if `qwenpaw.log` is missing.
  - Accurate metadata and content in responses.
  - Proper handling when neither log file exists.
  - Validation of the `lines` query parameter. (`tests/unit/routers/test_console_debug_logs.py`, [tests/unit/routers/test_console_debug_logs.pyR1-R206](diffhunk://#diff-6a061787c894329200b7b7dddb0b05ebbd65cece79c42a3ccfef04fc2b0a73a4R1-R206))