### PR TITLE
feat(provider/messages)Enable cross provider switch within conversation

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -113,9 +113,18 @@ def _normalize_messages_for_formatter(
     supports_multimodal = _supports_multimodal_for_current_model()
     if getattr(formatter_instance, "_qwenpaw_force_strip_media", False):
         supports_multimodal = False
+
+    if is_anthropic_formatter:
+        target_family = "anthropic"
+    elif is_gemini_formatter:
+        target_family = "gemini"
+    else:
+        target_family = "openai"
+
     normalized_msgs = normalize_messages_for_model_request(
         msgs,
         supports_multimodal=supports_multimodal,
+        target_family=target_family,
     )
 
     return normalized_msgs, is_anthropic_formatter, is_gemini_formatter
@@ -733,14 +742,20 @@ def _create_file_block_support_formatter(
             # Normalize non-standard MIME types (e.g. image/jpg → image/jpeg)
             _fix_image_mime_types(messages)
 
-            if extra_contents:
+            if extra_contents and _is_gemini_formatter:
                 for message in messages:
                     for tc in message.get("tool_calls", []):
                         ec = extra_contents.get(tc.get("id"))
                         if ec:
                             tc["extra_content"] = ec
 
-            if reasoning_contents:
+            if reasoning_contents and not is_anthropic_formatter:
+                # Anthropic passes thinking blocks natively through
+                # _format_anthropic_messages; injecting reasoning_content
+                # would be redundant and the API doesn't use this field.
+                # OpenAI/Gemini (OpenAI-compat) formatters drop thinking
+                # blocks, so we re-inject the content as reasoning_content.
+                #
                 # Build a list of reasoning values aligned with surviving
                 # assistant messages.  The parent formatter drops
                 # thinking-only messages (no content/tool_calls), so we

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -18,6 +18,50 @@ from .tool_message_utils import _sanitize_tool_messages
 
 _MEDIA_BLOCK_TYPES = {"image", "audio", "video"}
 
+# Fields that are provider-specific and should not leak across families.
+# Gemini: extra_content carries thought_signature.
+# AgentScope internal: raw_input is a stream-parsing artefact.
+_PROVIDER_ONLY_TOOL_USE_FIELDS = frozenset({"extra_content", "raw_input"})
+
+# The subset that is preserved when the target is its native family.
+_GEMINI_NATIVE_FIELDS = frozenset({"extra_content"})
+
+
+def _clean_provider_specific_fields(
+    msgs: list[Msg],
+    target_family: str,
+) -> None:
+    """Remove provider-specific fields that may leak from a previous provider.
+
+    Operates **in-place** on already-cloned messages so the stored
+    conversation history is never mutated.
+
+    Current rules
+    ~~~~~~~~~~~~~
+    * ``extra_content`` – Gemini-specific (``thought_signature``).
+      Kept only when *target_family* is ``"gemini"``.
+    * ``raw_input`` – AgentScope stream-parsing artefact.
+      Stripped unconditionally; some providers reject unknown fields.
+    """
+    preserve = (
+        _GEMINI_NATIVE_FIELDS if target_family == "gemini" else frozenset()
+    )
+    strip_fields = _PROVIDER_ONLY_TOOL_USE_FIELDS - preserve
+
+    if not strip_fields:
+        return
+
+    for msg in msgs:
+        if not isinstance(msg.content, list):
+            continue
+        for block in msg.content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_use":
+                continue
+            for field in strip_fields:
+                block.pop(field, None)
+
 
 def _clone_msg(msg: Msg) -> Msg:
     """Return a deep copy of an AgentScope message."""
@@ -88,10 +132,24 @@ def normalize_messages_for_model_request(
     msgs: list[Msg],
     *,
     supports_multimodal: bool,
+    target_family: str = "openai",
 ) -> list[Msg]:
-    """Return a normalized copy for provider request formatting."""
+    """Return a normalized copy for provider request formatting.
+
+    Args:
+        msgs: Source messages (will **not** be mutated).
+        supports_multimodal: Whether the target model handles media.
+        target_family: Provider family of the *current* model
+            (``"openai"`` | ``"anthropic"`` | ``"gemini"``).
+            Used to strip fields that belong to other providers.
+    """
     normalized = _clone_messages(msgs)
+    # Sanitize first: _repair_empty_tool_inputs needs raw_input to fix
+    # empty input fields.  _clean_provider_specific_fields runs after so
+    # that raw_input (and other provider artefacts) are stripped only once
+    # the repair has had its chance.
     normalized = _sanitize_tool_messages(normalized)
+    _clean_provider_specific_fields(normalized, target_family)
     if not supports_multimodal:
         _strip_media_blocks_in_place(normalized)
     return normalized

--- a/tests/unit/agents/test_cross_provider_normalization.py
+++ b/tests/unit/agents/test_cross_provider_normalization.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for cross-provider message normalization.
+
+Simulates a conversation that starts on one provider and is then formatted
+for a *different* provider.  The key invariant: provider-specific artefacts
+from the first provider must not leak into the request payload for the
+second provider, while the original in-memory messages must remain untouched.
+"""
+
+# pylint: disable=protected-access,redefined-outer-name
+from types import SimpleNamespace
+
+import pytest
+from agentscope.formatter import OpenAIChatFormatter
+from agentscope.message import Msg, ToolResultBlock
+
+try:
+    from agentscope.formatter import AnthropicChatFormatter
+except ImportError:  # pragma: no cover
+    AnthropicChatFormatter = None
+
+try:
+    from agentscope.formatter import GeminiChatFormatter
+except ImportError:  # pragma: no cover
+    GeminiChatFormatter = None
+
+from qwenpaw.agents import model_factory
+
+
+def _gemini_session_history() -> list[Msg]:
+    """Simulate a history that was built while Gemini was the active model.
+
+    Includes:
+    * An assistant message with a tool_use block carrying ``extra_content``
+      (Gemini's ``thought_signature``).
+    * A matching tool_result.
+    * A final assistant text reply.
+    """
+    return [
+        Msg(name="user", role="user", content="Find the weather in Tokyo"),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "tc_gemini_1",
+                    "name": "get_weather",
+                    "input": {"city": "Tokyo"},
+                    "extra_content": {
+                        "thought_signature": "gemini_sig_abc",
+                    },
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="tc_gemini_1",
+                    name="get_weather",
+                    output="Sunny, 25°C",
+                ),
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content="The weather in Tokyo is sunny and 25°C.",
+        ),
+    ]
+
+
+def _openai_session_history() -> list[Msg]:
+    """Simulate a plain history with no provider-specific artefacts."""
+    return [
+        Msg(name="user", role="user", content="Say hello"),
+        Msg(name="assistant", role="assistant", content="Hello!"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Gemini → OpenAI switch
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_history_to_openai(monkeypatch) -> None:
+    """Switching from Gemini to OpenAI should strip extra_content."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = _gemini_session_history()
+    original_ec = history[1].content[0]["extra_content"].copy()
+
+    (
+        normalized,
+        is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert is_anthropic is False
+    assert is_gemini is False
+
+    tool_use_block = normalized[1].content[0]
+    assert "extra_content" not in tool_use_block
+    assert tool_use_block["id"] == "tc_gemini_1"
+    assert tool_use_block["input"] == {"city": "Tokyo"}
+
+    # Original history must be unchanged.
+    assert history[1].content[0]["extra_content"] == original_ec
+
+
+# ---------------------------------------------------------------------------
+# Gemini → Anthropic switch
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_history_to_anthropic(monkeypatch) -> None:
+    """Switching from Gemini to Anthropic should strip extra_content."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = _gemini_session_history()
+
+    (
+        normalized,
+        is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        AnthropicChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert is_anthropic is True
+    assert "extra_content" not in normalized[1].content[0]
+
+
+# ---------------------------------------------------------------------------
+# Gemini → Gemini (same provider, no stripping)
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_history_stays_gemini(monkeypatch) -> None:
+    """Staying on Gemini should preserve extra_content."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = _gemini_session_history()
+
+    (
+        normalized,
+        _is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        GeminiChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert is_gemini is True
+    block = normalized[1].content[0]
+    assert "extra_content" in block
+    assert block["extra_content"]["thought_signature"] == "gemini_sig_abc"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI → Gemini (nothing to strip, no crash)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_history_to_gemini(monkeypatch) -> None:
+    """Plain OpenAI history should work fine when switching to Gemini."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = _openai_session_history()
+
+    (
+        normalized,
+        _is_anthropic,
+        is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        GeminiChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert is_gemini is True
+    assert normalized[0].content == "Say hello"
+    assert normalized[1].content == "Hello!"
+
+
+# ---------------------------------------------------------------------------
+# Multiple tool calls in one message
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_multi_toolcall_to_openai(monkeypatch) -> None:
+    """Multiple tool_use blocks with extra_content all get cleaned."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    msgs = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "tc_a",
+                    "name": "fn_a",
+                    "input": {},
+                    "extra_content": {"thought_signature": "sig_a"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tc_b",
+                    "name": "fn_b",
+                    "input": {},
+                    "extra_content": {"thought_signature": "sig_b"},
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="tc_a",
+                    name="fn_a",
+                    output="ok_a",
+                ),
+                ToolResultBlock(
+                    type="tool_result",
+                    id="tc_b",
+                    name="fn_b",
+                    output="ok_b",
+                ),
+            ],
+        ),
+    ]
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        msgs,
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    for block in normalized[0].content:
+        if block.get("type") == "tool_use":
+            assert "extra_content" not in block
+
+
+# ---------------------------------------------------------------------------
+# Thinking blocks cross-provider: stored in memory as provider-agnostic
+# {"type": "thinking", "thinking": "..."} — should survive normalization
+# for ALL target families.
+# ---------------------------------------------------------------------------
+
+
+def _history_with_thinking() -> list[Msg]:
+    """Simulate a history that contains Anthropic-style thinking blocks."""
+    return [
+        Msg(name="user", role="user", content="Think about this"),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "Let me consider..."},
+                {"type": "text", "text": "Here is my answer."},
+            ],
+        ),
+    ]
+
+
+def test_thinking_blocks_preserved_for_openai(monkeypatch) -> None:
+    """Thinking blocks in memory must survive normalization for OpenAI."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _history_with_thinking(),
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    blocks = normalized[1].content
+    thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+    assert len(thinking_blocks) == 1
+    assert thinking_blocks[0]["thinking"] == "Let me consider..."
+
+
+def test_thinking_blocks_preserved_for_anthropic(monkeypatch) -> None:
+    """Thinking blocks must survive normalization for Anthropic."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _history_with_thinking(),
+        AnthropicChatFormatter,
+        SimpleNamespace(),
+    )
+
+    blocks = normalized[1].content
+    thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+    assert len(thinking_blocks) == 1
+
+
+def test_thinking_blocks_preserved_for_gemini(monkeypatch) -> None:
+    """Thinking blocks must survive normalization for Gemini."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _history_with_thinking(),
+        GeminiChatFormatter,
+        SimpleNamespace(),
+    )
+
+    blocks = normalized[1].content
+    thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+    assert len(thinking_blocks) == 1
+
+
+# ---------------------------------------------------------------------------
+# raw_input repair survives across provider switches
+# ---------------------------------------------------------------------------
+
+
+def _history_with_raw_input_needing_repair() -> list[Msg]:
+    """Simulate tool_use with empty input but valid raw_input."""
+    return [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "tc_repair",
+                    "name": "search",
+                    "input": {},
+                    "raw_input": '{"query": "hello"}',
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="tc_repair",
+                    name="search",
+                    output="found it",
+                ),
+            ],
+        ),
+    ]
+
+
+def test_raw_input_repair_works_before_cross_provider_clean(
+    monkeypatch,
+) -> None:
+    """raw_input must repair empty input BEFORE being stripped."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = _history_with_raw_input_needing_repair()
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    block = normalized[0].content[0]
+    assert block["input"] == {"query": "hello"}
+    assert "raw_input" not in block

