### PR TITLE
feat(security): add shell invasion guard configuration

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1387,6 +1387,7 @@ class ToolGuardConfig(BaseModel):
     denied_tools: List[str] = Field(default_factory=list)
     custom_rules: List[ToolGuardRuleConfig] = Field(default_factory=list)
     disabled_rules: List[str] = Field(default_factory=list)
+    shell_evasion_checks: Dict[str, bool] = Field(default_factory=dict)
 
 
 class FileGuardConfig(BaseModel):

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -137,6 +137,7 @@ def _check_command_substitution(
                 GuardSeverity.HIGH,
                 "Command contains backtick (`) command substitution",
                 command,
+                risk_type="command_substitution",
                 matched=command[snippet_start:snippet_end],
                 snippet=command[snippet_start:snippet_end],
             )
@@ -150,6 +151,7 @@ def _check_command_substitution(
                 GuardSeverity.HIGH,
                 f"Command contains {label}",
                 command,
+                risk_type="command_substitution",
                 matched=m.group(0),
                 pattern=pattern.pattern,
             )
@@ -170,6 +172,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
             "Command contains ANSI-C quoting ($'...') "
             "which can hide characters",
             command,
+            risk_type="obfuscated_flags",
         )
 
     if _LOCALE_QUOTE_RE.search(command):
@@ -179,6 +182,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
             'Command contains locale quoting ($"...") '
             "which can hide characters",
             command,
+            risk_type="obfuscated_flags",
         )
 
     if _EMPTY_SPECIAL_QUOTE_DASH_RE.search(command):
@@ -188,6 +192,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
             "Command contains empty special quotes before dash "
             "(potential bypass)",
             command,
+            risk_type="obfuscated_flags",
         )
 
     if _EMPTY_QUOTE_DASH_RE.search(command):
@@ -197,6 +202,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
             "Command contains empty quotes before dash "
             "(potential flag bypass)",
             command,
+            risk_type="obfuscated_flags",
         )
 
     # Quoted flag content: whitespace + quote + dash-letter inside quote
@@ -225,6 +231,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
                         "Command contains quoted flag name "
                         "(potential obfuscation)",
                         command,
+                        risk_type="obfuscated_flags",
                         matched=command[i : j + 1],
                     )
 
@@ -253,6 +260,7 @@ def _check_backslash_escaped_whitespace(
                     "Command contains backslash-escaped whitespace"
                     " that could alter command parsing",
                     command,
+                    risk_type="backslash_escaped_whitespace",
                     matched=command[max(0, i - 1) : i + 1],
                 )
             state.feed(ch)
@@ -290,6 +298,7 @@ def _check_backslash_escaped_operators(
                     f"Command contains backslash before shell operator"
                     f" (\\{ch}) which can hide command structure",
                     command,
+                    risk_type="backslash_escaped_operators",
                     matched=command[max(0, i - 1) : i + 1],
                 )
             state.feed(ch)
@@ -321,6 +330,7 @@ def _check_newlines(command: str) -> GuardFinding | None:
                 "Command contains carriage return (\\r) which shell-quote"
                 " and bash tokenize differently",
                 command,
+                risk_type="newlines",
             )
 
     # Newline outside quotes followed by non-whitespace (hidden command)
@@ -339,6 +349,7 @@ def _check_newlines(command: str) -> GuardFinding | None:
                     "Command contains newlines that could separate"
                     " multiple commands",
                     command,
+                    risk_type="newlines",
                 )
 
     return None
@@ -390,6 +401,7 @@ def _check_comment_quote_desync(command: str) -> GuardFinding | None:
                     "Command contains quote characters inside a # comment"
                     " which can desync quote tracking",
                     command,
+                    risk_type="comment_quote_desync",
                     matched=command[
                         i : (line_end if line_end != -1 else i + 40)
                     ],
@@ -432,6 +444,7 @@ def _check_quoted_newline(command: str) -> GuardFinding | None:
                     " #-prefixed line, which can hide arguments from"
                     " line-based permission checks",
                     command,
+                    risk_type="quoted_newline",
                     matched=command[
                         max(0, i - 10) : min(len(command), line_end + 10)
                     ],
