### PR TITLE
feat(DingTalk): add @mention sender on reply in group chats

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -28,6 +28,7 @@ export interface DingTalkConfig extends BaseChannelConfig {
   card_template_id: string;
   card_template_key: string;
   robot_code: string;
+  at_sender_on_reply?: boolean;
 }
 
 export interface FeishuConfig extends BaseChannelConfig {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -613,6 +613,8 @@
     "dingtalkAuthSuccess": "DingTalk bot created. Client ID and Client Secret have been filled in.",
     "dingtalkQrcodeFailed": "Failed to get DingTalk QR code. Please try again.",
     "dingtalkQrcodeExpired": "QR code expired, please get a new one.",
+    "atSenderOnReply": "@ Sender on Reply",
+    "atSenderOnReplyTooltip": "When enabled, the bot will @mention the sender in its first reply message in group chats. Note: In card mode, @mention only works for enterprise internal members.",
     "wecomCancelled": "Authorization cancelled",
     "wecomAuthFailed": "Authorization failed: {{msg}}",
     "voiceSetupGuide": "Set up a Twilio account, purchase a phone number, then enter your credentials below. Find your Account SID and Auth Token on the Twilio Console dashboard. The Phone Number SID is listed under Phone Numbers → Active Numbers.",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -554,6 +554,8 @@
     "dingtalkAuthSuccess": "DingTalkボットが作成されました。Client IDとClient Secretが自動入力されました。",
     "dingtalkQrcodeFailed": "DingTalk QRコードの取得に失敗しました。もう一度お試しください。",
     "dingtalkQrcodeExpired": "QRコードの有効期限が切れました。再取得してください。",
+    "atSenderOnReply": "返信時に送信者を@メンション",
+    "atSenderOnReplyTooltip": "有効にすると、ボットはグループチャットでの返信の最初のメッセージで送信者を@メンションします。注意：カードモードでは、@メンションは企業内部メンバーのみ有効です。",
     "wecomCancelled": "認証がキャンセルされました",
     "wecomAuthFailed": "認証に失敗しました: {{msg}}",
     "filterAll": "すべて",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -559,6 +559,8 @@
     "dingtalkAuthSuccess": "Бот DingTalk создан. Client ID и Client Secret заполнены автоматически.",
     "dingtalkQrcodeFailed": "Не удалось получить QR-код DingTalk. Попробуйте ещё раз.",
     "dingtalkQrcodeExpired": "QR-код истёк. Получите новый.",
+    "atSenderOnReply": "@ отправителя при ответе",
+    "atSenderOnReplyTooltip": "При включении бот будет упоминать отправителя в первом сообщении ответа в групповых чатах. Примечание: в режиме карточек @упоминание работает только для внутренних сотрудников организации.",
     "wecomCancelled": "Авторизация отменена",
     "wecomAuthFailed": "Ошибка авторизации: {{msg}}",
     "filterAll": "Все",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -587,6 +587,8 @@
     "dingtalkAuthSuccess": "钉钉机器人创建成功，Client ID 与 Client Secret 已自动填入",
     "dingtalkQrcodeFailed": "获取钉钉二维码失败，请稍后重试",
     "dingtalkQrcodeExpired": "二维码已过期，请重新获取",
+    "atSenderOnReply": "回复时@发送者",
+    "atSenderOnReplyTooltip": "开启后，机器人在群聊中回复时会在第一条消息中@发送者。注意：卡片模式下，@功能仅对企业内部成员生效。",
     "wecomCancelled": "授权已取消",
     "wecomAuthFailed": "授权失败：{{msg}}",
     "voiceSetupGuide": "请先注册 Twilio 账户并购买电话号码，然后在下方填写凭据。Account SID 和 Auth Token 可在 Twilio 控制台首页找到。Phone Number SID 在 Phone Numbers → Active Numbers 中查看。",

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -439,6 +439,14 @@ export function ChannelDrawer({
                 );
               }}
             </Form.Item>
+            <Form.Item
+              name="at_sender_on_reply"
+              label={t("channels.atSenderOnReply")}
+              tooltip={t("channels.atSenderOnReplyTooltip")}
+              valuePropName="checked"
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -156,6 +156,7 @@ class DingTalkChannel(BaseChannel):
         filter_thinking: bool = False,
         require_mention: bool = False,
         card_auto_layout: bool = False,
+        at_sender_on_reply: bool = False,
     ):
         super().__init__(
             process,
@@ -178,6 +179,7 @@ class DingTalkChannel(BaseChannel):
         self.card_template_key = card_template_key or "content"
         self.robot_code = robot_code or self.client_id
         self.card_auto_layout = card_auto_layout
+        self.at_sender_on_reply = at_sender_on_reply
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
         )