--- a/tests/unit/agents/test_message_request_normalizer.py
+++ b/tests/unit/agents/test_message_request_normalizer.py
@@ -6,6 +6,7 @@ import pytest
 from agentscope.message import Msg, ToolResultBlock
 
 from qwenpaw.agents.utils.message_request_normalizer import (
+    _clean_provider_specific_fields,
     _clone_msg,
     _clone_messages,
     _strip_media_blocks_in_place,
@@ -390,3 +391,260 @@ def test_normalize_conversation_with_multiple_messages():
     # Originals unchanged
     assert msgs[0].content[1]["type"] == "image"
     assert msgs[2].content[0]["type"] == "video"
+
+
+# -----------------------------------------------------------------------------
+# _clean_provider_specific_fields tests
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool_use_with_extra_content():
+    """Create an assistant message with Gemini extra_content on tool_use."""
+    return Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "search",
+                "input": {"q": "test"},
+                "extra_content": {"thought_signature": "sig123"},
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def tool_use_with_raw_input():
+    """Create an assistant message with raw_input on tool_use."""
+    return Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            {
+                "type": "tool_use",
+                "id": "call_2",
+                "name": "read_file",
+                "input": {"path": "/tmp/x"},
+                "raw_input": '{"path": "/tmp/x"}',
+            },
+        ],
+    )
+
+
+def test_clean_strips_extra_content_for_openai(tool_use_with_extra_content):
+    """extra_content should be removed when targeting OpenAI."""
+    msgs = [tool_use_with_extra_content]
+    _clean_provider_specific_fields(msgs, "openai")
+
+    block = msgs[0].content[0]
+    assert "extra_content" not in block
+    assert block["id"] == "call_1"
+    assert block["input"] == {"q": "test"}
+
+
+def test_clean_strips_extra_content_for_anthropic(
+    tool_use_with_extra_content,
+):
+    """extra_content should be removed when targeting Anthropic."""
+    msgs = [tool_use_with_extra_content]
+    _clean_provider_specific_fields(msgs, "anthropic")
+
+    assert "extra_content" not in msgs[0].content[0]
+
+
+def test_clean_preserves_extra_content_for_gemini(
+    tool_use_with_extra_content,
+):
+    """extra_content should be preserved when targeting Gemini."""
+    msgs = [tool_use_with_extra_content]
+    _clean_provider_specific_fields(msgs, "gemini")
+
+    block = msgs[0].content[0]
+    assert "extra_content" in block
+    assert block["extra_content"]["thought_signature"] == "sig123"
+
+
+def test_clean_strips_raw_input_for_all_targets():
+    """raw_input should be stripped regardless of target family."""
+    for family in ("openai", "anthropic", "gemini"):
+        msg = Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call_2",
+                    "name": "read_file",
+                    "input": {"path": "/tmp/x"},
+                    "raw_input": '{"path": "/tmp/x"}',
+                },
+            ],
+        )
+        _clean_provider_specific_fields([msg], family)
+        assert (
+            "raw_input" not in msg.content[0]
+        ), f"raw_input should be stripped for {family}"
+        assert msg.content[0]["input"] == {"path": "/tmp/x"}
+
+
+def test_clean_ignores_non_tool_use_blocks():
+    """Blocks other than tool_use should not be touched."""
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            {
+                "type": "thinking",
+                "thinking": "some thought",
+            },
+            {
+                "type": "text",
+                "text": "hello",
+            },
+        ],
+    )
+    _clean_provider_specific_fields([msg], "openai")
+
+    assert msg.content[0] == {"type": "thinking", "thinking": "some thought"}
+    assert msg.content[1] == {"type": "text", "text": "hello"}
+
+
+def test_clean_handles_string_content():
+    """Messages with plain string content should be skipped safely."""
+    msg = Msg(name="user", role="user", content="just text")
+    _clean_provider_specific_fields([msg], "openai")
+
+    assert msg.content == "just text"
+
+
+def test_clean_handles_empty_list():
+    """Empty message list should not raise."""
+    _clean_provider_specific_fields([], "openai")
+
+
+# -----------------------------------------------------------------------------
+# normalize_messages_for_model_request with target_family tests
+# -----------------------------------------------------------------------------
+
+
+def _paired_tool_messages(extra_fields=None):
+    """Helper: create a tool_use + tool_result pair so sanitization keeps them.
+
+    ``extra_fields`` are merged into the tool_use block dict.
+    """
+    tool_use_block = {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "foo",
+        "input": {},
+    }
+    if extra_fields:
+        tool_use_block.update(extra_fields)
+
+    return [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[tool_use_block],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="call_1",
+                    name="foo",
+                    output="ok",
+                ),
+            ],
+        ),
+    ]
+
+
+def test_normalize_default_target_family_strips_extra_content():
+    """Default target_family ('openai') should strip extra_content."""
+    msgs = _paired_tool_messages({"extra_content": {"sig": "x"}})
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+    )
+    assert "extra_content" not in normalized[0].content[0]
+
+
+def test_normalize_does_not_mutate_original_with_target_family():
+    """Original messages must not be modified by target_family cleaning."""
+    msgs = _paired_tool_messages(
+        {"extra_content": {"sig": "x"}, "raw_input": "{}"},
+    )
+    original_dicts = [m.to_dict() for m in msgs]
+
+    normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+        target_family="openai",
+    )
+
+    assert [m.to_dict() for m in msgs] == original_dicts
+
+
+def test_normalize_gemini_target_keeps_extra_content():
+    """target_family='gemini' should preserve extra_content."""
+    msgs = _paired_tool_messages({"extra_content": {"sig": "x"}})
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+        target_family="gemini",
+    )
+    assert "extra_content" in normalized[0].content[0]
+
+
+def test_raw_input_used_for_repair_before_stripping():
+    """raw_input must be consumed by _repair_empty_tool_inputs before
+    _clean_provider_specific_fields strips it.
+
+    Scenario: tool_use with empty input={} but valid raw_input JSON.
+    After normalize, input should be populated AND raw_input removed.
+    """
+    msgs = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call_repair",
+                    "name": "run",
+                    "input": {},
+                    "raw_input": '{"cmd": "ls"}',
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="call_repair",
+                    name="run",
+                    output="file.txt",
+                ),
+            ],
+        ),
+    ]
+
+    normalized = normalize_messages_for_model_request(
+        msgs,
+        supports_multimodal=True,
+        target_family="openai",
+    )
+
+    block = normalized[0].content[0]
+    assert block["input"] == {
+        "cmd": "ls",
+    }, "raw_input should have repaired the empty input before being stripped"
+    assert "raw_input" not in block, "raw_input should be cleaned after repair"

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -292,3 +292,130 @@ def test_original_messages_not_modified_by_formatter_prep() -> None:
     # Original message should be completely unchanged
     assert original.to_dict() == original_dict
     assert original.content[1]["type"] == "image"
