### PR TITLE
feat(cli): add routing management commands

### DIFF
--- a/src/qwenpaw/cli/providers_cmd.py
+++ b/src/qwenpaw/cli/providers_cmd.py
@@ -7,6 +7,7 @@ import time
 from typing import Optional
 
 import click
+import httpx
 
 from agentscope_runtime.engine.schemas.exception import (
     AppBaseException,
@@ -14,6 +15,7 @@ from agentscope_runtime.engine.schemas.exception import (
 
 from ..providers.provider import ModelInfo, Provider, ProviderInfo
 from ..providers.provider_manager import ProviderManager
+from .http import client as http_client, print_json, resolve_base_url
 from .utils import prompt_choice
 
 
@@ -556,6 +558,201 @@ def config_key_cmd(provider_id: str | None) -> None:
 def set_llm_cmd() -> None:
     """Interactively set the active LLM model."""
     configure_llm_slot_interactive()
+
+
+def _routing_params(agent_id: str | None) -> dict[str, str] | None:
+    if agent_id:
+        return {"agent_id": agent_id}
+    return None
+
+
+def _request_routing_config(
+    base_url: str,
+    *,
+    agent_id: str | None = None,
+) -> dict:
+    with http_client(base_url) as client:
+        response = client.get(
+            "/config/agents/llm-routing",
+            params=_routing_params(agent_id),
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _update_routing_config(
+    base_url: str,
+    body: dict,
+    *,
+    agent_id: str | None = None,
+) -> dict:
+    with http_client(base_url) as client:
+        response = client.put(
+            "/config/agents/llm-routing",
+            params=_routing_params(agent_id),
+            json=body,
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _print_routing_config(
+    payload: dict,
+    *,
+    agent_id: str | None,
+) -> None:
+    scope = f"agent:{agent_id}" if agent_id else "global"
+    click.echo(f"Scope   : {scope}")
+    click.echo(f"Enabled : {payload.get('enabled', False)}")
+    click.echo(f"Mode    : {payload.get('mode', 'local_first')}")
+
+    local = payload.get("local") or {}
+    cloud = payload.get("cloud") or {}
+    local_display = (
+        f"{local.get('provider_id', '')} / {local.get('model', '')}"
+        if local
+        else "(empty)"
+    )
+    cloud_display = (
+        f"{cloud.get('provider_id', '')} / {cloud.get('model', '')}"
+        if cloud
+        else "(empty)"
+    )
+    click.echo(f"Local   : {local_display}")
+    click.echo(f"Cloud   : {cloud_display}")
+
+
+@models_group.group("routing")
+def routing_group() -> None:
+    """Manage LLM routing through the running QwenPaw app."""
+
+
+@routing_group.command("get")
+@click.option("--agent-id", default=None, help="Optional agent-scoped view.")
+@click.option("--json", "json_output", is_flag=True, help="Print raw JSON.")
+@click.option("--base-url", default=None, help="Server base URL.")
+@click.pass_context
+def routing_get_cmd(
+    ctx: click.Context,
+    agent_id: str | None,
+    json_output: bool,
+    base_url: str | None,
+) -> None:
+    """Show routing settings."""
+    resolved_base_url = resolve_base_url(ctx, base_url)
+    try:
+        payload = _request_routing_config(
+            resolved_base_url,
+            agent_id=agent_id,
+        )
+    except httpx.HTTPError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if json_output:
+        print_json(payload)
+        return
+
+    _print_routing_config(payload, agent_id=agent_id)
+
+
+@routing_group.command("set")
+@click.option("--agent-id", default=None, help="Optional agent-scoped write.")
+@click.option(
+    "--mode",
+    required=True,
+    type=click.Choice(["local_first", "cloud_first"], case_sensitive=False),
+    help="Routing mode to enable.",
+)
+@click.option("--local-provider", required=True, help="Local slot provider.")
+@click.option("--local-model", required=True, help="Local slot model.")
+@click.option("--cloud-provider", default=None, help="Cloud slot provider.")
+@click.option("--cloud-model", default=None, help="Cloud slot model.")
+@click.option("--json", "json_output", is_flag=True, help="Print raw JSON.")
+@click.option("--base-url", default=None, help="Server base URL.")
+@click.pass_context
+def routing_set_cmd(
+    ctx: click.Context,
+    agent_id: str | None,
+    mode: str,
+    local_provider: str,
+    local_model: str,
+    cloud_provider: str | None,
+    cloud_model: str | None,
+    json_output: bool,
+    base_url: str | None,
+) -> None:
+    """Enable routing and update slot configuration."""
+    if bool(cloud_provider) != bool(cloud_model):
+        raise click.ClickException(
+            "Provide both --cloud-provider and --cloud-model together.",
+        )
+
+    resolved_base_url = resolve_base_url(ctx, base_url)
+    body: dict = {
+        "enabled": True,
+        "mode": mode,
+        "local": {
+            "provider_id": local_provider,
+            "model": local_model,
+        },
+        "cloud": (
+            {
+                "provider_id": cloud_provider,
+                "model": cloud_model,
+            }
+            if cloud_provider and cloud_model
+            else None
+        ),
+    }
+
+    try:
+        payload = _update_routing_config(
+            resolved_base_url,
+            body,
+            agent_id=agent_id,
+        )
+    except httpx.HTTPError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if json_output:
+        print_json(payload)
+        return
+
+    _print_routing_config(payload, agent_id=agent_id)
+
+
+@routing_group.command("disable")
+@click.option("--agent-id", default=None, help="Optional agent-scoped write.")
+@click.option("--json", "json_output", is_flag=True, help="Print raw JSON.")
+@click.option("--base-url", default=None, help="Server base URL.")
+@click.pass_context
+def routing_disable_cmd(
+    ctx: click.Context,
+    agent_id: str | None,
+    json_output: bool,
+    base_url: str | None,
+) -> None:
+    """Disable routing while preserving current slot values."""
+    resolved_base_url = resolve_base_url(ctx, base_url)
+    try:
+        current = _request_routing_config(
+            resolved_base_url,
+            agent_id=agent_id,
+        )
+        current["enabled"] = False
+        payload = _update_routing_config(
+            resolved_base_url,
+            current,
+            agent_id=agent_id,
+        )
+    except httpx.HTTPError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if json_output:
+        print_json(payload)
+        return
+
+    _print_routing_config(payload, agent_id=agent_id)
 
 
 @models_group.command("add-provider")

--- a/tests/unit/cli/test_cli_models_routing.py
+++ b/tests/unit/cli/test_cli_models_routing.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from qwenpaw.cli.main import cli
+
+
+class DummyResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class DummyClient:
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], DummyResponse],
+    ) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict | None, dict | None]] = []
+
+    def __enter__(self) -> DummyClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, path: str, params: dict | None = None):
+        self.calls.append(("GET", path, params, None))
+        return self.responses[("GET", path)]
+
+    def put(
+        self,
+        path: str,
+        *,
+        params: dict | None = None,
+        json: dict | None = None,
+    ):
+        self.calls.append(("PUT", path, params, json))
+        return self.responses[("PUT", path)]
+
+
+def test_models_routing_get_json(monkeypatch) -> None:
+    dummy = DummyClient(
+        {
+            (
+                "GET",
+                "/config/agents/llm-routing",
+            ): DummyResponse(
+                {
+                    "enabled": True,
+                    "mode": "cloud_first",
+                    "local": {
+                        "provider_id": "openclaw-local",
+                        "model": "Kimi K2.5",
+                    },
+                    "cloud": {
+                        "provider_id": "opencode",
+                        "model": "nemotron-3-super-free",
+                    },
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "qwenpaw.cli.providers_cmd.http_client",
+        lambda _base_url: dummy,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "models",
+            "routing",
+            "get",
+            "--agent-id",
+            "agent-1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert '"mode": "cloud_first"' in result.output
+    assert dummy.calls == [
+        (
+            "GET",
+            "/config/agents/llm-routing",
+            {"agent_id": "agent-1"},
+            None,
+        ),
+    ]
+
+
+def test_models_routing_set_sends_expected_body(monkeypatch) -> None:
+    dummy = DummyClient(
+        {
+            (
+                "PUT",
+                "/config/agents/llm-routing",
+            ): DummyResponse(
+                {
+                    "enabled": True,
+                    "mode": "local_first",
+                    "local": {
+                        "provider_id": "openclaw-local",
+                        "model": "Kimi K2.5",
+                    },
+                    "cloud": {
+                        "provider_id": "opencode",
+                        "model": "nemotron-3-super-free",
+                    },
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "qwenpaw.cli.providers_cmd.http_client",
+        lambda _base_url: dummy,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "models",
+            "routing",
+            "set",
+            "--mode",
+            "local_first",
+            "--local-provider",
+            "openclaw-local",
+            "--local-model",
+            "Kimi K2.5",
+            "--cloud-provider",
+            "opencode",
+            "--cloud-model",
+            "nemotron-3-super-free",
+            "--agent-id",
+            "agent-1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Enabled : True" in result.output
+    assert dummy.calls == [
+        (
+            "PUT",
+            "/config/agents/llm-routing",
+            {"agent_id": "agent-1"},
+            {
+                "enabled": True,
+                "mode": "local_first",
+                "local": {
+                    "provider_id": "openclaw-local",
+                    "model": "Kimi K2.5",
+                },
+                "cloud": {
+                    "provider_id": "opencode",
+                    "model": "nemotron-3-super-free",
+                },
+            },
+        ),
+    ]
+
+
+def test_models_routing_disable_preserves_current_slots(monkeypatch) -> None:
+    dummy = DummyClient(
+        {
+            (
+                "GET",
+                "/config/agents/llm-routing",
+            ): DummyResponse(
+                {
+                    "enabled": True,
+                    "mode": "cloud_first",
+                    "local": {
+                        "provider_id": "openclaw-local",
+                        "model": "Kimi K2.5",
+                    },
+                    "cloud": {
+                        "provider_id": "opencode",
+                        "model": "nemotron-3-super-free",
+                    },
+                },
+            ),
+            (
+                "PUT",
+                "/config/agents/llm-routing",
+            ): DummyResponse(
+                {
+                    "enabled": False,
+                    "mode": "cloud_first",
+                    "local": {
+                        "provider_id": "openclaw-local",
+                        "model": "Kimi K2.5",
+                    },
+                    "cloud": {
+                        "provider_id": "opencode",
+                        "model": "nemotron-3-super-free",
+                    },
+                },
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "qwenpaw.cli.providers_cmd.http_client",
+        lambda _base_url: dummy,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["models", "routing", "disable"],
+    )
+
+    assert result.exit_code == 0
+    assert "Enabled : False" in result.output
+    assert dummy.calls == [
+        ("GET", "/config/agents/llm-routing", None, None),
+        (
+            "PUT",
+            "/config/agents/llm-routing",
+            None,
+            {
+                "enabled": False,
+                "mode": "cloud_first",
+                "local": {
+                    "provider_id": "openclaw-local",
+                    "model": "Kimi K2.5",
+                },
+                "cloud": {
+                    "provider_id": "opencode",
+                    "model": "nemotron-3-super-free",
+                },
+            },
+        ),
+    ]
+
+
+def test_models_routing_set_requires_complete_cloud_pair() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "models",
+            "routing",
+            "set",
+            "--mode",
+            "local_first",
+            "--local-provider",
+            "openclaw-local",
+            "--local-model",
+            "Kimi K2.5",
+            "--cloud-provider",
+            "opencode",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Provide both --cloud-provider and --cloud-model together." in (
+        result.output
+    )


### PR DESCRIPTION
## Summary

Adds CLI commands for reading and updating routing config through the running QwenPaw app API:

- `qwenpaw models routing get [--agent-id] [--json]`
- `qwenpaw models routing set --mode ... --local-provider ... --local-model ... [--cloud-provider ... --cloud-model ...] [--agent-id]`
- `qwenpaw models routing disable [--agent-id] [--json]`

This keeps CLI behavior aligned with the backend routing API instead of duplicating validation or config-write logic locally.

## Relation to other PRs

- Depends on `#3550` for the backend API surface (`/config/agents/llm-routing` with `agent_id` support and current routing semantics).
- Complements `#3452` by giving non-UI users a routing control surface.

## Test plan

- [x] `PYTHONPATH=/Users/tianhao/Documents/GitHub/QwenPaw-routing-cli-pr/src /Users/tianhao/Documents/GitHub/QwenPaw-routing-ui/.venv/bin/python -m pytest tests/unit/cli/test_cli_models_routing.py`
- [x] `pre-commit run flake8 --files src/qwenpaw/cli/providers_cmd.py tests/unit/cli/test_cli_models_routing.py`
- [x] `pre-commit run pylint --files src/qwenpaw/cli/providers_cmd.py tests/unit/cli/test_cli_models_routing.py`
- [x] Manual CLI/API round-trip against a live local backend:
  - `qwenpaw --host 127.0.0.1 --port 18088 models routing get --json`
  - `qwenpaw --host 127.0.0.1 --port 18088 models routing set --agent-id 7fmUUz --mode local_first --local-provider openclaw-local --local-model 'Kimi K2.5' --cloud-provider opencode --cloud-model nemotron-3-super-free`
  - `qwenpaw --host 127.0.0.1 --port 18088 models routing disable --agent-id 7fmUUz --json`
- [x] End-to-end validation on a live backend:
  - verified CLI-written routing changes affect `effective` model resolution
  - verified the same backend remains usable from both the official frontend and the new routing UI frontend
