### PR TITLE
docs(website): improve FAQ formatting and add troubleshooting details

### DIFF
--- a/website/public/docs/desktop.en.md
+++ b/website/public/docs/desktop.en.md
@@ -73,23 +73,25 @@ After installation, you'll see **two launch shortcuts**:
 ### Common Issues
 
 **Q: The app window is blank/white screen and cannot display properly?**
+
 A: This is usually because the system is missing the **Microsoft WebView2** runtime (some Windows 10 systems do not have it pre-installed).
 Download and install it from the Microsoft website:
 [Microsoft WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
 Restart the application after installation.
 
 **Q: Application doesn't respond after launch?**
+
 A: Use "QwenPaw Desktop (Debug)" mode to view terminal output for error messages
 
 **Q: How to uninstall?**
+
 A: Go to Windows Settings → Apps → Installed apps → Find "QwenPaw Desktop" → Uninstall
 
 **Q: Is the installer safe?**
-A:
 
-- The application is **not Microsoft code-signed** (costs $200-800/year), so Windows Defender SmartScreen will show a warning
-- This is normal behavior; click "More info" → "Run anyway" to proceed
-- The code is completely open source, and the build process is transparently verifiable on GitHub Actions
+A: The application is **not Microsoft code-signed** (costs $200-800/year), so Windows Defender SmartScreen will show a warning
+This is normal behavior; click "More info" → "Run anyway" to proceed
+The code is completely open source, and the build process is transparently verifiable on GitHub Actions
 
 ---
 
@@ -204,25 +206,27 @@ tail -f ~/.qwenpaw/desktop.log
 ### Common Issues
 
 **Q: Nothing happens after double-clicking?**
-A:
+
+A: Try the following steps:
 
 1. Check the `~/.qwenpaw/desktop.log` file for errors
 2. Use the terminal command above to launch and view real-time output
 
 **Q: Message "Apple cannot verify this application"?**
+
 A: Follow the "Bypassing System Security Restrictions" steps above
 
 **Q: How to uninstall?**
+
 A: Drag `QwenPaw.app` to the Trash, then delete the `~/.qwenpaw` configuration folder
 
 **Q: Can I use it on Intel Mac?**
+
 A: Yes, but you cannot use MLX model acceleration (MLX only supports Apple Silicon)
 
 **Q: Why is the app not signed, and why does the system show a risk warning?**
 
-A:
-
-Currently using:
+A: Currently using:
 
 - ✅ **Open source transparency**: All code and build processes are public on GitHub
 - ✅ **CI/CD verifiable**: GitHub Actions automated builds with viewable logs

--- a/website/public/docs/desktop.zh.md
+++ b/website/public/docs/desktop.zh.md
@@ -73,23 +73,25 @@
 ### 常见问题
 
 **Q: 应用启动后窗口白屏，无法正常显示？**
+
 A: 这通常是因为系统缺少 **Microsoft WebView2** 运行时（部分 Windows 10 系统未预装）。
 请前往微软官网下载并安装：
 [Microsoft WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
 安装完成后重启应用即可。
 
 **Q: 应用启动后没有反应？**
+
 A: 使用 "QwenPaw Desktop (Debug)" 模式启动，查看终端输出的错误信息
 
 **Q: 如何卸载？**
+
 A: 在 Windows 设置 → 应用 → 已安装的应用 → 找到 "QwenPaw Desktop" → 卸载
 
 **Q: 安装包是否安全？**
-A:
 
-- 应用未经过 **Microsoft 代码签名**（成本 $200-800/年），Windows Defender SmartScreen 会显示警告
-- 这是正常现象，点击 "更多信息" → "仍要运行" 即可
-- 代码完全开源，构建过程在 GitHub Actions 上透明可查
+A: 应用未经过 **Microsoft 代码签名**（成本 $200-800/年），Windows Defender SmartScreen 会显示警告
+这是正常现象，点击 "更多信息" → "仍要运行" 即可
+代码完全开源，构建过程在 GitHub Actions 上透明可查
 
 ---
 
@@ -204,25 +206,27 @@ tail -f ~/.qwenpaw/desktop.log
 ### 常见问题
 
 **Q: 双击后没有任何反应？**
-A:
+
+A: 请尝试以下步骤：
 
 1. 检查 `~/.qwenpaw/desktop.log` 文件查看错误
 2. 使用上述终端命令启动，查看实时输出
 
 **Q: 提示"Apple 无法验证此应用"？**
+
 A: 按照上述"解除系统安全限制"步骤操作
 
 **Q: 如何卸载？**
+
 A: 将 `QwenPaw.app` 拖到废纸篓，然后删除 `~/.qwenpaw` 配置文件夹
 
 **Q: Intel Mac 可以用吗？**
+
 A: 可以运行，但无法使用 MLX 模型加速（MLX 仅支持 Apple Silicon）
 
 **Q: 应用为什么没有签名，为什么系统会提示有风险？**
 
-A:
-
-当前采用
+A: 当前采用
 
 - ✅ **开源透明**：所有代码和构建流程公开在 GitHub
 - ✅ **CI/CD 可验证**：GitHub Actions 自动构建，日志可查


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

Before:
<img width="1578" height="746" alt="image" src="https://github.com/user-attachments/assets/43f676b5-935e-4ad4-b431-3371b89d6412" />


After

<img width="1668" height="948" alt="image" src="https://github.com/user-attachments/assets/396d3a73-6768-479b-a87a-caa34933296c" />


**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
