### PR TITLE
fix(send_file): percent-encode non-ASCII chars in file:// URL to fix ValueError on Windows

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -14,7 +14,7 @@ import base64
 import logging
 import os
 from typing import List, Sequence, Tuple, Type, Any, Union, Optional
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from agentscope.formatter import FormatterBase, OpenAIChatFormatter
 from agentscope.model import ChatModelBase, OpenAIChatModel
@@ -49,12 +49,13 @@ from ..token_usage import TokenRecordingModelWrapper
 def _file_url_to_path(url: str) -> str:
     """
     Strip file:// to path. On Windows file:///C:/path -> C:/path not /C:/path.
+    Percent-decodes the path so non-ASCII filenames resolve correctly.
     """
     s = url.removeprefix("file://")
     # Windows: file:///C:/path yields "/C:/path"; remove leading slash.
     if len(s) >= 3 and s.startswith("/") and s[1].isalpha() and s[2] == ":":
         s = s[1:]
-    return s
+    return unquote(s)
 
 
 logger = logging.getLogger(__name__)
@@ -221,7 +222,7 @@ def _format_openai_video_block(video_block: dict) -> dict:
         media_type = source["media_type"]
         url = f"data:{media_type};base64,{source['data']}"
     elif source["type"] == "url":
-        raw_url = source["url"].removeprefix("file://")
+        raw_url = _file_url_to_path(source["url"])
         if os.path.exists(raw_url) and os.path.isfile(raw_url):
             ext = os.path.splitext(raw_url)[1].lower()
             media_type = _SUPPORTED_VIDEO_EXTENSIONS.get(ext)

--- a/src/qwenpaw/agents/tools/send_file.py
+++ b/src/qwenpaw/agents/tools/send_file.py
@@ -37,7 +37,12 @@ def _path_to_file_url(path: str) -> str:
     # Keep alphanumerics and safe chars unencoded
     encoded_path = quote(abs_path, safe="/:@%")
 
-    # RFC 8089: file:/// for local paths
+    # RFC 8089: file:///  (authority is empty → three slashes)
+    # On Windows abs_path starts with "C:/…" (no leading slash),
+    # so we need an explicit extra slash.  On POSIX abs_path already
+    # starts with "/" so "file://" + "/home/…" naturally gives three.
+    if os.name == "nt":
+        return f"file:///{encoded_path}"
     return f"file://{encoded_path}"
 
 

--- a/src/qwenpaw/agents/tools/send_file.py
+++ b/src/qwenpaw/agents/tools/send_file.py
@@ -4,6 +4,7 @@
 import os
 import mimetypes
 import unicodedata
