### PR TITLE
fix(WeCom): fix duplicate chat entry for group messages & fix CI coverage

### DIFF
--- a/.github/workflows/channel-tests.yml
+++ b/.github/workflows/channel-tests.yml
@@ -204,27 +204,28 @@ jobs:
               --cov-report=xml:coverage.xml \
               --cov-report=term-missing
           else
-            # Targeted coverage for affected channels only
-            COV_SOURCES="src/qwenpaw/app/channels/base.py"
+            # Targeted coverage for affected channels only.
+            # pytest-cov requires separate --cov flags per source path;
+            # a comma-separated string is treated as one module name.
+            COV_FLAGS="--cov=src/qwenpaw/app/channels/base.py"
 
-            # Add affected channel sources
             for ch in ${{ needs.detect-changes.outputs.affected_channels }}; do
               if [ -d "src/qwenpaw/app/channels/$ch" ]; then
-                COV_SOURCES="$COV_SOURCES,src/qwenpaw/app/channels/$ch"
+                COV_FLAGS="$COV_FLAGS --cov=src/qwenpaw/app/channels/$ch"
               fi
             done
 
             # 1. Run unit tests with targeted coverage
             pytest tests/unit/channels/ \
               -v \
-              --cov="$COV_SOURCES" \
+              $COV_FLAGS \
               --cov-report=xml:coverage.xml \
               --cov-report=term-missing
 
             # 2. Run contract tests and append coverage
             pytest tests/contract/channels/ \
               -v \
-              --cov="$COV_SOURCES" \
+              $COV_FLAGS \
               --cov-append \
               --cov-report=xml:coverage.xml \
               --cov-report=term-missing

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -591,9 +591,9 @@ class WecomChannel(BaseChannel):
             native = {
                 "channel_id": self.channel,
                 "sender_id": sender_id,
-                # Group chats share one session; omit user_id so the
-                # session file is keyed by session_id only.
-                "user_id": "" if is_group else sender_id,
+                # Group chats use a non-empty placeholder to prevent
+                # Runner.stream_query from overwriting it with session_id.
+                "user_id": "group" if is_group else sender_id,
                 "session_id": session_id,
                 "content_parts": content_parts,
                 "meta": meta,


### PR DESCRIPTION
## Description

Two fixes in this PR:

1.fix(WeCom): Use a non-empty placeholder "group" as user_id for WeCom group chats instead of an empty string. Runner.stream_query normalizes empty user_id to session_id, which caused get_or_create_chat to be called with inconsistent user_id values, resulting in duplicate chat entries in chats.json. 

2.fix(ci): Fix --cov argument format in channel-tests.yml targeted coverage mode. pytest-cov requires separate --cov flags per source path; the previous comma-separated string was treated as a single module name, yielding 0% coverage and triggering the fail_under threshold.
**Related Issue:** Fixes #3523 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