@@ -451,21 +464,24 @@ def _finding(
     description: str,
     command: str,
     *,
+    risk_type: str | None = None,
     matched: str | None = None,
     pattern: str | None = None,
     snippet: str | None = None,
 ) -> GuardFinding:
+    details = (
+        f"ShellEvasionGuardian: {description}\n"
+        f"Risk type: {risk_type or 'unknown'}\n\n"
+        "This pattern is commonly used to bypass shell command"
+        " security checks."
+    )
     return GuardFinding(
         id=f"GUARD-{uuid.uuid4().hex}",
         rule_id=rule_id,
         category=GuardThreatCategory.CODE_EXECUTION,
         severity=severity,
         title=f"[{severity.value}] {description}",
-        description=(
-            f"ShellEvasionGuardian: {description}\n\n"
-            "This pattern is commonly used to bypass shell command"
-            " security checks."
-        ),
+        description=details,
         tool_name="execute_shell_command",
         param_name="command",
         matched_value=matched,
@@ -476,6 +492,7 @@ def _finding(
             " intentional, approve manually."
         ),
         guardian="shell_evasion_guardian",
+        metadata={"risk_type": risk_type} if risk_type else {},
     )
 
 

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -116,7 +116,7 @@ def _check_command_substitution(
     command: str,
     unquoted: str,
 ) -> GuardFinding | None:
-    """bashSecurity #8: detect command substitution patterns.
+    """detect command substitution patterns.
 
     Also detects unescaped backticks (outside quotes) which are the
     legacy command substitution syntax.