+from urllib.parse import quote
 
 from agentscope.tool import ToolResponse
 from agentscope.message import (
@@ -15,6 +16,29 @@ from agentscope.message import (
 
 from ..schema import FileBlock
 from .file_io import _resolve_file_path
+
+
+def _path_to_file_url(path: str) -> str:
+    """Convert a local file path to a proper file:// URL (RFC 8089).
+
+    On Windows, converts:
+      C:\\path\\file.txt  →  file:///C:/path/file.txt
+
+    Non-ASCII characters are percent-encoded.
+    """
+    # Normalize to absolute path
+    abs_path = os.path.abspath(path)
+
+    # Convert backslashes to forward slashes (Windows)
+    if os.name == "nt":
+        abs_path = abs_path.replace("\\", "/")
+
+    # Percent-encode non-ASCII and reserved characters
+    # Keep alphanumerics and safe chars unencoded
+    encoded_path = quote(abs_path, safe="/:@%")
+
+    # RFC 8089: file:/// for local paths
+    return f"file://{encoded_path}"
 
 
 def _auto_as_type(mt: str) -> str:
@@ -78,8 +102,7 @@ async def send_file_to_user(
 
     try:
         # Use local file URL instead of base64
-        absolute_path = os.path.abspath(file_path)
-        file_url = f"file://{absolute_path}"
+        file_url = _path_to_file_url(file_path)
         source = {"type": "url", "url": file_url}
 
         if as_type == "image":

--- a/src/qwenpaw/agents/tools/send_file.py
+++ b/src/qwenpaw/agents/tools/send_file.py
@@ -22,9 +22,11 @@ def _path_to_file_url(path: str) -> str:
     """Convert a local file path to a proper file:// URL (RFC 8089).
 
     On Windows, converts:
-      C:\\path\\file.txt  →  file:///C:/path/file.txt
+      C:\\path\\file.txt      →  file:///C:/path/file.txt
+      \\\\server\\share\\f.txt  →  file://server/share/f.txt
 
-    Non-ASCII characters are percent-encoded.
+    Non-ASCII characters and ``%`` are percent-encoded so the URL is
+    always valid ASCII and round-trips correctly through url2pathname.
     """
     # Normalize to absolute path
     abs_path = os.path.abspath(path)
@@ -33,16 +35,19 @@ def _path_to_file_url(path: str) -> str:
     if os.name == "nt":
         abs_path = abs_path.replace("\\", "/")
 
-    # Percent-encode non-ASCII and reserved characters
-    # Keep alphanumerics and safe chars unencoded
-    encoded_path = quote(abs_path, safe="/:@%")
+    # Percent-encode non-ASCII and special characters.
+    # ``%`` must NOT be in *safe* — otherwise a literal ``%25`` in a
+    # filename would survive un-encoded and be mis-decoded later.
+    encoded_path = quote(abs_path, safe="/:@")
 
     # RFC 8089: file:///  (authority is empty → three slashes)
-    # On Windows abs_path starts with "C:/…" (no leading slash),
-    # so we need an explicit extra slash.  On POSIX abs_path already
-    # starts with "/" so "file://" + "/home/…" naturally gives three.
     if os.name == "nt":
+        # UNC path: //server/share/… → file://server/share/…
+        if encoded_path.startswith("//"):
+            return f"file:{encoded_path}"
+        # Local drive: C:/… → file:///C:/…
         return f"file:///{encoded_path}"
+    # POSIX: abs_path already starts with "/" → file:///…
     return f"file://{encoded_path}"
 
 

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -50,6 +50,7 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
 )
 
 from ....app.channels.base import BaseChannel
+from ....app.channels.utils import file_url_to_local_path
 from ....constant import WORKING_DIR
 
 logger = logging.getLogger("qwenpaw.channels.matrix")
@@ -1349,7 +1350,7 @@ class MatrixChannel(BaseChannel):
             return None
         try:
             # file_ref may be a file:// URI or a plain path
-            path = Path(file_ref.removeprefix("file://"))
+            path = Path(file_url_to_local_path(file_ref) or file_ref)
             if not path.exists():
                 logger.warning(
                     "MatrixChannel: upload source not found: %s",
@@ -2100,7 +2101,7 @@ class MatrixChannel(BaseChannel):
 
         # Build and send the Matrix room event
         try:
-            path_str = file_ref.removeprefix("file://")
+            path_str = file_url_to_local_path(file_ref) or file_ref
             filename = os.path.basename(path_str) or "file"
             mime_type, _ = mimetypes.guess_type(path_str)
             mime_type = mime_type or "application/octet-stream"

--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -27,6 +27,7 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
+from ..utils import file_url_to_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -947,8 +948,7 @@ class MattermostChannel(BaseChannel):
 
         if not local_path:
             return
-        if local_path.startswith("file://"):
-            local_path = local_path[len("file://") :]
+        local_path = file_url_to_local_path(local_path) or local_path
 
         file_id = await self._upload_file(mm_channel_id, local_path)
         if file_id:

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -44,7 +44,7 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import split_text
+from ..utils import file_url_to_local_path, split_text
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -1741,7 +1741,7 @@ class QQChannel(BaseChannel):
 
         # file:// protocol → treat as local file
         if raw.startswith("file://"):
-            resolved = raw[7:]  # strip "file://"
+            resolved = file_url_to_local_path(raw) or raw
             if os.path.isfile(resolved):
                 local_path = resolved
             else:

--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -16,13 +16,19 @@ _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 
 
 def _is_windows_drive(netloc: str) -> bool:
-    """Check if netloc is a Windows drive letter (e.g., 'C:')."""
-    return (
-        os.name == "nt"
-        and len(netloc) == 2
-        and netloc[1] == ":"
-        and netloc[0].isalpha()
-    )
+    """Check if netloc looks like a Windows drive letter.
+
+    Handles both the legacy single-letter form (``C``, from
+    ``file://C/path``) and the colon form (``C:``, from
+    ``file://C:/path``).
+    """
+    if os.name != "nt" or not netloc:
+        return False
+    if len(netloc) == 1 and netloc[0].isalpha():
+        return True
+    if len(netloc) == 2 and netloc[0].isalpha() and netloc[1] == ":":
+        return True
+    return False
 
 
 def split_text(text: str, max_len: int = 3000) -> List[str]:
@@ -110,7 +116,11 @@ def file_url_to_local_path(url: str) -> Optional[str]:
         elif (
             path and parsed.netloc and _is_windows_drive(netloc=parsed.netloc)
         ):
-            path = f"{parsed.netloc}{path}"
+            # netloc may be "C:" (new format) or "C" (legacy format)
+            drive = (
+                parsed.netloc if ":" in parsed.netloc else f"{parsed.netloc}:"
+            )
+            path = f"{drive}{path}"
         return path if path else None
     if parsed.scheme in ("http", "https"):
         return None

--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -15,6 +15,16 @@ from urllib.request import url2pathname
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 
 
+def _is_windows_drive(netloc: str) -> bool:
+    """Check if netloc is a Windows drive letter (e.g., 'C:')."""
+    return (
+        os.name == "nt"
+        and len(netloc) == 2
+        and netloc[1] == ":"
+        and netloc[0].isalpha()
+    )
+
+
 def split_text(text: str, max_len: int = 3000) -> List[str]:
     """Split text into chunks that fit within max_len characters.
 
@@ -98,12 +108,9 @@ def file_url_to_local_path(url: str) -> Optional[str]:
         if not path and parsed.netloc:
             path = url2pathname(parsed.netloc.replace("\\", "/"))
         elif (
-            path
-            and parsed.netloc
-            and len(parsed.netloc) == 1
-            and os.name == "nt"
+            path and parsed.netloc and _is_windows_drive(netloc=parsed.netloc)
         ):
-            path = f"{parsed.netloc}:{path}"
+            path = f"{parsed.netloc}{path}"
         return path if path else None
     if parsed.scheme in ("http", "https"):
         return None

--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -121,6 +121,9 @@ def file_url_to_local_path(url: str) -> Optional[str]:
                 parsed.netloc if ":" in parsed.netloc else f"{parsed.netloc}:"
             )
             path = f"{drive}{path}"
+        elif path and parsed.netloc and os.name == "nt":
+            # UNC: file://server/share/… → \\server\share\…
+            path = f"\\\\{parsed.netloc}{path}"
         return path if path else None
     if parsed.scheme in ("http", "https"):
         return None

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -43,7 +43,7 @@ from ..base import (
     ProcessHandler,
 )
 from .utils import compress_image_for_wecom, format_markdown_tables
-from ..utils import split_text
+from ..utils import file_url_to_local_path, split_text
 
 logger = logging.getLogger(__name__)
 
@@ -770,7 +770,7 @@ class WecomChannel(BaseChannel):
         if not self._client or not self._upload_lock:
             return None
         # Strip file:// prefix
-        local = path.removeprefix("file://")
+        local = file_url_to_local_path(path) or path
         p = Path(local)
         if not p.is_file():
             logger.warning("wecom upload: file not found: %s", local[:80])
@@ -874,7 +874,7 @@ class WecomChannel(BaseChannel):
                 or ""
             )
             # WeCom voice only supports AMR; send other formats as file.
-            _local = raw_path.removeprefix("file://")
+            _local = file_url_to_local_path(raw_path) or raw_path
             media_type = (
                 "voice" if Path(_local).suffix.lower() == ".amr" else "file"
             )

--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -45,7 +45,7 @@ from ..base import (
     OutgoingContentPart,
     ProcessHandler,
 )
-from ..utils import split_text
+from ..utils import file_url_to_local_path, split_text
 from .client import ILinkClient, _DEFAULT_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -1001,8 +1001,7 @@ class WeixinChannel(BaseChannel):
 
         try:
             # Convert URL to local path if it's a file:// URL
-            if file_path.startswith("file://"):
-                file_path = file_path[7:]
+            file_path = file_url_to_local_path(file_path) or file_path
 
             # Check if file exists
             path_obj = Path(file_path)

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -4,7 +4,7 @@ import logging
 import platform
 from datetime import datetime, timezone
 from typing import List, Optional, Union
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from agentscope.message import Msg
@@ -118,12 +118,15 @@ def _is_local_file_url(url: str) -> bool:
 
 
 def _abspath_from_url(url: str) -> str:
-    """Extract absolute path from file:// URL."""
+    """Extract absolute path from file:// URL.
+
+    Percent-decodes the path so non-ASCII filenames resolve correctly.
+    """
     s = url.strip()
     if s.lower().startswith("file:"):
         s = s[5:]
     s = "/" + s.lstrip("/")
-    return s
+    return unquote(s)
 
 
 def _resolve_content_url(url: str) -> str:


### PR DESCRIPTION
## Description

fix(send_file): percent-encode non-ASCII chars in file:// URL to fix ValueError on Windows

`send_file_to_user` fails with `ValueError` on Windows when the file path contains non-ASCII characters (e.g. Chinese full-width punctuation `，。（）` ). The root cause is that the old code constructs the `file://` URL by naively concatenating `f"file://{os.path.abspath(path)}"`, producing a URL with raw non-ASCII bytes that downstream consumers reject.

This PR introduces a proper `_path_to_file_url()` helper that:

* Percent-encodes all non-ASCII and special characters via urllib.parse.quote, producing a valid ASCII-only URL.
* Generates RFC 8089-compliant file:/// URLs (three slashes for local paths on all platforms).
* Handles Windows UNC paths (\\server\share\... → file://server/share/...).
* Excludes `%` from safe to prevent double-encoding when filenames contain literal % characters.

The decode side (`file_url_to_local_path` in `utils.py`) is also updated to:

Recognize both `C:` (new) and `C` (legacy) netloc formats as Windows drive letters.
Reconstruct UNC paths when netloc is a server name (not a drive letter).
All changes are cross-platform compatible (Windows / Linux / macOS).

**Related Issue:** #3580 also mentioned this bug。

**Security Considerations:** N/A . purely local file path handling, no auth or config changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Verified roundtrip correctness (`_path_to_file_url` → `file_url_to_local_path`) with 36 edge cases covering:

| Category | Examples |
|---|---|
| Relative paths | `test.txt`, `../sibling/file.txt`, `./here/file.txt`, `.` |
| Spaces & ASCII specials | `my file.txt`, `file#1.txt`, `100%.txt`, `Q&A.txt`, `a;b.txt`, `C++ primer.pdf`, `data[2026].csv` |
| CJK & Unicode | `文件，测试。.txt` (issue repro), `報告（最終版）.docx`, `テスト.txt`, `테스트.txt`, `📊report.xlsx` |
| Drive letters | `C:\`, `D:\`, lowercase `c:\` |
| UNC paths | `\\server\share\path\file.txt` |
| Legacy URL compat | `file://C/path` (old format), `file://C:/path`, `file:///C:/path` |
| Double-encoding guard | Filenames with literal `%25` |
| Tilde expansion | `~/test.txt` |

All 36 cases PASS on Windows. POSIX paths use the same `quote` + `url2pathname` roundtrip and are unaffected.

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

- The old `file_url_to_local_path` only matched single-letter netloc (`len == 1`) for Windows drives. The new `_is_windows_drive()` also accepts `len == 2` (`C:` format) while preserving backward compatibility with the legacy `C` format.


<img width="873" height="1467" alt="image" src="https://github.com/user-attachments/assets/0c2d6efc-18b2-43d1-9534-1c30f9e7d9ed" />

<img width="834" height="1203" alt="image" src="https://github.com/user-attachments/assets/afb32eb2-a447-4e17-81b1-c751d7cd1f1f" />
