### PR TITLE
docs: add README banner artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![QwenPaw README Banner](docs/readme-banner.png)
+
 <div align="center">
 
 # QwenPaw


### PR DESCRIPTION
## Summary
- add a new README banner image and place it at the top of the README
- store the artwork in `docs/readme-banner.png` so the README stays self-contained

## Why
This is a very beautiful banner image that gives the project a much stronger first impression. It helps improve the README's visual polish and makes the project more compelling for sharing, discovery, and overall promotion.

## Testing
- verified the branch README now starts with the new banner image block
- verified the new banner asset returns `200 image/png`
