### PR TITLE
fix(console): dark mode text color for empty select dropdown

### DIFF
--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -305,7 +305,7 @@ html.dark-mode .ant-select-item {
 
 html.dark-mode .qwenpaw-select-item-empty,
 html.dark-mode .ant-select-item-empty {
-  color: rgba(255, 255, 255, 0.65) !important;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 html.dark-mode .qwenpaw-select-item-option-active,

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -303,6 +303,11 @@ html.dark-mode .ant-select-item {
   color: rgba(255, 255, 255, 0.85) !important;
 }
 
+html.dark-mode .qwenpaw-select-item-empty,
+html.dark-mode .ant-select-item-empty {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
 html.dark-mode .qwenpaw-select-item-option-active,
 html.dark-mode .ant-select-item-option-active {
   background: rgba(97, 92, 237, 0.12) !important;


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

- **Bug fixed**: In dark mode, the empty-state text ("No available models were found...") inside antd `AutoComplete`/`Select` dropdown rendered with near-invisible `rgba(0, 0, 0, 0.25)` text on a dark background.

- Before:

<img width="1020" height="514" alt="image" src="https://github.com/user-attachments/assets/cafc987f-5829-474c-9e4b-aa7b179962db" />

- After:

<img width="1030" height="539" alt="image" src="https://github.com/user-attachments/assets/68c97d31-1ce7-4903-b1f2-7462497e467d" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
