### PR TITLE
view_image/videos enabled by default, fallback when not supported

### DIFF
--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -413,18 +413,22 @@ def get_active_model_supports_multimodal() -> bool:
 
 
 def get_active_model_multimodal_raw() -> bool | None:
-    """Return the raw multimodal capability flag for the active model.
+    """Return the effective multimodal capability flag for the active model.
 
-    Unlike ``get_active_model_supports_multimodal`` (which collapses
-    ``None`` → ``False``), this returns the three-valued flag directly:
+    Checks ``supports_multimodal``, ``supports_image``, and
+    ``supports_video`` — any of them being ``True`` means multimodal
+    is confirmed.
 
-    - ``True``: confirmed multimodal support
-    - ``False``: confirmed text-only
-    - ``None``: unknown / not yet probed
+    - ``True``: confirmed multimodal support (via any of the three flags)
+    - ``False``: confirmed text-only (supports_multimodal is explicitly
+      False and neither supports_image nor supports_video is True)
+    - ``None``: unknown / not yet probed (all three are None)
     """
     model_info, _ = _get_active_model_info()
     if model_info is None:
         return None
+    if model_info.supports_image or model_info.supports_video:
+        return True
     return model_info.supports_multimodal
 
 

--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -412,6 +412,22 @@ def get_active_model_supports_multimodal() -> bool:
     return bool(model_info.supports_multimodal)
 
 
+def get_active_model_multimodal_raw() -> bool | None:
+    """Return the raw multimodal capability flag for the active model.
+
+    Unlike ``get_active_model_supports_multimodal`` (which collapses
+    ``None`` → ``False``), this returns the three-valued flag directly:
+
+    - ``True``: confirmed multimodal support
+    - ``False``: confirmed text-only
+    - ``None``: unknown / not yet probed
+    """
+    model_info, _ = _get_active_model_info()
+    if model_info is None:
+        return None
+    return model_info.supports_multimodal
+
+
 def build_multimodal_hint() -> str:
     """Build a short system-prompt snippet describing multimodal capability."""
     model_info, model_name = _get_active_model_info()
@@ -441,6 +457,7 @@ __all__ = [
     "build_multimodal_hint",
     "format_multimodal_hint",
     "get_active_model_supports_multimodal",
+    "get_active_model_multimodal_raw",
     "PromptBuilder",
     "PromptConfig",
     "DEFAULT_SYS_PROMPT",

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -252,20 +252,11 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             "check_agent_task": check_agent_task,
         }
 
-        multimodal = get_active_model_supports_multimodal()
-
         # Register only enabled tools
         for tool_name, tool_func in tool_functions.items():
             # If tool not in config, enable by default (backward compatibility)
             if not enabled_tools.get(tool_name, True):
                 logger.debug("Skipped disabled tool: %s", tool_name)
-                continue
-
-            if tool_name in ("view_image", "view_video") and not multimodal:
-                logger.debug(
-                    "Skipped %s — model does not support multimodal",
-                    tool_name,
-                )
                 continue
 
             # Get async_execution setting (default to False for backward

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -116,14 +116,23 @@ def _validate_media_path(
     return resolved, None
 
 
-async def _probe_multimodal_if_needed() -> bool | None:
+async def _probe_multimodal_if_needed(
+    media_type: str = "image",
+) -> bool | None:
     """Trigger a multimodal probe if capability is unknown (None).
 
-    Uses the same agent-specific model resolution as ``_get_active_model_info``
-    so that per-agent model overrides are respected (rather than falling back
-    to the global active model, which may be a different model).
+    For ``image``: runs an image-only probe (~3s) and fires the full
+    probe (image + video) as a background task so video support is
+    persisted without blocking the caller.
 
