### PR TITLE
feat(cli/channels): add interactive configure_weixin wizard

### DIFF
--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -26,6 +26,7 @@ from ..config.config import (
     IMessageChannelConfig,
     QQConfig,
     VoiceChannelConfig,
+    WeixinConfig,
     load_agent_config,
     save_agent_config,
 )
@@ -386,6 +387,57 @@ def configure_feishu(current_config: FeishuConfig) -> FeishuConfig:
     return current_config
 
 
+def configure_weixin(current_config: WeixinConfig) -> WeixinConfig:
+    """Configure WeChat (iLink Bot) personal account channel interactively.
+
+    ``bot_token`` is intentionally not prompted: it is a short-lived bearer
+    token obtained via QR-code login at runtime and persisted to
+    ``bot_token_file``. The wizard only collects the surrounding config.
+    """
+    click.echo("\n=== Configure WeChat (iLink Bot) Channel ===")
+
+    enabled = prompt_confirm(
+        "Enable WeChat channel?",
+        default=current_config.enabled,
+    )
+
+    if not enabled:
+        current_config.enabled = False
+        return current_config
+
+    current_config.enabled = True
+
+    click.echo(
+        "Note: bot_token is obtained via QR-code login at runtime and "
+        "persisted to bot_token_file; it is not prompted here.",
+    )
+
+    bot_token_file = click.prompt(
+        "bot_token file path",
+        default=(
+            current_config.bot_token_file or "~/.qwenpaw/weixin_bot_token"
+        ),
+        type=str,
+    )
+    current_config.bot_token_file = bot_token_file
+
+    base_url = click.prompt(
+        "iLink API base URL (leave empty for default)",
+        default=current_config.base_url or "",
+        type=str,
+    )
+    current_config.base_url = base_url
+
+    media_dir = click.prompt(
+        "Local media download directory (leave empty to disable)",
+        default=current_config.media_dir or "",
+        type=str,
+    )
+    current_config.media_dir = media_dir or None
+
+    return current_config
+
+
 def configure_qq(current_config: QQConfig) -> QQConfig:
     """Configure QQ channel interactively."""
     click.echo("\n=== Configure QQ Channel ===")
@@ -642,6 +694,7 @@ _ALL_CHANNEL_CONFIGURATORS = {
     "telegram": ("Telegram", configure_telegram),
     "dingtalk": ("DingTalk", configure_dingtalk),
     "feishu": ("Feishu", configure_feishu),
+    "weixin": ("WeChat (iLink Bot)", configure_weixin),
     "qq": ("QQ", configure_qq),
     "console": ("Console", configure_console),
     "voice": ("Twilio", configure_voice),


### PR DESCRIPTION
## Summary

- weixin was the only built-in single-user channel without an entry in `_ALL_CHANNEL_CONFIGURATORS` in `src/qwenpaw/cli/channels_cmd.py`, so `qwenpaw init` / `qwenpaw channels configure` skipped it and users had to hand-edit `config.json` to enable WeChat (iLink Bot).
- Adds a `configure_weixin` wizard mirroring the `configure_feishu` / `configure_dingtalk` shape (prompt enabled → then `bot_token_file` / `base_url` / `media_dir`).
- Registers it in `_ALL_CHANNEL_CONFIGURATORS` between `feishu` and `qq`.

## Type of Change

- Feature (CLI enhancement)

## Component(s) Affected

- CLI (`src/qwenpaw/cli/channels_cmd.py`)

## Design notes

`bot_token` itself is **intentionally not prompted**: it is a short-lived bearer token obtained via QR-code login at runtime (handled by `qwenpaw.app.channels.qrcode_auth_handler.WeixinQRCodeAuthHandler`) and persisted to `bot_token_file`. Manual paste would be error-prone and immediately out of date. The wizard only collects the surrounding config so the file path / API base / media dir are set before QR login runs.

## Checklist

- [x] Run and pass \`pre-commit run --files src/qwenpaw/cli/channels_cmd.py\`
- [x] Run and pass relevant tests (\`tests/unit/channels/test_weixin.py\`)

No new unit tests: no other \`configure_*\` in \`channels_cmd.py\` has unit tests (the wizard functions run behind \`click.prompt\`); following the existing convention. Happy to add a focused smoke test if you'd prefer.

## Testing

Interactive smoke (manual):

1. \`qwenpaw init\` → select WeChat (iLink Bot) from the channel menu → verify prompts appear in order: enabled → bot_token_file → base_url → media_dir.
2. \`qwenpaw channels list --agent-id <id>\` → verify \`weixin\` section shows the new values.
3. \`qwenpaw doctor <id>\` → existing doctor check (\`doctor_checks.py:859\`) still fires when \`bot_token\` and \`bot_token_file\` are both empty.

## Local Verification Evidence

\`\`\`bash
\$ pre-commit run --files src/qwenpaw/cli/channels_cmd.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

\$ python -m pytest tests/unit/channels/test_weixin.py -q
78 passed, 2 warnings in 0.70s
\`\`\`