### PR TITLE
feat(Channels): add per-agent channel health check and restart API

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -1303,6 +1303,23 @@ class BaseChannel(ABC):
             ),
         )
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Return health status for this channel.
+
+        Default implementation returns a basic status dict.
+        Subclasses can override to add channel-specific checks
+        (e.g. webhook reachability, token validity, polling status).
+
+        Returns:
+            Dict with at least: channel, status ("healthy" / "unhealthy"),
+            and optional detail, error fields.
+        """
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Channel is loaded and running.",
+        }
+
     async def start(self) -> None:
         raise NotImplementedError
 

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -577,6 +577,20 @@ class ConsoleChannel(BaseChannel):
 
     # ── lifecycle ───────────────────────────────────────────────────
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Console channel is always healthy when enabled."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Console channel is disabled.",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Console channel is running.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("console channel disabled")

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -2643,6 +2643,31 @@ class DingTalkChannel(BaseChannel):
             except asyncio.TimeoutError:
                 pass
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check DingTalk stream client and HTTP session status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "DingTalk channel is disabled.",
+            }
+        issues = []
+        if self._client is None:
+            issues.append("Stream client not initialized")
+        if self._http is None or self._http.closed:
+            issues.append("HTTP session not available")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "DingTalk stream client and HTTP session are active.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("disabled by env DINGTALK_CHANNEL_ENABLED=0")

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -10,7 +10,7 @@ import tempfile
 from collections import deque
 from pathlib import Path
 from urllib.parse import urlparse
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import aiohttp
 from agentscope_runtime.engine.schemas.agent_schemas import (
@@ -637,6 +637,41 @@ class DiscordChannel(BaseChannel):
         if not self.enabled or not self.token or not self._client:
             return
         await self._client.start(self.token, reconnect=True)
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Discord gateway connection status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Discord channel is disabled.",
+            }
+        if not self._client:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Discord client not initialized.",
+            }
+        if not self._client.is_ready():
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": (
+                    "Discord client is not ready" " (gateway not connected)."
+                ),
+            }
+        task_alive = self._task is not None and not self._task.done()
+        if not task_alive:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Discord gateway task is not running.",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Discord gateway is connected and ready.",
+        }
 
     async def start(self) -> None:
         if not self.enabled:

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -2150,6 +2150,34 @@ class FeishuChannel(BaseChannel):
         # Final cleanup signal
         self._stop_event.set()
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Feishu WebSocket and SDK client status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Feishu channel is disabled.",
+            }
+        issues = []
+        if self._client is None:
+            issues.append("Feishu SDK client not initialized")
+        ws_thread_alive = (
+            self._ws_thread is not None and self._ws_thread.is_alive()
+        )
+        if not ws_thread_alive:
+            issues.append("WebSocket thread is not running")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Feishu SDK client and WebSocket are active.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("feishu channel disabled")

--- a/src/qwenpaw/app/channels/imessage/channel.py
+++ b/src/qwenpaw/app/channels/imessage/channel.py
@@ -341,6 +341,32 @@ ORDER BY m.ROWID ASC
         """Send error via imessage _send_sync (sync API)."""
         await asyncio.to_thread(self._send_sync, to_handle, err_text)
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check iMessage watcher thread status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "iMessage channel is disabled.",
+            }
+        issues = []
+        if self._imsg_path is None:
+            issues.append("imsg binary path not set")
+        thread_alive = self._thread is not None and self._thread.is_alive()
+        if not thread_alive:
+            issues.append("Watcher thread is not running")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "iMessage watcher is running.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("disabled by env IMESSAGE_ENABLED=0")

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -385,18 +385,20 @@ class ChannelManager:
             f"priority={priority_level}",
         )
 
-        # Get channel instance
-        ch = await self.get_channel(channel_id)
-        if not ch:
-            logger.error(
-                f"Consumer: channel not found: channel_id={channel_id}",
-            )
-            return
-
         while True:
             try:
                 # Get first payload
                 payload = await queue.get()
+
+                # Re-fetch channel each iteration so replace_channel()
+                # swaps are picked up automatically.
+                ch = await self.get_channel(channel_id)
+                if not ch:
+                    logger.error(
+                        "Consumer: channel not found: "
+                        f"channel_id={channel_id}",
+                    )
+                    return
 
                 # Drain queue for same-key payloads (batch merge logic)
                 # Note: In new architecture, same-key means same QueueKey,
@@ -530,6 +532,100 @@ class ChannelManager:
                 if ch.channel == channel:
                     return ch
             return None
+
+    async def get_channel_health(
+        self,
+        channel_name: str,
+    ) -> Dict[str, Any]:
+        """Get health status for a specific channel.
+
+        Args:
+            channel_name: Channel identifier (e.g. "dingtalk", "telegram")
+
+        Returns:
+            Health status dict from the channel's health_check() method.
+
+        Raises:
+            KeyError: If channel is not found in this manager.
+        """
+        channel_instance = await self.get_channel(channel_name)
+        if channel_instance is None:
+            raise KeyError(f"Channel not found: {channel_name}")
+        try:
+            return await channel_instance.health_check()
+        except Exception as exc:
+            logger.exception(
+                "health_check failed for channel=%s",
+                channel_name,
+            )
+            return {
+                "channel": channel_name,
+                "status": "unhealthy",
+                "detail": str(exc),
+            }
+
+    async def restart_channel(self, channel_name: str) -> Dict[str, Any]:
+        """Restart a single channel by stopping and re-starting it.
+
+        The channel is stopped, then a fresh instance is created via
+        clone() with the current config, and started via replace_channel().
+
+        Args:
+            channel_name: Channel identifier (e.g. "dingtalk", "telegram")
+
+        Returns:
+            Dict with restart result: channel, status, detail.
+
+        Raises:
+            KeyError: If channel is not found in this manager.
+        """
+        channel_instance = await self.get_channel(channel_name)
+        if channel_instance is None:
+            raise KeyError(f"Channel not found: {channel_name}")
+
+        logger.info("Restarting channel: %s", channel_name)
+
+        # Load the latest config for this channel
+        from ...config.config import load_agent_config
+
+        agent_id = self._workspace.agent_id if self._workspace else None
+        if agent_id is None:
+            raise RuntimeError(
+                "Cannot restart channel: workspace not set on ChannelManager",
+            )
+
+        agent_config = load_agent_config(agent_id)
+        channels_cfg = agent_config.channels
+        if channels_cfg is None:
+            raise RuntimeError(
+                f"No channels config found for agent {agent_id}",
+            )
+
+        # Get channel-specific config
+        channel_cfg = getattr(channels_cfg, channel_name, None)
+        if channel_cfg is None:
+            extra = getattr(channels_cfg, "__pydantic_extra__", None) or {}
+            channel_cfg = extra.get(channel_name)
+        if channel_cfg is None:
+            raise RuntimeError(
+                f"No config found for channel '{channel_name}'",
+            )
+
+        # Clone a fresh channel instance with current config and replace
+        new_channel = channel_instance.clone(channel_cfg)
+        if self._workspace is not None:
+            new_channel.set_workspace(
+                self._workspace,
+                self._command_registry,
+            )
+        await self.replace_channel(new_channel)
+
+        logger.info("Channel restarted successfully: %s", channel_name)
+        return {
+            "channel": channel_name,
+            "status": "restarted",
+            "detail": f"Channel '{channel_name}' has been restarted.",
+        }
 
     def set_workspace(self, workspace) -> None:
         """Set workspace and inject to all channels.

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -80,6 +80,9 @@ class ChannelManager:
         self._queue_manager: UnifiedQueueManager | None = None
         self._workspace = None
 