-    Returns the probe result (True/False) if a probe was run,
+    For ``video``: runs the full probe and waits for the video result,
+    since video support cannot be inferred from the image probe alone.
+
+    Uses the same agent-specific model resolution as
+    ``_get_active_model_info`` so that per-agent model overrides are
+    respected.
+
+    Returns the probe result (True/False) for the requested media type,
     or None if no probe was needed or the probe failed.
     """
     try:
@@ -152,51 +161,83 @@ async def _probe_multimodal_if_needed() -> bool | None:
         if not active:
             return None
 
-        logger.info(
-            "Multimodal capability unknown for %s/%s — "
-            "running image-only probe on first view_image/view_video call...",
-            active.provider_id,
-            active.model,
-        )
-        result = await manager.probe_model_multimodal(
-            active.provider_id,
-            active.model,
-            image_only=True,
-        )
-        supports = result.get("supports_image", False)
-        logger.info(
-            "Image probe completed for %s/%s: supports_image=%s",
-            active.provider_id,
-            active.model,
-            supports,
-        )
-        # Fire full probe in background to also determine video support
-        import asyncio
+        if media_type == "image":
+            logger.info(
+                "Multimodal capability unknown for %s/%s — "
+                "running image-only probe...",
+                active.provider_id,
+                active.model,
+            )
+            result = await manager.probe_model_multimodal(
+                active.provider_id,
+                active.model,
+                image_only=True,
+            )
+            supports = result.get("supports_image", False)
+            logger.info(
+                "Image probe completed for %s/%s: supports_image=%s",
+                active.provider_id,
+                active.model,
+                supports,
+            )
+            # Fire full probe in background to persist video support too
+            import asyncio
 
-        asyncio.create_task(
-            manager.probe_model_multimodal(active.provider_id, active.model),
-        )
+            asyncio.create_task(
+                manager.probe_model_multimodal(
+                    active.provider_id,
+                    active.model,
+                ),
+            )
+        else:
+            # video: must run full probe to get video result
+            logger.info(
+                "Multimodal capability unknown for %s/%s — "
+                "running full probe for video support...",
+                active.provider_id,
+                active.model,
+            )
+            result = await manager.probe_model_multimodal(
+                active.provider_id,
+                active.model,
+            )
+            supports = result.get("supports_video", False)
+            logger.info(
+                "Full probe completed for %s/%s: supports_video=%s",
+                active.provider_id,
+                active.model,
+                supports,
+            )
         return supports
     except Exception as e:
         logger.warning("Auto-probe in view_media failed: %s", e)
         return None
 
 
-def _check_multimodal_support() -> bool:
-    """Check whether the active model supports multimodal input (sync).
+def _check_multimodal_support(media_type: str = "image") -> bool:
+    """Check whether the active model supports the given media type (sync).
 
-    Returns True only when explicitly confirmed. Returns False for
-    unknown (None) or explicitly unsupported (False).
+    For ``image``: returns True when supports_image or supports_multimodal
+    is explicitly True.
+    For ``video``: returns True only when supports_video is explicitly True.
 
-    The tool is still *registered* so the agent can attempt to call it;
-    the async version ``_check_and_probe_multimodal`` handles the
+    Returns False for unknown (None) or explicitly unsupported (False).
+    The tool is still *registered*; the async probe path handles the
     probe-on-demand logic.
     """
     try:
-        from ..prompt import get_active_model_multimodal_raw
+        from ..prompt import _get_active_model_info
 
-        raw = get_active_model_multimodal_raw()
-        return raw is True
+        model_info, _ = _get_active_model_info()
+        if model_info is None:
+            return True
+        if media_type == "video":
+            return model_info.supports_video is True
+        # image: True if supports_image or the combined supports_multimodal
+        return (
+            model_info.supports_image is True
+            or model_info.supports_multimodal is True
+        )
     except Exception:
         return True
 
@@ -277,8 +318,8 @@ async def view_image(image_path: str) -> ToolResponse:
     """
     # Determine whether we need a fallback hint
     fallback_hint: str | None = None
-    if not _check_multimodal_support():
-        probe_result = await _probe_multimodal_if_needed()
+    if not _check_multimodal_support("image"):
+        probe_result = await _probe_multimodal_if_needed("image")
         if probe_result is not True:
             fallback_hint = _get_multimodal_fallback_hint("image", image_path)
 
@@ -347,8 +388,8 @@ async def view_video(video_path: str) -> ToolResponse:
             A VideoBlock the model can inspect, or an error message.
     """
     fallback_hint: str | None = None
