### PR TITLE
fix(console): avoid SSE crash on malformed surrogate text

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -593,7 +593,11 @@ class BaseChannel(ABC):
         if isinstance(value, dict):
             out: Dict[Any, Any] = {}
             for k, v in value.items():
-                nk = cls._sanitize_surrogate_text(k) if isinstance(k, str) else k
+                nk = (
+                    cls._sanitize_surrogate_text(k)
+                    if isinstance(k, str)
+                    else k
+                )
                 out[nk] = cls._sanitize_for_json(v)
             return out
         return value

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -507,12 +507,7 @@ class BaseChannel(ABC):
         try:
             process_iterator = self._process(request)
             async for event in process_iterator:
-                if hasattr(event, "model_dump_json"):
-                    data = event.model_dump_json()
-                elif hasattr(event, "json"):
-                    data = event.json()
-                else:
-                    data = json.dumps({"text": str(event)})
+                data = self._serialize_event_for_sse(event)
 
                 yield f"data: {data}\n\n"
 
@@ -577,6 +572,69 @@ class BaseChannel(ABC):
                 "Internal error",
             )
             raise
+
+    @staticmethod
+    def _sanitize_surrogate_text(text: str) -> str:
+        try:
+            text.encode("utf-8")
+            return text
+        except UnicodeEncodeError:
+            return text.encode("utf-8", errors="replace").decode(
+                "utf-8",
+                errors="replace",
+            )
+
+    @classmethod
+    def _sanitize_for_json(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return cls._sanitize_surrogate_text(value)
+        if isinstance(value, list):
+            return [cls._sanitize_for_json(v) for v in value]
+        if isinstance(value, dict):
+            out: Dict[Any, Any] = {}
+            for k, v in value.items():
+                nk = cls._sanitize_surrogate_text(k) if isinstance(k, str) else k
+                out[nk] = cls._sanitize_for_json(v)
+            return out
+        return value
+
+    def _serialize_event_for_sse(self, event: Any) -> str:
+        try:
+            if hasattr(event, "model_dump_json"):
+                data = event.model_dump_json()
+            elif hasattr(event, "json"):
+                data = event.json()
+            else:
+                data = json.dumps({"text": str(event)}, ensure_ascii=True)
+
+            return self._sanitize_surrogate_text(data)
+
+        except Exception as err:
+            logger.warning(
+                "Event JSON serialization failed; using safe fallback: %s",
+                err,
+            )
+            try:
+                if hasattr(event, "model_dump"):
+                    payload = event.model_dump(mode="python")
+                elif hasattr(event, "dict"):
+                    payload = event.dict()
+                else:
+                    payload = {"text": str(event)}
+
+                payload = self._sanitize_for_json(payload)
+                return json.dumps(payload, ensure_ascii=True, default=str)
+            except Exception as fallback_err:
+                logger.error(
+                    "Fallback event serialization failed: %s",
+                    fallback_err,
+                )
+                return json.dumps(
+                    {
+                        "text": self._sanitize_surrogate_text(str(event)),
+                    },
+                    ensure_ascii=True,
+                )
 
     @classmethod
     def from_env(

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -350,7 +350,11 @@ class ConsoleChannel(BaseChannel):
         if isinstance(value, dict):
             out: Dict[Any, Any] = {}
             for k, v in value.items():
-                nk = cls._sanitize_surrogate_text(k) if isinstance(k, str) else k
+                nk = (
+                    cls._sanitize_surrogate_text(k)
+                    if isinstance(k, str)
+                    else k
+                )
                 out[nk] = cls._sanitize_for_json(v)
             return out
         return value
@@ -444,7 +448,10 @@ class ConsoleChannel(BaseChannel):
                     ev_type,
                 )
 
-                if event.object == "response" and event.status == RunStatus.Completed:
+                if (
+                    event.object == "response"
+                    and event.status == RunStatus.Completed
+                ):
                     event_output = event.output
                     event.output = []
                     if event_output is not None:
@@ -561,7 +568,11 @@ class ConsoleChannel(BaseChannel):
             elif t == ContentType.AUDIO and getattr(p, "data", None):
                 self._safe_print(f"{_YELLOW}🔊 [Audio]{_RESET}")
             elif t == ContentType.FILE:
-                url = getattr(p, "file_url", None) or getattr(p, "file_id", None) or ""
+                url = (
+                    getattr(p, "file_url", None)
+                    or getattr(p, "file_id", None)
+                    or ""
+                )
                 self._safe_print(f"{_YELLOW}📎 [File: {url}]{_RESET}")
         self._safe_print("")
 
@@ -606,7 +617,8 @@ class ConsoleChannel(BaseChannel):
         ts = _ts()
         prefix = (meta or {}).get("bot_prefix", self.bot_prefix) or ""
         self._safe_print(
-            f"\n{_GREEN}{_BOLD}🤖 [{ts}] Bot → {to_handle}{_RESET}\n{prefix}{text}\n",
+            f"\n{_GREEN}{_BOLD}🤖 [{ts}] Bot → {to_handle}{_RESET}\n"
+            f"{prefix}{text}\n",
         )
         sid = (meta or {}).get("session_id")
         if sid and text.strip():

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -16,7 +16,6 @@ import copy
 import logging
 import os
 import sys
-import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
@@ -329,73 +328,6 @@ class ConsoleChannel(BaseChannel):
         usage = TokenRecordingModelWrapper.pop_usage_for_session(session_id)
         logger.info("Usage for session %s (cleaned up): %s", session_id, usage)
         return usage
-
-    @staticmethod
-    def _sanitize_surrogate_text(text: str) -> str:
-        try:
-            text.encode("utf-8")
-            return text
-        except UnicodeEncodeError:
-            return text.encode("utf-8", errors="replace").decode(
-                "utf-8",
-                errors="replace",
-            )
-
-    @classmethod
-    def _sanitize_for_json(cls, value: Any) -> Any:
-        if isinstance(value, str):
-            return cls._sanitize_surrogate_text(value)
-        if isinstance(value, list):
-            return [cls._sanitize_for_json(v) for v in value]
-        if isinstance(value, dict):
-            out: Dict[Any, Any] = {}
-            for k, v in value.items():
-                nk = (
-                    cls._sanitize_surrogate_text(k)
-                    if isinstance(k, str)
-                    else k
-                )
-                out[nk] = cls._sanitize_for_json(v)
-            return out
-        return value
-
-    def _serialize_event_for_sse(self, event: Any) -> str:
-        try:
-            if hasattr(event, "model_dump_json"):
-                data = event.model_dump_json()
-            elif hasattr(event, "json"):
-                data = event.json()
-            else:
-                data = json.dumps({"text": str(event)}, ensure_ascii=True)
-
-            return self._sanitize_surrogate_text(data)
-
-        except Exception as err:
-            logger.warning(
-                "Event JSON serialization failed; using safe fallback: %s",
-                err,
-            )
-            try:
-                if hasattr(event, "model_dump"):
-                    payload = event.model_dump(mode="python")
-                elif hasattr(event, "dict"):
-                    payload = event.dict()
-                else:
-                    payload = {"text": str(event)}
-
-                payload = self._sanitize_for_json(payload)
-                return json.dumps(payload, ensure_ascii=True, default=str)
-            except Exception as fallback_err:
-                logger.error(
-                    "Fallback event serialization failed: %s",
-                    fallback_err,
-                )
-                return json.dumps(
-                    {
-                        "text": self._sanitize_surrogate_text(str(event)),
-                    },
-                    ensure_ascii=True,
-                )
 
     async def stream_one(self, payload: Any) -> AsyncGenerator[str, None]:
         """Process one payload and yield SSE-formatted events"""

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -9,6 +9,7 @@ endpoint or via POST /console/chat. This channel handles the **output** side:
 whenever a completed message event or a proactive send arrives, it is
 pretty-printed to the terminal.
 """
+
 from __future__ import annotations
 
 import copy
@@ -329,6 +330,65 @@ class ConsoleChannel(BaseChannel):
         logger.info("Usage for session %s (cleaned up): %s", session_id, usage)
         return usage
 
+    @staticmethod
+    def _sanitize_surrogate_text(text: str) -> str:
+        return text.encode("utf-8", errors="replace").decode(
+            "utf-8",
+            errors="replace",
+        )
+
+    @classmethod
+    def _sanitize_for_json(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return cls._sanitize_surrogate_text(value)
+        if isinstance(value, list):
+            return [cls._sanitize_for_json(v) for v in value]
+        if isinstance(value, dict):
+            out: Dict[Any, Any] = {}
+            for k, v in value.items():
+                nk = cls._sanitize_surrogate_text(k) if isinstance(k, str) else k
+                out[nk] = cls._sanitize_for_json(v)
+            return out
+        return value
+
+    def _serialize_event_for_sse(self, event: Any) -> str:
+        try:
+            if hasattr(event, "model_dump_json"):
+                data = event.model_dump_json()
+            elif hasattr(event, "json"):
+                data = event.json()
+            else:
+                data = json.dumps({"text": str(event)}, ensure_ascii=True)
+
+            return self._sanitize_surrogate_text(data)
+
+        except Exception as err:
+            logger.warning(
+                "Event JSON serialization failed; using safe fallback: %s",
+                err,
+            )
+            try:
+                if hasattr(event, "model_dump"):
+                    payload = event.model_dump(mode="python")
+                elif hasattr(event, "dict"):
+                    payload = event.dict()
+                else:
+                    payload = {"text": str(event)}
+
+                payload = self._sanitize_for_json(payload)
+                return json.dumps(payload, ensure_ascii=True, default=str)
+            except Exception as fallback_err:
+                logger.error(
+                    "Fallback event serialization failed: %s",
+                    fallback_err,
+                )
+                return json.dumps(
+                    {
+                        "text": self._sanitize_surrogate_text(str(event)),
+                    },
+                    ensure_ascii=True,
+                )
+
     async def stream_one(self, payload: Any) -> AsyncGenerator[str, None]:
         """Process one payload and yield SSE-formatted events"""
         if isinstance(payload, dict) and "content_parts" in payload:
@@ -380,10 +440,7 @@ class ConsoleChannel(BaseChannel):
                     ev_type,
                 )
 
-                if (
-                    event.object == "response"
-                    and event.status == RunStatus.Completed
-                ):
+                if event.object == "response" and event.status == RunStatus.Completed:
                     event_output = event.output
                     event.output = []
                     if event_output is not None:
@@ -400,18 +457,16 @@ class ConsoleChannel(BaseChannel):
                     if usage_data and hasattr(event, "usage"):
                         setattr(event, "usage", usage_data)
 
-                if hasattr(event, "model_dump_json"):
-                    data = event.model_dump_json()
-                elif hasattr(event, "json"):
-                    data = event.json()
-                else:
-                    data = json.dumps({"text": str(event)})
+                data = self._serialize_event_for_sse(event)
                 yield f"data: {data}\n\n"
 
                 if obj == "message" and status == RunStatus.Completed:
                     media_message = await self._extract_media_message(event)
                     if media_message:
-                        yield f"data: {media_message.model_dump_json()}\n\n"
+                        media_json = self._serialize_event_for_sse(
+                            media_message,
+                        )
+                        yield f"data: {media_json}\n\n"
 
                     parts = self._message_to_content_parts(event)
                     self._print_parts(parts, ev_type)
@@ -502,19 +557,14 @@ class ConsoleChannel(BaseChannel):
             elif t == ContentType.AUDIO and getattr(p, "data", None):
                 self._safe_print(f"{_YELLOW}🔊 [Audio]{_RESET}")
             elif t == ContentType.FILE:
-                url = (
-                    getattr(p, "file_url", None)
-                    or getattr(p, "file_id", None)
-                    or ""
-                )
+                url = getattr(p, "file_url", None) or getattr(p, "file_id", None) or ""
                 self._safe_print(f"{_YELLOW}📎 [File: {url}]{_RESET}")
         self._safe_print("")
 
     def _print_error(self, err: str) -> None:
         ts = _ts()
         self._safe_print(
-            f"\n{_RED}{_BOLD}❌ [{ts}] Error{_RESET}\n"
-            f"{_RED}{err}{_RESET}\n",
+            f"\n{_RED}{_BOLD}❌ [{ts}] Error{_RESET}\n{_RED}{err}{_RESET}\n",
         )
 
     def _parts_to_text(
@@ -552,8 +602,7 @@ class ConsoleChannel(BaseChannel):
         ts = _ts()
         prefix = (meta or {}).get("bot_prefix", self.bot_prefix) or ""
         self._safe_print(
-            f"\n{_GREEN}{_BOLD}🤖 [{ts}] Bot → {to_handle}{_RESET}\n"
-            f"{prefix}{text}\n",
+            f"\n{_GREEN}{_BOLD}🤖 [{ts}] Bot → {to_handle}{_RESET}\n{prefix}{text}\n",
         )
         sid = (meta or {}).get("session_id")
         if sid and text.strip():

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -332,10 +332,14 @@ class ConsoleChannel(BaseChannel):
 
     @staticmethod
     def _sanitize_surrogate_text(text: str) -> str:
-        return text.encode("utf-8", errors="replace").decode(
-            "utf-8",
-            errors="replace",
-        )
+        try:
+            text.encode("utf-8")
+            return text
+        except UnicodeEncodeError:
+            return text.encode("utf-8", errors="replace").decode(
+                "utf-8",
+                errors="replace",
+            )
 
     @classmethod
     def _sanitize_for_json(cls, value: Any) -> Any:

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -2377,13 +2377,7 @@ class DingTalkChannel(BaseChannel):
                 to_handle=to_handle,
             )
             async for event in core_iter:
-                # SSE serialization
-                if hasattr(event, "model_dump_json"):
-                    data = event.model_dump_json()
-                elif hasattr(event, "json"):
-                    data = event.json()
-                else:
-                    data = json.dumps({"text": str(event)})
+                data = self._serialize_event_for_sse(event)
                 yield f"data: {data}\n\n"
 
                 obj = getattr(event, "object", None)

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -993,6 +993,69 @@ class TestStreamWithTracker:
                             ):
                                 pass
 
+    async def test_stream_with_tracker_falls_back_on_surrogate_json_error(
+        self,
+        base_channel,
+    ):
+        """_stream_with_tracker should fallback on malformed surrogate data."""
+        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
+
+        class BrokenJsonEvent:
+            object = "response"
+            status = RunStatus.Completed
+            type = "response.completed"
+
+            def model_dump_json(self):
+                raise UnicodeEncodeError(
+                    "utf-8",
+                    "\ud83c",
+                    0,
+                    1,
+                    "surrogates not allowed",
+                )
+
+            def model_dump(self, mode="python"):
+                del mode
+                return {
+                    "object": "response",
+                    "status": "completed",
+                    "text": "\ud83c broken",
+                }
+
+        async def mock_process(_request):
+            yield BrokenJsonEvent()
+
+        base_channel._process = mock_process
+
+        with patch.object(
+            base_channel,
+            "_payload_to_request",
+            return_value=MagicMock(
+                session_id="test:session",
+                user_id="user123",
+                channel="test",
+                channel_meta={},
+            ),
+        ):
+            with patch.object(
+                base_channel,
+                "get_to_handle_from_request",
+                return_value="user123",
+            ):
+                with patch.object(
+                    base_channel,
+                    "_before_consume_process",
+                ):
+                    events = []
+                    async for event in base_channel._stream_with_tracker({}):
+                        events.append(event)
+                        break
+
+        assert len(events) == 1
+        assert events[0].startswith("data: ")
+        assert "\\ud83c" not in events[0]
+        assert "? broken" in events[0]
+
 
 # =============================================================================
 # P2: Audio Content Detection

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -522,6 +522,66 @@ class TestConsoleStreaming:
 
             assert len(events) == 1
 
+    async def test_stream_one_falls_back_on_surrogate_json_error(
+        self,
+        stream_channel,
+    ):
+        """stream_one should fallback instead of crashing on bad surrogate."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            TextContent,
+            ContentType,
+        )
+
+        class BrokenJsonEvent:
+            object = "response"
+            status = RunStatus.Completed
+            type = "response.completed"
+            output = []
+
+            def model_dump_json(self):
+                raise UnicodeEncodeError(
+                    "utf-8",
+                    "\ud83d",
+                    0,
+                    1,
+                    "surrogates not allowed",
+                )
+
+            def model_dump(self, mode="python"):
+                del mode
+                return {
+                    "object": "response",
+                    "status": "completed",
+                    "text": "\ud83d broken",
+                }
+
+        async def mock_process(_request):
+            yield BrokenJsonEvent()
+
+        stream_channel._process = mock_process
+
+        payload = {
+            "sender_id": "user123",
+            "content_parts": [
+                TextContent(
+                    type=ContentType.TEXT,
+                    text="Hello",
+                ),
+            ],
+            "meta": {},
+        }
+
+        events = []
+        async for event in stream_channel.stream_one(payload):
+            events.append(event)
+            break
+
+        assert len(events) == 1
+        assert events[0].startswith("data: ")
+        assert "\\ud83d" not in events[0]
+        assert "? broken" in events[0]
+
     async def test_consume_one_drain_stream(self, stream_channel):
         """consume_one should drain stream_one."""
         from unittest.mock import patch, AsyncMock