+        # Per-channel locks to prevent concurrent restarts
+        self._restart_locks: dict[str, asyncio.Lock] = {}
+
         # Track enqueue tasks for graceful shutdown
         self._enqueue_tasks: set[asyncio.Task] = set()
 
@@ -394,11 +397,21 @@ class ChannelManager:
                 # swaps are picked up automatically.
                 ch = await self.get_channel(channel_id)
                 if not ch:
-                    logger.error(
-                        "Consumer: channel not found: "
-                        f"channel_id={channel_id}",
-                    )
-                    return
+                    # Channel may be temporarily absent during a
+                    # replace_channel() swap.  Retry a few times before
+                    # giving up so we don't silently drop the payload.
+                    for _retry in range(3):
+                        await asyncio.sleep(0.5)
+                        ch = await self.get_channel(channel_id)
+                        if ch:
+                            break
+                    if not ch:
+                        logger.error(
+                            "Consumer: channel not found after"
+                            " retries: channel_id=%s",
+                            channel_id,
+                        )
+                        return
 
                 # Drain queue for same-key payloads (batch merge logic)
                 # Note: In new architecture, same-key means same QueueKey,
@@ -579,53 +592,77 @@ class ChannelManager:
         Raises:
             KeyError: If channel is not found in this manager.
         """
-        channel_instance = await self.get_channel(channel_name)
-        if channel_instance is None:
-            raise KeyError(f"Channel not found: {channel_name}")
+        # Per-channel lock prevents concurrent restarts from
+        # leaking resources (two clones started, one discarded).
+        lock = self._restart_locks.setdefault(
+            channel_name,
+            asyncio.Lock(),
+        )
+        async with lock:
+            channel_instance = await self.get_channel(channel_name)
+            if channel_instance is None:
+                raise KeyError(
+                    f"Channel not found: {channel_name}",
+                )
 
-        logger.info("Restarting channel: %s", channel_name)
+            logger.info("Restarting channel: %s", channel_name)
 
-        # Load the latest config for this channel
-        from ...config.config import load_agent_config
+            # Load the latest config for this channel
+            from ...config.config import load_agent_config
 
-        agent_id = self._workspace.agent_id if self._workspace else None
-        if agent_id is None:
-            raise RuntimeError(
-                "Cannot restart channel: workspace not set on ChannelManager",
+            agent_id = self._workspace.agent_id if self._workspace else None
+            if agent_id is None:
+                raise RuntimeError(
+                    "Cannot restart channel: workspace not set"
+                    " on ChannelManager",
+                )
+
+            agent_config = load_agent_config(agent_id)
+            channels_cfg = agent_config.channels
+            if channels_cfg is None:
+                raise RuntimeError(
+                    f"No channels config found for agent" f" {agent_id}",
+                )
+
+            # Get channel-specific config
+            channel_cfg = getattr(
+                channels_cfg,
+                channel_name,
+                None,
             )
+            if channel_cfg is None:
+                extra = (
+                    getattr(
+                        channels_cfg,
+                        "__pydantic_extra__",
+                        None,
+                    )
+                    or {}
+                )
+                channel_cfg = extra.get(channel_name)
+            if channel_cfg is None:
+                raise RuntimeError(
+                    f"No config found for channel" f" '{channel_name}'",
+                )
 
-        agent_config = load_agent_config(agent_id)
-        channels_cfg = agent_config.channels
-        if channels_cfg is None:
-            raise RuntimeError(
-                f"No channels config found for agent {agent_id}",
+            # Clone a fresh instance and replace
+            new_channel = channel_instance.clone(channel_cfg)
+            if self._workspace is not None:
+                new_channel.set_workspace(
+                    self._workspace,
+                    self._command_registry,
+                )
+            await self.replace_channel(new_channel)
+
+            logger.info(
+                "Channel restarted successfully: %s",
+                channel_name,
             )
-
-        # Get channel-specific config
-        channel_cfg = getattr(channels_cfg, channel_name, None)
-        if channel_cfg is None:
-            extra = getattr(channels_cfg, "__pydantic_extra__", None) or {}
-            channel_cfg = extra.get(channel_name)
-        if channel_cfg is None:
-            raise RuntimeError(
-                f"No config found for channel '{channel_name}'",
-            )
-
-        # Clone a fresh channel instance with current config and replace
-        new_channel = channel_instance.clone(channel_cfg)
-        if self._workspace is not None:
-            new_channel.set_workspace(
-                self._workspace,
-                self._command_registry,
-            )
-        await self.replace_channel(new_channel)
-
-        logger.info("Channel restarted successfully: %s", channel_name)
-        return {
-            "channel": channel_name,
-            "status": "restarted",
-            "detail": f"Channel '{channel_name}' has been restarted.",
-        }
+            return {
+                "channel": channel_name,
+                "status": "restarted",
+                "detail": (f"Channel '{channel_name}'" " has been restarted."),
+            }
 
     def set_workspace(self, workspace) -> None:
         """Set workspace and inject to all channels.

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -338,6 +338,33 @@ class MatrixChannel(BaseChannel):
             request_timeout=request_timeout,
         )
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Matrix client connection status."""
+        if not getattr(self, "enabled", True) or not self._cfg.homeserver:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Matrix homeserver not configured.",
+            }
+        if self._client is None:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Matrix client not initialized.",
+            }
+        has_token = bool(self._client.access_token)
+        if not has_token:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Matrix client has no access token (not logged in).",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Matrix client is connected.",
+        }
+
     # pylint: disable=too-many-branches
     async def start(self) -> None:
         if not self._cfg.homeserver:

--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -9,7 +9,7 @@ import logging
 import re
 import uuid
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import httpx
 from agentscope_runtime.engine.schemas.agent_schemas import (
@@ -251,6 +251,36 @@ class MattermostChannel(BaseChannel):
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Mattermost WebSocket and bot identity status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Mattermost channel is disabled.",
+            }
+        issues = []
+        task_alive = self._task is not None and not self._task.done()
+        if not task_alive:
+            issues.append("WebSocket task is not running")
+        if not self._bot_id:
+            issues.append("Bot identity not resolved (bot_id is empty)")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": (
+                f"Mattermost bot is connected "
+                f"(bot_id={self._bot_id}, "
+                f"username={self._bot_username})."
+            ),
+        }
 
     async def start(self) -> None:
         if not self.enabled:

--- a/src/qwenpaw/app/channels/mqtt/channel.py
+++ b/src/qwenpaw/app/channels/mqtt/channel.py
@@ -6,7 +6,7 @@ import json
 import uuid
 import logging
 import threading
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import paho.mqtt.client as mqtt
 from paho.mqtt import MQTTException
@@ -283,6 +283,32 @@ class MQTTChannel(BaseChannel):
                 f"Error processing MQTT message: {str(e)}",
                 exc_info=True,
             )
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check MQTT broker connection status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "MQTT channel is disabled.",
+            }
+        if self.client is None:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "MQTT client not initialized.",
+            }
+        if not self.connected:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "MQTT client is not connected to broker.",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": f"MQTT connected to {self.host}:{self.port}.",
+        }
 
     async def start(self) -> None:
         if not self.enabled:

--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -173,6 +173,41 @@ class OneBotChannel(BaseChannel):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check OneBot reverse WebSocket server status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "OneBot channel is disabled.",
+            }
+        if self._site is None:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "WebSocket server is not running.",
+            }
+        connection_count = len(self._connections)
+        if connection_count == 0:
+            return {
+                "channel": self.channel,
+                "status": "healthy",
+                "detail": (
+                    f"WebSocket server listening on "
+                    f"{self._ws_host}:{self._ws_port}, "
+                    f"no active connections."
+                ),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": (
+                f"WebSocket server listening on "
+                f"{self._ws_host}:{self._ws_port}, "
+                f"{connection_count} active connection(s)."
+            ),
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("onebot channel disabled")

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1648,6 +1648,34 @@ class QQChannel(BaseChannel):
             self._stop_event.set()
             logger.info("qq ws thread stopped")
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check QQ WebSocket and HTTP session status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "QQ channel is disabled.",
+            }
+        issues = []
+        ws_thread_alive = (
+            self._ws_thread is not None and self._ws_thread.is_alive()
+        )
+        if not ws_thread_alive:
+            issues.append("WebSocket thread is not running")
+        if self._http is None or self._http.closed:
+            issues.append("HTTP session not available")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "QQ WebSocket and HTTP session are active.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("qq channel disabled by QQ_CHANNEL_ENABLED=0")

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -10,7 +10,7 @@ import logging
 import re
 import uuid
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from telegram import BotCommand
 from telegram.constants import ParseMode
@@ -1029,6 +1029,33 @@ class TelegramChannel(BaseChannel):
             )
             await asyncio.sleep(delay)
             delay = min(delay * _RECONNECT_FACTOR, _RECONNECT_MAX_S)
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Telegram polling task status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Telegram channel is disabled.",
+            }
+        if not self._bot_token:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Telegram bot token is not configured.",
+            }
+        task_alive = self._task is not None and not self._task.done()
+        if not task_alive:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Telegram polling task is not running.",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Telegram polling task is running.",
+        }
 
     async def start(self) -> None:
         if not self.enabled or not self._bot_token:

--- a/src/qwenpaw/app/channels/voice/channel.py
+++ b/src/qwenpaw/app/channels/voice/channel.py
@@ -78,6 +78,35 @@ class VoiceChannel(BaseChannel):
         # Tunnel driver is created lazily on start()
         return instance
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Voice channel tunnel and Twilio status."""
+        if not self._enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Voice channel is disabled.",
+            }
+        issues = []
+        if self.twilio_mgr is None:
+            issues.append("Twilio credentials not configured")
+        if self.tunnel_mgr is None:
+            issues.append("Cloudflare tunnel not started")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        active_sessions = len(list(self.session_mgr.active_sessions()))
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": (
+                f"Voice channel is running with "
+                f"{active_sessions} active call session(s)."
+            ),
+        }
+
     async def start(self) -> None:
         """Start the voice channel: tunnel + Twilio webhook."""
         if not self._enabled:

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -1157,6 +1157,34 @@ class WecomChannel(BaseChannel):
                 pass
             self._ws_loop = None
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check WeCom WebSocket client status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "WeCom channel is disabled.",
+            }
+        issues = []
+        if self._client is None:
+            issues.append("WeCom WebSocket client not initialized")
+        ws_thread_alive = (
+            self._ws_thread is not None and self._ws_thread.is_alive()
+        )
+        if not ws_thread_alive:
+            issues.append("WebSocket thread is not running")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "WeCom WebSocket client is connected.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("wecom channel disabled")

