### PR TITLE
perf(agent-stats): optimize session file processing with fast-skip and bounded concurrency for /agent-stats API

### DIFF
--- a/src/qwenpaw/agent_stats/service.py
+++ b/src/qwenpaw/agent_stats/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import date, timedelta
 from pathlib import Path
 
@@ -22,6 +23,77 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _should_skip_by_mtime(
+    session_file: Path,
+    start_date: date,
+    end_date: date,
+) -> bool:
+    try:
+        mtime = session_file.stat().st_mtime
+        mtime_date = date.fromtimestamp(mtime)
+        buffered_end = end_date + timedelta(days=1)
+        if mtime_date < start_date or mtime_date > buffered_end:
+            logger.debug(
+                "Skipping %s by mtime (%s) outside range [%s, %s]",
+                session_file.name,
+                mtime_date.isoformat(),
+                start_date.isoformat(),
+                end_date.isoformat(),
+            )
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def _should_skip_by_content_range(
+    session_data: dict,
+    start_date_str: str,
+    end_date_str: str,
+) -> bool:
+    memories = (
+        session_data.get("agent", {}).get("memory", {}).get("memories")
+    ) or session_data.get("agent", {}).get("memory", {}).get("content", [])
+
+    if not memories:
+        return True
+
+    timestamps: list[str] = []
+    for msg_item in memories:
+        if isinstance(msg_item, list) and len(msg_item) > 0:
+            msg_data = msg_item[0]
+        elif isinstance(msg_item, dict):
+            msg_data = msg_item
+        else:
+            continue
+
+        if not isinstance(msg_data, dict):
+            continue
+
+        timestamp = msg_data.get("timestamp")
+        if timestamp:
+            timestamps.append(str(timestamp)[:10])
+
+    if not timestamps:
+        return True
+
+    first_date = timestamps[0]
+    last_date = timestamps[-1]
+
+    if last_date < start_date_str or first_date > end_date_str:
+        logger.debug(
+            "Skipping session by content range [%s, %s] "
+            "outside target [%s, %s]",
+            first_date,
+            last_date,
+            start_date_str,
+            end_date_str,
+        )
+        return True
+
+    return False
 
 
 # pylint:disable=too-many-statements,too-many-branches
@@ -101,8 +173,8 @@ def _process_session_file(
     except Exception as e:
         logger.debug("Failed to count messages in session: %s", e)
 
-    if has_messages_in_range:
-        stats["session_count"] += 1
+    if has_messages_in_range and channel in channel_stats:
+        channel_stats[channel]["session_count"] += 1
 
     return tool_call_count, has_messages_in_range
 
@@ -177,7 +249,16 @@ class AgentStatsService:
                     if name.endswith(".json")
                 ]
 
+                session_fd_sem = asyncio.Semaphore((os.cpu_count() or 4) * 2)
+
                 async def _process_one(session_file: Path) -> tuple[int, bool]:
+                    if _should_skip_by_mtime(
+                        session_file,
+                        start_date,
+                        end_date,
+                    ):
+                        return 0, False
+
                     try:
                         async with aiofiles.open(
                             session_file,
@@ -192,19 +273,28 @@ class AgentStatsService:
                             e,
                         )
                         return 0, False
-                    stem = session_file.stem
-                    channel = session_file_to_channel.get(stem, "console")
 
-                    return _process_session_file(
+                    if _should_skip_by_content_range(
                         session_data,
                         start_date_str,
                         end_date_str,
-                        daily_stats,
-                        channel_stats,
-                        channel,
-                        stem,
-                        active_sessions,
-                    )
+                    ):
+                        return 0, False
+
+                    stem = session_file.stem
+                    channel = session_file_to_channel.get(stem, "console")
+
+                    async with session_fd_sem:
+                        return _process_session_file(
+                            session_data,
+                            start_date_str,
+                            end_date_str,
+                            daily_stats,
+                            channel_stats,
+                            channel,
+                            stem,
+                            active_sessions,
+                        )
 
                 tasks = [_process_one(sf) for sf in session_files]
                 results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/src/qwenpaw/agent_stats/service.py
+++ b/src/qwenpaw/agent_stats/service.py
@@ -25,6 +25,7 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable=unused-argument
 def _should_skip_by_mtime(
     session_file: Path,
     start_date: date,
@@ -33,14 +34,12 @@ def _should_skip_by_mtime(
     try:
         mtime = session_file.stat().st_mtime
         mtime_date = date.fromtimestamp(mtime)
-        buffered_end = end_date + timedelta(days=1)
-        if mtime_date < start_date or mtime_date > buffered_end:
+        if mtime_date < start_date:
             logger.debug(
-                "Skipping %s by mtime (%s) outside range [%s, %s]",
+                "Skipping %s by mtime (%s) before start date %s",
                 session_file.name,
                 mtime_date.isoformat(),
                 start_date.isoformat(),
-                end_date.isoformat(),
             )
             return True
     except OSError:
@@ -252,39 +251,39 @@ class AgentStatsService:
                 session_fd_sem = asyncio.Semaphore((os.cpu_count() or 4) * 2)
 
                 async def _process_one(session_file: Path) -> tuple[int, bool]:
-                    if _should_skip_by_mtime(
-                        session_file,
-                        start_date,
-                        end_date,
-                    ):
-                        return 0, False
-
-                    try:
-                        async with aiofiles.open(
-                            session_file,
-                            "r",
-                            encoding="utf-8",
-                        ) as f:
-                            session_data = orjson.loads(await f.read())
-                    except Exception as e:
-                        logger.debug(
-                            "Failed to read session file %s: %s",
-                            session_file,
-                            e,
-                        )
-                        return 0, False
-
-                    if _should_skip_by_content_range(
-                        session_data,
-                        start_date_str,
-                        end_date_str,
-                    ):
-                        return 0, False
-
-                    stem = session_file.stem
-                    channel = session_file_to_channel.get(stem, "console")
-
                     async with session_fd_sem:
+                        if _should_skip_by_mtime(
+                            session_file,
+                            start_date,
+                            end_date,
+                        ):
+                            return 0, False
+
+                        try:
+                            async with aiofiles.open(
+                                session_file,
+                                "r",
+                                encoding="utf-8",
+                            ) as f:
+                                session_data = orjson.loads(await f.read())
+                        except Exception as e:
+                            logger.debug(
+                                "Failed to read session file %s: %s",
+                                session_file,
+                                e,
+                            )
+                            return 0, False
+
+                        if _should_skip_by_content_range(
+                            session_data,
+                            start_date_str,
+                            end_date_str,
+                        ):
+                            return 0, False
+
+                        stem = session_file.stem
+                        channel = session_file_to_channel.get(stem, "console")
+
                         return _process_session_file(
                             session_data,
                             start_date_str,


### PR DESCRIPTION

## Description

[Describe what this PR does and why]

Changed:
- Fast-skip by mtime: Skip session files whose modification time falls outside the query date range (with +1 day buffer), avoiding unnecessary disk reads.
- Fast-skip by content range: After loading a session file, check the first and last message timestamps. Skip the entire file if no messages overlap the query range.
- Bounded concurrency (session_fd_sem): Limit concurrent session processing to cpu_count * 2 via asyncio.Semaphore, preventing unbounded memory growth with large session directories.
- Bugfix: Fixed a possibly-unbound stats variable in _process_session_file.

Impact:
- Significantly reduces I/O and CPU for date-range queries on large session directories.
- Safer resource usage under high session counts.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
