### PR TITLE
fix(app): reload running agents after global LLM updates

### DIFF
--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional
 from fastapi import APIRouter, Body, HTTPException, Path, Request
 from pydantic import BaseModel
 
-from ..utils import schedule_agent_reload
+from ..utils import schedule_agent_reload, schedule_all_agents_reload
 from ...config import (
     load_config,
     save_config,
@@ -358,11 +358,13 @@ async def get_agents_llm_routing() -> AgentsLLMRoutingConfig:
     summary="Update agent LLM routing settings",
 )
 async def put_agents_llm_routing(
+    request: Request,
     body: AgentsLLMRoutingConfig = Body(...),
 ) -> AgentsLLMRoutingConfig:
     config = load_config()
     config.agents.llm_routing = body
     save_config(config)
+    schedule_all_agents_reload(request)
     return body
 
 

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -23,7 +23,7 @@ from agentscope_runtime.engine.schemas.exception import (
 )
 
 from ..agent_context import get_agent_for_request
-from ..utils import schedule_agent_reload
+from ..utils import schedule_agent_reload, schedule_all_agents_reload
 from ...config.config import load_agent_config, save_agent_config
 from ...providers.provider import ProviderInfo, ModelInfo
 from ...providers.provider_manager import ActiveModelsInfo, ProviderManager
@@ -632,6 +632,10 @@ async def set_active_model(
             if "provider" in lower_msg and "not found" in lower_msg:
                 raise HTTPException(status_code=404, detail=message) from exc
             raise HTTPException(status_code=400, detail=message) from exc
+        # Agents bind their model at construction time, so a persisted
+        # global swap only takes effect after each running agent is
+        # hot-reloaded.
+        schedule_all_agents_reload(request)
         return ActiveModelsInfo(active_llm=manager.get_active_model())
 
     if not body.agent_id:

--- a/src/qwenpaw/app/utils.py
+++ b/src/qwenpaw/app/utils.py
@@ -56,3 +56,30 @@ def schedule_agent_reload(request: "Request", agent_id: str) -> None:
             )
 
     asyncio.create_task(reload_in_background())
+
+
+def schedule_all_agents_reload(request: "Request") -> None:
+    """Schedule a reload for every currently-running agent.
+
+    Global-scope configuration changes (e.g. the default LLM in Settings)
+    must propagate to agents that are already instantiated in memory,
+    since ``ReActAgent`` binds its model at construction time. Without
+    this, a global model swap is persisted but silently ignored until
+    each agent is individually reloaded.
+    """
+    manager: "MultiAgentManager" = getattr(
+        request.app.state,
+        "multi_agent_manager",
+        None,
+    )
+
+    if manager is None:
+        logger.warning(
+            "Cannot schedule global agent reload: "
+            "MultiAgentManager not initialized in app state",
+        )
+        return
+
+    agent_ids = list(manager.agents.keys())
+    for agent_id in agent_ids:
+        schedule_agent_reload(request, agent_id)