--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -1383,6 +1383,36 @@ class WeixinChannel(BaseChannel):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check WeChat long-poll client status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "WeChat channel is disabled.",
+            }
+        issues = []
+        if self._client is None:
+            issues.append("WeChat client not initialized")
+        if not self.bot_token:
+            issues.append("Bot token not available (not logged in)")
+        poll_thread_alive = (
+            self._poll_thread is not None and self._poll_thread.is_alive()
+        )
+        if not poll_thread_alive:
+            issues.append("Long-poll thread is not running")
+        if issues:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "; ".join(issues),
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "WeChat client is connected and polling.",
+        }
+
     async def start(self) -> None:
         if not self.enabled:
             logger.debug("weixin channel disabled")

--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -209,6 +209,32 @@ class XiaoYiChannel(BaseChannel):
         if not self.agent_id:
             raise ValueError("XiaoYi Agent ID is required")
 
+    async def health_check(self) -> Dict[str, Any]:
+        """Check XiaoYi WebSocket connection status."""
+        if not self.enabled:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "XiaoYi channel is disabled.",
+            }
+        if not self._connected:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "XiaoYi WebSocket is not connected.",
+            }
+        if self._ws is None or self._ws.closed:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "XiaoYi WebSocket connection is closed.",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "XiaoYi WebSocket is connected.",
+        }
+
     async def start(self) -> None:
         """Start WebSocket connection."""
         if not self.enabled:

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
-from fastapi import APIRouter, Body, HTTPException, Path, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from pydantic import BaseModel
 
 from ..utils import schedule_agent_reload
