### PR TITLE
feat: add progress observing hook and PlanNotebook config support

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -40,6 +40,7 @@ from .tools import (
     delegate_external_agent,
     chat_with_agent,
     check_agent_task,
+    query_task_detail,
     submit_to_agent,
     desktop_screenshot,
     edit_file,
@@ -57,6 +58,7 @@ from .tools import (
     write_file,
     create_memory_search_tool,
 )
+from .tools.task_detail import ProgressObservingHook, PLAN_CHANGE_HOOK_TYPE
 from .utils import process_file_and_media_blocks_in_message
 from ..constant import (
     MEDIA_UNSUPPORTED_PLACEHOLDER,
@@ -158,6 +160,24 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             f"Agent '{agent_config.id}' initialized with model: "
             f"{model_info} (class: {model.__class__.__name__})",
         )
+
+        # Create PlanNotebook if configured
+        plan_notebook = None
+        if (
+            hasattr(agent_config, "plan_notebook")
+            and agent_config.plan_notebook is not None
+            and agent_config.plan_notebook.enabled
+        ):
+            from agentscope.plan import PlanNotebook as _PlanNotebook
+
+            plan_notebook = _PlanNotebook(
+                max_subtasks=agent_config.plan_notebook.max_subtasks,
+            )
+            logger.info(
+                f"PlanNotebook enabled for agent '{agent_config.id}'"
+                f" (max_subtasks={agent_config.plan_notebook.max_subtasks})",
+            )
+
         # Initialize parent ReActAgent
         super().__init__(
             name="Friday",
@@ -167,6 +187,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             memory=InMemoryMemory(),
             formatter=formatter,
             max_iters=running_config.max_iters,
+            plan_notebook=plan_notebook,
         )
 
         # Setup memory manager
@@ -217,11 +238,13 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 }
                 # Only execute_shell_command supports async_execution
                 async_execution_tools = {
-                    "execute_shell_command": builtin_tools.get(
-                        "execute_shell_command",
-                    ).async_execution
-                    if "execute_shell_command" in builtin_tools
-                    else False,
+                    "execute_shell_command": (
+                        builtin_tools.get(
+                            "execute_shell_command",
+                        ).async_execution
+                        if "execute_shell_command" in builtin_tools
+                        else False
+                    ),
                 }
         except Exception as e:
             logger.warning(
@@ -250,6 +273,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             "chat_with_agent": chat_with_agent,
             "submit_to_agent": submit_to_agent,
             "check_agent_task": check_agent_task,
+            "query_task_detail": query_task_detail,
         }
 
         # Register only enabled tools
@@ -454,6 +478,42 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 hook=memory_compact_hook.__call__,
             )
             logger.debug("Registered memory compaction hook")
