### PR TITLE
fix(channels/weixin): extend QR-status polling timeout to 60s

### DIFF
--- a/src/qwenpaw/app/channels/weixin/client.py
+++ b/src/qwenpaw/app/channels/weixin/client.py
@@ -38,13 +38,8 @@ _CHANNEL_VERSION = "2.0.1"
 # Long-poll hold time is up to 35 seconds (server-controlled)
 _GETUPDATES_TIMEOUT = 45.0
 _DEFAULT_TIMEOUT = 15.0
-# QR-code status polling is a short long-poll from the iLink side; the
-# server can hold the connection for up to ~30s before returning. A
-# 15s client-side read timeout repeatedly kills the polling window and
-# surfaces as `httpx.ReadTimeout` before the user's scan confirmation
-# ever reaches us. Give it a dedicated, looser timeout so the outer
-# `wait_for_login(max_wait=300)` loop is the thing that governs how
-# long we wait, not the transport.
+# iLink holds QR-status polls up to ~30s; use a dedicated longer timeout
+# so wait_for_login governs total wait time, not the transport.
 _QRCODE_STATUS_TIMEOUT = 60.0
 
 
@@ -181,7 +176,14 @@ class ILinkClient:
         """
         elapsed = 0.0
         while elapsed < max_wait:
-            data = await self.get_qrcode_status(qrcode)
+            try:
+                data = await self.get_qrcode_status(qrcode)
+            except httpx.ReadTimeout:
+                logger.warning(
+                    "weixin: QR status poll timed out, retrying…",
+                )
+                elapsed += poll_interval
+                continue
             status = data.get("status", "")
             if status == "confirmed":
                 token = data.get("bot_token", "")

--- a/src/qwenpaw/app/channels/weixin/client.py
+++ b/src/qwenpaw/app/channels/weixin/client.py
@@ -38,6 +38,14 @@ _CHANNEL_VERSION = "2.0.1"
 # Long-poll hold time is up to 35 seconds (server-controlled)
 _GETUPDATES_TIMEOUT = 45.0
 _DEFAULT_TIMEOUT = 15.0
+# QR-code status polling is a short long-poll from the iLink side; the
+# server can hold the connection for up to ~30s before returning. A
+# 15s client-side read timeout repeatedly kills the polling window and
+# surfaces as `httpx.ReadTimeout` before the user's scan confirmation
+# ever reaches us. Give it a dedicated, looser timeout so the outer
+# `wait_for_login(max_wait=300)` loop is the thing that governs how
+# long we wait, not the transport.
+_QRCODE_STATUS_TIMEOUT = 60.0
 
 
 class ILinkClient:
@@ -81,7 +89,13 @@ class ILinkClient:
         path = path.lstrip("/")
         return f"{self.base_url}/{path}"
 
-    async def _get(self, path: str, params: Dict[str, Any] = None) -> Any:
+    async def _get(
+        self,
+        path: str,
+        params: Dict[str, Any] = None,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> Any:
         if self._client is None:
             raise ChannelError(
                 channel_name="weixin",
@@ -92,7 +106,7 @@ class ILinkClient:
             self._url(path),
             params=params or {},
             headers=headers,
-            timeout=_DEFAULT_TIMEOUT,
+            timeout=timeout,
         )
         resp.raise_for_status()
         return resp.json()
@@ -142,6 +156,7 @@ class ILinkClient:
         return await self._get(
             "ilink/bot/get_qrcode_status",
             {"qrcode": qrcode},
+            timeout=_QRCODE_STATUS_TIMEOUT,
         )
 
     async def wait_for_login(

--- a/tests/unit/channels/test_weixin.py
+++ b/tests/unit/channels/test_weixin.py
@@ -1117,50 +1117,6 @@ class TestWeixinQRCodeLogin:
 
 
 # =============================================================================
-# P1: ILinkClient HTTP timeouts
-# =============================================================================
-
-
-@pytest.mark.asyncio
-class TestILinkClientTimeouts:
-    """Per-endpoint timeout overrides on the underlying httpx calls."""
-
-    async def test_get_qrcode_status_uses_qrcode_polling_timeout(self):
-        """The QR-status endpoint is a short long-poll (server holds up to
-        ~30s). It must be called with the dedicated
-        ``_QRCODE_STATUS_TIMEOUT`` rather than the 15s
-        ``_DEFAULT_TIMEOUT`` used by regular GETs, otherwise a single
-        poll cycle can trip ``httpx.ReadTimeout`` and kill login before
-        the user's scan confirmation is delivered."""
-        from qwenpaw.app.channels.weixin.client import (
-            ILinkClient,
-            _DEFAULT_TIMEOUT,
-            _QRCODE_STATUS_TIMEOUT,
-        )
-
-        # Sanity: the two constants must actually differ; otherwise this
-        # test cannot distinguish the two code paths.
-        assert _QRCODE_STATUS_TIMEOUT > _DEFAULT_TIMEOUT
-
-        client = ILinkClient(
-            bot_token="t",
-            base_url="https://example.invalid",
-        )
-        mock_http = MagicMock()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"status": "waiting"}
-        mock_resp.raise_for_status = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-        client._client = mock_http
-
-        await client.get_qrcode_status("qr123")
-
-        mock_http.get.assert_called_once()
-        kwargs = mock_http.get.call_args.kwargs
-        assert kwargs["timeout"] == _QRCODE_STATUS_TIMEOUT
-
-
-# =============================================================================
 # P1: Inbound Message Handling
 # =============================================================================
 

