### PR TITLE
feat(routing): align scope-aware effective model semantics

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -36,6 +36,13 @@ except ImportError:  # pragma: no cover - compatibility fallback
 from .utils.message_request_normalizer import (
     normalize_messages_for_model_request,
 )
+from .routing_chat_model import (
+    _load_global_routing_config,
+    _resolve_routed_model_slot,
+    _routing_enabled,
+    _select_scoped_model_config,
+)
+from ..config.config import has_configured_model_slot
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.retry_chat_model import (
@@ -981,12 +988,14 @@ def create_model_and_formatter(
 
     # Try to get agent-specific model first
     model_slot = None
+    routing_cfg = None
     retry_config = None
     rate_limit_config = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
             model_slot = agent_config.active_model
+            routing_cfg = getattr(agent_config, "llm_routing", None)
             retry_config = RetryConfig(
                 enabled=agent_config.running.llm_retry_enabled,
                 max_retries=agent_config.running.llm_max_retries,
@@ -1003,10 +1012,22 @@ def create_model_and_formatter(
         except Exception:
             pass
 
+    manager = ProviderManager.get_instance()
+    global_model_slot = manager.get_active_model()
+    global_routing_cfg = _load_global_routing_config()
+    scoped_fallback_slot, scoped_routing_cfg = _select_scoped_model_config(
+        agent_model_slot=model_slot,
+        agent_routing_cfg=routing_cfg,
+        global_model_slot=global_model_slot,
+        global_routing_cfg=global_routing_cfg,
+    )
+    model_slot = _resolve_routed_model_slot(
+        scoped_routing_cfg,
+    )
+
     # Create chat model from agent-specific or global config
-    if model_slot and model_slot.provider_id and model_slot.model:
-        # Use agent-specific model
-        manager = ProviderManager.get_instance()
+    if has_configured_model_slot(model_slot):
+        # Use the slot selected for the effective scope.
         provider = manager.get_provider(model_slot.provider_id)
         if provider is None:
             raise ProviderError(
@@ -1016,9 +1037,22 @@ def create_model_and_formatter(
         model = provider.get_chat_model_instance(model_slot.model)
         provider_id = model_slot.provider_id
     else:
-        # Fallback to global active model
-        model = ProviderManager.get_active_chat_model()
-        global_model = ProviderManager.get_instance().get_active_model()
+        if _routing_enabled(scoped_routing_cfg):
+            selected_mode = getattr(
+                scoped_routing_cfg,
+                "mode",
+                "local_first",
+            )
+            raise ProviderError(
+                message=(
+                    "LLM routing mode "
+                    f"'{selected_mode}' selected an unconfigured slot."
+                ),
+            )
+
+        # Agent runtime settings still apply even when the selected
+        # effective model falls back to the global slot.
+        global_model = scoped_fallback_slot or global_model_slot
         if not global_model:
             raise ProviderError(
                 message=(
@@ -1027,6 +1061,14 @@ def create_model_and_formatter(
                     "or set an agent-specific model."
                 ),
             )
+        provider = manager.get_provider(global_model.provider_id)
+        if provider is None:
+            raise ProviderError(
+                message=(
+                    f"Active provider '{global_model.provider_id}' not found."
+                ),
+            )
+        model = provider.get_chat_model_instance(global_model.model)
         provider_id = global_model.provider_id
 
     # Create the formatter based on the real model class

--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -382,25 +382,12 @@ def _get_active_model_info():
         when the active model cannot be resolved.
     """
     try:
-        from ..app.agent_context import get_current_agent_id
-        from ..config.config import load_agent_config
+        from .routing_chat_model import resolve_effective_model_slot
         from ..providers.provider_manager import ProviderManager
 
         manager = ProviderManager.get_instance()
 
-        # Try to get agent-specific model first
-        active = None
-        try:
-            agent_id = get_current_agent_id()
-            agent_config = load_agent_config(agent_id)
-            if agent_config.active_model:
-                active = agent_config.active_model
-        except Exception:
-            pass
-
-        # Fallback to global active model
-        if not active:
-            active = manager.get_active_model()
+        active = resolve_effective_model_slot()
 
         if not active:
             return None, None

--- a/src/qwenpaw/agents/routing_chat_model.py
+++ b/src/qwenpaw/agents/routing_chat_model.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, AsyncGenerator, Literal, Type
+from typing import Any, AsyncGenerator, Literal, Optional, Type
 
 from agentscope.formatter import FormatterBase
 from agentscope.model import ChatModelBase
 from agentscope.model._model_response import ChatResponse
 from pydantic import BaseModel
 
-from ..config.config import AgentsLLMRoutingConfig
+from ..config.config import (
+    AgentsLLMRoutingConfig,
+    has_configured_model_slot,
+    ModelSlotConfig,
+    routing_has_explicit_override,
+)
+from ..providers import ProviderManager
 
 logger = logging.getLogger(__name__)
 
@@ -120,3 +126,91 @@ class RoutingChatModel(ChatModelBase):
             structured_model=structured_model,
             **kwargs,
         )
+
+
+def _routing_enabled(routing_cfg) -> bool:
+    return bool(routing_cfg and getattr(routing_cfg, "enabled", False))
+
+
+def _select_scoped_model_config(
+    *,
+    agent_model_slot: ModelSlotConfig | None,
+    agent_routing_cfg,
+    global_model_slot: ModelSlotConfig | None,
+    global_routing_cfg,
+) -> tuple[ModelSlotConfig | None, object | None]:
+    agent_has_selection = has_configured_model_slot(
+        agent_model_slot,
+    )
+    agent_has_routing_override = routing_has_explicit_override(
+        agent_routing_cfg,
+    )
+    if agent_has_selection or agent_has_routing_override:
+        return (
+            agent_model_slot or global_model_slot,
+            agent_routing_cfg,
+        )
+    return global_model_slot, global_routing_cfg
+
+
+def _resolve_routed_model_slot(
+    routing_cfg,
+) -> ModelSlotConfig | None:
+    if not _routing_enabled(routing_cfg):
+        return None
+
+    decision = RoutingPolicy(routing_cfg).decide()
+    if decision.route == "local":
+        return routing_cfg.local
+    return routing_cfg.cloud
+
+
+def _load_global_routing_config():
+    from ..config.utils import load_config
+
+    try:
+        return load_config().agents.llm_routing
+    except Exception:
+        return None
+
+
+def resolve_effective_model_slot(
+    agent_id: Optional[str] = None,
+) -> ModelSlotConfig | None:
+    """Resolve the concrete model slot for the current scope."""
+    from ..config.config import load_agent_config
+
+    if agent_id is None:
+        from ..app.agent_context import get_current_agent_id
+
+        try:
+            agent_id = get_current_agent_id()
+        except Exception:
+            pass
+
+    agent_model_slot = None
+    agent_routing_cfg = None
+    if agent_id:
+        try:
+            agent_config = load_agent_config(agent_id)
+            agent_model_slot = agent_config.active_model
+            agent_routing_cfg = getattr(agent_config, "llm_routing", None)
+        except Exception:
+            pass
+    manager = ProviderManager.get_instance()
+    global_model_slot = manager.get_active_model()
+    global_routing_cfg = _load_global_routing_config()
+    scoped_fallback_slot, scoped_routing_cfg = _select_scoped_model_config(
+        agent_model_slot=agent_model_slot,
+        agent_routing_cfg=agent_routing_cfg,
+        global_model_slot=global_model_slot,
+        global_routing_cfg=global_routing_cfg,
+    )
+    model_slot = _resolve_routed_model_slot(
+        scoped_routing_cfg,
+    )
+    if has_configured_model_slot(model_slot):
+        return model_slot
+    if _routing_enabled(scoped_routing_cfg):
+        return None
+    return scoped_fallback_slot

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -73,6 +73,84 @@ _ALLOWED_ACP_TOOL_PARSE_MODES = {
 }
 
 
+def _is_local_provider(provider) -> bool:
+    from urllib.parse import urlparse
+
+    if getattr(provider, "is_local", False):
+        return True
+    base_url = getattr(provider, "base_url", "") or ""
+    if not base_url:
+        return False
+    try:
+        hostname = urlparse(base_url).hostname or ""
+    except Exception:
+        return False
+    return hostname in {"127.0.0.1", "localhost", "::1"}
+
+
+def _validate_routing_config(body: AgentsLLMRoutingConfig) -> None:
+    from ...config.config import has_configured_model_slot
+    from ...providers import ProviderManager
+
+    selected_slot = body.local if body.mode == "local_first" else body.cloud
+    if body.enabled and not has_configured_model_slot(selected_slot):
+        raise HTTPException(
+            status_code=400,
+            detail="Configure the selected mode slot before enabling routing.",
+        )
+
+    if (
+        body.enabled
+        and has_configured_model_slot(body.local)
+        and has_configured_model_slot(body.cloud)
+        and body.local.provider_id == body.cloud.provider_id
+        and body.local.model == body.cloud.model
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Local and cloud slots must point to different "
+                "provider/model pairs."
+            ),
+        )
+
+    if not body.enabled:
+        return
+
+    manager = ProviderManager.get_instance()
+    selected_kind = "local" if body.mode == "local_first" else "cloud"
+
+    if not has_configured_model_slot(selected_slot):
+        return
+
+    provider = manager.get_provider(selected_slot.provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Provider '{selected_slot.provider_id}' not found.",
+        )
+    if not provider.has_model(selected_slot.model):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model '{selected_slot.model}' not found for provider "
+                f"'{selected_slot.provider_id}'."
+            ),
+        )
+
+    is_local_provider = _is_local_provider(provider)
+    if selected_kind == "local" and not is_local_provider:
+        raise HTTPException(
+            status_code=400,
+            detail="Local slot must use a local or loopback provider.",
+        )
+    if selected_kind == "cloud" and is_local_provider:
+        raise HTTPException(
+            status_code=400,
+            detail="Cloud slot must use a non-local provider.",
+        )
+
+
 @router.get(
     "/channels",
     summary="List all channels",
@@ -569,8 +647,31 @@ async def put_heartbeat(
     response_model=AgentsLLMRoutingConfig,
     summary="Get agent LLM routing settings",
 )
-async def get_agents_llm_routing() -> AgentsLLMRoutingConfig:
+async def get_agents_llm_routing(
+    agent_id: str | None = None,
+) -> AgentsLLMRoutingConfig:
+    """Return effective routing settings.
+
+    Without ``agent_id``, returns the global routing config. With ``agent_id``,
+    returns the agent-specific routing config when it is meaningfully set;
+    otherwise falls back to the global config. An explicit agent
+    ``active_model`` masks inherited global routing, so this endpoint
+    reports ``enabled=False`` in that case.
+    """
+    from ...config.config import (
+        has_configured_model_slot,
+        load_agent_config,
+        routing_has_explicit_override,
+    )
+
     config = load_config()
+    if agent_id:
+        agent_config = load_agent_config(agent_id)
+        routing_cfg = agent_config.llm_routing
+        if routing_has_explicit_override(routing_cfg):
+            return routing_cfg
+        if has_configured_model_slot(agent_config.active_model):
+            return AgentsLLMRoutingConfig(enabled=False)
     return config.agents.llm_routing
 
 
@@ -580,8 +681,26 @@ async def get_agents_llm_routing() -> AgentsLLMRoutingConfig:
     summary="Update agent LLM routing settings",
 )
 async def put_agents_llm_routing(
+    request: Request,
     body: AgentsLLMRoutingConfig = Body(...),
+    agent_id: str | None = None,
 ) -> AgentsLLMRoutingConfig:
+    """Update routing settings.
+
+    Without ``agent_id``, updates the global routing config. With ``agent_id``,
+    writes the agent-specific routing config and schedules an agent reload.
+    """
+    from ...config.config import load_agent_config, save_agent_config
+
+    _validate_routing_config(body)
+
+    if agent_id:
+        agent_config = load_agent_config(agent_id)
+        agent_config.llm_routing = body
+        save_agent_config(agent_id, agent_config)
+        schedule_agent_reload(request, agent_id)
+        return body
+
     config = load_config()
     config.agents.llm_routing = body
     save_config(config)

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -577,12 +577,16 @@ async def get_active_models(
         )
 
     try:
+        from ...agents.routing_chat_model import (
+            resolve_effective_model_slot,
+        )
+
         target_agent_id = agent_id
         if target_agent_id is None:
             workspace = await get_agent_for_request(request)
             target_agent_id = workspace.agent_id
 
-        agent_model = await _load_agent_model(request, target_agent_id)
+        agent_model = resolve_effective_model_slot(target_agent_id)
         if agent_model:
             logger.info(
                 "Returning agent-specific model for %s: %s",
@@ -590,6 +594,11 @@ async def get_active_models(
                 agent_model,
             )
             return ActiveModelsInfo(active_llm=agent_model)
+        logger.info(
+            "Agent-specific model for %s is unresolved under routing mode",
+            target_agent_id,
+        )
+        return ActiveModelsInfo(active_llm=None)
     except (
         HTTPException,
         OSError,

--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -32,7 +32,9 @@ from ..config.config import (
     MCPConfig,
     SecurityConfig,
     ToolsConfig,
+    has_configured_model_slot,
     load_agent_config,
+    routing_has_explicit_override,
 )
 from ..config.utils import (
     _normalize_working_dir_bound_paths,
@@ -1080,37 +1082,59 @@ def qwenpaw_local_llm_deep_notes() -> list[str]:
     return notes
 
 
-def _slot_is_set(slot: Any) -> bool:
-    return bool(
-        getattr(slot, "provider_id", None) and getattr(slot, "model", None),
-    )
-
-
 def _resolve_agent_effective_model_slot(
     agent_cfg: AgentProfileConfig,
     active_slot: Any | None,
+    global_routing: Any | None = None,
 ) -> tuple[Any | None, str]:
     """Resolve provider/model for the agent default chat model."""
-    if agent_cfg.active_model is not None and _slot_is_set(
-        agent_cfg.active_model,
+    agent_routing = agent_cfg.llm_routing
+    agent_has_selection = (
+        agent_cfg.active_model is not None
+        and has_configured_model_slot(agent_cfg.active_model)
+    )
+    agent_has_routing_override = routing_has_explicit_override(
+        agent_routing,
+    )
+    if agent_has_selection or agent_has_routing_override:
+        scoped_routing = agent_routing
+        scoped_fallback = agent_cfg.active_model or active_slot
+        scope_label = "agent"
+    else:
+        scoped_routing = global_routing
+        scoped_fallback = active_slot
+        scope_label = "global"
+
+    if getattr(scoped_routing, "enabled", False):
+        if scoped_routing.mode == "cloud_first":
+            if scoped_routing.cloud is not None and has_configured_model_slot(
+                scoped_routing.cloud,
+            ):
+                return scoped_routing.cloud, f"{scope_label}.llm_routing.cloud"
+            return (
+                None,
+                f"{scope_label} routing enabled but cloud slot is not set",
+            )
+        # local_first
+        if scoped_routing.local is not None and has_configured_model_slot(
+            scoped_routing.local,
+        ):
+            return scoped_routing.local, f"{scope_label}.llm_routing.local"
+        return None, f"{scope_label} routing enabled but local slot is not set"
+
+    if (
+        scope_label == "agent"
+        and agent_cfg.active_model is not None
+        and has_configured_model_slot(
+            agent_cfg.active_model,
+        )
     ):
         return agent_cfg.active_model, "agent.active_model"
 
-    routing = agent_cfg.llm_routing
-    if getattr(routing, "enabled", False):
-        if routing.mode == "cloud_first":
-            if routing.cloud is not None and _slot_is_set(routing.cloud):
-                return routing.cloud, "agent.llm_routing.cloud"
-            if active_slot is not None and _slot_is_set(active_slot):
-                return active_slot, "providers.active_llm (cloud fallback)"
-            return None, "routing enabled but no cloud slot and no active LLM"
-        # local_first
-        if routing.local is not None and _slot_is_set(routing.local):
-            return routing.local, "agent.llm_routing.local"
-        return None, "routing enabled but local slot is not set"
-
-    if active_slot is not None and _slot_is_set(active_slot):
-        return active_slot, "providers.active_llm"
+    if scoped_fallback is not None and has_configured_model_slot(
+        scoped_fallback,
+    ):
+        return scoped_fallback, "providers.active_llm"
     return None, "no agent.active_model and no active LLM"
 
 
@@ -1144,7 +1168,11 @@ async def check_enabled_agents_model_connections(
             )
             continue
 
-        slot, source = _resolve_agent_effective_model_slot(ac, active_slot)
+        slot, source = _resolve_agent_effective_model_slot(
+            ac,
+            active_slot,
+            getattr(cfg.agents, "llm_routing", None),
+        )
         if slot is None:
             all_ok = False
             lines.append(f"{agent_id}: FAIL — no model resolved ({source})")

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -880,8 +880,33 @@ class AgentsLLMRoutingConfig(BaseModel):
     cloud: Optional[ModelSlotConfig] = Field(
         default=None,
         description=(
-            "Optional explicit cloud model slot; when null, uses "
-            "providers.json active_llm."
+            "Optional explicit cloud model slot. Required when "
+            "mode is cloud_first."
+        ),
+    )
+
+
+def has_configured_model_slot(slot: ModelSlotConfig | None) -> bool:
+    """Return True when a provider/model pair is configured."""
+    return bool(slot and slot.provider_id and slot.model)
+
+
+def routing_has_explicit_override(
+    routing_cfg: AgentsLLMRoutingConfig | None,
+) -> bool:
+    """Return True when a scope defines its own routing state.
+
+    Configured slots count as an override even when ``enabled`` is False.
+    This preserves agent-scope intent: once an agent has its own routing
+    slots, inherited global routing stays masked until those slots are
+    explicitly cleared.
+    """
+    return bool(
+        routing_cfg
+        and (
+            routing_cfg.enabled
+            or has_configured_model_slot(routing_cfg.local)
+            or has_configured_model_slot(routing_cfg.cloud)
         ),
     )
 

--- a/tests/unit/agents/test_model_factory_routing.py
+++ b/tests/unit/agents/test_model_factory_routing.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+from agentscope.model import ChatModelBase
+
+from qwenpaw.agents import model_factory
+from qwenpaw.config import config as config_module
+from qwenpaw.config import utils as config_utils
+from qwenpaw.config.config import AgentsLLMRoutingConfig, ModelSlotConfig
+
+
+class DummyChatModel(ChatModelBase):
+    def __init__(self, model_name: str) -> None:
+        super().__init__(model_name=model_name, stream=True)
+
+    async def __call__(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class DummyProvider:
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+
+    def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
+        return DummyChatModel(f"{self.provider_id}:{model_id}")
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.providers = {
+            "agent": DummyProvider("agent"),
+            "local": DummyProvider("local"),
+            "global": DummyProvider("global"),
+        }
+        self.active_model = ModelSlotConfig(
+            provider_id="global",
+            model="global-model",
+        )
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+def build_running_config():
+    return SimpleNamespace(
+        llm_retry_enabled=False,
+        llm_max_retries=1,
+        llm_backoff_base=0.1,
+        llm_backoff_cap=1.0,
+        llm_max_concurrent=1,
+        llm_max_qpm=0,
+        llm_rate_limit_pause=1.0,
+        llm_rate_limit_jitter=0.0,
+        llm_acquire_timeout=10.0,
+    )
+
+
+def unwrap_provider_id(
+    wrapped_model,
+) -> str:
+    inner = vars(wrapped_model)["_inner"]
+    return vars(inner)["_provider_id"]
+
+
+def test_factory_uses_global_routing_local_slot(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=None,
+            llm_routing=AgentsLLMRoutingConfig(),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    wrapped_model, formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert unwrap_provider_id(wrapped_model) == "local"
+    assert formatter == "formatter"
+
+
+def test_global_routing_does_not_override_agent_model(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="agent",
+                model="agent-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="cloud_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                    cloud=None,
+                ),
+            ),
+        ),
+    )
+
+    wrapped_model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert unwrap_provider_id(wrapped_model) == "agent"
+
+
+def test_global_cloud_without_slot_raises(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=None,
+            llm_routing=AgentsLLMRoutingConfig(),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="cloud_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                    cloud=None,
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        model_factory.create_model_and_formatter(agent_id="agent-1")
+
+    assert "unconfigured slot" in str(exc_info.value)
+
+
+def test_agent_routing_overrides_agent_model(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="agent",
+                model="agent-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="local_first",
+                local=ModelSlotConfig(
+                    provider_id="local",
+                    model="local-model",
+                ),
+            ),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    wrapped_model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert unwrap_provider_id(wrapped_model) == "local"
+
+
+def test_agent_cloud_without_slot_raises(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="agent",
+                model="agent-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="cloud_first",
+                local=ModelSlotConfig(
+                    provider_id="local",
+                    model="local-model",
+                ),
+                cloud=None,
+            ),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="global",
+                        model="global-local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        model_factory.create_model_and_formatter(agent_id="agent-1")
+
+    assert "unconfigured slot" in str(exc_info.value)
+
+
+def test_falls_back_to_global_active_model_when_routing_disabled(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=None,
+            llm_routing=AgentsLLMRoutingConfig(enabled=False),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=False,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    wrapped_model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert unwrap_provider_id(wrapped_model) == "global"
+
+
+def test_agent_disabled_routing_override_blocks_global_routing(
+    monkeypatch,
+):
+    manager = DummyProviderManager()
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        staticmethod(lambda: manager),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _: "formatter",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=None,
+            llm_routing=AgentsLLMRoutingConfig(
+                enabled=False,
+                mode="local_first",
+                local=ModelSlotConfig(
+                    provider_id="local",
+                    model="local-model",
+                ),
+            ),
+            running=build_running_config(),
+        ),
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="local",
+                        model="local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    wrapped_model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-1",
+    )
+
+    assert unwrap_provider_id(wrapped_model) == "global"

--- a/tests/unit/agents/test_prompt_multimodal_routing.py
+++ b/tests/unit/agents/test_prompt_multimodal_routing.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+from qwenpaw.agents import prompt, routing_chat_model
+from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.providers.provider import ModelInfo
+from qwenpaw.providers import provider_manager as provider_manager_module
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.provider = SimpleNamespace(
+            models=[
+                ModelInfo(
+                    id="routed-model",
+                    name="Routed Model",
+                    supports_multimodal=True,
+                    supports_image=True,
+                    supports_video=False,
+                    generate_kwargs={},
+                ),
+            ],
+            extra_models=[],
+        )
+
+    def get_provider(self, provider_id: str):
+        if provider_id == "local":
+            return self.provider
+        return None
+
+
+def _resolved_local_model():
+    return ModelSlotConfig(provider_id="local", model="routed-model")
+
+
+def test_prompt_multimodal_uses_effective_model_slot(monkeypatch):
+    monkeypatch.setattr(
+        routing_chat_model,
+        "resolve_effective_model_slot",
+        _resolved_local_model,
+    )
+    monkeypatch.setattr(
+        provider_manager_module.ProviderManager,
+        "get_instance",
+        staticmethod(DummyProviderManager),
+    )
+
+    assert prompt.get_active_model_supports_multimodal() is True

--- a/tests/unit/app/routers/test_config_llm_routing.py
+++ b/tests/unit/app/routers/test_config_llm_routing.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from qwenpaw.app.routers import config as config_router
+from qwenpaw.config import config as config_module
+from qwenpaw.config.config import AgentsLLMRoutingConfig, ModelSlotConfig
+from qwenpaw import providers as providers_module
+
+
+class DummyProvider:
+    def __init__(
+        self,
+        *,
+        is_local: bool,
+        base_url: str,
+        models: set[str],
+    ) -> None:
+        self.is_local = is_local
+        self.base_url = base_url
+        self._models = models
+
+    def has_model(self, model_id: str) -> bool:
+        return model_id in self._models
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.providers = {
+            "local-provider": DummyProvider(
+                is_local=True,
+                base_url="http://127.0.0.1:1234/v1",
+                models={"local-model", "other-local-model"},
+            ),
+            "cloud-provider": DummyProvider(
+                is_local=False,
+                base_url="https://api.example.com/v1",
+                models={"cloud-model"},
+            ),
+        }
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+
+def _dummy_provider_manager():
+    return DummyProviderManager()
+
+
+def test_validate_routing_config_allows_disabled_stale_slots(monkeypatch):
+    monkeypatch.setattr(
+        providers_module.ProviderManager,
+        "get_instance",
+        staticmethod(_dummy_provider_manager),
+    )
+
+    config_router._validate_routing_config(
+        AgentsLLMRoutingConfig(
+            enabled=False,
+            mode="local_first",
+            local=ModelSlotConfig(
+                provider_id="missing-provider",
+                model="missing-model",
+            ),
+            cloud=ModelSlotConfig(
+                provider_id="local-provider",
+                model="local-model",
+            ),
+        ),
+    )
+
+
+def test_validate_routing_config_skips_inactive_slot(monkeypatch):
+    monkeypatch.setattr(
+        providers_module.ProviderManager,
+        "get_instance",
+        staticmethod(_dummy_provider_manager),
+    )
+
+    config_router._validate_routing_config(
+        AgentsLLMRoutingConfig(
+            enabled=True,
+            mode="local_first",
+            local=ModelSlotConfig(
+                provider_id="local-provider",
+                model="local-model",
+            ),
+            cloud=ModelSlotConfig(
+                provider_id="missing-provider",
+                model="missing-model",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_hides_inherited_global_routing_when_agent_model_exists(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        config_router,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(
+                    enabled=True,
+                    mode="local_first",
+                    local=ModelSlotConfig(
+                        provider_id="local-provider",
+                        model="local-model",
+                    ),
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="cloud-provider",
+                model="cloud-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(),
+        ),
+    )
+
+    routing = await config_router.get_agents_llm_routing(agent_id="agent-1")
+
+    assert routing.enabled is False
+    assert routing.local.provider_id == ""
+    assert routing.cloud is None
+
+
+@pytest.mark.asyncio
+async def test_put_agent_llm_routing_rejects_unknown_provider(monkeypatch):
+    monkeypatch.setattr(
+        providers_module.ProviderManager,
+        "get_instance",
+        staticmethod(_dummy_provider_manager),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await config_router.put_agents_llm_routing(
+            request=None,
+            body=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="local_first",
+                local=ModelSlotConfig(
+                    provider_id="missing-provider",
+                    model="local-model",
+                ),
+            ),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "not found" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_put_agent_llm_routing_rejects_local_provider_in_cloud_slot(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        providers_module.ProviderManager,
+        "get_instance",
+        staticmethod(_dummy_provider_manager),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await config_router.put_agents_llm_routing(
+            request=None,
+            body=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="cloud_first",
+                local=ModelSlotConfig(
+                    provider_id="local-provider",
+                    model="local-model",
+                ),
+                cloud=ModelSlotConfig(
+                    provider_id="local-provider",
+                    model="other-local-model",
+                ),
+            ),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "Cloud slot must use a non-local provider." in str(
+        exc_info.value.detail,
+    )

--- a/tests/unit/app/routers/test_providers_active_model.py
+++ b/tests/unit/app/routers/test_providers_active_model.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from qwenpaw.app.routers import providers as providers_router
+from qwenpaw.config.config import ModelSlotConfig
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.active_model = ModelSlotConfig(
+            provider_id="global",
+            model="global-model",
+        )
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+@pytest.mark.asyncio
+async def test_get_active_models_effective_returns_global_routed_slot(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "qwenpaw.agents.routing_chat_model.resolve_effective_model_slot",
+        lambda _agent_id=None: ModelSlotConfig(
+            provider_id="local",
+            model="local-model",
+        ),
+    )
+
+    result = await providers_router.get_active_models(
+        request=None,
+        manager=DummyProviderManager(),
+        scope="effective",
+        agent_id="agent-1",
+    )
+
+    assert result.active_llm == ModelSlotConfig(
+        provider_id="local",
+        model="local-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_effective_returns_agent_model_when_routing_disabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "qwenpaw.agents.routing_chat_model.resolve_effective_model_slot",
+        lambda _agent_id=None: ModelSlotConfig(
+            provider_id="agent",
+            model="agent-model",
+        ),
+    )
+
+    result = await providers_router.get_active_models(
+        request=None,
+        manager=DummyProviderManager(),
+        scope="effective",
+        agent_id="agent-1",
+    )
+
+    assert result.active_llm == ModelSlotConfig(
+        provider_id="agent",
+        model="agent-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_active_models_effective_returns_agent_routed_slot(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "qwenpaw.agents.routing_chat_model.resolve_effective_model_slot",
+        lambda _agent_id=None: ModelSlotConfig(
+            provider_id="cloud",
+            model="cloud-model",
+        ),
+    )
+
+    result = await providers_router.get_active_models(
+        request=None,
+        manager=DummyProviderManager(),
+        scope="effective",
+        agent_id="agent-1",
+    )
+
+    assert result.active_llm == ModelSlotConfig(
+        provider_id="cloud",
+        model="cloud-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_effective_returns_none_when_routed_slot_unresolved(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "qwenpaw.agents.routing_chat_model.resolve_effective_model_slot",
+        lambda _agent_id=None: None,
+    )
+
+    result = await providers_router.get_active_models(
+        request=None,
+        manager=DummyProviderManager(),
+        scope="effective",
+        agent_id="agent-1",
+    )
+
+    assert result.active_llm is None

--- a/tests/unit/cli/test_doctor_checks.py
+++ b/tests/unit/cli/test_doctor_checks.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from types import SimpleNamespace
+
+from qwenpaw.cli import doctor_checks
+from qwenpaw.config.config import AgentsLLMRoutingConfig, ModelSlotConfig
+
+
+def test_resolve_agent_effective_model_slot_prefers_enabled_routing():
+    slot, source = doctor_checks._resolve_agent_effective_model_slot(
+        SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="agent-provider",
+                model="agent-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="local_first",
+                local=ModelSlotConfig(
+                    provider_id="local-provider",
+                    model="local-model",
+                ),
+            ),
+        ),
+        active_slot=None,
+    )
+
+    assert slot == ModelSlotConfig(
+        provider_id="local-provider",
+        model="local-model",
+    )
+    assert source == "agent.llm_routing.local"
+
+
+def test_resolve_agent_effective_model_slot_reports_missing_selected_slot():
+    slot, source = doctor_checks._resolve_agent_effective_model_slot(
+        SimpleNamespace(
+            active_model=ModelSlotConfig(
+                provider_id="agent-provider",
+                model="agent-model",
+            ),
+            llm_routing=AgentsLLMRoutingConfig(
+                enabled=True,
+                mode="cloud_first",
+                local=ModelSlotConfig(
+                    provider_id="local-provider",
+                    model="local-model",
+                ),
+                cloud=None,
+            ),
+        ),
+        active_slot=None,
+    )
+
+    assert slot is None
+    assert source == "agent routing enabled but cloud slot is not set"
+
+
+def test_resolve_effective_model_slot_uses_global_routing():
+    slot, source = doctor_checks._resolve_agent_effective_model_slot(
+        SimpleNamespace(
+            active_model=None,
+            llm_routing=AgentsLLMRoutingConfig(),
+        ),
+        active_slot=ModelSlotConfig(
+            provider_id="global-provider",
+            model="global-model",
+        ),
+        global_routing=AgentsLLMRoutingConfig(
+            enabled=True,
+            mode="local_first",
+            local=ModelSlotConfig(
+                provider_id="local-provider",
+                model="local-model",
+            ),
+        ),
+    )
+
+    assert slot == ModelSlotConfig(
+        provider_id="local-provider",
+        model="local-model",
+    )
+    assert source == "global.llm_routing.local"


### PR DESCRIPTION
## Description

Aligns scope-aware routing semantics across backend runtime and read paths on top of #849.

#849 added the minimal LLM routing foundation. This PR makes the backend consistently answer the same question for a given agent: which concrete primary model slot is effective right now?

The aligned surfaces are:

- runtime model creation
- `/models/active?scope=effective`
- prompt multimodal capability checks
- `qwenpaw doctor` diagnostics
- agent-scoped `GET/PUT /config/agents/llm-routing`

This remains backend/runtime work. The console UI is tracked separately in #3452, and CLI management commands are tracked separately in #3670.

**Related Issue / PR:** Builds on #849

**Security Considerations:** No new auth surface. Changes are limited to model/routing config resolution and validation.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend: agents, app routers, config, providers
- [x] CLI diagnostics: `qwenpaw doctor`
- [x] Tests

## Checklist

- [x] Targeted pre-commit checks pass locally
- [x] Relevant pytest suite passes locally
- [x] Manual runtime/browser checks completed
- [ ] Documentation updated (not needed for this backend follow-up)
- [x] Ready for review

## Local Verification

```bash
pre-commit run --files src/qwenpaw/agents/model_factory.py src/qwenpaw/agents/prompt.py src/qwenpaw/agents/routing_chat_model.py src/qwenpaw/app/routers/config.py src/qwenpaw/app/routers/providers.py src/qwenpaw/cli/doctor_checks.py src/qwenpaw/config/config.py tests/unit/agents/test_model_factory_routing.py tests/unit/agents/test_prompt_multimodal_routing.py tests/unit/app/routers/test_config_llm_routing.py tests/unit/app/routers/test_providers_active_model.py tests/unit/cli/test_doctor_checks.py
# Passed

PYTHONPATH=/Users/tianhao/Documents/GitHub/QwenPaw/src /Users/tianhao/Documents/GitHub/QwenPaw-routing-ui/.venv/bin/python -m pytest tests/unit/agents/test_model_factory_routing.py tests/unit/agents/test_prompt_multimodal_routing.py tests/unit/app/routers/test_config_llm_routing.py tests/unit/app/routers/test_providers_active_model.py tests/unit/cli/test_doctor_checks.py
# 20 passed

PYTHONPATH=/Users/tianhao/Documents/GitHub/QwenPaw/src /Users/tianhao/Documents/GitHub/QwenPaw-routing-ui/.venv/bin/python -m qwenpaw doctor --timeout 5 --llm-timeout 20
# Passed with local app running on http://127.0.0.1:60595
```

Manual runtime/browser checks completed:

- current backend + official frontend basic chat path
- current backend + #3452 frontend routing settings round-trip
- global routing with no agent override reflected in Chat effective model and runtime behavior
- agent-scoped routing override masks global routing in effective reads and runtime calls
- local route verified through OpenAI-compatible Kimi endpoint at `http://127.0.0.1:18790/v1`