-    if not _check_multimodal_support():
-        probe_result = await _probe_multimodal_if_needed()
+    if not _check_multimodal_support("video"):
+        probe_result = await _probe_multimodal_if_needed("video")
         if probe_result is not True:
             fallback_hint = _get_multimodal_fallback_hint("video", video_path)
 

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -154,20 +154,27 @@ async def _probe_multimodal_if_needed() -> bool | None:
 
         logger.info(
             "Multimodal capability unknown for %s/%s — "
-            "running probe on first view_image/view_video call...",
+            "running image-only probe on first view_image/view_video call...",
             active.provider_id,
             active.model,
         )
         result = await manager.probe_model_multimodal(
             active.provider_id,
             active.model,
+            image_only=True,
         )
         supports = result.get("supports_image", False)
         logger.info(
-            "Multimodal probe completed for %s/%s: supports_image=%s",
+            "Image probe completed for %s/%s: supports_image=%s",
             active.provider_id,
             active.model,
             supports,
+        )
+        # Fire full probe in background to also determine video support
+        import asyncio
+
+        asyncio.create_task(
+            manager.probe_model_multimodal(active.provider_id, active.model),
         )
         return supports
     except Exception as e:

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -219,13 +219,13 @@ def _get_multimodal_fallback_hint(media_type: str, path: str) -> str:
             path,
         )
         return (
-            f"[Note: the current model's multimodal capability is not "
-            f"configured — you cannot see this {media_type}, but it has "
-            f"been shown to the user. Inform the user that you cannot "
-            f"analyze the {media_type} content. If they believe this model "
-            f"supports vision/multimodal, they can go to provider settings "
-            f"and set `supports_multimodal: true` for this model, then "
-            f"retry.]"
+            f"[Note: this model does not appear to support multimodal "
+            f"input — no multimodal capability was detected. You cannot "
+            f"see this {media_type}, but it has been shown to the user. "
+            f"Inform the user that you cannot analyze the {media_type} "
+            f"content. If they believe this model supports vision, they "
+            f"can override this in provider settings by setting "
+            f"`supports_multimodal: true`, then retry.]"
         )
 
     logger.warning(

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -116,17 +116,57 @@ def _validate_media_path(
     return resolved, None
 
 
+async def _probe_multimodal_if_needed() -> bool | None:
+    """Trigger a multimodal probe if capability is unknown (None).
+
+    Returns the probe result (True/False) if a probe was run,
+    or None if no probe was needed or the probe failed.
+    """
+    try:
+        from ..prompt import _get_active_model_info
+        from ...providers.provider_manager import ProviderManager
+
+        model_info, _ = _get_active_model_info()
+        if model_info is None or model_info.supports_multimodal is not None:
+            return None
+
+        manager = ProviderManager.get_instance()
+        active = manager.get_active_model()
+        if not active:
+            return None
+
+        logger.info(
+            "Multimodal capability unknown for %s/%s — "
+            "running probe on first view_image/view_video call...",
+            active.provider_id,
+            active.model,
+        )
+        result = await manager.probe_model_multimodal(
+            active.provider_id,
+            active.model,
+        )
+        supports = result.get("supports_image", False)
+        logger.info(
+            "Multimodal probe completed for %s/%s: supports_image=%s",
+            active.provider_id,
+            active.model,
+            supports,
+        )
+        return supports
+    except Exception as e:
+        logger.warning("Auto-probe in view_media failed: %s", e)
+        return None
+
+
 def _check_multimodal_support() -> bool:
-    """Check whether the active model supports multimodal input.
+    """Check whether the active model supports multimodal input (sync).
 
-    Returns False when multimodal is explicitly unsupported OR unknown
-    (not yet probed). This stays consistent with the proactive media
-    stripping in ``_reasoning``/``_summarizing`` which uses
-    ``get_active_model_supports_multimodal()`` (also treats None as False).
+    Returns True only when explicitly confirmed. Returns False for
+    unknown (None) or explicitly unsupported (False).
 
-    The tool is still *registered* so the agent can attempt to call it,
-    but at runtime it gets a clear text fallback guiding the user to
-    configure multimodal support.
+    The tool is still *registered* so the agent can attempt to call it;
+    the async version ``_check_and_probe_multimodal`` handles the
+    probe-on-demand logic.
     """
     try:
         from ..prompt import get_active_model_multimodal_raw
@@ -137,8 +177,13 @@ def _check_multimodal_support() -> bool:
         return True
 
 
-def _multimodal_fallback_response(media_type: str, path: str) -> ToolResponse:
-    """Return a text-only fallback when multimodal is not available."""
+def _get_multimodal_fallback_hint(media_type: str, path: str) -> str:
+    """Build a text hint for the model when multimodal is not available.
+
+    The actual media block is still included in the response so the
+    frontend/user can see it; the hint tells the agent it cannot perceive
+    the media itself.
+    """
     try:
         from ..prompt import get_active_model_multimodal_raw
 
@@ -149,43 +194,38 @@ def _multimodal_fallback_response(media_type: str, path: str) -> ToolResponse:
     if raw is None:
         logger.warning(
             "view_%s was called but multimodal capability has not been "
-            "confirmed for the active model. The %s at '%s' cannot be "
-            "sent to the model yet. To enable, set supports_multimodal=true "
-            "in the model's provider configuration, or trigger a multimodal "
-            "probe by connecting the model with a vision-capable endpoint.",
+            "confirmed for the active model. The %s at '%s' will be "
+            "shown to the user but the model cannot see it. "
+            "To fix, set supports_multimodal=true in provider settings.",
             media_type,
             media_type,
             path,
         )
-        user_hint = (
-            f"[Multimodal not configured] The {media_type} at '{path}' "
-            f"was located successfully, but the current model has not been "
-            f"confirmed to support multimodal ({media_type}) input. "
-            f"Please inform the user: to enable {media_type} viewing, "
-            f"set `supports_multimodal: true` in the model configuration "
-            f"(provider settings), or connect to a vision-capable model."
-        )
-    else:
-        logger.warning(
-            "view_%s was called but the active model explicitly does not "
-            "support multimodal input. The %s at '%s' cannot be sent to "
-            "the model.",
-            media_type,
-            media_type,
-            path,
-        )
-        user_hint = (
-            f"[Multimodal not supported] The {media_type} at '{path}' "
-            f"was located successfully, but the current model does not "
-            f"support multimodal ({media_type}) input. Please inform the "
-            f"user that this model cannot process {media_type} content, "
-            f"and suggest switching to a vision-capable model."
+        return (
+            f"[Note: the current model's multimodal capability is not "
+            f"configured — you cannot see this {media_type}, but it has "
+            f"been shown to the user. Inform the user that you cannot "
+            f"analyze the {media_type} content. If they believe this model "
+            f"supports vision/multimodal, they can go to provider settings "
+            f"and set `supports_multimodal: true` for this model, then "
+            f"retry.]"
         )
 
-    return ToolResponse(
-        content=[
-            TextBlock(type="text", text=user_hint),
-        ],
+    logger.warning(
+        "view_%s was called but the active model explicitly does not "
+        "support multimodal input. The %s at '%s' will be shown to "
+        "the user but the model cannot see it.",
+        media_type,
+        media_type,
+        path,
+    )
+    return (
+        f"[Note: the current model does not support multimodal input — "
+        f"you cannot see this {media_type}, but it has been shown to "
+        f"the user. Inform the user that you cannot analyze the "
+        f"{media_type} content. If they believe this model actually "
+        f"supports vision, they can override `supports_multimodal: true` "
+        f"in the provider settings, or switch to a vision-capable model.]"
     )
 
 
@@ -197,6 +237,12 @@ async def view_image(image_path: str) -> ToolResponse:
     online images — the URL is passed directly to the model without
     downloading.
 
+    When the model does not support multimodal, the image is still
+    returned (so the user/frontend can see it) along with a text hint
+    telling the agent it cannot perceive the image. The downstream
+    media-stripping pipeline will remove the ImageBlock before sending
+    to the model.
+
     Args:
         image_path (`str`):
             Local path or HTTP(S) URL of the image to view.
@@ -205,8 +251,12 @@ async def view_image(image_path: str) -> ToolResponse:
         `ToolResponse`:
             An ImageBlock the model can inspect, or an error message.
     """
+    # Determine whether we need a fallback hint
+    fallback_hint: str | None = None
     if not _check_multimodal_support():
-        return _multimodal_fallback_response("image", image_path)
+        probe_result = await _probe_multimodal_if_needed()
+        if probe_result is not True:
+            fallback_hint = _get_multimodal_fallback_hint("image", image_path)
 
     if _is_url(image_path):
         err = _validate_url_extension(
@@ -216,16 +266,18 @@ async def view_image(image_path: str) -> ToolResponse:
         )
         if err is not None:
             return err
+        text_msg = (
+            fallback_hint
+            if fallback_hint
+            else f"Image loaded from URL: {image_path}"
+        )
         return ToolResponse(
             content=[
                 ImageBlock(
                     type="image",
                     source={"type": "url", "url": image_path},
                 ),
-                TextBlock(
-                    type="text",
-                    text=f"Image loaded from URL: {image_path}",
-                ),
+                TextBlock(type="text", text=text_msg),
             ],
         )
 
@@ -237,16 +289,16 @@ async def view_image(image_path: str) -> ToolResponse:
     if err is not None:
         return err
 
+    text_msg = (
+        fallback_hint if fallback_hint else f"Image loaded: {resolved.name}"
+    )
     return ToolResponse(
         content=[
             ImageBlock(
                 type="image",
                 source={"type": "url", "url": str(resolved)},
             ),
-            TextBlock(
-                type="text",
-                text=f"Image loaded: {resolved.name}",
-            ),
+            TextBlock(type="text", text=text_msg),
         ],
     )
 
@@ -258,6 +310,10 @@ async def view_video(video_path: str) -> ToolResponse:
     tool produces a video file path.  Also accepts an HTTP(S) URL —
     the URL is passed directly to the model without downloading.
 
+    When the model does not support multimodal, the video is still
+    returned (so the user/frontend can see it) along with a text hint
+    telling the agent it cannot perceive the video.
+
     Args:
         video_path (`str`):
             Local path or HTTP(S) URL of the video to view.
@@ -266,8 +322,11 @@ async def view_video(video_path: str) -> ToolResponse:
         `ToolResponse`:
             A VideoBlock the model can inspect, or an error message.
     """
+    fallback_hint: str | None = None
     if not _check_multimodal_support():
-        return _multimodal_fallback_response("video", video_path)
+        probe_result = await _probe_multimodal_if_needed()
+        if probe_result is not True:
+            fallback_hint = _get_multimodal_fallback_hint("video", video_path)
 
     if _is_url(video_path):
         err = _validate_url_extension(
@@ -277,16 +336,18 @@ async def view_video(video_path: str) -> ToolResponse:
         )
         if err is not None:
             return err
+        text_msg = (
+            fallback_hint
+            if fallback_hint
+            else f"Video loaded from URL: {video_path}"
+        )
         return ToolResponse(
             content=[
                 VideoBlock(
                     type="video",
                     source={"type": "url", "url": video_path},
                 ),
-                TextBlock(
-                    type="text",
-                    text=f"Video loaded from URL: {video_path}",
-                ),
+                TextBlock(type="text", text=text_msg),
             ],
         )
 
@@ -298,15 +359,15 @@ async def view_video(video_path: str) -> ToolResponse:
     if err is not None:
         return err
 
+    text_msg = (
+        fallback_hint if fallback_hint else f"Video loaded: {resolved.name}"
+    )
     return ToolResponse(
         content=[
             VideoBlock(
                 type="video",
                 source={"type": "url", "url": str(resolved)},
             ),
-            TextBlock(
-                type="text",
-                text=f"Video loaded: {resolved.name}",
-            ),
+            TextBlock(type="text", text=text_msg),
         ],
     )

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Load image or video files into the LLM context for analysis."""
 
+import logging
 import mimetypes
 import os
 import unicodedata
@@ -10,6 +11,8 @@ from typing import Optional
 
 from agentscope.message import ImageBlock, TextBlock, VideoBlock
 from agentscope.tool import ToolResponse
+
+logger = logging.getLogger(__name__)
 
 _IMAGE_EXTENSIONS = {
     ".png",
@@ -113,6 +116,79 @@ def _validate_media_path(
     return resolved, None
 
 
+def _check_multimodal_support() -> bool:
+    """Check whether the active model supports multimodal input.
+
+    Returns False when multimodal is explicitly unsupported OR unknown
+    (not yet probed). This stays consistent with the proactive media
+    stripping in ``_reasoning``/``_summarizing`` which uses
+    ``get_active_model_supports_multimodal()`` (also treats None as False).
+
+    The tool is still *registered* so the agent can attempt to call it,
+    but at runtime it gets a clear text fallback guiding the user to
+    configure multimodal support.
+    """
+    try:
+        from ..prompt import get_active_model_multimodal_raw
+
+        raw = get_active_model_multimodal_raw()
+        return raw is True
+    except Exception:
+        return True
+
+
+def _multimodal_fallback_response(media_type: str, path: str) -> ToolResponse:
+    """Return a text-only fallback when multimodal is not available."""
+    try:
+        from ..prompt import get_active_model_multimodal_raw
+
+        raw = get_active_model_multimodal_raw()
+    except Exception:
+        raw = None
+
+    if raw is None:
+        logger.warning(
+            "view_%s was called but multimodal capability has not been "
+            "confirmed for the active model. The %s at '%s' cannot be "
+            "sent to the model yet. To enable, set supports_multimodal=true "
+            "in the model's provider configuration, or trigger a multimodal "
+            "probe by connecting the model with a vision-capable endpoint.",
+            media_type,
+            media_type,
+            path,
+        )
+        user_hint = (
+            f"[Multimodal not configured] The {media_type} at '{path}' "
+            f"was located successfully, but the current model has not been "
+            f"confirmed to support multimodal ({media_type}) input. "
+            f"Please inform the user: to enable {media_type} viewing, "
+            f"set `supports_multimodal: true` in the model configuration "
+            f"(provider settings), or connect to a vision-capable model."
+        )
+    else:
+        logger.warning(
+            "view_%s was called but the active model explicitly does not "
+            "support multimodal input. The %s at '%s' cannot be sent to "
+            "the model.",
+            media_type,
+            media_type,
+            path,
+        )
+        user_hint = (
+            f"[Multimodal not supported] The {media_type} at '{path}' "
+            f"was located successfully, but the current model does not "
+            f"support multimodal ({media_type}) input. Please inform the "
+            f"user that this model cannot process {media_type} content, "
+            f"and suggest switching to a vision-capable model."
+        )
+
+    return ToolResponse(
+        content=[
+            TextBlock(type="text", text=user_hint),
+        ],
+    )
+
+
 async def view_image(image_path: str) -> ToolResponse:
     """Load an image file into the LLM context so the model can see it.
 
@@ -129,6 +205,9 @@ async def view_image(image_path: str) -> ToolResponse:
         `ToolResponse`:
             An ImageBlock the model can inspect, or an error message.
     """
+    if not _check_multimodal_support():
+        return _multimodal_fallback_response("image", image_path)
+
     if _is_url(image_path):
         err = _validate_url_extension(
             image_path,
@@ -187,6 +266,9 @@ async def view_video(video_path: str) -> ToolResponse:
         `ToolResponse`:
             A VideoBlock the model can inspect, or an error message.
     """
+    if not _check_multimodal_support():
+        return _multimodal_fallback_response("video", video_path)
+
     if _is_url(video_path):
         err = _validate_url_extension(
             video_path,

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -119,6 +119,10 @@ def _validate_media_path(
 async def _probe_multimodal_if_needed() -> bool | None:
     """Trigger a multimodal probe if capability is unknown (None).
 
+    Uses the same agent-specific model resolution as ``_get_active_model_info``
+    so that per-agent model overrides are respected (rather than falling back
+    to the global active model, which may be a different model).
+
     Returns the probe result (True/False) if a probe was run,
     or None if no probe was needed or the probe failed.
     """
@@ -130,8 +134,21 @@ async def _probe_multimodal_if_needed() -> bool | None:
         if model_info is None or model_info.supports_multimodal is not None:
             return None
 
+        # Resolve agent-specific active model (mirrors _get_active_model_info)
         manager = ProviderManager.get_instance()
-        active = manager.get_active_model()
+        active = None
+        try:
+            from ...app.agent_context import get_current_agent_id
+            from ...config.config import load_agent_config
+
+            agent_id = get_current_agent_id()
+            agent_config = load_agent_config(agent_id)
+            if agent_config.active_model:
+                active = agent_config.active_model
+        except Exception:
+            pass
+        if not active:
+            active = manager.get_active_model()
         if not active:
             return None
 

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -169,6 +169,7 @@ class AnthropicProvider(Provider):
         self,
         model_id: str,
         timeout: float = 10,
+        image_only: bool = False,  # pylint: disable=unused-argument
     ) -> ProbeResult:
         """Probe multimodal support using Anthropic messages API format.
 

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -145,6 +145,7 @@ class GeminiProvider(Provider):
         self,
         model_id: str,
         timeout: float = 10,
+        image_only: bool = False,
     ) -> ProbeResult:
         """Probe multimodal support using Gemini generateContent API.
 
@@ -152,6 +153,13 @@ class GeminiProvider(Provider):
         modality is probed independently with a minimal payload.
         """
         img_ok, img_msg = await self._probe_image_support(model_id, timeout)
+        if image_only:
+            return ProbeResult(
+                supports_image=img_ok,
+                supports_video=False,
+                image_message=img_msg,
+                video_message="Skipped: image_only=True",
+            )
         vid_ok, vid_msg = await self._probe_video_support(model_id, timeout)
         return ProbeResult(
             supports_image=img_ok,

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -180,6 +180,7 @@ class OpenAIProvider(Provider):
         self,
         model_id: str,
         timeout: float = 10,
+        image_only: bool = False,
     ) -> ProbeResult:
         """Probe multimodal support via OpenAI-compatible API."""
         from .multimodal_prober import ProbeResult
@@ -198,6 +199,13 @@ class OpenAIProvider(Provider):
                 supports_video=False,
                 image_message=img_msg,
                 video_message="Skipped: image probe failed",
+            )
+        if image_only:
+            return ProbeResult(
+                supports_image=img_ok,
+                supports_video=False,
+                image_message=img_msg,
+                video_message="Skipped: image_only=True",
             )
         vid_ok, vid_msg = await self._probe_video_support(
             model_id,

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -315,8 +315,17 @@ class Provider(ProviderInfo, ABC):
         self,
         model_id: str,  # pylint: disable=unused-argument
         timeout: float = 10,  # pylint: disable=unused-argument
+        image_only: bool = False,  # pylint: disable=unused-argument
     ) -> ProbeResult:
         """Probe if a model supports multimodal input.
+
+        Args:
+            model_id: Model identifier.
+            timeout: Per-probe timeout in seconds.
+            image_only: When True, skip the video probe and return after
+                the image probe only.  Use this for fast checks (e.g.
+                from ``view_image``) to avoid blocking on the slower
+                video probe.
 
         Default implementation returns ProbeResult() (all False).
         Subclasses with API access should override.

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1117,21 +1117,41 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         self,
         provider_id: str,
         model_id: str,
+        image_only: bool = False,
     ) -> dict:
-        """Probe a model's multimodal capabilities and persist the result."""
+        """Probe a model's multimodal capabilities and persist the result.
+
+        Args:
+            provider_id: Provider identifier.
+            model_id: Model identifier.
+            image_only: When True, skip the video probe for a faster result.
+                Only ``supports_image`` will be accurate; ``supports_video``
+                will remain at its previous value (not updated).
+        """
         provider_id = self._normalize_provider_id(provider_id)
         provider = self.get_provider(provider_id)
         if not provider:
             return {"error": f"Provider '{provider_id}' not found"}
 
-        result = await provider.probe_model_multimodal(model_id)
+        result = await provider.probe_model_multimodal(
+            model_id,
+            image_only=image_only,
+        )
 
-        # Update the model's capability flags
+        # Update the model's capability flags.
+        # For image_only probes, leave supports_video untouched so a
+        # subsequent full probe can fill it in correctly.
         for model in provider.models + provider.extra_models:
             if model.id == model_id:
                 model.supports_image = result.supports_image
-                model.supports_video = result.supports_video
-                model.supports_multimodal = result.supports_multimodal
+                if not image_only:
+                    model.supports_video = result.supports_video
+                    model.supports_multimodal = result.supports_multimodal
+                else:
+                    # Partial update: derive supports_multimodal from
+                    # image alone; video will be updated by the full probe.
+                    if result.supports_image:
+                        model.supports_multimodal = True
                 model.probe_source = "probed"
                 break
 


### PR DESCRIPTION
## Description

Always register `view_image`/`view_video` tools when enabled in config, instead of filtering them out at registration time based on model multimodal capability. When called at runtime without multimodal support, return a clear text fallback guiding the user to configure their model, rather than silently hiding the tools.

**Related Issue:** Fixes #3566

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review