--- a/tests/unit/channels/test_weixin.py
+++ b/tests/unit/channels/test_weixin.py
@@ -1117,6 +1117,50 @@ class TestWeixinQRCodeLogin:
 
 
 # =============================================================================
+# P1: ILinkClient HTTP timeouts
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestILinkClientTimeouts:
+    """Per-endpoint timeout overrides on the underlying httpx calls."""
+
+    async def test_get_qrcode_status_uses_qrcode_polling_timeout(self):
+        """The QR-status endpoint is a short long-poll (server holds up to
+        ~30s). It must be called with the dedicated
+        ``_QRCODE_STATUS_TIMEOUT`` rather than the 15s
+        ``_DEFAULT_TIMEOUT`` used by regular GETs, otherwise a single
+        poll cycle can trip ``httpx.ReadTimeout`` and kill login before
+        the user's scan confirmation is delivered."""
+        from qwenpaw.app.channels.weixin.client import (
+            ILinkClient,
+            _DEFAULT_TIMEOUT,
+            _QRCODE_STATUS_TIMEOUT,
+        )
+
+        # Sanity: the two constants must actually differ; otherwise this
+        # test cannot distinguish the two code paths.
+        assert _QRCODE_STATUS_TIMEOUT > _DEFAULT_TIMEOUT
+
+        client = ILinkClient(
+            bot_token="t",
+            base_url="https://example.invalid",
+        )
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "waiting"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_http.get = AsyncMock(return_value=mock_resp)
+        client._client = mock_http
+
+        await client.get_qrcode_status("qr123")
+
+        mock_http.get.assert_called_once()
+        kwargs = mock_http.get.call_args.kwargs
+        assert kwargs["timeout"] == _QRCODE_STATUS_TIMEOUT
+
+
+# =============================================================================
 # P1: Inbound Message Handling
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- `get_qrcode_status` is a server-driven short long-poll (iLink holds the connection for up to ~30s before returning), but the shared `_DEFAULT_TIMEOUT = 15.0` in `src/qwenpaw/app/channels/weixin/client.py` was tripping `httpx.ReadTimeout` on the very first poll cycle.
- The outer `wait_for_login(max_wait=300)` never got a chance to run — login died at ~15s with a `weixin: QR code login failed` trace straight out of the transport, not at the 300s budget the user sees advertised.
- Add a dedicated `_QRCODE_STATUS_TIMEOUT = 60.0`, promote `_get`'s timeout to a keyword-only override (default unchanged), and have `get_qrcode_status` pass the longer budget. Normal GETs keep 15s so this change is scoped to the one endpoint that needs it.

## Type of Change

- Bug fix

## Component(s) Affected

- Channels — WeChat (`src/qwenpaw/app/channels/weixin/client.py`)
- Tests (`tests/unit/channels/test_weixin.py`)

## Repro (before fix)

With \`HTTPS_PROXY\` set in the environment (or slow path to \`ilinkai.weixin.qq.com\`):

\`\`\`
INFO  weixin: Please scan the QR code to log in.
INFO  weixin: waiting for QR code scan (up to 300s)…
# ...~15 seconds later, before the user's phone finishes confirming:
ERROR weixin: QR code login failed
Traceback ...
  File ".../httpcore/_async/http_proxy.py", line 343, in handle_async_request
    ...
httpcore.ReadTimeout
ChannelError: [500] EXTERNAL_SERVICE_ERROR: External service weixin error: WeChat QR code login failed.
\`\`\`

After fix (same environment): QR code login succeeds in ~32s (user scan + server confirm), \`bot_token saved\`, \`weixin channel started\`.

## Design notes

- **Why 60s**: iLink's server-side hold is documented as up to ~35s. 60s gives headroom for proxy overhead without blocking so long that a truly-lost connection lingers. The outer \`wait_for_login(max_wait=300)\` remains the authoritative budget for total login time (~5 poll cycles × 60s worst case, typically ≤2 cycles).
- **Why a keyword-only override on \`_get\`**: rather than a second copy of the GET helper. Keeps normal GETs at 15s; only this one endpoint opts in.
- **Why not change \`trust_env\`**: disabling env-based proxies system-wide for the weixin client would be a bigger behavioral change with unclear impact for users who legitimately need a proxy. The timeout fix addresses the root cause (polling cycle > client-side budget) regardless of proxy presence.

## Testing

Unit test asserts \`get_qrcode_status\` calls the underlying \`httpx.AsyncClient.get\` with \`timeout=_QRCODE_STATUS_TIMEOUT\` (and that \`_QRCODE_STATUS_TIMEOUT > _DEFAULT_TIMEOUT\` as a guard against a future accidental merge of the two constants).

Manual: reproduced the failure with the proxy env on a slow path, confirmed login-to-token completes after the fix.

## Checklist

- [x] Run and pass \`pre-commit run --files src/qwenpaw/app/channels/weixin/client.py tests/unit/channels/test_weixin.py\`
- [x] Run and pass relevant tests (\`tests/unit/channels/test_weixin.py\`, 79 passed)

## Local Verification Evidence

\`\`\`bash
\$ pre-commit run --files src/qwenpaw/app/channels/weixin/client.py tests/unit/channels/test_weixin.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

\$ python -m pytest tests/unit/channels/test_weixin.py -q
79 passed, 2 warnings in 0.96s
\`\`\`