### PR TITLE
fix (console): fix search in the skill page

### DIFF
--- a/console/src/pages/Agent/Skills/index.tsx
+++ b/console/src/pages/Agent/Skills/index.tsx
@@ -782,20 +782,35 @@ function SkillsPage() {
               onChange={setSearchTags}
               searchValue={searchQuery}
               onSearch={setSearchQuery}
-              open={filterOpen && allTags.length > 0}
+              open={filterOpen}
               onDropdownVisibleChange={setFilterOpen}
               allowClear
               maxTagCount="responsive"
               suffixIcon={<SearchOutlined />}
               notFoundContent={<></>}
-              dropdownRender={() => (
-                <SkillFilterDropdown
-                  allTags={allTags}
-                  searchTags={searchTags}
-                  setSearchTags={setSearchTags}
-                  styles={styles}
-                />
-              )}
+              dropdownStyle={
+                allTags.length === 0
+                  ? {
+                      padding: 0,
+                      border: "none",
+                      boxShadow: "none",
+                      height: 0,
+                      overflow: "hidden",
+                    }
+                  : undefined
+              }
+              dropdownRender={() =>
+                allTags.length > 0 ? (
+                  <SkillFilterDropdown
+                    allTags={allTags}
+                    searchTags={searchTags}
+                    setSearchTags={setSearchTags}
+                    styles={styles}
+                  />
+                ) : (
+                  <div />
+                )
+              }
             />
           </div>
           <div className={styles.toolbarRight}>

--- a/console/src/pages/Settings/SkillPool/index.tsx
+++ b/console/src/pages/Settings/SkillPool/index.tsx
@@ -183,20 +183,35 @@ function SkillPoolPage() {
                 onChange={pool.setSearchTags}
                 searchValue={pool.searchQuery}
                 onSearch={pool.setSearchQuery}
-                open={pool.filterOpen && pool.allTags.length > 0}
+                open={pool.filterOpen}
                 onDropdownVisibleChange={pool.setFilterOpen}
                 allowClear
                 maxTagCount="responsive"
                 suffixIcon={<SearchOutlined />}
                 notFoundContent={<></>}
-                dropdownRender={() => (
-                  <SkillFilterDropdown
-                    allTags={pool.allTags}
-                    searchTags={pool.searchTags}
-                    setSearchTags={pool.setSearchTags}
-                    styles={styles}
-                  />
-                )}
+                dropdownStyle={
+                  pool.allTags.length === 0
+                    ? {
+                        padding: 0,
+                        border: "none",
+                        boxShadow: "none",
+                        height: 0,
+                        overflow: "hidden",
+                      }
+                    : undefined
+                }
+                dropdownRender={() =>
+                  pool.allTags.length > 0 ? (
+                    <SkillFilterDropdown
+                      allTags={pool.allTags}
+                      searchTags={pool.searchTags}
+                      setSearchTags={pool.setSearchTags}
+                      styles={styles}
+                    />
+                  ) : (
+                    <div />
+                  )
+                }
               />
             </div>
             <div className={styles.toolbarRight}>


### PR DESCRIPTION
## Description

When a skill has no tags set (allTags.length === 0), open is always false. In Ant Design 5.x's Select, in controlled open mode, when open is always false, it assumes the dropdown menu is "closed" after each input, automatically triggering onSearch("") to clear the search values, thus preventing the user from inputting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