+
+        # Progress observing hook - snapshots PlanNotebook state to
+        # ProgressStore for query_task_detail lookups
+        progress_cfg = getattr(self._agent_config, "progress_observing", None)
+        if progress_cfg is not None and progress_cfg.enabled:
+            observing_hook = ProgressObservingHook(
+                agent_id=self._agent_config.id,
+                hook_type=progress_cfg.hook_type,
+            )
+            observing_type = progress_cfg.hook_type
+
+            if observing_type == PLAN_CHANGE_HOOK_TYPE:
+                if self.plan_notebook is not None:
+                    self.plan_notebook.register_plan_change_hook(
+                        hook_name="progress_observing",
+                        hook=observing_hook.on_plan_change,
+                    )
+                    logger.debug(
+                        "Registered progress_observing hook "
+                        "(type=plan_change on PlanNotebook)",
+                    )
+                else:
+                    logger.warning(
+                        "progress_observing hook_type=plan_change "
+                        "requires PlanNotebook to be enabled, skipping",
+                    )
+            else:
+                self.register_instance_hook(
+                    hook_type=observing_type,
+                    hook_name="progress_observing",
+                    hook=observing_hook.__call__,
+                )
+                logger.debug(
+                    f"Registered progress_observing hook "
+                    f"(type={observing_type})",
+                )
 
     def rebuild_sys_prompt(self) -> None:
         """Rebuild and replace the system prompt.

--- a/src/qwenpaw/agents/skills/task_progress-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/task_progress-en/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: task_progress
+description: Use this skill when you need to check the detailed progress of a background task, especially when you want to know what subtask an agent is currently working on.
+metadata:
+  builtin_skill_version: "1.0"
+  qwenpaw:
+    emoji: "📋"
+---
+
+# Task Progress Tracking
+
+## When to Use
+
+Use this skill when you need to **monitor the detailed progress of a background task** that was dispatched via `submit_to_agent`. Unlike `check_agent_task` which only returns lifecycle status (running / finished), this skill provides live progress details including the current tool being executed, plan progress, and subtask status.
+
+### Should Use
+
+- You submitted a background task and want to know what the target agent is currently doing
+- You need to track PlanNotebook subtask progress (which subtask is in_progress, how many are done)
+- You want to see the last tool call, its input/output, or the agent's latest reasoning
+- The user asks "what is agent X doing right now?" or "how far along is the task?"
+
+### Should Not Use
+
+- You only need to know whether a task is finished or still running (use `check_agent_task` instead)
+- You are waiting for a task result and don't need intermediate progress
+- You want to interact with the target agent (use `chat_with_agent` instead)
+
+## Instructions
+
+### Step 1: Identify the Task
+
+You need the `task_id` that was returned by `submit_to_agent`, and optionally the `agent_id` of the target agent.
+
+### Step 2: Query Task Detail
+
+Call `query_task_detail` with the task_id and agent_id:
+
+```
+query_task_detail(task_id="<task_id>", agent_id="<agent_id>")
+```
+
+### Step 3: Interpret the Result
+
+The `live_status` field contains the progress snapshot:
+
+- **`hook_type`**: Which hook captured this data (e.g., `post_acting`, `plan_change`)
+- **`last_update`**: Unix timestamp of the last update
+- **`last_tool`** / **`last_tool_input`** / **`last_tool_output`**: The most recent tool call (from `post_acting` hook)
+- **`plan_name`** / **`plan_progress`** / **`current_subtask`**: Plan progress (when PlanNotebook is enabled)
+
+### Step 4: Report to User
+
+Summarize the progress in a human-readable format. For example:
+
+- "Agent `qa_agent` is currently running tool `read_file` on `test_results.json`"
+- "Plan `QA Pipeline` is 3/5 complete. Current subtask: `Run Integration Tests`"
+
+## Tips
+
+- If `live_status` is null, the target agent may not have `progress_observing` enabled in its config
+- Progress is session-aware: concurrent sessions on the same agent are tracked independently
+- You can call `query_task_detail` multiple times to get updates as the task progresses

--- a/src/qwenpaw/agents/skills/task_progress-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/task_progress-zh/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: task_progress
+description: 当你需要查看后台任务的详细进度时使用此技能，尤其是当你想了解 agent 当前正在执行哪个子任务时。
+metadata:
+  builtin_skill_version: "1.0"
+  qwenpaw:
+    emoji: "📋"
+---
+
+# 任务进度追踪
+
+## 何时使用
+
+当你需要**监控通过 `submit_to_agent` 提交的后台任务的详细进度**时使用此技能。与只返回生命周期状态（运行中 / 已完成）的 `check_agent_task` 不同，此技能提供实时进度详情，包括当前执行的工具、计划进度和子任务状态。
+
+### 应该使用
+
+- 你提交了后台任务，想知道目标 agent 当前在做什么
+- 你需要追踪 PlanNotebook 子任务进度（哪个子任务正在进行，完成了多少）
+- 你想查看最后一次工具调用、其输入/输出，或 agent 最新的推理
+- 用户问"agent X 现在在做什么？"或"任务进展到哪了？"
+
+### 不应使用
+
+- 你只需要知道任务是否已完成或仍在运行（改用 `check_agent_task`）
+- 你在等待任务结果，不需要中间进度
+- 你想与目标 agent 交互（改用 `chat_with_agent`）
+
+## 使用说明
+
+### 第一步：确认任务
+
+你需要 `submit_to_agent` 返回的 `task_id`，以及可选的目标 agent 的 `agent_id`。
+
+### 第二步：查询任务详情
+
+使用 task_id 和 agent_id 调用 `query_task_detail`：
+
+```
+query_task_detail(task_id="<task_id>", agent_id="<agent_id>")
+```
+
+### 第三步：解读结果
+
+`live_status` 字段包含进度快照：
+
+- **`hook_type`**：捕获此数据的钩子类型（如 `post_acting`、`plan_change`）
+- **`last_update`**：最后更新的 Unix 时间戳
+- **`last_tool`** / **`last_tool_input`** / **`last_tool_output`**：最近的工具调用（来自 `post_acting` 钩子）
+- **`plan_name`** / **`plan_progress`** / **`current_subtask`**：计划进度（当 PlanNotebook 启用时）
+
+### 第四步：向用户汇报
+
+以人类可读的格式总结进度。例如：
+
+- "Agent `qa_agent` 当前正在对 `test_results.json` 执行 `read_file` 工具"
+- "计划 `QA Pipeline` 已完成 3/5。当前子任务：`运行集成测试`"
+
+## 提示
+
+- 如果 `live_status` 为 null，目标 agent 可能未在配置中启用 `progress_observing`
+- 进度支持会话感知：同一 agent 的并发会话会被独立追踪
+- 你可以多次调用 `query_task_detail` 以获取任务进展的最新状态

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -30,6 +30,7 @@ from .agent_management import (
     check_agent_task,
 )
 from .delegate_external_agent import delegate_external_agent
+from .task_detail import query_task_detail
 
 __all__ = [
     "execute_python_code",
@@ -52,6 +53,7 @@ __all__ = [
     "set_user_timezone",
     "get_token_usage",
     "delegate_external_agent",
+    "query_task_detail",
     "list_agents",
     "chat_with_agent",
     "submit_to_agent",

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -14,7 +14,6 @@ from agentscope.tool import ToolResponse
 
 from ...config.utils import read_last_api
 
-
 DEFAULT_AGENT_API_BASE_URL = "http://127.0.0.1:8088"
 DEFAULT_AGENT_API_TIMEOUT = 30.0
 
@@ -139,7 +138,17 @@ def extract_agent_text_content(response_data: Dict[str, Any]) -> str:
         if not output:
             return ""
 
-        last_msg = output[-1]
+        # Search backwards for a message-type item,
+        # skipping trailing reasoning / tool-output items.
+        last_msg = None
+        for msg in reversed(output):
+            if msg.get("type") == "message":
+                last_msg = msg
+                break
+
+        if not last_msg:
+            return ""
+
         content = last_msg.get("content", [])
 
         text_parts = []

--- a/src/qwenpaw/agents/tools/task_detail.py
+++ b/src/qwenpaw/agents/tools/task_detail.py
@@ -1,0 +1,410 @@
+# -*- coding: utf-8 -*-
+"""Built-in tool for querying detailed progress of a running background task.
+
+When agent A dispatches a background task to agent B via
+``submit_to_agent``, the existing ``check_agent_task`` tool only returns
+lifecycle status (submitted / pending / running / finished) — no details.
+
+This module provides:
+
+1. **ProgressStore** – process-level shared registry (``agent_id`` → progress).
+2. **ProgressObservingHook** – snapshots agent progress into ProgressStore.
+   Writes a structured dict per hook_type; if PlanNotebook is enabled,
+   adds a plan overlay.  Configured via ``ProgressObservingConfig``.
+3. **query_task_detail** – built-in tool that reads ProgressStore and
+   returns ``live_status`` (the raw progress dict) plus task lifecycle.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+from agentscope.message import Msg
+from agentscope.tool import ToolResponse
+
+from .agent_management import (
+    _tool_text_response,
+    format_background_status_text,
+    get_agent_chat_task_status,
+    normalize_id,
+)
+
+logger = logging.getLogger(__name__)
+
+# Hook type that triggers via PlanNotebook.register_plan_change_hook
+PLAN_CHANGE_HOOK_TYPE = "plan_change"
+
+
+# =========================================================================
+# ProgressStore – process-level shared registry
+# =========================================================================
+
+
+class _ProgressStore:
+    """Process-level registry mapping ``agent_id`` → progress data.
+
+    Written by ProgressObservingHook (single writer per agent) and read
+    by ``query_task_detail`` (read-only).  No locking is needed because
+    dict assignment in CPython is atomic under the GIL.
+    """
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[str, Any]] = {}
+
+    def set(self, agent_id: str, progress: Dict[str, Any]) -> None:
+        self._data[agent_id] = progress
+
+    def get(self, agent_id: str) -> Dict[str, Any]:
+        return self._data.get(agent_id, {})
+
+    def remove(self, agent_id: str) -> None:
+        self._data.pop(agent_id, None)
+
+
+progress_store = _ProgressStore()
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _truncate(text: str, max_len: int = 300) -> str:
+    """Truncate text to max_len with ellipsis indicator."""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+def _extract_plan_overlay(plan: Any) -> Dict[str, Any]:
+    """Extract plan progress fields from a Plan object.
+
+    Returns a dict with:
+    - plan_name: plan.name
+    - plan_progress: "done_count/total" (e.g. "3/5")
+    - plan_progress_pct: percentage of done+abandoned subtasks
+    - current_subtask: name of the first in_progress subtask, or None
+    """
+    overlay: Dict[str, Any] = {
+        "plan_name": getattr(plan, "name", ""),
+    }
+
+    subtasks = getattr(plan, "subtasks", [])
+    total = len(subtasks)
+    if total > 0:
+        done = sum(
+            1
+            for s in subtasks
+            if getattr(s, "state", "") in ("done", "abandoned")
+        )
+        overlay["plan_progress"] = f"{done}/{total}"
+        overlay["plan_progress_pct"] = round(done / total * 100)
+        # Find current in-progress subtask
+        for s in subtasks:
+            if getattr(s, "state", "") == "in_progress":
+                overlay["current_subtask"] = getattr(s, "name", "")
+                break
+        else:
+            overlay["current_subtask"] = None
+    else:
+        overlay["plan_progress"] = "0/0"
+        overlay["plan_progress_pct"] = 0
+        overlay["current_subtask"] = None
+
+    return overlay
+
+
+def _extract_tool_output(output: Any) -> str:
+    """Extract a short text representation from acting output."""
+    if output is None:
+        return ""
+    if isinstance(output, dict):
+        return _truncate(json.dumps(output, ensure_ascii=False), 500)
+    if isinstance(output, Msg):
+        return _extract_msg_text(output, max_len=500)
+    return _truncate(str(output), 500)
+
+
+def _extract_msg_text(msg: Any, max_len: int = 300) -> str:
+    """Extract text content from a Msg object."""
+    if msg is None:
+        return ""
+    if isinstance(msg, Msg):
+        text_parts = []
+        for block in msg.get_content_blocks():
+            if isinstance(block, dict):
+                btype = block.get("type", "")
+                if btype == "text":
+                    text_parts.append(block.get("text", ""))
+                elif btype == "thinking":
+                    text_parts.append(block.get("thinking", ""))
+            elif isinstance(block, str):
+                text_parts.append(block)
+        combined = " ".join(text_parts).strip()
+        return _truncate(combined, max_len)
+    return _truncate(str(msg), max_len)
+
+
+# =========================================================================
+# ProgressObservingHook
+# =========================================================================
+
+
+class ProgressObservingHook:
+    """Hook that snapshots agent progress into ProgressStore.
+
+    Each hook type writes a structured dict with two common fields:
+
+    - ``hook_type`` – which hook triggered the write
+    - ``last_update`` – Unix timestamp of the write
+
+    Plus type-specific fields.  If PlanNotebook is enabled, a plan
+    overlay (``plan_name``, ``plan_progress``, ``plan_progress_pct``,
+    ``current_subtask``) is merged in for instance hooks.
+    """
+
+    def __init__(self, agent_id: str, hook_type: str = "post_acting") -> None:
+        self.agent_id = agent_id
+        self.hook_type = hook_type
+
+    # ----- instance hook entry point -----
+
+    async def __call__(
+        self,
+        agent: Any,
+        kwargs: dict[str, Any],
+        output: Any = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Instance hook: snapshot agent progress into ProgressStore.
+
+        Works with both pre-hooks (2 args: agent, kwargs) and post-hooks
+        (3 args: agent, kwargs, output).
+
+        Returns:
+            None (hook doesn't modify kwargs or output).
+        """
+        try:
+            progress = self._build_progress(agent, kwargs, output)
+            if progress:
+                progress_store.set(self.agent_id, progress)
+                logger.debug(
+                    "ProgressObservingHook[%s]: agent='%s'",
+                    self.hook_type,
+                    self.agent_id,
+                )
+        except Exception:
+            logger.exception(
+                "ProgressObservingHook error for agent '%s'",
+                self.agent_id,
+            )
+
+        return None
+
+    # ---- small helpers for each hook type ----
+
+    def _acting_progress(
+        self,
+        ht: str,
+        kwargs: Dict[str, Any],
+        output: Any,
+    ) -> Dict[str, Any]:
+        """Build progress for acting hooks."""
+        progress: Dict[str, Any] = {}
+        tool_call = kwargs.get("tool_call")
+        if tool_call and isinstance(tool_call, dict):
+            if ht == "post_acting":
+                progress["last_tool"] = tool_call.get("name", "")
+                progress["last_tool_input"] = _truncate(
+                    json.dumps(
+                        tool_call.get("input", {}),
+                        ensure_ascii=False,
+                    ),
+                    500,
+                )
+            else:  # pre_acting
+                progress["current_tool"] = tool_call.get("name", "")
+                progress["current_tool_input"] = _truncate(
+                    json.dumps(
+                        tool_call.get("input", {}),
+                        ensure_ascii=False,
+                    ),
+                    500,
+                )
+        if ht == "post_acting" and output is not None:
+            progress["last_tool_output"] = _extract_tool_output(output)
+        return progress
+
+    def _text_progress(
+        self,
+        ht: str,
+        kwargs: Dict[str, Any],
+        output: Any,
+    ) -> Dict[str, Any]:
+        """Build progress for reasoning/reply/observe/print hooks."""
+        progress: Dict[str, Any] = {}
+        if ht == "post_reasoning" and output is not None:
+            progress["last_thought"] = _extract_msg_text(output, max_len=500)
+        elif ht == "pre_reasoning":
+            progress["status"] = "running"
+        elif ht == "post_reply" and output is not None:
+            progress["last_reply"] = _extract_msg_text(output, max_len=500)
+        elif ht == "pre_reply":
+            progress["status"] = "running"
+        elif ht in ("pre_observe", "post_observe"):
+            msg = kwargs.get("msg")
+            if msg is not None:
+                progress["last_observed"] = _extract_msg_text(msg, max_len=300)
+        elif ht in ("pre_print", "post_print"):
+            msg = kwargs.get("msg")
+            if msg is not None:
+                progress["last_output"] = _extract_msg_text(msg, max_len=300)
+        return progress
+
+    def _build_progress(
+        self,
+        agent: Any,
+        kwargs: Dict[str, Any],
+        output: Any,
+    ) -> Dict[str, Any]:
+        """Build the progress dict for the current hook invocation."""
+        ht = self.hook_type
+        progress: Dict[str, Any] = {
+            "hook_type": ht,
+            "last_update": time.time(),
+        }
+
+        # ---- acting hooks ----
+        if ht in ("post_acting", "pre_acting"):
+            progress.update(self._acting_progress(ht, kwargs, output))
+        else:
+            progress.update(self._text_progress(ht, kwargs, output))
+
+        # ---- plan overlay (for all instance hooks) ----
+        if ht != PLAN_CHANGE_HOOK_TYPE:
+            plan_notebook = getattr(agent, "plan_notebook", None)
+            if plan_notebook is not None:
+                plan = getattr(plan_notebook, "current_plan", None)
+                if plan is not None:
+                    progress.update(_extract_plan_overlay(plan))
+
+        return progress
+
+    # ----- plan_change hook entry point -----
+
+    def on_plan_change(self, _plan_notebook: Any, plan: Any) -> None:
+        """PlanNotebook plan_change hook: write plan progress to ProgressStore.
+
+        Registered via ``plan_notebook.register_plan_change_hook()``.
+        Called every time the plan changes.  If ``plan`` is None (plan
+        cleared), the ProgressStore entry for this agent is cleared too.
+        """
+        try:
+            if plan is None:
+                progress_store.remove(self.agent_id)
+                return
+
+            progress: Dict[str, Any] = {
+                "hook_type": PLAN_CHANGE_HOOK_TYPE,
+                "last_update": time.time(),
+            }
+            progress.update(_extract_plan_overlay(plan))
+            progress_store.set(self.agent_id, progress)
+
+            logger.debug(
+                "ProgressObservingHook[plan_change]: agent='%s' plan='%s'",
+                self.agent_id,
+                getattr(plan, "name", ""),
+            )
+        except Exception:
+            logger.exception(
+                "ProgressObservingHook[plan_change] error for agent '%s'",
+                self.agent_id,
+            )
+
+
+# =========================================================================
+# Built-in tool
+# =========================================================================
+
+
+async def query_task_detail(
+    task_id: str,
+    agent_id: Optional[str] = None,
+) -> ToolResponse:
+    """Query detailed progress of a running background task.
+
+    Unlike ``check_agent_task`` which only returns lifecycle status
+    (running / finished / …), this tool also retrieves the executing
+    agent's ``live_status`` from the shared ProgressStore when the task
+    is running.
+
+    The returned JSON structure:
+
+    .. code-block:: json
+
+        {
+          "to_agent": "qa_agent",
+          "status": "running",
+          "live_status": { ... },
+          "task_status": "running",
+          "task_result": null
+        }
+
+    ``live_status`` is the raw progress dict written by whichever hook
+    is configured (see ``ProgressObservingConfig``).  ``task_status``
+    and ``task_result`` come from the Task API.
+
+    Args:
+        task_id (`str`):
+            The background task ID returned by ``submit_to_agent``.
+        agent_id (`str`, optional):
+            The ID of the agent executing the task.  When provided, the
+            tool can look up progress from the shared ProgressStore.
+
+    Returns:
+        `ToolResponse`:
+            A JSON response with task status and live progress details.
+    """
+    normalized_task_id = normalize_id(task_id)
+    if not normalized_task_id:
+        return _tool_text_response(
+            "ERROR: 'task_id' is required to query task detail",
+        )
+
+    # 1. Get lifecycle status via existing API
+    status_result = await asyncio.to_thread(
+        get_agent_chat_task_status,
+        None,
+        normalized_task_id,
+        to_agent=None,
+        timeout=10,
+    )
+
+    status = status_result.get("status", "unknown")
+
+    # 2. Non-running: reuse existing format_background_status_text
+    if status != "running":
+        return _tool_text_response(
+            format_background_status_text(normalized_task_id, status_result),
+        )
+
+    # 3. Running: assemble structured result
+    result: Dict[str, Any] = {
+        "to_agent": status_result.get("to_agent", ""),
+        "status": status,
+        "live_status": None,
+        "task_status": status,
+        "task_result": status_result.get("task_result"),
+    }
+
+    if agent_id:
+        normalized_agent_id = normalize_id(agent_id)
+        progress = progress_store.get(normalized_agent_id or "")
+        if progress:
+            result["live_status"] = progress
+
+    return _tool_text_response(
+        json.dumps(result, ensure_ascii=False, indent=2),
+    )

--- a/src/qwenpaw/agents/tools/task_detail.py
+++ b/src/qwenpaw/agents/tools/task_detail.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, Optional, Tuple
 from agentscope.message import Msg
 from agentscope.tool import ToolResponse
 
-from ...app.agent_context import get_current_session_id
 from .agent_management import (
     _tool_text_response,
     format_background_status_text,
@@ -74,22 +73,17 @@ class _ProgressStore:
     ) -> Dict[str, Any]:
         """Look up progress by (agent_id, session_id).
 
-        Falls back to ``(agent_id, None)`` if the exact key is not
-        found, so callers that don't know the session still get a
-        result.
+        If an exact ``(agent_id, session_id)`` key is not found, falls
+        back to the most-recently written entry for that agent so that
+        callers without a session_id still get a result.
         """
         result = self._data.get((agent_id, session_id))
         if result is not None:
             return result
-        # Fallback: any session for this agent
-        if session_id is not None:
-            result = self._data.get((agent_id, None))
-            if result is not None:
-                return result
-            # Last resort: most recent entry for this agent
-            for key, val in reversed(list(self._data.items())):
-                if key[0] == agent_id:
-                    return val
+        # Fallback: most recent entry for this agent regardless of session
+        for key, val in reversed(list(self._data.items())):
+            if key[0] == agent_id:
+                return val
         return {}
 
     def remove(
@@ -106,6 +100,15 @@ progress_store = _ProgressStore()
 # =========================================================================
 # Helpers
 # =========================================================================
+
+
+def _get_current_session_id() -> Optional[str]:
+    """Lazily import get_current_session_id to avoid circular import."""
+    from ...app.agent_context import (  # noqa: PLC0415
+        get_current_session_id,
+    )
+
+    return get_current_session_id()
 
 
 def _truncate(text: str, max_len: int = 300) -> str:
@@ -225,7 +228,7 @@ class ProgressObservingHook:
         try:
             progress = self._build_progress(agent, kwargs, output)
             if progress:
-                session_id = get_current_session_id()
+                session_id = _get_current_session_id()
                 progress_store.set(
                     self.agent_id,
                     progress,
@@ -345,7 +348,7 @@ class ProgressObservingHook:
         """
         try:
             if plan is None:
-                session_id = get_current_session_id()
+                session_id = _get_current_session_id()
                 progress_store.remove(
                     self.agent_id,
                     session_id=session_id,
@@ -357,7 +360,7 @@ class ProgressObservingHook:
                 "last_update": time.time(),
             }
             progress.update(_extract_plan_overlay(plan))
-            session_id = get_current_session_id()
+            session_id = _get_current_session_id()
             progress_store.set(
                 self.agent_id,
                 progress,
@@ -384,6 +387,7 @@ class ProgressObservingHook:
 async def query_task_detail(
     task_id: str,
     agent_id: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> ToolResponse:
     """Query detailed progress of a running background task.
 
@@ -414,6 +418,11 @@ async def query_task_detail(
         agent_id (`str`, optional):
             The ID of the agent executing the task.  When provided, the
             tool can look up progress from the shared ProgressStore.
+        session_id (`str`, optional):
+            The session ID returned by ``submit_to_agent`` in the
+            ``[SESSION: ...]`` header.  Used for precise per-session
+            lookup in ProgressStore when the same agent has multiple
+            concurrent conversations.
 
     Returns:
         `ToolResponse`:
@@ -453,11 +462,10 @@ async def query_task_detail(
 
     if agent_id:
         normalized_agent_id = normalize_id(agent_id)
-        # Try session-scoped lookup first, then agent-only
-        task_session = status_result.get("session_id")
+        normalized_session_id = normalize_id(session_id)
         progress = progress_store.get(
             normalized_agent_id or "",
-            session_id=task_session,
+            session_id=normalized_session_id,
         )
         if progress:
             result["live_status"] = progress

--- a/src/qwenpaw/agents/tools/task_detail.py
+++ b/src/qwenpaw/agents/tools/task_detail.py
@@ -7,7 +7,8 @@ lifecycle status (submitted / pending / running / finished) — no details.
 
 This module provides:
 
-1. **ProgressStore** – process-level shared registry (``agent_id`` → progress).
+1. **ProgressStore** – process-level shared registry
+   (``(agent_id, session_id)`` → progress).
 2. **ProgressObservingHook** – snapshots agent progress into ProgressStore.
    Writes a structured dict per hook_type; if PlanNotebook is enabled,
    adds a plan overlay.  Configured via ``ProgressObservingConfig``.
@@ -19,11 +20,12 @@ import asyncio
 import json
 import logging
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from agentscope.message import Msg
 from agentscope.tool import ToolResponse
 
+from ...app.agent_context import get_current_session_id
 from .agent_management import (
     _tool_text_response,
     format_background_status_text,
@@ -43,24 +45,59 @@ PLAN_CHANGE_HOOK_TYPE = "plan_change"
 
 
 class _ProgressStore:
-    """Process-level registry mapping ``agent_id`` → progress data.
+    """Process-level registry mapping ``(agent_id, session_id)`` → progress.
 
-    Written by ProgressObservingHook (single writer per agent) and read
-    by ``query_task_detail`` (read-only).  No locking is needed because
-    dict assignment in CPython is atomic under the GIL.
+    Written by ProgressObservingHook (single writer per agent/session)
+    and read by ``query_task_detail`` (read-only).  No locking is needed
+    because dict assignment in CPython is atomic under the GIL.
+
+    The key is a ``(agent_id, session_id)`` tuple so that concurrent
+    sessions on the same agent don't overwrite each other's progress.
+    ``session_id`` may be ``None`` for agents that don't use sessions.
     """
 
     def __init__(self) -> None:
-        self._data: Dict[str, Dict[str, Any]] = {}
+        self._data: Dict[Tuple[str, Optional[str]], Dict[str, Any]] = {}
 
-    def set(self, agent_id: str, progress: Dict[str, Any]) -> None:
-        self._data[agent_id] = progress
+    def set(
+        self,
+        agent_id: str,
+        progress: Dict[str, Any],
+        session_id: Optional[str] = None,
+    ) -> None:
+        self._data[(agent_id, session_id)] = progress
 
-    def get(self, agent_id: str) -> Dict[str, Any]:
-        return self._data.get(agent_id, {})
+    def get(
+        self,
+        agent_id: str,
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Look up progress by (agent_id, session_id).
 
-    def remove(self, agent_id: str) -> None:
-        self._data.pop(agent_id, None)
+        Falls back to ``(agent_id, None)`` if the exact key is not
+        found, so callers that don't know the session still get a
+        result.
+        """
+        result = self._data.get((agent_id, session_id))
+        if result is not None:
+            return result
+        # Fallback: any session for this agent
+        if session_id is not None:
+            result = self._data.get((agent_id, None))
+            if result is not None:
+                return result
+            # Last resort: most recent entry for this agent
+            for key, val in reversed(list(self._data.items())):
+                if key[0] == agent_id:
+                    return val
+        return {}
+
+    def remove(
+        self,
+        agent_id: str,
+        session_id: Optional[str] = None,
+    ) -> None:
+        self._data.pop((agent_id, session_id), None)
 
 
 progress_store = _ProgressStore()
@@ -188,11 +225,17 @@ class ProgressObservingHook:
         try:
             progress = self._build_progress(agent, kwargs, output)
             if progress:
-                progress_store.set(self.agent_id, progress)
+                session_id = get_current_session_id()
+                progress_store.set(
+                    self.agent_id,
+                    progress,
+                    session_id=session_id,
+                )
                 logger.debug(
-                    "ProgressObservingHook[%s]: agent='%s'",
+                    "ProgressObservingHook[%s]: agent='%s' session='%s'",
                     self.hook_type,
                     self.agent_id,
+                    session_id,
                 )
         except Exception:
             logger.exception(
@@ -302,7 +345,11 @@ class ProgressObservingHook:
         """
         try:
             if plan is None:
-                progress_store.remove(self.agent_id)
+                session_id = get_current_session_id()
+                progress_store.remove(
+                    self.agent_id,
+                    session_id=session_id,
+                )
                 return
 
             progress: Dict[str, Any] = {
@@ -310,7 +357,12 @@ class ProgressObservingHook:
                 "last_update": time.time(),
             }
             progress.update(_extract_plan_overlay(plan))
-            progress_store.set(self.agent_id, progress)
+            session_id = get_current_session_id()
+            progress_store.set(
+                self.agent_id,
+                progress,
+                session_id=session_id,
+            )
 
             logger.debug(
                 "ProgressObservingHook[plan_change]: agent='%s' plan='%s'",
@@ -401,7 +453,12 @@ async def query_task_detail(
 
     if agent_id:
         normalized_agent_id = normalize_id(agent_id)
-        progress = progress_store.get(normalized_agent_id or "")
+        # Try session-scoped lookup first, then agent-only
+        task_session = status_result.get("session_id")
+        progress = progress_store.get(
+            normalized_agent_id or "",
+            session_id=task_session,
+        )
         if progress:
             result["live_status"] = progress
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -34,7 +34,6 @@ from ..constant import (
     WORKING_DIR,
 )
 
-
 # ============================================================================
 # Core config models (moved here to avoid circular imports)
 # ============================================================================
@@ -62,10 +61,6 @@ class ACPAgentConfig(BaseModel):
     env: Dict[str, str] = Field(default_factory=dict)
     trusted: bool = True
     tool_parse_mode: str = "call_title"
-    stdio_buffer_limit_bytes: int = Field(
-        default=50 * 1024 * 1024,
-        gt=0,
-    )
 
 
 def _get_default_acp_agents() -> Dict[str, ACPAgentConfig]:
@@ -856,6 +851,80 @@ class AgentProfileRef(BaseModel):
     )
 
 
+class PlanNotebookConfig(BaseModel):
+    """Configuration for agentscope PlanNotebook integration.
+
+    When enabled, the agent gets plan/subtask tools (create_plan,
+    view_subtasks, finish_subtask, etc.) that help track complex
+    multi-step task progress.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable PlanNotebook for this agent",
+    )
+    max_subtasks: Optional[int] = Field(
+        default=None,
+        description=(
+            "Maximum number of subtasks in a plan. "
+            "None means no limit (agentscope default)."
+        ),
+    )
+
+
+class ProgressObservingConfig(BaseModel):
+    """Configuration for the progress_observing hook.
+
+    This hook snapshots agent progress into ProgressStore so that
+    ``query_task_detail`` can report what a running agent is doing.
+
+    All writes include two common fields: ``hook_type`` and
+    ``last_update`` (Unix timestamp).  Each hook type writes
+    additional fields:
+
+    - ``post_acting``: last_tool, last_tool_input, last_tool_output
+    - ``pre_acting``: current_tool, current_tool_input
+    - ``post_reasoning``: last_thought
+    - ``pre_reasoning``: status="running"
+    - ``plan_change``: plan_name, plan_progress, plan_progress_pct,
+      current_subtask
+
+    When PlanNotebook is enabled, instance hooks also add a plan
+    overlay (plan_name, plan_progress, plan_progress_pct,
+    current_subtask).
+
+    Supported hook_type values:
+
+    - Instance hooks (registered via ``register_instance_hook``):
+      pre_reply, post_reply, pre_print, post_print, pre_observe,
+      post_observe, pre_reasoning, post_reasoning, pre_acting,
+      post_acting.
+    - ``plan_change`` (registered via
+      ``plan_notebook.register_plan_change_hook``): fires when the
+      PlanNotebook's plan changes.  More efficient, but requires
+      PlanNotebook to be enabled.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable the progress_observing hook",
+    )
+    hook_type: str = Field(
+        default="post_acting",
+        description=(
+            "Hook type to register on. "
+            "Instance hooks: pre_reply, post_reply, pre_print, "
+            "post_print, pre_observe, post_observe, pre_reasoning, "
+            "post_reasoning, pre_acting, post_acting. "
+            "PlanNotebook hook: plan_change (requires PlanNotebook enabled)."
+        ),
+    )
+
+
 class AgentProfileConfig(BaseModel):
     """Complete Agent Profile configuration (stored in workspace/agent.json).
 
@@ -919,9 +988,13 @@ class AgentProfileConfig(BaseModel):
         default=None,
         description="Security configuration for this agent",
     )
-    acp: Optional[ACPConfig] = Field(
+    plan_notebook: Optional[PlanNotebookConfig] = Field(
         default=None,
-        description="ACP configuration for this agent",
+        description="PlanNotebook configuration for this agent",
+    )
+    progress_observing: Optional[ProgressObservingConfig] = Field(
+        default=None,
+        description="Progress observing hook configuration",
     )
 
 
@@ -1250,6 +1323,15 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
             enabled=True,
             description="Check the status of a background agent task",
             icon="⏳",
+        ),
+        "query_task_detail": BuiltinToolConfig(
+            name="query_task_detail",
+            enabled=True,
+            description=(
+                "Query detailed progress of a running background task,"
+                " including PlanNotebook state and subtask progress"
+            ),
+            icon="📋",
         ),
     }
 


### PR DESCRIPTION
## Description

Add configurable progress observing hooks and PlanNotebook integration for agents, enabling live task progress tracking via the `query_task_detail` built-in tool.

- `PlanNotebookConfig` / `ProgressObservingConfig` in `config.py` allow per-agent configuration
- Dual-mode hook: instance hook (`post_acting` etc.) or PlanNotebook hook (`plan_change`)
- `query_task_detail` tool returns live progress store data and plan overlay
- Backward compatible: both fields optional, default disabled

**Related Issue:** None

**Security Considerations:** None — read-only progress observation, no auth or credential handling

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Ready for review


## Testing


1. Configure `agent.json` with `"plan_notebook": {"enabled": true}` and `"progress_observing": {"enabled": true, "hook_type": "plan_change"}`
2. Start `qwenpaw app` and send a task to the agent
3. Call `query_task_detail` to verify progress store and plan overlay data

## Local Verification Evidence


```
flake8: passed
pytest: 1 pre-existing failure (missing pytest-asyncio, unrelated to this PR)
pre-commit: skipped (network issue, hooks require GitHub access)
```

