### PR TITLE
fix: replace deleted media files with text placeholders before formatting

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -629,6 +629,53 @@ def _fix_image_mime_types(messages: list[dict]) -> None:
                     )
 
 
+_MEDIA_BLOCK_TYPES = ("image", "audio", "video")
+
+
+def _fixup_media_list(items: list) -> None:
+    """Normalize media blocks in a list in-place.
+
+    - Strips ``file://`` prefixes from source URLs.
+    - Replaces media blocks whose local file no longer exists with
+      a text placeholder so the downstream formatter won't throw.
+    - Recurses into ``tool_result`` output lists.
+    """
+    for i, block in enumerate(items):
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype in _MEDIA_BLOCK_TYPES:
+            source = block.get("source")
+            if not (
+                isinstance(source, dict)
+                and source.get("type") == "url"
+                and isinstance(source.get("url"), str)
+            ):
+                continue
+            if source["url"].startswith("file://"):
+                source["url"] = _file_url_to_path(source["url"])
+            url = source["url"]
+            if not url.startswith(
+                ("http://", "https://", "data:"),
+            ) and not os.path.exists(url):
+                logger.warning(
+                    "Media file no longer exists, "
+                    "replacing with placeholder: %s",
+                    url,
+                )
+                items[i] = {
+                    "type": "text",
+                    "text": (
+                        f"[{btype.title()} unavailable"
+                        f" — file deleted from disk]"
+                    ),
+                }
+        elif btype == "tool_result":
+            output = block.get("output")
+            if isinstance(output, list):
+                _fixup_media_list(output)
+
+
 # pylint: disable-next=too-many-statements
 def _create_file_block_support_formatter(
     base_formatter_class: Type[FormatterBase],
@@ -688,18 +735,11 @@ def _create_file_block_support_formatter(
                         extra_contents[block["id"]] = block["extra_content"]
 
             # Convert file:// URLs to paths for all media blocks,
+            # and replace deleted local files with text placeholders.
             # TODO: remove this after AgentScope updated
             for msg in normalized_msgs:
-                for block in msg.get_content_blocks():
-                    if block.get("type") in ("image", "audio", "video"):
-                        source = block.get("source")
-                        if (
-                            isinstance(source, dict)
-                            and source.get("type") == "url"
-                            and isinstance(source.get("url"), str)
-                            and source["url"].startswith("file://")
-                        ):
-                            source["url"] = _file_url_to_path(source["url"])
+                if isinstance(msg.content, list):
+                    _fixup_media_list(msg.content)
 
             # For Anthropic, fully override formatting to handle
             # media blocks (top-level & inside tool_result output).


### PR DESCRIPTION
## Description

When session history references local media files that have been deleted from disk, the upstream agentscope formatter throws Invalid image URL, blocking the entire request — including newly uploaded images.

Added _fixup_media_list to normalize media blocks before passing to the formatter. It strips file:// prefixes and replaces blocks referencing missing local files with text placeholders. Recurses into tool_result output lists to handle media from tool calls (e.g. view_image).

**Related Issue:** Fixes #3628 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