@@ -261,6 +263,11 @@ class DingTalkChannel(BaseChannel):
             require_mention=os.getenv("DINGTALK_REQUIRE_MENTION", "0") == "1",
             card_auto_layout=os.getenv("DINGTALK_CARD_AUTO_LAYOUT", "0")
             == "1",
+            at_sender_on_reply=os.getenv(
+                "DINGTALK_AT_SENDER_ON_REPLY",
+                "0",
+            )
+            == "1",
         )
 
     @classmethod
@@ -298,6 +305,11 @@ class DingTalkChannel(BaseChannel):
             filter_thinking=filter_thinking,
             require_mention=config.require_mention,
             card_auto_layout=getattr(config, "card_auto_layout", False),
+            at_sender_on_reply=getattr(
+                config,
+                "at_sender_on_reply",
+                False,
+            ),
         )
 
     # ---------------------------
@@ -864,12 +876,41 @@ class DingTalkChannel(BaseChannel):
         session_webhook: str,
         body: str,
         bot_prefix: str = "",
+        at_user_ids: Optional[List[str]] = None,
+        at_dingtalk_ids: Optional[List[str]] = None,
     ) -> bool:
         """Send one text message via DingTalk sessionWebhook. Returns True
-        on success."""
+        on success.
+
+        When ``at_user_ids`` or ``at_dingtalk_ids`` is provided, the
+        ``at`` field is added to the webhook payload so that the
+        mentioned users receive a push notification.  The @mention text
+        is also prepended to the message body (DingTalk requires both).
+        """
         text = (bot_prefix + "  " + body) if body else bot_prefix
+
+        # Build at payload
+        has_at = bool(at_user_ids or at_dingtalk_ids)
+        at_payload: Optional[Dict[str, Any]] = None
+        if has_at:
+            at_payload = {}
+            if at_user_ids:
+                at_payload["atUserIds"] = at_user_ids
+            if at_dingtalk_ids:
+                at_payload["atDingtalkIds"] = at_dingtalk_ids
+            # Prepend @mention text (DingTalk requires it in body too)
+            mentions = []
+            if at_user_ids:
+                mentions.extend(f"@{uid}" for uid in at_user_ids)
+            if at_dingtalk_ids:
+                mentions.extend(f"@{did}" for did in at_dingtalk_ids)
+            text = " ".join(mentions) + "\n" + text
+
         if len(text) > 3500:
-            payload = {"msgtype": "text", "text": {"content": text}}
+            payload: Dict[str, Any] = {
+                "msgtype": "text",
+                "text": {"content": text},
+            }
         else:
             norm = dingtalk_markdown.normalize_dingtalk_markdown(text)
             payload = {
@@ -879,6 +920,10 @@ class DingTalkChannel(BaseChannel):
                     "text": norm,
                 },
             }
+
+        if at_payload:
+            payload["at"] = at_payload
+
         return await self._send_payload_via_session_webhook(
             session_webhook,
             payload,
@@ -2083,6 +2128,7 @@ class DingTalkChannel(BaseChannel):
         last_response = None
         accumulated_parts: list = []
         _acked_early = False
+        _at_sent = False  # Track whether @mention has been sent
         conversation_id = str(meta.get("conversation_id") or "")
         incoming_msg_id = str(meta.get("message_id") or "")
 
@@ -2108,6 +2154,19 @@ class DingTalkChannel(BaseChannel):
 
         card: Optional[ActiveAICard] = None
         card_full_text = ""
+        # Build @mention prefix for AI card content.
+        # DingTalk STREAM cards require <a atId=userId>nick</a> in the
+        # Markdown body to trigger the @ notification.
+        card_at_prefix = ""
+        if (
+            self.at_sender_on_reply
+            and meta.get("is_group", False)
+            and meta.get("sender_staff_id", "")
+        ):
+            at_id = meta["sender_staff_id"]
+            at_nick = meta.get("sender_nick", "") or at_id
+            card_at_prefix = f"<a atId={at_id}>{at_nick}</a>\n"
+
         if use_ai_card:
             try:
                 card = await self._create_ai_card(
@@ -2154,7 +2213,7 @@ class DingTalkChannel(BaseChannel):
                             card_full_text = next_text
                             await self._stream_ai_card(
                                 card,
-                                card_full_text,
+                                card_at_prefix + card_full_text,
                                 finalize=False,
                             )
                     except Exception:
@@ -2185,10 +2244,31 @@ class DingTalkChannel(BaseChannel):
                     )
                 elif use_multi and parts and session_webhook:
                     if body.strip():
+                        # Resolve @mention for the first message.
+                        at_uids = None
+                        at_dids = None
+                        is_group = meta.get("is_group", False)
+                        if (
+                            self.at_sender_on_reply
+                            and not _at_sent
+                            and is_group
+                        ):
+                            staff_id = meta.get("sender_staff_id", "")
+                            dingtalk_id = meta.get(
+                                "sender_dingtalk_id",
+                                "",
+                            )
+                            if staff_id:
+                                at_uids = [staff_id]
+                            elif dingtalk_id:
+                                at_dids = [dingtalk_id]
+                            _at_sent = True
                         await self._send_via_session_webhook(
                             session_webhook,
                             body.strip(),
                             bot_prefix="",
+                            at_user_ids=at_uids,
+                            at_dingtalk_ids=at_dids,
                         )
                         if not _acked_early:
                             self._ack_early(
@@ -2236,7 +2316,7 @@ class DingTalkChannel(BaseChannel):
                     final_text = bot_prefix + f"Error: {err_msg}"
                 await self._stream_ai_card(
                     card,
-                    final_text,
+                    card_at_prefix + final_text,
                     finalize=True,
                 )
             except Exception:
@@ -2838,6 +2918,15 @@ class DingTalkChannel(BaseChannel):
         )
         runtime = tea_util_models.RuntimeOptions()
 
+        # Resolve @mention for AI card in group chat.
+        # card_at_user_ids on CreateCardRequest accepts List[str] of
+        # enterprise userId (senderStaffId).  Only set when available.
+        card_at_user_ids: Optional[List[str]] = None
+        card_user_id_type: Optional[int] = None
+        if self.at_sender_on_reply and is_group and sender_staff_id:
+            card_at_user_ids = [sender_staff_id]
+            card_user_id_type = 1
+
         create_request = dingtalk_card_models.CreateCardRequest(
             card_template_id=self.card_template_id,
             out_track_id=card_instance_id,
@@ -2855,6 +2944,8 @@ class DingTalkChannel(BaseChannel):
                     support_forward=True,
                 )
             ),
+            card_at_user_ids=card_at_user_ids,
+            user_id_type=card_user_id_type,
         )
 
         logger.info(

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -889,20 +889,16 @@ class DingTalkChannel(BaseChannel):
         """
         text = (bot_prefix + "  " + body) if body else bot_prefix
 
