### PR TITLE
feat(chat): display sender identity and timestamps in conversation history

### DIFF
--- a/console/src/api/types/chat.ts
+++ b/console/src/api/types/chat.ts
@@ -13,9 +13,18 @@ export interface ChatSpec {
   pinned?: boolean; // Whether the chat is pinned to the top
 }
 
+export interface MessageMetadata {
+  original_id?: string;
+  original_name?: string;
+  original_timestamp?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
 export interface Message {
   role: string;
   content: unknown;
+  name?: string;
+  metadata?: MessageMetadata | null;
   [key: string]: unknown;
 }
 

--- a/console/src/pages/Chat/components/SenderInfoCard/index.module.less
+++ b/console/src/pages/Chat/components/SenderInfoCard/index.module.less
@@ -1,0 +1,25 @@
+.senderInfo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 0 4px 0;
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: 0.65;
+}
+
+.senderName {
+  font-weight: 600;
+  color: inherit;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timestamp {
+  color: inherit;
+  font-size: 11px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}

--- a/console/src/pages/Chat/components/SenderInfoCard/index.tsx
+++ b/console/src/pages/Chat/components/SenderInfoCard/index.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import styles from "./index.module.less";
+
+interface SenderInfoCardProps {
+  data: {
+    name: string;
+    role: "user" | "assistant" | string;
+    timestamp: string | null;
+  };
+}
+
+/**
+ * CoPawSenderInfoCard — displays sender name and message timestamp
+ * in the conversation history.
+ *
+ * Rendered as a custom card before each AgentScopeRuntimeRequestCard
+ * or AgentScopeRuntimeResponseCard.
+ */
+const SenderInfoCard: React.FC<SenderInfoCardProps> = ({ data }) => {
+  const { name, timestamp } = data;
+
+  const formattedTime = React.useMemo(() => {
+    if (!timestamp) return null;
+    try {
+      const date = new Date(timestamp);
+      if (isNaN(date.getTime())) return null;
+      return date.toLocaleString(undefined, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      });
+    } catch {
+      return null;
+    }
+  }, [timestamp]);
+
+  return (
+    <div className={styles.senderInfo}>
+      <span className={styles.senderName}>{name}</span>
+      {formattedTime && (
+        <span className={styles.timestamp}>{formattedTime}</span>
+      )}
+    </div>
+  );
+};
+
+export default SenderInfoCard;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -12,6 +12,7 @@ import { usePlugins } from "../../plugins/PluginContext";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import sessionApi from "./sessionApi";
+import SenderInfoCard from "./components/SenderInfoCard";
 import defaultConfig, { getDefaultConfig } from "./OptionsPanel/defaultConfig";
 import { chatApi } from "../../api/modules/chat";
 import { getApiUrl } from "../../api/config";
@@ -886,6 +887,9 @@ export default function ChatPage() {
       },
       customToolRenderConfig:
         Object.keys(toolRenderConfig).length > 0 ? toolRenderConfig : undefined,
