### PR TITLE
fix(channels): respect filter_tool_messages in on_event_content

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -960,6 +960,8 @@ class BaseChannel(ABC):
         status = getattr(event, "status", None)
         if status != RunStatus.InProgress:
             return False
+        if self._filter_tool_messages:
+            return False
         data = getattr(event, "data", None) or {}
         if not isinstance(data, dict) or "output" not in data:
             return False


### PR DESCRIPTION
## Summary
- **Bug**: When `filter_tool_messages` is enabled, `on_event_content` still sends streaming tool output to channels, bypassing the filter. This causes message bombing on channels like Feishu where each tool call is sent as a separate message.
- **Fix**: Add early return when `_filter_tool_messages` is True in `on_event_content`, consistent with the behavior in v1.1.2.

## Root Cause
In the main branch (1.1.3b2), `on_event_content` was refactored to use `_format_stream_tool_output_body` for streaming tool output, but the `_filter_tool_messages` check was removed. This means even when users configure `filter_tool_messages: true`, streaming tool messages are still sent to the channel, causing spam.

## Change
```diff
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -960,6 +960,8 @@
         status = getattr(event, "status", None)
         if status != RunStatus.InProgress:
             return False
+        if self._filter_tool_messages:
+            return False
         data = getattr(event, "data", None) or {}
```

## Impact
- Fixes message bombing on Feishu, DingTalk, and other channels when `filter_tool_messages` is enabled
- No breaking changes; restores expected filtering behavior