### PR TITLE
fix(console): log container and text color for debug page in dark mode

### DIFF
--- a/console/src/pages/Debug/index.tsx
+++ b/console/src/pages/Debug/index.tsx
@@ -269,7 +269,7 @@ export default function DebugPage() {
           </Space>
 
           {backendLogs?.path && (
-            <Text type="secondary">
+            <Text type="secondary" className="debug-log-path">
               <Text strong>{t("debug.backend.path", "Log file")}:</Text>{" "}
               {backendLogs.path}
             </Text>
@@ -290,12 +290,11 @@ export default function DebugPage() {
 
           <Spin spinning={initialLoading} tip={t("common.loading", "Loading")}>
             <div
+              className="debug-log-container"
               style={{
-                border: "1px solid rgba(0,0,0,0.06)",
                 borderRadius: 8,
                 padding: 12,
                 minHeight: 120,
-                background: "rgba(0,0,0,0.02)",
                 fontFamily:
                   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
                 fontSize: 12,

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -1046,3 +1046,27 @@ html.dark-mode .ant-empty-description {
 html.dark-mode .qwenpaw-input-prefix {
   color: rgba(255, 255, 255, 0.85) !important;
 }
+
+.debug-log-container {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+html.dark-mode .debug-log-container {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+html.dark-mode .debug-log-container mark {
+  background: rgba(255, 214, 102, 0.35) !important;
+  color: rgba(0, 0, 0, 0.9);
+}
+
+html.dark-mode .qwenpaw-typography-secondary,
+html.dark-mode .ant-typography-secondary {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
+html.dark-mode .debug-log-path strong {
+  color: rgba(255, 255, 255, 0.85) !important;
+}


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

- Before：
<img width="1499" height="771" alt="image" src="https://github.com/user-attachments/assets/e24e46b9-5a44-4912-958a-9914ee50e670" />

- After：
<img width="1497" height="757" alt="image" src="https://github.com/user-attachments/assets/94c3bb88-4902-45fa-9ce6-daba3ef0b929" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
