### PR TITLE
feat(DingTalk): use built-in voice recognition from DingTalk callback

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/handler.py
+++ b/src/qwenpaw/app/channels/dingtalk/handler.py
@@ -212,8 +212,6 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
 
     async def process(self, callback: CallbackMessage) -> tuple[int, str]:
         # pylint: disable=too-many-branches,too-many-statements
-        print(callback)
-        print("*" * 100)
         try:
             # Raw msgId from channel callback for dedup (not assigned id).
             raw_data = getattr(callback, "data", None) or {}

--- a/src/qwenpaw/app/channels/dingtalk/handler.py
+++ b/src/qwenpaw/app/channels/dingtalk/handler.py
@@ -99,13 +99,58 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
                 return val.strip()
         return None
 
+    def _resolve_single_download(
+        self,
+        content_dict: Dict[str, Any],
+        msg_dict: Dict[str, Any],
+        robot_code: Optional[str],
+    ) -> Optional[Any]:
+        """Resolve a single downloadCode into a Content object.
+
+        For voice messages (``mapped == "audio"``), prefer the built-in
+        ``recognition`` text from DingTalk over downloading the AMR file.
+        """
+        dl_code = content_dict.get("downloadCode") or content_dict.get(
+            "download_code",
+        )
+        if not dl_code or not robot_code:
+            return None
+
+        type_mapping = get_type_mapping()
+        msgtype = (msg_dict.get("msgtype") or "").lower().strip()
+        mapped = type_mapping.get(msgtype, msgtype or "file")
+        if mapped not in ("image", "file", "video", "audio"):
+            mapped = "file"
+
+        # Voice messages from DingTalk include a ``recognition`` field
+        # with the transcribed text.  Use it directly instead of
+        # downloading the AMR file and running our own transcription.
+        if mapped == "audio":
+            recognition = (content_dict.get("recognition") or "").strip()
+            if recognition:
+                logger.info(
+                    "Using DingTalk voice recognition: %s",
+                    recognition[:80],
+                )
+                return TextContent(
+                    type=ContentType.TEXT,
+                    text=recognition,
+                )
+
+        filename_hint = self._extract_filename_hint(content_dict)
+        return self._fetch_download_url_and_content(
+            dl_code,
+            robot_code,
+            mapped,
+            filename_hint=filename_hint,
+        )
+
     def _parse_rich_content(
         self,
         incoming_message: Any,
     ) -> List[Any]:
         """Parse richText from incoming_message into runtime Content list."""
         content: List[Any] = []
-        type_mapping = get_type_mapping()
         try:
             robot_code = getattr(
                 incoming_message,
@@ -117,6 +162,7 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
             raw = c.get("richText")
             raw = raw or c.get("rich_text")
             rich_list = raw if isinstance(raw, list) else []
+            type_mapping = get_type_mapping()
             for item in rich_list:
                 if not isinstance(item, dict):
                     continue
@@ -156,33 +202,9 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
 
             # -------- 2) single downloadCode (pure picture/file) --------
             if not content:
-                dl_code = c.get("downloadCode") or c.get("download_code")
-                if dl_code and robot_code:
-                    msgtype = (
-                        (
-                            msg_dict.get(
-                                "msgtype",
-                            )
-                            or ""
-                        )
-                        .lower()
-                        .strip()
-                    )
-                    mapped = type_mapping.get(
-                        msgtype,
-                        msgtype or "file",
-                    )
-                    if mapped not in ("image", "file", "video", "audio"):
-                        mapped = "file"
-                    filename_hint = self._extract_filename_hint(c)
-                    part_content = self._fetch_download_url_and_content(
-                        dl_code,
-                        robot_code,
-                        mapped,
-                        filename_hint=filename_hint,
-                    )
-                    if part_content is not None:
-                        content.append(part_content)
+                part = self._resolve_single_download(c, msg_dict, robot_code)
+                if part is not None:
+                    content.append(part)
 
         except Exception:
             logger.exception("failed to fetch richText download url(s)")
@@ -190,6 +212,8 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
 
     async def process(self, callback: CallbackMessage) -> tuple[int, str]:
         # pylint: disable=too-many-branches,too-many-statements
+        print(callback)
+        print("*" * 100)
         try:
             # Raw msgId from channel callback for dedup (not assigned id).
             raw_data = getattr(callback, "data", None) or {}


### PR DESCRIPTION
## Description

DingTalk callbacks already include transcribed text in the recognition field for voice messages, making it unnecessary to download AMR files and run our own transcription — saving disk space and processing time.

### Changes

- When msgtype is audio and content.recognition is present, use the transcribed text directly as TextContent, skipping the AMR file download.
- Fall back to the original download-and-transcribe flow if recognition is empty or missing.
- Extracted _resolve_single_download() from _parse_rich_content() to reduce nesting depth and branch count (fixes pylint warnings).

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
