### PR TITLE
fix(app): avoid ACP optional dependency breaking startup

### DIFF
--- a/src/qwenpaw/agents/acp/__init__.py
+++ b/src/qwenpaw/agents/acp/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """ACP client and server exports."""
 
+from __future__ import annotations
+
 from .core import (
     ACPConfigurationError,
     ACPProtocolError,
@@ -10,7 +12,6 @@ from .core import (
     PermissionResolution,
     SuspendedPermission,
 )
-from .server import QwenPawACPAgent, run_qwenpaw_agent
 from .service import ACPService, get_acp_service, init_acp_service
 
 __all__ = [
@@ -27,3 +28,24 @@ __all__ = [
     "run_qwenpaw_agent",
     "SuspendedPermission",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily import ACP server bindings.
+
+    The web app imports ACP helper packages transitively during startup. The
+    ACP server implementation depends on the optional third-party `acp`
+    package, so importing it eagerly turns that optional feature into a hard
+    startup requirement.
+    """
+    if name in {"QwenPawACPAgent", "run_qwenpaw_agent"}:
+        from .server import QwenPawACPAgent, run_qwenpaw_agent
+
+        globals().update(
+            {
+                "QwenPawACPAgent": QwenPawACPAgent,
+                "run_qwenpaw_agent": run_qwenpaw_agent,
+            },
+        )
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/qwenpaw/cli/acp_cmd.py
+++ b/src/qwenpaw/cli/acp_cmd.py
@@ -42,7 +42,16 @@ def acp_cmd(
 
     workspace_dir = Path(workspace) if workspace else None
 
-    from ..agents.acp.server import run_qwenpaw_agent
+    try:
+        from ..agents.acp.server import run_qwenpaw_agent
+    except ModuleNotFoundError as exc:
+        if exc.name != "acp":
+            raise
+        raise click.ClickException(
+            "ACP support is not installed in this environment. "
+            "Reinstall or sync dependencies so the "
+            "`agent-client-protocol` package is available.",
+        ) from exc
 
     asyncio.run(
         run_qwenpaw_agent(

--- a/tests/unit/agents/test_optional_acp_imports.py
+++ b/tests/unit/agents/test_optional_acp_imports.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for optional ACP imports."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _reload_module(module_name: str):
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_tools_package_imports_without_acp_server_dependency():
+    sys.modules.pop("qwenpaw.agents.acp.tool_adapter", None)
+    sys.modules.pop("qwenpaw.agents.tools.delegate_external_agent", None)
+
+    tools_module = _reload_module("qwenpaw.agents.tools")
+
+    assert hasattr(tools_module, "delegate_external_agent")
+
+
+def test_acp_package_exposes_service_symbols_without_loading_server():
+    acp_module = _reload_module("qwenpaw.agents.acp")
+
+    assert hasattr(acp_module, "get_acp_service")
+    assert "qwenpaw.agents.acp.server" not in sys.modules


### PR DESCRIPTION
## Description

Fix app startup failure when the optional ACP dependency is missing.

`qwenpaw app` currently imports ACP server bindings transitively during startup through the built-in tools package. Because ACP server mode depends on the optional third-party `acp` module, missing `agent-client-protocol` causes the whole app to fail to start, even though ACP is optional.

This PR:
- lazily loads ACP server exports in `qwenpaw.agents.acp`
- keeps `qwenpaw app` startup independent from the optional ACP server dependency
- improves the `qwenpaw acp` error message when ACP support is not installed
- adds a regression test covering imports without the ACP server dependency

Related Issue: N/A

Security Considerations: none

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] CLI
- [x] Tests

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `pytest tests/unit/agents/test_optional_acp_imports.py`
- `.venv/bin/python -c "import qwenpaw.agents.tools, qwenpaw.app._app; print('imports-ok')"`
- `.venv/bin/qwenpaw app`

## Additional Notes

This keeps ACP server functionality optional instead of making it a hard startup dependency for the web app.
