### PR TITLE
fix(channels): unify media_dir workspace fallback across all channels

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -17,6 +17,7 @@ import { getChannelLabel, type ChannelKey } from "./constants";
 import { useChannelQrcode } from "./useChannelQrcode";
 import styles from "../index.module.less";
 import { useTheme } from "../../../../contexts/ThemeContext";
+import { useAgentStore } from "../../../../stores/agentStore";
 
 const CHANNELS_WITH_ACCESS_CONTROL: ChannelKey[] = [
   "telegram",
@@ -109,6 +110,11 @@ export function ChannelDrawer({
 }: ChannelDrawerProps) {
   const { t, i18n } = useTranslation();
   const { isDark } = useTheme();
+  const { selectedAgent, agents } = useAgentStore();
+  const currentAgent = agents.find((a) => a.id === selectedAgent);
+  const defaultMediaDir = currentAgent?.workspace_dir
+    ? `${currentAgent.workspace_dir}/media`
+    : "~/.qwenpaw/media";
   const currentLang = i18n.language?.startsWith("zh") ? "zh" : "en";
   const label = activeKey ? getChannelLabel(activeKey, t) : activeLabel;
   const { message } = useAppMessage();
@@ -489,7 +495,7 @@ export function ChannelDrawer({
               <Input placeholder="Optional" />
             </Form.Item>
             <Form.Item name="media_dir" label={t("channels.weixinMediaDir")}>
-              <Input placeholder="~/.qwenpaw/media" />
+              <Input placeholder={defaultMediaDir} />
             </Form.Item>
           </>
         );
@@ -666,7 +672,7 @@ export function ChannelDrawer({
               <Input.Password placeholder="Mattermost bot token" />
             </Form.Item>
             <Form.Item name="media_dir" label={t("channels.weixinMediaDir")}>
-              <Input placeholder="~/.qwenpaw/media/mattermost" />
+              <Input placeholder={defaultMediaDir} />
             </Form.Item>
             <Form.Item
               name="show_typing"
@@ -802,7 +808,7 @@ export function ChannelDrawer({
               <Input.Password placeholder="Secret from WeCom backend" />
             </Form.Item>
             <Form.Item name="media_dir" label={t("channels.weixinMediaDir")}>
-              <Input placeholder="~/.qwenpaw/media" />
+              <Input placeholder={defaultMediaDir} />
             </Form.Item>
             <Form.Item
               name="welcome_text"
@@ -921,7 +927,7 @@ export function ChannelDrawer({
               <Input placeholder="~/.qwenpaw/weixin_bot_token" />
             </Form.Item>
             <Form.Item name="media_dir" label={t("channels.weixinMediaDir")}>
-              <Input placeholder="~/.qwenpaw/media" />
+              <Input placeholder={defaultMediaDir} />
             </Form.Item>
           </>
         );

--- a/src/qwenpaw/app/channels/imessage/channel.py
+++ b/src/qwenpaw/app/channels/imessage/channel.py
@@ -47,6 +47,7 @@ class IMessageChannel(BaseChannel):
         poll_sec: float,
         bot_prefix: str,
         media_dir: str = "",
+        workspace_dir: Path | None = None,
         max_decoded_size: int = 10 * 1024 * 1024,  # 10MB default
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
@@ -79,9 +80,16 @@ class IMessageChannel(BaseChannel):
         self.bot_prefix = bot_prefix
 
         # Create media directory for downloaded files
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else DEFAULT_MEDIA_DIR
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
         )
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = DEFAULT_MEDIA_DIR
         self._media_dir.mkdir(parents=True, exist_ok=True)
 
         # Base64 data size limit
@@ -138,6 +146,7 @@ class IMessageChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "IMessageChannel":
         return cls(
             process=process,
@@ -146,6 +155,7 @@ class IMessageChannel(BaseChannel):
             poll_sec=config.poll_sec,
             bot_prefix=config.bot_prefix or "",
             media_dir=config.media_dir if config.media_dir else "",
+            workspace_dir=workspace_dir,
             max_decoded_size=config.max_decoded_size,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -223,6 +223,7 @@ class MatrixChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> None:
         super().__init__(
             process=process,
@@ -232,6 +233,9 @@ class MatrixChannel(BaseChannel):
             filter_thinking=filter_thinking,
         )
         self._cfg = config
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
+        )
         self._client: Optional[AsyncClient] = None
         self._user_id: Optional[str] = None
         self._sync_task: Optional[asyncio.Task] = None
@@ -275,6 +279,7 @@ class MatrixChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "MatrixChannel":
         if isinstance(config, dict):
             cfg = MatrixChannelConfig(config)
@@ -291,6 +296,7 @@ class MatrixChannel(BaseChannel):
             filter_tool_messages=filter_tool_messages
             or cfg.filter_tool_messages,
             filter_thinking=filter_thinking or cfg.filter_thinking,
+            workspace_dir=workspace_dir,
         )
 
     @classmethod
@@ -1018,6 +1024,8 @@ class MatrixChannel(BaseChannel):
 
     def _media_dir(self) -> Path:
         """Return (and create) the local media storage directory."""
+        if self._workspace_dir:
+            return self._workspace_dir / "media"
         return WORKING_DIR / "media"
 
     def _mxc_to_http(self, mxc_url: str) -> str:

--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -105,6 +105,7 @@ class MattermostChannel(BaseChannel):
         bot_token: str,
         bot_prefix: str = "",
         media_dir: str = "",
+        workspace_dir: Path | None = None,
         show_typing: Optional[bool] = None,
         thread_follow_without_mention: bool = False,
         on_reply_sent: OnReplySent = None,
@@ -131,9 +132,16 @@ class MattermostChannel(BaseChannel):
         self.bot_prefix = bot_prefix
         self._url = url.rstrip("/")
         self._bot_token = bot_token
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
         )
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = _DEFAULT_MEDIA_DIR
         self._show_typing = show_typing if show_typing is not None else True
         self._thread_follow = thread_follow_without_mention
 
@@ -176,6 +184,7 @@ class MattermostChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "MattermostChannel":
         if isinstance(config, dict):
             c = config
@@ -192,6 +201,7 @@ class MattermostChannel(BaseChannel):
             bot_token=_s("bot_token"),
             bot_prefix=_s("bot_prefix"),
             media_dir=_s("media_dir"),
+            workspace_dir=workspace_dir,
             show_typing=c.get("show_typing"),
             thread_follow_without_mention=bool(
                 c.get("thread_follow_without_mention", False),

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -646,6 +646,7 @@ class QQChannel(BaseChannel):
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
         media_dir: str = "",
+        workspace_dir: Path | None = None,
         max_reconnect_attempts: int = 100,
         ack_message: str = "",
     ):
@@ -661,9 +662,16 @@ class QQChannel(BaseChannel):
         self.client_secret = client_secret
         self.bot_prefix = bot_prefix
         self._markdown_enabled = markdown_enabled
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
         )
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = _DEFAULT_MEDIA_DIR
         self._max_reconnect_attempts = max_reconnect_attempts
         self._ack_message = ack_message
 
@@ -784,6 +792,7 @@ class QQChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "QQChannel":
         return cls(
             process=process,
@@ -797,6 +806,7 @@ class QQChannel(BaseChannel):
             filter_tool_messages=filter_tool_messages,
             filter_thinking=filter_thinking,
             media_dir=getattr(config, "media_dir", ""),
+            workspace_dir=workspace_dir,
             max_reconnect_attempts=getattr(
                 config,
                 "max_reconnect_attempts",

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -305,12 +305,16 @@ class TelegramChannel(BaseChannel):
         self._http_proxy = http_proxy or ""
         self._http_proxy_auth = http_proxy_auth or ""
         self.bot_prefix = bot_prefix
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else _DEFAULT_MEDIA_DIR
-        )
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
         )
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = _DEFAULT_MEDIA_DIR
         self._show_typing = show_typing
         self._typing_tasks: dict[str, asyncio.Task] = {}
         self._is_processing: dict[str, bool] = {}

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -105,6 +105,7 @@ class WecomChannel(BaseChannel):
         bot_prefix: str = "",
         media_dir: str = "",
         welcome_text: str = "",
+        workspace_dir: Path | None = None,
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
@@ -131,12 +132,16 @@ class WecomChannel(BaseChannel):
         self.secret = secret
         self.bot_prefix = bot_prefix
         self.welcome_text = welcome_text
-        # Store media_dir config, will be resolved in set_workspace()
-        self._media_dir_config = (
-            Path(media_dir).expanduser() if media_dir else None
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
         )
-        # Default to config or global default until set_workspace is called
-        self._media_dir = self._media_dir_config or DEFAULT_MEDIA_DIR
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = DEFAULT_MEDIA_DIR
         self._max_reconnect_attempts = max_reconnect_attempts
 
         self._client: Any = None
@@ -190,6 +195,7 @@ class WecomChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "WecomChannel":
         return cls(
             process=process,
@@ -199,6 +205,7 @@ class WecomChannel(BaseChannel):
             bot_prefix=getattr(config, "bot_prefix", "") or "",
             media_dir=getattr(config, "media_dir", None) or "",
             welcome_text=getattr(config, "welcome_text", "") or "",
+            workspace_dir=workspace_dir,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,
@@ -1252,57 +1259,6 @@ class WecomChannel(BaseChannel):
             "wecom channel started (bot_id=%s)",
             (self.bot_id or "")[:12],
         )
-
-    def set_workspace(self, workspace, command_registry=None) -> None:
-        """Set workspace and resolve media directory.
-
-        This is called by ChannelManager when the channel is registered.
-        Priority order:
-        1. User-provided config (WECOM_MEDIA_DIR / media_dir param)
-        2. {workspace_dir}/media (e.g. ./workspaces/default/media)
-        3. Global default (e.g. ~/.copaw/media)
-        """
-        # Call parent set_workspace to set _workspace and _command_registry
-        super().set_workspace(workspace, command_registry)
-
-        # User-provided config takes highest priority
-        if self._media_dir_config:
-            self._media_dir = self._media_dir_config
-            logger.info(
-                "wecom media_dir: using user config path=%s",
-                self._media_dir,
-            )
-            return
-
-        if workspace:
-            workspace_dir = workspace.workspace_dir
-            media_dir = workspace_dir / "media"
-            if not media_dir.is_dir():
-                try:
-                    media_dir.mkdir(parents=True, exist_ok=True)
-                    logger.info(
-                        "wecom media_dir: created workspace path=%s",
-                        media_dir,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "wecom media_dir: failed to create path=%s, err=%s",
-                        media_dir,
-                        e,
-                    )
-                    media_dir = DEFAULT_MEDIA_DIR
-            self._media_dir = media_dir
-            logger.info(
-                "wecom media_dir: using workspace path=%s",
-                self._media_dir,
-            )
-        else:
-            # No workspace, use global default
-            self._media_dir = DEFAULT_MEDIA_DIR
-            logger.info(
-                "wecom media_dir: using default path=%s",
-                self._media_dir,
-            )
 
     async def stop(self) -> None:
         if not self.enabled:

--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -76,6 +76,7 @@ class WeixinChannel(BaseChannel):
         base_url: str = "",
         bot_prefix: str = "",
         media_dir: str = "",
+        workspace_dir: Path | None = None,
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
@@ -108,9 +109,16 @@ class WeixinChannel(BaseChannel):
         self._context_tokens_file = (
             self._bot_token_file.parent / "weixin_context_tokens.json"
         )
-        self._media_dir = (
-            Path(media_dir).expanduser() if media_dir else DEFAULT_MEDIA_DIR
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
         )
+        # Use workspace-specific media dir if workspace_dir is provided
+        if not media_dir and self._workspace_dir:
+            self._media_dir = self._workspace_dir / "media"
+        elif media_dir:
+            self._media_dir = Path(media_dir).expanduser()
+        else:
+            self._media_dir = DEFAULT_MEDIA_DIR
 
         self._client: Optional[ILinkClient] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -181,6 +189,7 @@ class WeixinChannel(BaseChannel):
         show_tool_details: bool = True,
         filter_tool_messages: bool = False,
         filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
     ) -> "WeixinChannel":
         return cls(
             process=process,
@@ -190,6 +199,7 @@ class WeixinChannel(BaseChannel):
             base_url=getattr(config, "base_url", "") or "",
             bot_prefix=getattr(config, "bot_prefix", "") or "",
             media_dir=getattr(config, "media_dir", None) or "",
+            workspace_dir=workspace_dir,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
             filter_tool_messages=filter_tool_messages,


### PR DESCRIPTION
## Description

When running multiple workspaces, several channels without workspace_dir support in from_config would fall back to the global DEFAULT_MEDIA_DIR instead of the workspace-specific media directory, causing media files from different agents to be mixed in the same global directory.

Root cause: ChannelManager.from_config uses inspect.signature to filter kwargs before passing to each channel's from_config. Channels whose from_config lacked the workspace_dir parameter silently dropped it. This was introduced in PR #1375 (multi-workspace architecture) but only applied to dingtalk/feishu at the time.

Backend: Added workspace_dir support to 7 channels:

- wecom, mattermost, qq, imessage, weixin — added workspace_dir to both __init__ and from_config
- telegram — had workspace_dir param but didn't use it for _media_dir fallback; fixed
- matrix — _media_dir() was hardcoded to global path; now respects workspace_dir
Frontend: Updated ChannelDrawer.tsx to dynamically display the workspace-aware default media path from agentStore instead of hardcoded ~/.qwenpaw/media.

<img width="1643" height="853" alt="image" src="https://github.com/user-attachments/assets/b7a59a2d-f765-4fbe-af4e-789fb5510aea" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