--- a/tests/integration/test_global_llm_reload_e2e.py
+++ b/tests/integration/test_global_llm_reload_e2e.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""End-to-end: PUT /models/active with scope=global reloads running agents.
+
+Exercises the real HTTP stack — a minimal FastAPI app with the real
+providers router, a real MultiAgentManager, and stub Workspace objects
+that log their reload. Proves the whole path (HTTP → router →
+schedule_all_agents_reload → asyncio.create_task →
+MultiAgentManager.reload_agent) wires through correctly, not just the
+function in isolation.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Dict, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.multi_agent_manager import MultiAgentManager
+from qwenpaw.app.routers import providers as providers_router
+from qwenpaw.providers.models import ModelSlotConfig
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.active_model = ModelSlotConfig(
+            provider_id="opencode",
+            model="nemotron-3-super-free",
+        )
+        self.activate_calls: List[tuple[str, str]] = []
+
+    async def activate_model(self, provider_id: str, model_id: str) -> None:
+        self.activate_calls.append((provider_id, model_id))
+        self.active_model = ModelSlotConfig(
+            provider_id=provider_id,
+            model=model_id,
+        )
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+class _RecordingMultiAgentManager(MultiAgentManager):
+    """Real MultiAgentManager subclass that only records reload requests."""
+
+    def __init__(self, agent_ids: List[str]) -> None:
+        super().__init__()
+        self.reloaded: List[str] = []
+        self._reload_done = asyncio.Event()
+        for agent_id in agent_ids:
+            # Populate the internal dict directly with a placeholder so that
+            # ``list(self.agents.keys())`` returns them. reload_agent is
+            # overridden to avoid touching Workspace/config.
+            self.agents[agent_id] = SimpleNamespace(agent_id=agent_id)
+
+    async def reload_agent(self, agent_id: str) -> bool:
+        self.reloaded.append(agent_id)
+        if set(self.reloaded) >= set(self.agents.keys()):
+            self._reload_done.set()
+        return True
+
+    async def wait_for_reloads(self, timeout: float = 2.0) -> None:
+        await asyncio.wait_for(self._reload_done.wait(), timeout=timeout)
+
+
+def _make_app(
+    provider_manager: DummyProviderManager,
+    multi_agent: _RecordingMultiAgentManager,
+) -> FastAPI:
+    app = FastAPI()
+    app.state.provider_manager = provider_manager
+    app.state.multi_agent_manager = multi_agent
+
+    def _override_provider_manager():
+        return provider_manager
+
+    app.dependency_overrides[
+        providers_router.get_provider_manager
+    ] = _override_provider_manager
+    app.include_router(providers_router.router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_put_global_active_schedules_reload_for_every_agent():
+    """PUT /active with scope=global over real HTTP must propagate the
+    change to every agent currently in MultiAgentManager."""
+    provider = DummyProviderManager()
+    multi_agent = _RecordingMultiAgentManager(
+        ["default", "qa-bot", "worker-1"],
+    )
+    app = _make_app(provider, multi_agent)
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/models/active",
+            json={
+                "provider_id": "aliyun-codingplan",
+                "model": "qwen3.6-plus",
+                "scope": "global",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["active_llm"] == {
+            "provider_id": "aliyun-codingplan",
+            "model": "qwen3.6-plus",
+        }
+
+        await multi_agent.wait_for_reloads(timeout=3.0)
+
+    assert provider.activate_calls == [
+        ("aliyun-codingplan", "qwen3.6-plus"),
+    ]
+    assert sorted(multi_agent.reloaded) == [
+        "default",
+        "qa-bot",
+        "worker-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_put_agent_scope_does_not_reload_other_agents(monkeypatch):
+    """PUT /active with scope=agent must only reload that one agent —
+    the global-wide reload must not fire for agent-scoped writes."""
+    provider = DummyProviderManager()
+    multi_agent = _RecordingMultiAgentManager(
+        ["default", "qa-bot"],
+    )
+    app = _make_app(provider, multi_agent)
+
+    # Stub out the filesystem side of agent config so the handler
+    # persists a "write" without touching disk.
+    saved: Dict[str, ModelSlotConfig] = {}
+
+    def _fake_load_agent_config(_agent_id: str):
+        return SimpleNamespace(
+            active_model=saved.get(_agent_id),
+        )
+
+    def _fake_save_agent_config(agent_id: str, agent_config) -> None:
+        saved[agent_id] = agent_config.active_model
+
+    async def _fake_get_agent_for_request(_request, agent_id=None):
+        return SimpleNamespace(agent_id=agent_id or "default")
+
+    monkeypatch.setattr(
+        providers_router,
+        "load_agent_config",
+        _fake_load_agent_config,
+    )
+    monkeypatch.setattr(
+        providers_router,
+        "save_agent_config",
+        _fake_save_agent_config,
+    )
+    monkeypatch.setattr(
+        providers_router,
+        "get_agent_for_request",
+        _fake_get_agent_for_request,
+    )
+    monkeypatch.setattr(
+        providers_router,
+        "_validate_model_slot",
+        lambda *_args, **_kwargs: None,
+    )
+    # Guard: the probe must not raise in unit-land.
+    monkeypatch.setattr(
+        provider,
+        "maybe_probe_multimodal",
+        lambda *_args, **_kwargs: None,
+        raising=False,
+    )
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/models/active",
+            json={
+                "provider_id": "opencode",
+                "model": "big-pickle",
+                "scope": "agent",
+                "agent_id": "default",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    # Give any pending reload task a chance to run.
+    await asyncio.sleep(0.05)
+
+    # Only the targeted agent should be reloaded. The global-wide
+    # broadcast must not touch qa-bot.
+    assert "qa-bot" not in multi_agent.reloaded
+    assert "default" in multi_agent.reloaded

--- a/tests/unit/app/routers/test_config_set_llm_routing.py
+++ b/tests/unit/app/routers/test_config_set_llm_routing.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Regression tests: global routing changes must reload running agents."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw.app.routers import config as config_router
+from qwenpaw.config.config import AgentsLLMRoutingConfig
+from qwenpaw.providers.models import ModelSlotConfig
+
+
+class FakeMultiAgentManager:
+    """Minimal shape required by schedule_all_agents_reload()."""
+
+    def __init__(self, agent_ids: List[str]) -> None:
+        self.agents = {
+            agent_id: MagicMock(name=f"Workspace({agent_id})")
+            for agent_id in agent_ids
+        }
+        self.reloaded: List[str] = []
+
+    async def reload_agent(self, agent_id: str) -> bool:
+        self.reloaded.append(agent_id)
+        return True
+
+
+def _make_request(multi_agent_manager) -> SimpleNamespace:
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(multi_agent_manager=multi_agent_manager),
+        ),
+    )
+
+
+async def _drain_pending_tasks() -> None:
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_put_global_routing_reloads_every_running_agent(monkeypatch):
+    multi_agent = FakeMultiAgentManager(["agent-a", "agent-b"])
+    request = _make_request(multi_agent)
+    saved = {}
+
+    monkeypatch.setattr(
+        config_router,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        config_router,
+        "save_config",
+        lambda config: saved.setdefault("routing", config.agents.llm_routing),
+    )
+
+    body = AgentsLLMRoutingConfig(
+        enabled=True,
+        mode="local_first",
+        local=ModelSlotConfig(
+            provider_id="local-provider",
+            model="local-model",
+        ),
+    )
+
+    result = await config_router.put_agents_llm_routing(
+        request=request,
+        body=body,
+    )
+
+    await _drain_pending_tasks()
+
+    assert result == body
+    assert saved["routing"] == body
+    assert sorted(multi_agent.reloaded) == ["agent-a", "agent-b"]
+
+
+@pytest.mark.asyncio
+async def test_put_global_routing_without_running_agents_is_noop(monkeypatch):
+    request = _make_request(FakeMultiAgentManager([]))
+
+    monkeypatch.setattr(
+        config_router,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                llm_routing=AgentsLLMRoutingConfig(),
+            ),
+        ),
+    )
+    monkeypatch.setattr(config_router, "save_config", lambda _config: None)
+
+    await config_router.put_agents_llm_routing(
+        request=request,
+        body=AgentsLLMRoutingConfig(),
+    )
+
+    await _drain_pending_tasks()

