### PR TITLE
fix(channels): filter_tool_messages must suppress in-progress tool preview

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -963,6 +963,17 @@ class BaseChannel(ABC):
         data = getattr(event, "data", None) or {}
         if not isinstance(data, dict) or "output" not in data:
             return False
+        # At this point the event is a tool-output preview: InProgress DATA
+        # event carrying a ``data.output`` payload. ``filter_tool_messages``
+        # is meant to hide the tool execution process from end users, so
+        # drop the preview here -- otherwise channels like Feishu still
+        # leak intermediate shell/API output.
+        #
+        # This check MUST stay after the shape guard above. A blanket
+        # InProgress suppression would also swallow the agent's own
+        # streaming reply content, silently breaking the whole channel.
+        if self._filter_tool_messages:
+            return True
         body = self._format_stream_tool_output_body(event)
         if not body:
             return False

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -994,6 +994,86 @@ class TestStreamWithTracker:
                                 pass
 
 
+@pytest.mark.asyncio
+class TestOnEventContent:
+    """Regression tests for in-progress content event handling."""
+
+    async def test_filter_tool_messages_suppresses_stream_tool_preview(
+        self,
+        base_channel,
+    ):
+        """When filter_tool_messages is enabled, in-progress tool previews
+        should not be sent to the user."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            ContentType,
+            RunStatus,
+        )
+
+        base_channel._filter_tool_messages = True
+        event = MagicMock(
+            type=ContentType.DATA,
+            status=RunStatus.InProgress,
+            data={
+                "name": "execute_shell_command",
+                "output": [
+                    {"type": "text", "text": "preview chunk"},
+                ],
+            },
+        )
+
+        with patch.object(
+            base_channel,
+            "send_content_parts",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            handled = await base_channel.on_event_content(
+                MagicMock(),
+                "user123",
+                event,
+                {},
+            )
+
+        assert handled is True
+        mock_send.assert_not_awaited()
+
+    async def test_filter_tool_messages_does_not_swallow_non_tool_event(
+        self,
+        base_channel,
+    ):
+        """Regression: the filter_tool_messages check must live AFTER the
+        tool-shape guard. A blanket InProgress suppression would eat the
+        agent's own streaming reply content too, silently breaking the
+        channel (agent appears to hang with no output)."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            ContentType,
+            RunStatus,
+        )
+
+        base_channel._filter_tool_messages = True
+        # InProgress DATA event with NO "output" field -> not a tool preview.
+        event = MagicMock(
+            type=ContentType.DATA,
+            status=RunStatus.InProgress,
+            data={"thinking": "reasoning text, not a tool result"},
+        )
+
+        with patch.object(
+            base_channel,
+            "send_content_parts",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            handled = await base_channel.on_event_content(
+                MagicMock(),
+                "user123",
+                event,
+                {},
+            )
+
+        # Falls through to the default path (not handled here).
+        assert handled is False
+        mock_send.assert_not_awaited()
+
+
 # =============================================================================
 # P2: Audio Content Detection
 # =============================================================================


### PR DESCRIPTION
## Summary

`filter_tool_messages=True` is documented as a channel-level switch
that hides the agent's tool execution process from end users. It works
for completed `tool_use` / `tool_result` messages, but the **in-progress
tool output preview** emitted on the content stream still gets forwarded
to the channel. On Feishu this shows up as the user seeing shell command
output, API responses, etc. streaming in mid-execution — the exact
thing the flag is supposed to prevent.

## Reproduction

1. Configure a channel with `filter_tool_messages: true`
2. Ask the agent anything that triggers a tool call with a substantive
   payload (`list_devices`, `read_file`, an HTTP call, …)
3. Observe the tool's output / preview appearing in the chat before
   the final answer — even though `filter_tool_messages` is on.

## Fix

`BaseChannel._is_tool_progress_event` is the gate that decides whether
an in-progress content event should be dropped. It previously only
dropped events whose `data.output` looked tool-shaped. After this
change, when `self._filter_tool_messages` is set we short-circuit to
`True` for any in-progress event, so the whole preview stream is
suppressed before it reaches `send_content_parts`.

The scope is narrow: only in-progress events (`status=InProgress`) on
channels that explicitly opted into filtering are affected. Normal
content streaming and completed messages go through unchanged code
paths.

## Test plan

- [x] Added `TestOnEventContent::test_filter_tool_messages_suppresses_stream_tool_preview`:
      with the flag enabled, an `InProgress` `DATA` event carrying a
      tool output payload must be handled (returned True) and
      `send_content_parts` must not be awaited.
- [ ] CI (pre-commit + pytest) — requesting upstream validation; local
      dev env isn't set up on my side.

## Note

`CONTRIBUTING.md` suggests opening an issue first for new proposals.
This is a narrow correctness bug rather than a design change (the flag
already exists and is documented; it just misses one code path), so
I'm opening directly. Happy to split into an issue + PR if maintainers
prefer.