### PR TITLE
fix: table

### DIFF
--- a/console/src/pages/Control/CronJobs/index.tsx
+++ b/console/src/pages/Control/CronJobs/index.tsx
@@ -227,6 +227,7 @@ function CronJobsPage() {
           scroll={{ x: 2840 }}
           pagination={{
             pageSize: 10,
+            showSizeChanger: false,
           }}
         />
       </Card>

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -183,6 +183,7 @@ function SessionsPage() {
           scroll={{ x: 1500 }}
           pagination={{
             pageSize: 10,
+            showSizeChanger: false,
           }}
         />
       </Card>


### PR DESCRIPTION
## Description

Ant Design v5 (used in the current project): When total > 50, showSizeChanger is automatically displayed by default.

Ant Design v4: Not displayed by default; showSizeChanger: true needs to be set manually.
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
