### PR TITLE
feat(console): Add Insights sidebar category with Agent Statistics and Token Usage

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -235,16 +235,16 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       label: t("nav.security"),
     },
     {
-      key: "token-usage",
-      icon: <SparkDataLine size={18} />,
-      path: "/token-usage",
-      label: t("nav.tokenUsage"),
-    },
-    {
       key: "agent-stats",
       icon: <SparkBarChartLine size={18} />,
       path: "/agent-stats",
       label: t("nav.agentStats"),
+    },
+    {
+      key: "token-usage",
+      icon: <SparkDataLine size={18} />,
+      path: "/token-usage",
+      label: t("nav.tokenUsage"),
     },
     {
       key: "backups",
@@ -345,6 +345,27 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     },
   ];
 
+  // ── Menu items — insights ─────────────────────────────────────────────
+
+  const insightsMenuItems: MenuProps["items"] = [
+    {
+      key: "insights-group",
+      label: collapsed ? null : t("nav.insights"),
+      children: [
+        {
+          key: "agent-stats",
+          label: collapsed ? null : t("nav.agentStats"),
+          icon: <SparkBarChartLine size={16} />,
+        },
+        {
+          key: "token-usage",
+          label: collapsed ? null : t("nav.tokenUsage"),
+          icon: <SparkDataLine size={16} />,
+        },
+      ],
+    },
+  ];
+
   // ── Menu items — global settings ──────────────────────────────────────
 
   const settingsMenuItems: MenuProps["items"] = [
@@ -376,16 +397,6 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
           key: "security",
           label: collapsed ? null : t("nav.security"),
           icon: <SparkBrowseLine size={16} />,
-        },
-        {
-          key: "token-usage",
-          label: collapsed ? null : t("nav.tokenUsage"),
-          icon: <SparkDataLine size={16} />,
-        },
-        {
-          key: "agent-stats",
-          label: collapsed ? null : t("nav.agentStats"),
-          icon: <SparkBarChartLine size={16} />,
         },
         {
           key: "backups",
@@ -488,6 +499,20 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
               navigate(path);
             }}
             items={settingsMenuItems}
+            theme={isDark ? "dark" : "light"}
+            className={styles.sideMenu}
+          />
+
+          {/* Insights section */}
+          <Menu
+            mode="inline"
+            selectedKeys={[selectedKey]}
+            openKeys={DEFAULT_OPEN_KEYS}
+            onClick={({ key }) => {
+              const path = KEY_TO_PATH[String(key)];
+              if (path) navigate(path);
+            }}
+            items={insightsMenuItems}
             theme={isDark ? "dark" : "light"}
             className={styles.sideMenu}
           />

--- a/console/src/layouts/constants.ts
+++ b/console/src/layouts/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_OPEN_KEYS = [
   "control-group",
   "agent-group",
   "settings-group",
+  "insights-group",
 ];
 
 export const KEY_TO_PATH: Record<string, string> = {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -40,6 +40,7 @@
   },
   "nav": {
     "chat": "Chat",
+    "insights": "Insights",
     "control": "Control",
     "channels": "Channels",
     "sessions": "Sessions",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -38,6 +38,7 @@
   },
   "nav": {
     "chat": "チャット",
+    "insights": "インサイト",
     "control": "コントロール",
     "channels": "チャンネル",
     "sessions": "セッション",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -38,6 +38,7 @@
   },
   "nav": {
     "chat": "Чат",
+    "insights": "Инсайты",
     "control": "Управление",
     "channels": "Каналы",
     "sessions": "Сессии",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -40,6 +40,7 @@
   },
   "nav": {
     "chat": "聊天",
+    "insights": "洞察",
     "control": "控制",
     "channels": "频道",
     "sessions": "会话",


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

## Summary
- Add new "Insights" sidebar category, moving Agent Statistics and Token Usage from Settings
- Maintain both pages as children under the new Insights group
- Collapsed/folded sidebar view preserved
## Changes
- `Sidebar.tsx`: New `insightsMenuItems`, removed from `settingsMenuItems`, render order updated
- `constants.ts`: Add `insights-group` to `DEFAULT_OPEN_KEYS`
- `locales`: Add `insights` translation key (en, zh, ja, ru)

- Before:

<img width="244" height="774" alt="image" src="https://github.com/user-attachments/assets/2e3a1684-2301-49d7-ad97-a343871cf301" />


- After:

<img width="232" height="766" alt="image" src="https://github.com/user-attachments/assets/42c3a027-fc4c-4b26-86e4-6497be65b047" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