+
+
+# -----------------------------------------------------------------------------
+# target_family propagation tests
+# -----------------------------------------------------------------------------
+
+
+def _messages_with_extra_content() -> list[Msg]:
+    """Create messages that include Gemini-specific extra_content."""
+    return [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call_ec",
+                    "name": "search",
+                    "input": {"q": "hello"},
+                    "extra_content": {"thought_signature": "sig_abc"},
+                },
+            ],
+        ),
+        Msg(
+            name="system",
+            role="system",
+            content=[
+                ToolResultBlock(
+                    type="tool_result",
+                    id="call_ec",
+                    name="search",
+                    output="42",
+                ),
+            ],
+        ),
+    ]
+
+
+def test_openai_formatter_strips_extra_content(monkeypatch) -> None:
+    """OpenAI formatter should strip extra_content from tool_use blocks."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _messages_with_extra_content(),
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert "extra_content" not in normalized[0].content[0]
+
+
+def test_anthropic_formatter_strips_extra_content(monkeypatch) -> None:
+    """Anthropic formatter should strip extra_content from tool_use blocks."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _messages_with_extra_content(),
+        AnthropicChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert "extra_content" not in normalized[0].content[0]
+
+
+def test_gemini_formatter_preserves_extra_content(monkeypatch) -> None:
+    """Gemini formatter should keep extra_content on tool_use blocks."""
+    if GeminiChatFormatter is None:
+        pytest.skip("GeminiChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        _messages_with_extra_content(),
+        GeminiChatFormatter,
+        SimpleNamespace(),
+    )
+
+    block = normalized[0].content[0]
+    assert "extra_content" in block
+    assert block["extra_content"]["thought_signature"] == "sig_abc"
+
+
+def test_extra_content_original_preserved(monkeypatch) -> None:
+    """Cleaning for any target must not mutate the original messages."""
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    msgs = _messages_with_extra_content()
+    original_block = msgs[0].content[0].copy()
+
+    model_factory._normalize_messages_for_formatter(
+        msgs,
+        OpenAIChatFormatter,
+        SimpleNamespace(),
+    )
+
+    assert msgs[0].content[0] == original_block


