### PR TITLE
fix(console): map wechat channel key to WeChat icon in chat history sidebar

### DIFF
--- a/console/src/pages/Control/Channels/components/channelIcons.ts
+++ b/console/src/pages/Control/Channels/components/channelIcons.ts
@@ -32,5 +32,6 @@ export const CHANNEL_DEFAULT_ICON_URL =
   "https://gw.alicdn.com/imgextra/i3/O1CN01xqM0EN1oKrRiAFX3K_!!6000000005207-2-tps-400-400.png";
 
 export function getChannelIconUrl(channelKey: string): string {
+  channelKey = channelKey === "wechat" ? "weixin" : channelKey;
   return CHANNEL_ICON_URLS[channelKey] ?? CHANNEL_DEFAULT_ICON_URL;
 }


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

Description:  
The chat history sidebar displayed the default fallback icon for sessions created via the WeChat channel because the backend uses wechat as the channel key while the frontend only had weixin mapped. This adds a key normalization in getChannelIconUrl so wechat resolves to the correct WeChat icon URL.

Changed to use the aliased key "weixin" to look up the channel icon url for "wechat" which is the actual value from `chat.json`. The reason that we don't change "weixin" to "wechat" in the icon mapping is  it's also being used in `/channels` page , and that's using the key "weixin".

- Before:
<img width="377" height="569" alt="image" src="https://github.com/user-attachments/assets/4db27e4a-365f-48b8-a2c5-cf4617dd99ce" />



- After:
<img width="376" height="582" alt="image" src="https://github.com/user-attachments/assets/84e5977d-a490-4370-8b1d-e593d636d7d5" />

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
