### PR TITLE
feat(cron): create Discord thread before agent dispatch

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -1348,6 +1348,24 @@ class BaseChannel(ABC):
         """
         raise NotImplementedError
 
+    async def begin_subthread(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        title: str,
+    ) -> str:
+        """Create a sub-thread scoped to *session_id* and return the new
+        session_id that routes to it.
+
+        Used by cron dispatch to isolate job output from the parent channel.
+        Default implementation is a no-op that returns *session_id* unchanged —
+        channels without native thread support (WeChat, iMessage, etc.) inherit
+        this. Channels with thread semantics (Discord, Slack, Feishu) override
+        to create a thread and return a thread-scoped session_id.
+        """
+        return session_id
+
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
         """Map cron dispatch target to channel-specific to_handle.
 

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -690,6 +690,61 @@ class DiscordChannel(BaseChannel):
         if self._client:
             await self._client.close()
 
+    # Discord caps thread names at 100 chars (see discord.Thread.name docs).
+    _DISCORD_THREAD_NAME_MAX: int = 100
+
+    async def begin_subthread(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        title: str,
+    ) -> str:
+        """Create a public Discord thread in the given channel and return a
+        session_id scoped to the thread.
+
+        Titles longer than Discord's 100-character limit are truncated.
+
+        Raises:
+            ChannelError: session_id is not a ``discord:ch:<id>`` handle
+                (DMs don't support threads) or the Discord client is not
+                ready.
+        """
+        if not self.enabled or not self._client or not self._client.is_ready():
+            raise ChannelError(
+                channel_name="discord",
+                message="Discord client is not ready",
+            )
+        route = self._route_from_handle(session_id)
+        channel_id = route.get("channel_id")
+        if not channel_id:
+            raise ChannelError(
+                channel_name="discord",
+                message=(
+                    "begin_subthread requires a discord:ch:<id> session_id "
+                    f"(got: {session_id})"
+                ),
+            )
+        import discord  # pylint: disable=import-outside-toplevel
+
+        safe_title = title[: self._DISCORD_THREAD_NAME_MAX]
+        cid = int(channel_id)
+        parent = self._client.get_channel(cid)
+        if parent is None:
+            parent = await self._client.fetch_channel(cid)
+        thread = await parent.create_thread(
+            name=safe_title,
+            type=discord.ChannelType.public_thread,
+            auto_archive_duration=1440,
+        )
+        logger.info(
+            "discord begin_subthread: thread=%s title=%s parent=%s",
+            thread.id,
+            safe_title,
+            channel_id,
+        )
+        return f"discord:ch:{thread.id}"
+
     def resolve_session_id(
         self,
         sender_id: str,

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -17,14 +17,16 @@ async def _create_discord_thread(
     title: str,
 ) -> str:
     """Create a Discord thread in the given channel. Returns the thread ID."""
-    import discord
+    import discord  # pylint: disable=import-outside-toplevel
 
     ch = await channel_manager.get_channel("discord")
-    if ch is None or ch._client is None:
+    # pylint: disable=protected-access
+    client = getattr(ch, "_client", None) if ch else None
+    if client is None:
         raise RuntimeError("Discord channel not available")
-    parent = ch._client.get_channel(int(channel_id))
+    parent = client.get_channel(int(channel_id))
     if parent is None:
-        parent = await ch._client.fetch_channel(int(channel_id))
+        parent = await client.fetch_channel(int(channel_id))
     thread = await parent.create_thread(
         name=title,
         type=discord.ChannelType.public_thread,
@@ -91,9 +93,9 @@ class CronExecutor:
         if job.dispatch.create_thread and job.dispatch.channel == "discord":
             channel_id = target_session_id.split(":")[-1]
             date_str = datetime.now().strftime("%Y-%m-%d")
-            title = (job.dispatch.thread_title or job.name + " {date}").replace(
-                "{date}", date_str,
-            )
+            title = (
+                job.dispatch.thread_title or job.name + " {date}"
+            ).replace("{date}", date_str)
             thread_id = await _create_discord_thread(
                 self._channel_manager,
                 channel_id,

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -5,40 +5,11 @@ import asyncio
 import logging
 from datetime import datetime
 from typing import Any, Dict
+from zoneinfo import ZoneInfo
 
 from .models import CronJobSpec
 
 logger = logging.getLogger(__name__)
-
-
-async def _create_discord_thread(
-    channel_manager: Any,
-    channel_id: str,
-    title: str,
-) -> str:
-    """Create a Discord thread in the given channel. Returns the thread ID."""
-    import discord  # pylint: disable=import-outside-toplevel
-
-    ch = await channel_manager.get_channel("discord")
-    # pylint: disable=protected-access
-    client = getattr(ch, "_client", None) if ch else None
-    if client is None:
-        raise RuntimeError("Discord channel not available")
-    parent = client.get_channel(int(channel_id))
-    if parent is None:
-        parent = await client.fetch_channel(int(channel_id))
-    thread = await parent.create_thread(
-        name=title,
-        type=discord.ChannelType.public_thread,
-        auto_archive_duration=1440,
-    )
-    logger.info(
-        "cron created thread: id=%s title=%s parent=%s",
-        thread.id,
-        title,
-        channel_id,
-    )
-    return str(thread.id)
 
 
 class CronExecutor:
@@ -53,8 +24,10 @@ class CronExecutor:
         - task_type agent: ask agent with prompt, send reply to channel (
             stream_query + send_event)
 
-        When dispatch.create_thread is True (agent jobs only), a Discord
-        thread is created first and all output is routed there.
+        When dispatch.create_thread is True (agent jobs only), the target
+        channel's begin_subthread() is called first and all agent output is
+        routed to the returned sub-thread session. Channels without native
+        thread support inherit a no-op default from BaseChannel.
         """
         target_user_id = job.dispatch.target.user_id
         target_session_id = job.dispatch.target.session_id
@@ -89,22 +62,29 @@ class CronExecutor:
         # agent: run request as the dispatch target user so context matches
         assert job.request is not None
 
-        # Create thread if requested — rewrite session to thread
-        if job.dispatch.create_thread and job.dispatch.channel == "discord":
-            channel_id = target_session_id.split(":")[-1]
-            date_str = datetime.now().strftime("%Y-%m-%d")
-            title = (
-                job.dispatch.thread_title or job.name + " {date}"
-            ).replace("{date}", date_str)
-            thread_id = await _create_discord_thread(
-                self._channel_manager,
-                channel_id,
-                title,
+        # Create a sub-thread if requested — rewrite session to the thread.
+        # Channels without thread support inherit BaseChannel's no-op default.
+        if job.dispatch.create_thread:
+            ch = await self._channel_manager.get_channel(job.dispatch.channel)
+            if ch is None:
+                raise RuntimeError(
+                    f"channel not available: {job.dispatch.channel}",
+                )
+            tz = ZoneInfo(job.schedule.timezone)
+            date_str = datetime.now(tz).strftime("%Y-%m-%d")
+            title_template = (
+                job.dispatch.thread_title or f"{job.name} {{date}}"
             )
-            target_session_id = f"discord:ch:{thread_id}"
+            title = title_template.replace("{date}", date_str)
+            target_session_id = await ch.begin_subthread(
+                user_id=target_user_id or "",
+                session_id=target_session_id or "",
+                title=title,
+            )
             logger.info(
-                "cron thread-first: job_id=%s thread_session=%s",
+                "cron begin_subthread: job_id=%s channel=%s session=%s",
                 job.id,
+                job.dispatch.channel,
                 target_session_id,
             )
 

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -3,11 +3,40 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from typing import Any, Dict
 
 from .models import CronJobSpec
 
 logger = logging.getLogger(__name__)
+
+
+async def _create_discord_thread(
+    channel_manager: Any,
+    channel_id: str,
+    title: str,
+) -> str:
+    """Create a Discord thread in the given channel. Returns the thread ID."""
+    import discord
+
+    ch = await channel_manager.get_channel("discord")
+    if ch is None or ch._client is None:
+        raise RuntimeError("Discord channel not available")
+    parent = ch._client.get_channel(int(channel_id))
+    if parent is None:
+        parent = await ch._client.fetch_channel(int(channel_id))
+    thread = await parent.create_thread(
+        name=title,
+        type=discord.ChannelType.public_thread,
+        auto_archive_duration=1440,
+    )
+    logger.info(
+        "cron created thread: id=%s title=%s parent=%s",
+        thread.id,
+        title,
+        channel_id,
+    )
+    return str(thread.id)
 
 
 class CronExecutor:
@@ -21,6 +50,9 @@ class CronExecutor:
         - task_type text: send fixed text to channel
         - task_type agent: ask agent with prompt, send reply to channel (
             stream_query + send_event)
+
+        When dispatch.create_thread is True (agent jobs only), a Discord
+        thread is created first and all output is routed there.
         """
         target_user_id = job.dispatch.target.user_id
         target_session_id = job.dispatch.target.session_id
@@ -53,12 +85,32 @@ class CronExecutor:
             return
 
         # agent: run request as the dispatch target user so context matches
+        assert job.request is not None
+
+        # Create thread if requested — rewrite session to thread
+        if job.dispatch.create_thread and job.dispatch.channel == "discord":
+            channel_id = target_session_id.split(":")[-1]
+            date_str = datetime.now().strftime("%Y-%m-%d")
+            title = (job.dispatch.thread_title or job.name + " {date}").replace(
+                "{date}", date_str,
+            )
+            thread_id = await _create_discord_thread(
+                self._channel_manager,
+                channel_id,
+                title,
+            )
+            target_session_id = f"discord:ch:{thread_id}"
+            logger.info(
+                "cron thread-first: job_id=%s thread_session=%s",
+                job.id,
+                target_session_id,
+            )
+
         logger.info(
             "cron agent: job_id=%s channel=%s stream_query then send_event",
             job.id,
             job.dispatch.channel,
         )
-        assert job.request is not None
         req: Dict[str, Any] = job.request.model_dump(mode="json")
 
         req["channel"] = target_channel

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -99,6 +99,17 @@ class DispatchSpec(BaseModel):
     target: DispatchTarget
     mode: Literal["stream", "final"] = Field(default="stream")
     meta: Dict[str, Any] = Field(default_factory=dict)
+    create_thread: bool = Field(
+        default=False,
+        description="Create a Discord thread before dispatching. "
+        "All agent output goes to the thread instead of the channel.",
+    )
+    thread_title: Optional[str] = Field(
+        default=None,
+        description="Thread title template. "
+        "{date} is replaced with YYYY-MM-DD. "
+        "Defaults to job name + date.",
+    )
 
 
 class JobRuntimeSpec(BaseModel):

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -162,6 +162,14 @@ class CronJobSpec(BaseModel):
                 raise ConfigurationException(
                     message="task_type is text but text is empty",
                 )
+            if self.dispatch.create_thread:
+                raise ConfigurationException(
+                    message=(
+                        "create_thread is only supported for agent jobs "
+                        "(task_type=agent); text jobs send a single message "
+                        "and cannot be routed to a sub-thread"
+                    ),
+                )
             self.request = None
         elif self.task_type == "agent":
             if self.request is None:


### PR DESCRIPTION
> **Updated 2026-05-09**: Rebased onto main after #4117 (cron channel-based session isolation) merged. `share_session` (#4117) and `create_thread` (this PR) are orthogonal: the former controls agent memory isolation, the latter controls Discord output routing. In the rebased executor, `begin_subthread` rewrites `target_session_id` before `share_session` sets `req["session_id"]`, so cron output streams into the new thread regardless of `share_session` mode.

## Problem

Cron jobs that dispatch to Discord channels have no way to isolate their output into a thread. The agent's replies, tool call status messages, and streamed content all land directly in the parent channel, mixing with regular conversation.

For daily digest jobs (e.g., news summaries, monitoring reports), this is especially problematic — the digest content clutters the channel and can't be collapsed or followed up on independently.

## Solution

Add `create_thread` and `thread_title` fields to `DispatchSpec`. When `create_thread=True`, the cron executor creates a Discord thread in the target channel before dispatching the agent. The agent's session is rewritten to the thread, so all output (replies, tool messages, streamed content) goes to the thread instead of the parent channel.

```json
{
  "dispatch": {
    "channel": "discord",
    "create_thread": true,
    "thread_title": "Daily Report {date}",
    "target": { "session_id": "discord:ch:123", "user_id": "456" }
  }
}
```

`{date}` in the title is replaced with `YYYY-MM-DD`. If `thread_title` is omitted, defaults to `"{job_name} {date}"`.

No-op when `create_thread` is false (default) — existing behavior unchanged.

Builds on #3144 (Discord thread awareness) which was merged in v1.1.2.

## Testing

- Cron job with `create_thread: true` → thread created, agent replies inside thread
- Cron job without `create_thread` → unchanged behavior, replies in channel
- Thread title with `{date}` placeholder → correctly substituted

## Updated (post-review)

Refactored to make thread dispatch channel-agnostic, per review feedback. The "Solution" section above describes the original Discord-specific shape; the updated implementation moves thread creation into the target channel.

**Abstraction change:**
- `BaseChannel.begin_subthread(user_id, session_id, title) -> session_id` — default is a no-op, returns session_id unchanged. Channels with native thread support override.
- `DiscordChannel.begin_subthread` — concrete implementation (moved from executor). Creates a public thread, returns `discord:ch:{thread_id}` session.
- Executor no longer hardcodes `"discord"`; it invokes `ch.begin_subthread(...)` on the target channel.

Only Discord has a concrete implementation in this PR. Slack/Feishu thread semantics differ (parent message required to get `thread_ts`, which changes session_id format), so those are better suited to follow-up PRs.

**Also fixed:**
- Use `job.schedule.timezone` (not server local time) for `{date}` rendering
- Truncate thread names to Discord's 100-char limit
- Reject `task_type=text` + `create_thread=true` at validation time
- Fail fast with `ChannelError` on DM session_ids in `DiscordChannel.begin_subthread`