### PR DESCRIPTION
## Description

Clean up provider-specific field leakage when switching models mid-conversation.

When a user switches between providers (e.g. Gemini → OpenAI) during a chat session, provider-specific artifacts stored on `Msg` content blocks could leak into API requests for the new provider, potentially causing request rejections or wasted payload:

- **`extra_content`** (Gemini's `thought_signature`): Sent to OpenAI/Anthropic APIs which don't recognize it on tool call objects.
- **`raw_input`** (AgentScope stream-parsing artifact): Leaked to all providers; some reject unknown fields.
- **`reasoning_content` injection**: Applied unconditionally to all providers, including Anthropic which already passes `thinking` blocks natively via `_format_anthropic_messages`.

### Changes

1. **New `_clean_provider_specific_fields()`** in `message_request_normalizer.py`: Strips `extra_content` (unless target is Gemini) and `raw_input` (unconditionally) from cloned messages at normalization time.
2. **`target_family` parameter** threaded from `_normalize_messages_for_formatter` → `normalize_messages_for_model_request` so the normalizer knows which provider family to clean for.
3. **Conditional `extra_content` injection**: Only injected into formatted payload when target is Gemini formatter.
4. **Conditional `reasoning_content` injection**: Skipped for Anthropic (which handles thinking blocks natively), applied for OpenAI/Gemini.
5. **Fixed ordering bug**: `_sanitize_tool_messages` (which uses `raw_input` to repair empty `input` fields) now runs *before* `_clean_provider_specific_fields` (which strips `raw_input`).

All operations run on deep-cloned messages; the stored conversation history is never mutated.

**Related Issue:** Relates to #2314

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review