--- a/tests/unit/app/routers/test_providers_set_active_model.py
+++ b/tests/unit/app/routers/test_providers_set_active_model.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Regression tests: Settings → global LLM swap must hot-reload agents.
+
+A running ``ReActAgent`` binds its chat model at construction time
+(``react_agent.py:150``). Persisting a new global default via
+``PUT /models/active`` with ``scope="global"`` changes only the on-disk
+``ProviderManager`` state — without scheduling a reload, every agent
+currently in ``MultiAgentManager.agents`` keeps serving from the old
+model instance, so the chat page silently ignores the setting change.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw.app.routers import providers as providers_router
+from qwenpaw.providers.models import ModelSlotConfig
+
+
+class DummyProviderManager:
+    def __init__(self) -> None:
+        self.active_model = ModelSlotConfig(
+            provider_id="old-global",
+            model="old-model",
+        )
+        self.activate_calls: List[tuple[str, str]] = []
+
+    async def activate_model(self, provider_id: str, model_id: str) -> None:
+        self.activate_calls.append((provider_id, model_id))
+        self.active_model = ModelSlotConfig(
+            provider_id=provider_id,
+            model=model_id,
+        )
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self.active_model
+
+
+class FakeMultiAgentManager:
+    """Mirrors the ``agents`` dict + ``reload_agent`` entry points used by
+    :func:`qwenpaw.app.utils.schedule_all_agents_reload`."""
+
+    def __init__(self, agent_ids: List[str]) -> None:
+        self.agents = {
+            agent_id: MagicMock(name=f"Workspace({agent_id})")
+            for agent_id in agent_ids
+        }
+        self.reloaded: List[str] = []
+
+    async def reload_agent(self, agent_id: str) -> bool:
+        self.reloaded.append(agent_id)
+        return True
+
+
+def _make_request(multi_agent_manager) -> SimpleNamespace:
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(multi_agent_manager=multi_agent_manager),
+        ),
+    )
+
+
+async def _drain_pending_tasks() -> None:
+    """Let the background reload tasks run to completion."""
+    # Give asyncio.create_task() scheduling a chance to execute.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_global_set_reloads_every_running_agent():
+    """Saving a new global model must schedule a reload for each agent
+    currently instantiated in the MultiAgentManager — otherwise the
+    swap is invisible to live chat sessions."""
+    manager = DummyProviderManager()
+    multi_agent = FakeMultiAgentManager(["agent-a", "agent-b", "agent-c"])
+    request = _make_request(multi_agent)
+
+    body = providers_router.ModelSlotRequest(
+        provider_id="new-global",
+        model="new-model",
+        scope="global",
+    )
+
+    result = await providers_router.set_active_model(
+        request=request,
+        manager=manager,
+        body=body,
+    )
+
+    await _drain_pending_tasks()
+
+    assert manager.activate_calls == [("new-global", "new-model")]
+    assert result.active_llm == ModelSlotConfig(
+        provider_id="new-global",
+        model="new-model",
+    )
+    assert sorted(multi_agent.reloaded) == ["agent-a", "agent-b", "agent-c"]
+
+
+@pytest.mark.asyncio
+async def test_global_set_without_running_agents_is_noop():
+    """With no agents booted yet, the reload loop should simply do
+    nothing — not crash, not raise. Covers the cold-start path."""
+    manager = DummyProviderManager()
+    multi_agent = FakeMultiAgentManager([])
+    request = _make_request(multi_agent)
+
+    body = providers_router.ModelSlotRequest(
+        provider_id="new-global",
+        model="new-model",
+        scope="global",
+    )
+
+    await providers_router.set_active_model(
+        request=request,
+        manager=manager,
+        body=body,
+    )
+    await _drain_pending_tasks()
+
+    assert not multi_agent.reloaded
+
+
+@pytest.mark.asyncio
+async def test_global_set_tolerates_missing_multi_agent_manager():
+    """If the app state has no ``multi_agent_manager`` (e.g. CLI-only
+    boot), the global save path should log a warning and succeed, not
+    crash the request."""
+    manager = DummyProviderManager()
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace()),
+    )
+
+    body = providers_router.ModelSlotRequest(
+        provider_id="new-global",
+        model="new-model",
+        scope="global",
+    )
+
+    result = await providers_router.set_active_model(
+        request=request,
+        manager=manager,
+        body=body,
+    )
+    await _drain_pending_tasks()
+
+    assert result.active_llm == ModelSlotConfig(
+        provider_id="new-global",
+        model="new-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_set_reload_surface_before_fix(monkeypatch):
+    """Pin the contract: the global branch must call
+    ``schedule_all_agents_reload``. Regression test so the wiring can't
+    be silently dropped again."""
+    manager = DummyProviderManager()
+    multi_agent = FakeMultiAgentManager(["agent-a"])
+    request = _make_request(multi_agent)
+
+    called: list = []
+
+    def fake_reload_all(req) -> None:
+        called.append(req)
+
+    monkeypatch.setattr(
+        providers_router,
+        "schedule_all_agents_reload",
+        fake_reload_all,
+    )
+
+    body = providers_router.ModelSlotRequest(
+        provider_id="new-global",
+        model="new-model",
+        scope="global",
+    )
+
+    await providers_router.set_active_model(
+        request=request,
+        manager=manager,
+        body=body,
+    )
+
+    assert called == [request]


### PR DESCRIPTION
## Summary

Keep live chat sessions in sync with global-scope LLM configuration changes.

- reload every running agent after a global `PUT /models/active` change
- reload every running agent after a global `PUT /config/agents/llm-routing` change
- cover both paths with unit + FastAPI-TestClient integration tests (the latter guards the `asyncio.create_task` lifecycle under the real request path)

## Test plan

- [x] `./.venv/bin/pytest tests/unit/app/routers/test_providers_set_active_model.py tests/unit/app/routers/test_config_set_llm_routing.py tests/integration/test_global_llm_reload_e2e.py` — 8 passed
- [ ] Manual: change global active model in Settings and verify existing chat sessions pick it up without restart
- [ ] Manual: change global routing mode in Settings and verify existing chat sessions pick it up without restart