### PR DESCRIPTION
## Description
This PR fixes a Console channel crash when SSE serializes malformed Unicode surrogate text (for example half-emoji sequences like `\ud83d`).

Previously, `stream_one()` could raise `PydanticSerializationError` from `model_dump_json()` and abort the current `/api/console/chat` stream. This change adds a safe serialization path so the stream degrades gracefully instead of crashing.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Component(s) Affected
- [x] Console
- [ ] Core
- [ ] Channels (non-console)
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests

## What Changed
- Added surrogate-safe SSE serializer in `ConsoleChannel`.
- Added fast-path in `_sanitize_surrogate_text` (returns original text when UTF-8 encoding is valid; only fallback-replaces on `UnicodeEncodeError`).
- Routed both normal events and media-message events through the same safe serializer.
- Added regression test `test_stream_one_falls_back_on_surrogate_json_error`.

## Testing
### Targeted unit test
```bash
uv run --extra dev pytest tests/unit/channels/test_console.py -q
27 passed
```

### pre-commit checks
```bash
uv run --extra dev pre-commit run --all-files
```
Result summary:
- Passed hooks: `check python ast`, `check yaml/xml/toml/json`, `trim trailing whitespace`, `add trailing commas`, `black`, `flake8`, `pylint`, `prettier` (after follow-up fixes)
- `mypy` reports existing repository-wide errors outside this PR scope (e.g. `src/qwenpaw/cli/shutdown_cmd.py`), not introduced by this change

## Local Verification Evidence
- Reproduced original error path with malformed surrogate input.
- Verified stream no longer aborts; SSE output is still emitted with sanitized replacement.

## Related Issue
- Closes #3552