@@ -157,7 +157,7 @@ def _check_command_substitution(
 
 
 def _check_obfuscated_flags(command: str) -> GuardFinding | None:
-    """bashSecurity #4: detect ANSI-C / locale quoting and empty-quote
+    """detect ANSI-C / locale quoting and empty-quote
     flag obfuscation.
 
     These quoting mechanisms can hide flag characters (e.g. ``$'\\x2d exec'``
@@ -237,7 +237,7 @@ def _check_obfuscated_flags(command: str) -> GuardFinding | None:
 def _check_backslash_escaped_whitespace(
     command: str,
 ) -> GuardFinding | None:
-    """bashSecurity #15: detect backslash-escaped space/tab outside quotes.
+    """detect backslash-escaped space/tab outside quotes.
 
     ``echo\\ test`` is a single token in bash (command named "echo test"),
     but parsers may decode the escape and produce two separate tokens.
@@ -264,7 +264,7 @@ def _check_backslash_escaped_whitespace(
 def _check_backslash_escaped_operators(
     command: str,
 ) -> GuardFinding | None:
-    r"""bashSecurity #21: detect ``\;``, ``\|``, ``\&``, ``\<``, ``\>``
+    r"""detect ``\;``, ``\|``, ``\&``, ``\<``, ``\>``
     outside quotes.
 
     splitCommand normalises ``\;`` to bare ``;`` which causes a false
@@ -299,7 +299,7 @@ def _check_backslash_escaped_operators(
 
 
 def _check_newlines(command: str) -> GuardFinding | None:
-    """bashSecurity #7: detect newlines and carriage returns that could
+    """detect newlines and carriage returns that could
     separate hidden commands.
     """
     # Heredoc intentionally relies on multiline input and should not be
@@ -364,7 +364,7 @@ def _looks_like_heredoc(command: str) -> bool:
 
 
 def _check_comment_quote_desync(command: str) -> GuardFinding | None:
-    """bashSecurity #22: detect quote characters inside ``#`` comments.
+    """detect quote characters inside ``#`` comments.
 
     Everything after an unquoted ``#`` is a comment in bash, but quote
     trackers don't handle comments — a ``'`` or ``"`` in a comment
@@ -402,7 +402,7 @@ def _check_comment_quote_desync(command: str) -> GuardFinding | None:
 
 
 def _check_quoted_newline(command: str) -> GuardFinding | None:
-    """bashSecurity #23: detect newlines inside quoted strings where the
+    """detect newlines inside quoted strings where the
     next line starts with ``#``.
 
     Line-based processing (like stripCommentLines) drops ``#``-prefixed

--- a/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/shell_evasion_guardian.py
@@ -485,15 +485,38 @@ def _finding(
 
 # All checks, executed in order, collecting all matched findings.
 _ShellCheckFn = Callable[..., GuardFinding | None]
-_CHECKS: tuple[_ShellCheckFn, ...] = (
-    _check_command_substitution,
-    _check_obfuscated_flags,
-    _check_backslash_escaped_whitespace,
-    _check_backslash_escaped_operators,
-    _check_newlines,
-    _check_comment_quote_desync,
-    _check_quoted_newline,
+_CHECKS: tuple[tuple[str, _ShellCheckFn], ...] = (
+    ("command_substitution", _check_command_substitution),
+    ("obfuscated_flags", _check_obfuscated_flags),
+    ("backslash_escaped_whitespace", _check_backslash_escaped_whitespace),
+    ("backslash_escaped_operators", _check_backslash_escaped_operators),
+    ("newlines", _check_newlines),
+    ("comment_quote_desync", _check_comment_quote_desync),
+    ("quoted_newline", _check_quoted_newline),
 )
+_CHECK_NAMES: frozenset[str] = frozenset(name for name, _ in _CHECKS)
+
+
+def _load_check_enabled_map() -> dict[str, bool]:
+    """Load per-check enabled config from ``security.tool_guard``.
+
+    Unknown keys are ignored. Missing keys default to enabled.
+    """
+    try:
+        from qwenpaw.config import load_config
+
+        raw = load_config().security.tool_guard.shell_evasion_checks
+    except Exception:
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+
+    enabled: dict[str, bool] = {}
+    for key, value in raw.items():
+        if key in _CHECK_NAMES and isinstance(value, bool):
+            enabled[key] = value
+    return enabled
 
 
 class ShellEvasionGuardian(BaseToolGuardian):
@@ -506,6 +529,11 @@ class ShellEvasionGuardian(BaseToolGuardian):
 
     def __init__(self) -> None:
         super().__init__(name="shell_evasion_guardian")
+        self._check_enabled = _load_check_enabled_map()
+
+    def reload(self) -> None:
+        """Reload per-check enablement from config."""
+        self._check_enabled = _load_check_enabled_map()
 
     def guard(
         self,
@@ -523,7 +551,9 @@ class ShellEvasionGuardian(BaseToolGuardian):
         outside_single_quotes = _extract_outside_single_quotes(command)
 
         findings: list[GuardFinding] = []
-        for check in _CHECKS:
+        for check_name, check in _CHECKS:
+            if not self._check_enabled.get(check_name, True):
+                continue
             # Checks that need unquoted content have 2-arg signature;
             # others take only the raw command.
             try:


### PR DESCRIPTION
## Description

This PR adds per-check toggles for `ShellEvasionGuardian`, so each of the 7 shell evasion checks can be enabled or disabled independently via config, while preserving current behavior by default (all checks enabled when not configured).

Why:
- Different deployments may need stricter or more permissive shell-guard behavior.
- Previously, all checks were hardcoded and always executed together.
- This change improves operational flexibility without breaking existing setups.

What changed:
- Added `security.tool_guard.shell_evasion_checks` config field in `config.py` (`Dict[str, bool]`, default `{}`).
- Refactored check registry in `shell_evasion_guardian.py` to use stable check keys.
- Added config loader for per-check enablement (unknown keys ignored, missing keys default to enabled).
- Added `reload()` support in `ShellEvasionGuardian` so `reload_rules()` can refresh check toggles at runtime.

**Related Issue:** Relates to #(issue_number)

**Security Considerations:**  
This change affects security policy configuration only. Default remains fail-safe for compatibility (`all enabled`). Configuration parsing is strict (bool-only values, known check names only), reducing misconfiguration impact.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Manual/quick validation performed:
1. Added config model field and guardian runtime gating.
2. Verified syntax with `python -m py_compile` on modified files.
3. Confirmed lints show no new errors for touched files.

Suggested functional test:
- In `config.json`, set:
  - `"security.tool_guard.shell_evasion_checks.newlines": false`
- Trigger a command that only matches newline check and confirm no finding.
- Re-enable and confirm finding returns.

## Local Verification Evidence
