### PR TITLE
fix(mcp): resolve empty env values from os.environ at load time to re-enable disabled clients

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1077,6 +1077,26 @@ class MCPClientConfig(BaseModel):
         if "isActive" in payload and "enabled" not in payload:
             payload["enabled"] = payload["isActive"]
 
+        # Resolve empty env values from os.environ at load time so that
+        # env vars set via the UI (persisted in envs.json) are picked up
+        # even if agent.json was created before the key was configured.
+        if isinstance(payload.get("env"), dict):
+            original_env = dict(payload["env"])
+            resolved_env = {
+                k: (v if v else os.environ.get(k, v))
+                for k, v in original_env.items()
+            }
+            payload["env"] = resolved_env
+            # If client was disabled solely because a required env key was
+            # missing (empty), re-enable it now that the key is available.
+            if not payload.get("enabled", True):
+                key_newly_available = any(
+                    not original_env[k] and resolved_env[k]
+                    for k in original_env
+                )
+                if key_newly_available:
+                    payload["enabled"] = True
+
         if "baseUrl" in payload and "url" not in payload:
             payload["url"] = payload["baseUrl"]
 


### PR DESCRIPTION
## Summary

Fixes #3703

- When `agent.json` was created before an API key (e.g. `TAVILY_API_KEY`) was configured, the MCP client is persisted with `enabled: false` and an empty env value.
- After the user sets the key via **Settings → Environment Variables**, `os.environ` is updated but `agent.json` is not — the MCP client remains disabled on all subsequent runs.
- This PR fixes the issue by resolving empty `env` values from `os.environ` during `MCPClientConfig` deserialization, and auto-enabling the client if a previously-missing key is now available.

## Changes

**`src/qwenpaw/config/config.py`** — `MCPClientConfig._normalize_legacy_fields`:

```python
if isinstance(payload.get("env"), dict):
    original_env = dict(payload["env"])
    resolved_env = {
        k: (v if v else os.environ.get(k, v))
        for k, v in original_env.items()
    }
    payload["env"] = resolved_env
    if not payload.get("enabled", True):
        key_newly_available = any(
            not original_env[k] and resolved_env[k]
            for k in original_env
        )
        if key_newly_available:
            payload["enabled"] = True
```

## Test plan

- [ ] Start app without `TAVILY_API_KEY` — `tavily_search` client should remain disabled.
- [ ] Add `TAVILY_API_KEY` via Settings → Environment Variables.
- [ ] Restart app / trigger next agent run — `tavily_search` client should now be enabled and functional.
- [ ] Existing MCP clients with non-empty `env` values are unaffected.
- [ ] Clients explicitly disabled by the user (with non-empty env keys) remain disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)