+      cards: {
+        CoPawSenderInfoCard: SenderInfoCard,
+      },
       actions: {
         list: [
           {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -888,7 +888,7 @@ export default function ChatPage() {
       customToolRenderConfig:
         Object.keys(toolRenderConfig).length > 0 ? toolRenderConfig : undefined,
       cards: {
-        CoPawSenderInfoCard: SenderInfoCard,
+        QwenPawSenderInfoCard: SenderInfoCard,
       },
       actions: {
         list: [

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -8,6 +8,7 @@ import api, {
   type ChatHistory,
   type ChatStatus,
   type Message,
+  type MessageMetadata,
 } from "../../../api";
 import { toDisplayUrl } from "../utils";
 
@@ -24,6 +25,7 @@ const ROLE_ASSISTANT = "assistant";
 const TYPE_PLUGIN_CALL_OUTPUT = "plugin_call_output";
 // const CARD_REQUEST = "AgentScopeRuntimeRequestCard";
 const CARD_RESPONSE = "AgentScopeRuntimeResponseCard";
+const CARD_SENDER_INFO = "CoPawSenderInfoCard";
 
 // ---------------------------------------------------------------------------
 // Window globals
@@ -51,7 +53,7 @@ interface ContentItem {
 /** A backend message after role-normalisation (output of toOutputMessage). */
 interface OutputMessage extends Omit<Message, "role"> {
   role: string;
-  metadata: unknown;
+  metadata?: MessageMetadata | null;
   sequence_number?: number;
 }
 
@@ -161,10 +163,28 @@ const toOutputMessage = (msg: Message): OutputMessage => ({
 /** Build a user card (AgentScopeRuntimeRequestCard) from a user message. */
 function buildUserCard(msg: Message): IAgentScopeRuntimeWebUIMessage {
   const contentParts = contentToRequestParts(msg.content);
+  const metadata = msg.metadata as
+    | {
+        original_name?: string;
+        original_timestamp?: string | null;
+      }
+    | null
+    | undefined;
+  const senderName =
+    metadata?.original_name || (msg.name as string | undefined) || ROLE_USER;
+  const timestamp = metadata?.original_timestamp || null;
+
   return {
     id: (msg.id as string) || generateId(),
     role: "user",
     cards: [
+      {
+        code: CARD_SENDER_INFO,
+        data: {
+          name: senderName,
+          timestamp,
+        },
+      },
       {
         code: "AgentScopeRuntimeRequestCard",
         data: {
@@ -179,6 +199,31 @@ function buildUserCard(msg: Message): IAgentScopeRuntimeWebUIMessage {
       },
     ],
   };
+}
+
+/** Extract sender identity from a group of output messages. */
+function extractSenderInfo(outputMessages: OutputMessage[]): {
+  name: string;
+  timestamp: string | null;
+} {
+  for (const msg of outputMessages) {
+    const metadata = msg.metadata as
+      | {
+          original_name?: string;
+          original_timestamp?: string | null;
+        }
+      | null
+      | undefined;
+    const name =
+      metadata?.original_name ||
+      (msg.name as string | undefined) ||
+      ROLE_ASSISTANT;
+    const timestamp = metadata?.original_timestamp || null;
+    if (name !== ROLE_ASSISTANT || timestamp) {
+      return { name, timestamp };
+    }
+  }
+  return { name: ROLE_ASSISTANT, timestamp: null };
 }
 
 /**
@@ -199,10 +244,19 @@ const buildResponseCard = (
     content: normalizeOutputMessageContent(msg.content),
   }));
 
+  const senderInfo = extractSenderInfo(outputMessages);
+
   return {
     id: generateId(),
     role: ROLE_ASSISTANT,
     cards: [
+      {
+        code: CARD_SENDER_INFO,
+        data: {
+          name: senderInfo.name,
+          timestamp: senderInfo.timestamp,
+        },
+      },
       {
         code: CARD_RESPONSE,
         data: {
@@ -422,8 +476,11 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     const lastMsg = messages[messages.length - 1];
     if (lastMsg?.role === ROLE_USER) {
+      const requestCard = lastMsg?.cards?.find(
+        (c) => c.code === "AgentScopeRuntimeRequestCard",
+      );
       const text = extractTextFromContent(
-        lastMsg?.cards?.[0]?.data?.input?.[0]?.content,
+        requestCard?.data?.input?.[0]?.content,
       );
       if (!text) {
         lastMsg.cards = buildUserCard({

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -25,7 +25,7 @@ const ROLE_ASSISTANT = "assistant";
 const TYPE_PLUGIN_CALL_OUTPUT = "plugin_call_output";
 // const CARD_REQUEST = "AgentScopeRuntimeRequestCard";
 const CARD_RESPONSE = "AgentScopeRuntimeResponseCard";
-const CARD_SENDER_INFO = "CoPawSenderInfoCard";
+const CARD_SENDER_INFO = "QwenPawSenderInfoCard";
 
 // ---------------------------------------------------------------------------
 // Window globals

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -329,6 +329,7 @@ def agentscope_msg_to_message(
         metadata = {
             "original_id": msg.id,
             "original_name": msg.name,
+            "original_timestamp": msg.timestamp,
             "metadata": msg.metadata,
         }
 


### PR DESCRIPTION
## Summary

- Display sender name and timestamp above each message in the conversation history
- Backend: include `original_timestamp` from AgentScope `Msg` in message metadata
- Frontend: new `SenderInfoCard` component renders sender name + formatted timestamp
- Fix `patchLastUserMessage` to locate `RequestCard` by code instead of array index

## Changes

| File | Change |
|------|--------|
| `src/qwenpaw/app/runner/utils.py` | Add `original_timestamp: msg.timestamp` to metadata dict |
| `console/src/api/types/chat.ts` | Add `MessageMetadata` interface; extend `Message` with `name` and `metadata` |
| `console/src/pages/Chat/components/SenderInfoCard/` | New component (TSX + LESS) |
| `console/src/pages/Chat/sessionApi/index.ts` | Build `SenderInfoCard` before each Request/Response card; fix `patchLastUserMessage` |
| `console/src/pages/Chat/index.tsx` | Register `CoPawSenderInfoCard` in custom cards |

## Testing

- `tsc -b --noEmit` passes
- `prettier --check` passes
- `black --line-length=79` passes