-        # Build at payload
-        has_at = bool(at_user_ids or at_dingtalk_ids)
+        # Build at payload and prepend @mention text
         at_payload: Optional[Dict[str, Any]] = None
-        if has_at:
+        if at_user_ids or at_dingtalk_ids:
             at_payload = {}
-            if at_user_ids:
-                at_payload["atUserIds"] = at_user_ids
-            if at_dingtalk_ids:
-                at_payload["atDingtalkIds"] = at_dingtalk_ids
-            # Prepend @mention text (DingTalk requires it in body too)
             mentions = []
             if at_user_ids:
+                at_payload["atUserIds"] = at_user_ids
                 mentions.extend(f"@{uid}" for uid in at_user_ids)
             if at_dingtalk_ids:
+                at_payload["atDingtalkIds"] = at_dingtalk_ids
                 mentions.extend(f"@{did}" for did in at_dingtalk_ids)
             text = " ".join(mentions) + "\n" + text
 

--- a/src/qwenpaw/app/channels/dingtalk/handler.py
+++ b/src/qwenpaw/app/channels/dingtalk/handler.py
@@ -289,6 +289,20 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
                 )
                 or getattr(incoming_message, "senderStaffId", None)
                 or "",
+                "sender_dingtalk_id": getattr(
+                    incoming_message,
+                    "sender_id",
+                    None,
+                )
+                or getattr(incoming_message, "senderId", None)
+                or "",
+                "sender_nick": getattr(
+                    incoming_message,
+                    "sender_nick",
+                    None,
+                )
+                or getattr(incoming_message, "senderNick", None)
+                or "",
             }
             if is_bot_mentioned:
                 meta["bot_mentioned"] = True

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -224,6 +224,7 @@ class DingTalkConfig(BaseChannelConfig):
     robot_code: str = ""
     media_dir: Optional[str] = None
     card_auto_layout: bool = False
+    at_sender_on_reply: bool = False
 
 
 class FeishuConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

Add at_sender_on_reply option to DingTalk channel config. When enabled, the bot @mentions the sender in its first reply in group chats.

- Webhook (markdown) path: prepend @userId text and add at payload via sessionWebhook; prefer senderStaffId, fall back to senderId
- AI card (streaming) path: set card_at_user_ids on CreateCardRequest and embed <a atId=userId>nick</a> in streamed content; requires enterprise senderStaffId, skipped otherwise
- Frontend: add toggle switch with i18n (EN/ZH/JA/RU); tooltip notes card mode only supports enterprise members

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