@@ -36,7 +36,11 @@ from ...config.config import (
     WecomConfig,
 )
 
-from .schemas_config import HeartbeatBody
+from .schemas_config import (
+    ChannelHealthResponse,
+    ChannelRestartResponse,
+    HeartbeatBody,
+)
 from ..channels.qrcode_auth_handler import (
     QRCODE_AUTH_HANDLERS,
     generate_qrcode_image,
@@ -138,6 +142,102 @@ async def put_channels(
     schedule_agent_reload(request, agent.agent_id)
 
     return channels_config
+
+
+# ── Channel health check & restart ─────────────────────────────────────────
+
+
+async def _resolve_channel_manager(
+    request: Request,
+    channel_name: str = Path(
+        ...,
+        description="Name of the channel",
+        min_length=1,
+    ),
+):
+    """Shared dependency: validate channel name and return channel_manager."""
+    from ..agent_context import get_agent_for_request
+
+    available = get_available_channels()
+    if channel_name not in available:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Channel '{channel_name}' not available",
+        )
+
+    agent = await get_agent_for_request(request)
+    channel_manager = agent.channel_manager
+    if channel_manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel manager not initialized",
+        )
+    return channel_manager
+
+
+@router.get(
+    "/channels/{channel_name}/health",
+    response_model=ChannelHealthResponse,
+    summary="Health check for a channel",
+    description="Return the runtime health status of a specific channel",
+)
+async def get_channel_health(
+    channel_name: str = Path(
+        ...,
+        description="Name of the channel to check",
+        min_length=1,
+    ),
+    channel_manager=Depends(_resolve_channel_manager),
+) -> ChannelHealthResponse:
+    """Return health status for a specific channel."""
+    try:
+        return await channel_manager.get_channel_health(
+            channel_name,
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Channel '{channel_name}' is not running."
+                " It may be disabled or not configured."
+            ),
+        ) from exc
+
+
+@router.post(
+    "/channels/{channel_name}/restart",
+    response_model=ChannelRestartResponse,
+    summary="Restart a channel",
+    description=(
+        "Stop and re-start a specific channel" " without restarting the agent"
+    ),
+)
+async def restart_channel(
+    channel_name: str = Path(
+        ...,
+        description="Name of the channel to restart",
+        min_length=1,
+    ),
+    channel_manager=Depends(_resolve_channel_manager),
+) -> ChannelRestartResponse:
+    """Restart a specific channel."""
+    try:
+        return await channel_manager.restart_channel(
+            channel_name,
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Channel '{channel_name}' is not running."
+                " It may be disabled or not configured."
+            ),
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=(f"Failed to restart channel" f" '{channel_name}': {exc}"),
+        ) from exc
 
 
 # ── Unified QR code endpoints for all channels ─────────────────────────────

