### PR TITLE
fix: The image displayed on the front end returned a 404 error.

### DIFF
--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -43,7 +43,17 @@ export const chatApi = {
     if (!filename) return "";
     if (filename.startsWith("http://") || filename.startsWith("https://"))
       return filename;
-    const path = `${FILES_PREVIEW}/${filename.replace(/^\/+/, "")}`;
+    // Strip any existing /files/preview/ or /api/files/preview/ prefix to
+    // avoid double-prefixing when the URL is resolved a second time (e.g.
+    // when reloading chat history). See GitHub issue #3600.
+    let cleaned = filename.replace(/^\/+/, "");
+    const previewPrefix = FILES_PREVIEW.replace(/^\/+/, "");
+    if (cleaned.startsWith(`api/${previewPrefix}/`)) {
+      cleaned = cleaned.slice(`api/${previewPrefix}/`.length);
+    } else if (cleaned.startsWith(`${previewPrefix}/`)) {
+      cleaned = cleaned.slice(`${previewPrefix}/`.length);
+    }
+    const path = `${FILES_PREVIEW}/${cleaned}`;
     const url = getApiUrl(path);
 
     const token = getApiToken();


### PR DESCRIPTION
## Description

In the filePreviewUrl method, before concatenating the /files/preview/ prefix, check and remove any existing /files/preview/ or /api/files/preview/ prefixes in the filename to avoid duplicate concatenation.

Fixes #3600


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
