### PR TITLE
fix(working_dir): prioritize explicit QWENPAW_WORKING_DIR over legacy ~/.copaw 

### DIFF
--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -87,18 +87,18 @@ class EnvVarLoader:
 
 
 # WORKING_DIR priority:
-# 1. ~/.copaw exists (legacy installation) → use it as-is
-# 2. QWENPAW_WORKING_DIR / COPAW_WORKING_DIR env var is set → use it
+# 1. QWENPAW_WORKING_DIR / COPAW_WORKING_DIR env var is set → use it
+# 2. ~/.copaw exists (legacy installation) → use it as-is
 # 3. Default → ~/.qwenpaw
-_legacy_copaw_dir = Path("~/.copaw").expanduser()
-if _legacy_copaw_dir.exists():
-    WORKING_DIR = _legacy_copaw_dir.resolve()
+_explicit_working_dir = _get_env("QWENPAW_WORKING_DIR")
+if _explicit_working_dir:
+    WORKING_DIR = Path(_explicit_working_dir).expanduser().resolve()
 else:
-    WORKING_DIR = (
-        Path(_get_env("QWENPAW_WORKING_DIR", "~/.qwenpaw"))
-        .expanduser()
-        .resolve()
-    )
+    _legacy_copaw_dir = Path("~/.copaw").expanduser()
+    if _legacy_copaw_dir.exists():
+        WORKING_DIR = _legacy_copaw_dir.resolve()
+    else:
+        WORKING_DIR = Path("~/.qwenpaw").expanduser().resolve()
 SECRET_DIR = (
     Path(
         EnvVarLoader.get_str(


### PR DESCRIPTION
## Description

- An explicitly set `QWENPAW_WORKING_DIR` (or legacy `COPAW_WORKING_DIR`) environment variable always takes priority over the `~/.copaw` directory existence check.

## New priority order

1. `QWENPAW_WORKING_DIR` env var is set 
2. `~/.copaw` exists (legacy installation, no env var set) 
3. Default (`~/.qwenpaw`)

This follows the principle of "explicit configuration overrides implicit discovery".

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
