### PR TITLE
feat: Enable filtering options for console channel messages

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1093,26 +1093,22 @@ export function ChannelDrawer({
             </Form.Item>
           )}
 
-          {activeKey !== "console" && (
-            <>
-              <Form.Item
-                name="filter_tool_messages"
-                label={t("channels.filterToolMessages")}
-                valuePropName="checked"
-                tooltip={t("channels.filterToolMessagesTooltip")}
-              >
-                <Switch />
-              </Form.Item>
-              <Form.Item
-                name="filter_thinking"
-                label={t("channels.filterThinking")}
-                valuePropName="checked"
-                tooltip={t("channels.filterThinkingTooltip")}
-              >
-                <Switch />
-              </Form.Item>
-            </>
-          )}
+          <Form.Item
+            name="filter_tool_messages"
+            label={t("channels.filterToolMessages")}
+            valuePropName="checked"
+            tooltip={t("channels.filterToolMessagesTooltip")}
+          >
+            <Switch />
+          </Form.Item>
+          <Form.Item
+            name="filter_thinking"
+            label={t("channels.filterThinking")}
+            valuePropName="checked"
+            tooltip={t("channels.filterThinkingTooltip")}
+          >
+            <Switch />
+          </Form.Item>
 
           {isBuiltin
             ? renderBuiltinExtraFields(activeKey)

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -400,25 +400,25 @@ class ConsoleChannel(BaseChannel):
                     if usage_data and hasattr(event, "usage"):
                         setattr(event, "usage", usage_data)
 
-                # Check if we should filter this event based on filter configurations
+                # Check if we should filter this event
                 should_yield = True
 
                 if obj == "message" and (
                     self._filter_thinking or self._filter_tool_messages
                 ):
-                    # Use the renderer to check if this message would be filtered
+                    # Use renderer to check if this message is filtered
                     parts = self._message_to_content_parts(event)
-                    # If parts is empty, it means the renderer filtered out this message
+                    # If parts is empty, renderer filtered out this message
                     if not parts:
                         should_yield = False
 
-                # Additionally, check if it's a reasoning message when filter_thinking is enabled
+                # Check if it's a reasoning message when filter_thinking is on
                 if self._filter_thinking and obj == "message":
                     msg_type = getattr(event, "type", None)
                     if msg_type == MessageType.REASONING:
                         should_yield = False
 
-                # Check if it's a tool-related message when filter_tool_messages is enabled
+                # Check if it's a tool message when filter_tool_messages is on
                 if self._filter_tool_messages and obj == "message":
                     msg_type = getattr(event, "type", None)
                     if msg_type in [

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -400,15 +400,46 @@ class ConsoleChannel(BaseChannel):
                     if usage_data and hasattr(event, "usage"):
                         setattr(event, "usage", usage_data)
 
-                if hasattr(event, "model_dump_json"):
-                    data = event.model_dump_json()
-                elif hasattr(event, "json"):
-                    data = event.json()
-                else:
-                    data = json.dumps({"text": str(event)})
-                yield f"data: {data}\n\n"
+                # Check if we should filter this event based on filter configurations
+                should_yield = True
 
-                if obj == "message" and status == RunStatus.Completed:
+                if obj == "message" and (self._filter_thinking or self._filter_tool_messages):
+                    # Use the renderer to check if this message would be filtered
+                    parts = self._message_to_content_parts(event)
+                    # If parts is empty, it means the renderer filtered out this message
+                    if not parts:
+                        should_yield = False
+
+                # Additionally, check if it's a reasoning message when filter_thinking is enabled
+                if self._filter_thinking and obj == "message":
+                    msg_type = getattr(event, "type", None)
+                    if msg_type == MessageType.REASONING:
+                        should_yield = False
+
+                # Check if it's a tool-related message when filter_tool_messages is enabled
+                if self._filter_tool_messages and obj == "message":
+                    msg_type = getattr(event, "type", None)
+                    if msg_type in [
+                        MessageType.FUNCTION_CALL,
+                        MessageType.PLUGIN_CALL,
+                        MessageType.MCP_TOOL_CALL,
+                        MessageType.FUNCTION_CALL_OUTPUT,
+                        MessageType.PLUGIN_CALL_OUTPUT,
+                        MessageType.MCP_TOOL_CALL_OUTPUT,
+                    ]:
+                        should_yield = False
+
+                # Only yield the event if it passes all filters
+                if should_yield:
+                    if hasattr(event, "model_dump_json"):
+                        data = event.model_dump_json()
+                    elif hasattr(event, "json"):
+                        data = event.json()
+                    else:
+                        data = json.dumps({"text": str(event)})
+                    yield f"data: {data}\n\n"
+
+                if should_yield and obj == "message" and status == RunStatus.Completed:
                     media_message = await self._extract_media_message(event)
                     if media_message:
                         yield f"data: {media_message.model_dump_json()}\n\n"

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -403,7 +403,9 @@ class ConsoleChannel(BaseChannel):
                 # Check if we should filter this event based on filter configurations
                 should_yield = True
 
-                if obj == "message" and (self._filter_thinking or self._filter_tool_messages):
+                if obj == "message" and (
+                    self._filter_thinking or self._filter_tool_messages
+                ):
                     # Use the renderer to check if this message would be filtered
                     parts = self._message_to_content_parts(event)
                     # If parts is empty, it means the renderer filtered out this message
@@ -439,7 +441,11 @@ class ConsoleChannel(BaseChannel):
                         data = json.dumps({"text": str(event)})
                     yield f"data: {data}\n\n"
 
-                if should_yield and obj == "message" and status == RunStatus.Completed:
+                if (
+                    should_yield
+                    and obj == "message"
+                    and status == RunStatus.Completed
+                ):
                     media_message = await self._extract_media_message(event)
                     if media_message:
                         yield f"data: {media_message.model_dump_json()}\n\n"

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -418,16 +418,18 @@ class ConsoleChannel(BaseChannel):
                     if msg_type == MessageType.REASONING:
                         should_yield = False
 
-                # Check if it's a tool message when filter_tool_messages is on
+                # Check if it's a tool CALL message when
+                # filter_tool_messages is on.  Tool *output* messages
+                # are handled solely by the renderer parts-emptiness
+                # check above: when filtered, the renderer returns only
+                # media parts (if any), so the event is suppressed only
+                # when it would produce no user-visible content.
                 if self._filter_tool_messages and obj == "message":
                     msg_type = getattr(event, "type", None)
                     if msg_type in [
                         MessageType.FUNCTION_CALL,
                         MessageType.PLUGIN_CALL,
                         MessageType.MCP_TOOL_CALL,
-                        MessageType.FUNCTION_CALL_OUTPUT,
-                        MessageType.PLUGIN_CALL_OUTPUT,
-                        MessageType.MCP_TOOL_CALL_OUTPUT,
                     ]:
                         should_yield = False
 
@@ -441,17 +443,18 @@ class ConsoleChannel(BaseChannel):
                         data = json.dumps({"text": str(event)})
                     yield f"data: {data}\n\n"
 
-                if (
-                    should_yield
-                    and obj == "message"
-                    and status == RunStatus.Completed
-                ):
+                if obj == "message" and status == RunStatus.Completed:
+                    # Always attempt media extraction so that images/files
+                    # from tool-output messages are surfaced to users even
+                    # when the original tool message event is filtered by
+                    # filter_tool_messages.
                     media_message = await self._extract_media_message(event)
                     if media_message:
                         yield f"data: {media_message.model_dump_json()}\n\n"
 
-                    parts = self._message_to_content_parts(event)
-                    self._print_parts(parts, ev_type)
+                    if should_yield:
+                        parts = self._message_to_content_parts(event)
+                        self._print_parts(parts, ev_type)
 
                 elif obj == "response":
                     last_response = event

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -649,7 +649,7 @@ class TestConsoleStreamingFilters:
         async for evt in channel.stream_one(self._make_payload()):
             events.append(evt)
 
-        # No SSE data events should have been emitted for the reasoning msg
+        # No SSE data events should have been emitted for the reasoning message
         assert not any("data:" in e for e in events)
 
     async def test_filter_thinking_passes_normal_message(self):
@@ -790,7 +790,7 @@ class TestConsoleStreamingFilters:
             Role,
             DataContent,
         )
-        from unittest.mock import patch, AsyncMock as _AsyncMock
+        from unittest.mock import patch, AsyncMock
         import json
 
         media_output = json.dumps(
@@ -840,7 +840,7 @@ class TestConsoleStreamingFilters:
         with patch.object(
             channel,
             "_extract_media_message",
-            new=_AsyncMock(return_value=synthesised),
+            new=AsyncMock(return_value=synthesised),
         ):
             events = []
             async for evt in channel.stream_one(self._make_payload()):

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -565,3 +565,291 @@ class TestConsoleMediaHandling:
         result = media_channel.media_dir
 
         assert isinstance(result, Path)
+
+
+# =============================================================================
+# P2: Filtering behaviour (filter_thinking / filter_tool_messages)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestConsoleStreamingFilters:
+    """
+    Unit tests for filter_thinking and filter_tool_messages in stream_one.
+
+    Covers:
+    - Reasoning messages suppressed when filter_thinking is on.
+    - Tool-call messages suppressed when filter_tool_messages is on.
+    - Tool-output messages with no media suppressed when
+      filter_tool_messages is on.
+    - Media from tool-output messages is still surfaced (via
+      _extract_media_message) even when the original event is filtered.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_payload(self):
+        """Minimal dict payload that bypasses the debounce logic."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            TextContent,
+            ContentType,
+        )
+
+        return {
+            "sender_id": "user1",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="hi"),
+            ],
+            "meta": {},
+        }
+
+    def _make_channel(self, **kwargs):
+        from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+        return ConsoleChannel(
+            process=AsyncMock(),
+            enabled=True,
+            bot_prefix="",
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # filter_thinking
+    # ------------------------------------------------------------------
+
+    async def test_filter_thinking_suppresses_reasoning_message(self):
+        """Reasoning messages must not be yielded when filter_thinking=True."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        reasoning_msg = Message(
+            object="message",
+            type=MessageType.REASONING,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+            content=[TextContent(type=ContentType.TEXT, text="thinking...")],
+        )
+
+        channel = self._make_channel(filter_thinking=True)
+
+        async def mock_process(_request):
+            yield reasoning_msg
+
+        channel._process = mock_process
+
+        events = []
+        async for evt in channel.stream_one(self._make_payload()):
+            events.append(evt)
+
+        # No SSE data events should have been emitted for the reasoning msg
+        assert not any("data:" in e for e in events)
+
+    async def test_filter_thinking_passes_normal_message(self):
+        """Non-reasoning messages must still be yielded when
+        filter_thinking=True."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        normal_msg = Message(
+            object="message",
+            type=MessageType.MESSAGE,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+            content=[TextContent(type=ContentType.TEXT, text="hello")],
+        )
+
+        channel = self._make_channel(filter_thinking=True)
+
+        async def mock_process(_request):
+            yield normal_msg
+
+        channel._process = mock_process
+
+        events = []
+        async for evt in channel.stream_one(self._make_payload()):
+            events.append(evt)
+
+        assert any("data:" in e for e in events)
+
+    # ------------------------------------------------------------------
+    # filter_tool_messages – tool call (FUNCTION_CALL etc.)
+    # ------------------------------------------------------------------
+
+    async def test_filter_tool_messages_suppresses_tool_call(self):
+        """FUNCTION_CALL messages must not be yielded when
+        filter_tool_messages=True."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            DataContent,
+        )
+
+        tool_call_msg = Message(
+            object="message",
+            type=MessageType.FUNCTION_CALL,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+            content=[
+                DataContent(
+                    delta=False,
+                    index=None,
+                    data={
+                        "name": "my_tool",
+                        "arguments": "{}",
+                        "call_id": "c1",
+                    },
+                ),
+            ],
+        )
+
+        channel = self._make_channel(filter_tool_messages=True)
+
+        async def mock_process(_request):
+            yield tool_call_msg
+
+        channel._process = mock_process
+
+        events = []
+        async for evt in channel.stream_one(self._make_payload()):
+            events.append(evt)
+
+        assert not any("data:" in e for e in events)
+
+    async def test_filter_tool_messages_suppresses_tool_output_without_media(
+        self,
+    ):
+        """FUNCTION_CALL_OUTPUT messages with no media content must be
+        suppressed when filter_tool_messages=True."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            DataContent,
+        )
+
+        tool_output_msg = Message(
+            object="message",
+            type=MessageType.FUNCTION_CALL_OUTPUT,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+            content=[
+                DataContent(
+                    delta=False,
+                    index=None,
+                    data={
+                        "name": "my_tool",
+                        "output": "plain text result",
+                        "call_id": "c1",
+                    },
+                ),
+            ],
+        )
+
+        channel = self._make_channel(filter_tool_messages=True)
+
+        async def mock_process(_request):
+            yield tool_output_msg
+
+        channel._process = mock_process
+
+        events = []
+        async for evt in channel.stream_one(self._make_payload()):
+            events.append(evt)
+
+        assert not any("data:" in e for e in events)
+
+    # ------------------------------------------------------------------
+    # filter_tool_messages – tool output WITH media (core regression test)
+    # ------------------------------------------------------------------
+
+    async def test_filter_tool_messages_surfaces_media_from_tool_output(self):
+        """When filter_tool_messages=True and a tool-output message has
+        media content, _extract_media_message must still be called so that
+        the synthesised media message is surfaced to the user."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            DataContent,
+        )
+        from unittest.mock import patch, AsyncMock as _AsyncMock
+        import json
+
+        media_output = json.dumps(
+            [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "url",
+                        "url": "http://example.com/image.jpg",
+                    },
+                },
+            ],
+        )
+        tool_output_msg = Message(
+            object="message",
+            type=MessageType.FUNCTION_CALL_OUTPUT,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+            content=[
+                DataContent(
+                    delta=False,
+                    index=None,
+                    data={
+                        "name": "image_tool",
+                        "output": media_output,
+                        "call_id": "c2",
+                    },
+                ),
+            ],
+        )
+
+        channel = self._make_channel(filter_tool_messages=True)
+
+        async def mock_process(_request):
+            yield tool_output_msg
+
+        channel._process = mock_process
+
+        # Synthesised media message returned by _extract_media_message
+        synthesised = Message(
+            object="message",
+            type=MessageType.MESSAGE,
+            status=RunStatus.Completed,
+            role=Role.ASSISTANT,
+        )
+
+        with patch.object(
+            channel,
+            "_extract_media_message",
+            new=_AsyncMock(return_value=synthesised),
+        ):
+            events = []
+            async for evt in channel.stream_one(self._make_payload()):
+                events.append(evt)
+
+            # _extract_media_message must have been called despite filtering
+            channel._extract_media_message.assert_called_once_with(
+                tool_output_msg,
+            )
+
+            # The synthesised media message must appear in the SSE stream
+            assert any("data:" in e for e in events)


### PR DESCRIPTION
This pull request updates both the backend and frontend to improve how message filtering works for the console channel, ensuring that tool-related and reasoning messages are properly filtered according to user settings. The main changes include strengthening the backend filtering logic and modifying the frontend to always display the filter options for tool messages.

**Backend filtering improvements:**

* Enhanced the `stream_one` method in `channel.py` to more robustly filter out reasoning and tool-related messages based on the `filter_thinking` and `filter_tool_messages` flags, preventing these messages from being yielded if filtered.
* Ensured that media messages are only yielded if their associated message passes all filtering checks.

**Frontend adjustments:**

* Updated `ChannelDrawer.tsx` to always show the filter option for tool messages, regardless of the selected channel type, by removing the conditional rendering around the `filter_tool_messages` form item. [[1]](diffhunk://#diff-45fb2ee814e9835b3bfe2ac3e5a63b07ffc5602e889202dff959fc209c936843L1096-L1097) [[2]](diffhunk://#diff-45fb2ee814e9835b3bfe2ac3e5a63b07ffc5602e889202dff959fc209c936843L1114-L1115)