--- a/src/qwenpaw/app/routers/schemas_config.py
+++ b/src/qwenpaw/app/routers/schemas_config.py
@@ -20,3 +20,19 @@ class HeartbeatBody(BaseModel):
     )
 
     model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class ChannelHealthResponse(BaseModel):
+    """Response model for GET /config/channels/{channel_name}/health."""
+
+    channel: str
+    status: str
+    detail: str = ""
+
+
+class ChannelRestartResponse(BaseModel):
+    """Response model for POST /config/channels/{channel_name}/restart."""
+
+    channel: str
+    status: str
+    detail: str = ""

--- a/src/qwenpaw/app/routers/schemas_config.py
+++ b/src/qwenpaw/app/routers/schemas_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Request/response schemas for config API endpoints."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -26,7 +26,7 @@ class ChannelHealthResponse(BaseModel):
     """Response model for GET /config/channels/{channel_name}/health."""
 
     channel: str
-    status: str
+    status: Literal["healthy", "unhealthy", "disabled"]
     detail: str = ""
 
 
@@ -34,5 +34,5 @@ class ChannelRestartResponse(BaseModel):
     """Response model for POST /config/channels/{channel_name}/restart."""
 
     channel: str
-    status: str
+    status: Literal["restarted"]
     detail: str = ""


### PR DESCRIPTION
## Description

Add runtime health check and hot-restart HTTP APIs for individual channels,
enabling diagnosis and recovery without restarting the entire agent.

### API
- `GET /config/channels/{channel_name}/health` — runtime health status
- `POST /config/channels/{channel_name}/restart` — hot-restart a channel
- Shared `_resolve_channel_manager` FastAPI dependency for validation
- Pydantic response models with `Literal` status types

### Manager
- `get_channel_health()` with exception-safe fallback
- `restart_channel()` with per-channel `asyncio.Lock` to prevent concurrent restarts
- Consumer loop re-fetches channel instance per iteration with retry logic
  to handle transient unavailability during channel replacement

### Channels
- Default `health_check()` on `BaseChannel`
- Channel-specific `health_check()` for all 15 channels, each checking
  its own critical state (WebSocket, SDK client, HTTP session, etc.)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
