### PR TITLE
feat: Security

### DIFF
--- a/console/src/api/modules/security.ts
+++ b/console/src/api/modules/security.ts
@@ -18,6 +18,7 @@ export interface ToolGuardConfig {
   denied_tools: string[];
   custom_rules: ToolGuardRule[];
   disabled_rules: string[];
+  shell_evasion_checks: Record<string, boolean>;
 }
 
 // ── File Guard types ──────────────────────────────────────────────

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1607,6 +1607,53 @@
         "TOOL_CMD_SERVICE_RESTART": "Detects service management commands that can disrupt system services",
         "TOOL_CMD_PROCESS_KILL": "Detects process termination commands that may kill critical processes",
         "TOOL_CMD_PRIVILEGE_ESCALATION": "Detects privilege escalation attempts using sudo, su, doas, pkexec, or runas"
+      },
+      "categories": {
+        "command_injection": "Command Injection",
+        "code_execution": "Code Execution",
+        "data_exfiltration": "Data Exfiltration",
+        "path_traversal": "Path Traversal",
+        "sensitive_file_access": "Sensitive File Access",
+        "network_abuse": "Network Abuse",
+        "credential_exposure": "Credential Exposure",
+        "resource_abuse": "Resource Abuse",
+        "privilege_escalation": "Privilege Escalation",
+        "prompt_injection": "Prompt Injection",
+        "other": "Other"
+      }
+    },
+    "shellEvasion": {
+      "title": "Shell Evasion Detection",
+      "description": "Configure which shell evasion and obfuscation detection checks are enabled. These checks detect techniques that attempt to hide malicious intent from simpler regex-only detection.",
+      "checks": {
+        "command_substitution": {
+          "name": "Command Substitution",
+          "description": "Detects $(), backticks, process substitution, and other command substitution patterns"
+        },
+        "obfuscated_flags": {
+          "name": "Obfuscated Flags",
+          "description": "Detects ANSI-C quoting, locale quoting, and empty-quote flag obfuscation"
+        },
+        "backslash_escaped_whitespace": {
+          "name": "Backslash Escaped Whitespace",
+          "description": "Detects backslash-escaped spaces/tabs that can alter command parsing"
+        },
+        "backslash_escaped_operators": {
+          "name": "Backslash Escaped Operators",
+          "description": "Detects backslash before shell operators (;|&<>) that can hide command structure"
+        },
+        "newlines": {
+          "name": "Hidden Newlines",
+          "description": "Detects newlines and carriage returns that could separate hidden commands"
+        },
+        "comment_quote_desync": {
+          "name": "Comment Quote Desync",
+          "description": "Detects quote characters inside # comments that can desync quote tracking"
+        },
+        "quoted_newline": {
+          "name": "Quoted Newline",
+          "description": "Detects newlines inside quoted strings followed by #-prefixed lines that can hide arguments"
+        }
       }
     },
     "fileGuard": {

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1389,6 +1389,19 @@
         "TOOL_CMD_SERVICE_RESTART": "システムサービスを中断させる可能性のあるサービス管理コマンドを検出",
         "TOOL_CMD_PROCESS_KILL": "重要なプロセスを終了させる可能性のあるプロセス終了コマンドを検出",
         "TOOL_CMD_PRIVILEGE_ESCALATION": "sudo、su、doas、pkexec、または runas を使用した権限昇格の試みを検出"
+      },
+      "categories": {
+        "command_injection": "コマンドインジェクション",
+        "code_execution": "コード実行",
+        "data_exfiltration": "データ漏洩",
+        "path_traversal": "パストラバーサル",
+        "sensitive_file_access": "機密ファイルアクセス",
+        "network_abuse": "ネットワーク不正利用",
+        "credential_exposure": "認証情報漏洩",
+        "resource_abuse": "リソース不正利用",
+        "privilege_escalation": "権限昇格",
+        "prompt_injection": "プロンプトインジェクション",
+        "other": "その他"
       }
     },
     "fileGuard": {

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1404,6 +1404,19 @@
         "TOOL_CMD_SERVICE_RESTART": "Обнаруживает команды управления службами, которые могут нарушить работу системных служб",
         "TOOL_CMD_PROCESS_KILL": "Обнаруживает команды завершения процессов, которые могут остановить критические процессы",
         "TOOL_CMD_PRIVILEGE_ESCALATION": "Обнаруживает попытки повышения привилегий с использованием sudo, su, doas, pkexec или runas"
+      },
+      "categories": {
+        "command_injection": "Внедрение команд",
+        "code_execution": "Выполнение кода",
+        "data_exfiltration": "Утечка данных",
+        "path_traversal": "Обход пути",
+        "sensitive_file_access": "Доступ к конфиденциальным файлам",
+        "network_abuse": "Злоупотребление сетью",
+        "credential_exposure": "Утечка учётных данных",
+        "resource_abuse": "Злоупотребление ресурсами",
+        "privilege_escalation": "Повышение привилегий",
+        "prompt_injection": "Внедрение промпта",
+        "other": "Другое"
       }
     },
     "fileGuard": {

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1469,6 +1469,53 @@
         "TOOL_CMD_SERVICE_RESTART": "检测可能中断系统服务的服务管理命令",
         "TOOL_CMD_PROCESS_KILL": "检测可能终止关键进程的进程终止命令",
         "TOOL_CMD_PRIVILEGE_ESCALATION": "检测使用 sudo、su、doas、pkexec 或 runas 的权限提升尝试"
+      },
+      "categories": {
+        "command_injection": "命令注入",
+        "code_execution": "代码执行",
+        "data_exfiltration": "数据外泄",
+        "path_traversal": "路径穿越",
+        "sensitive_file_access": "敏感文件访问",
+        "network_abuse": "网络滥用",
+        "credential_exposure": "凭证泄露",
+        "resource_abuse": "资源滥用",
+        "privilege_escalation": "权限提升",
+        "prompt_injection": "提示注入",
+        "other": "其他"
+      }
+    },
+    "shellEvasion": {
+      "title": "Shell 逃逸检测",
+      "description": "配置启用哪些 Shell 逃逸和混淆检测。这些检测能够发现试图绕过简单正则检测来隐藏恶意意图的技术手段。",
+      "checks": {
+        "command_substitution": {
+          "name": "命令替换",
+          "description": "检测 $()、反引号、进程替换等命令替换模式"
+        },
+        "obfuscated_flags": {
+          "name": "混淆标志",
+          "description": "检测 ANSI-C 引号、本地化引号和空引号标志混淆"
+        },
+        "backslash_escaped_whitespace": {
+          "name": "反斜杠转义空白",
+          "description": "检测可能改变命令解析的反斜杠转义空格/制表符"
+        },
+        "backslash_escaped_operators": {
+          "name": "反斜杠转义操作符",
+          "description": "检测 Shell 操作符 (;|&<>) 前的反斜杠，可隐藏命令结构"
+        },
+        "newlines": {
+          "name": "隐藏换行符",
+          "description": "检测可能分隔隐藏命令的换行符和回车符"
+        },
+        "comment_quote_desync": {
+          "name": "注释引号失同步",
+          "description": "检测 # 注释中的引号字符，可导致引号追踪失同步"
+        },
+        "quoted_newline": {
+          "name": "引号内换行",
+          "description": "检测引号字符串中的换行符后跟 # 行，可隐藏参数"
+        }
       }
     },
     "fileGuard": {

--- a/console/src/pages/Settings/Security/components/RuleModal.tsx
+++ b/console/src/pages/Settings/Security/components/RuleModal.tsx
@@ -6,13 +6,15 @@ import type { ToolGuardRule } from "../../../../api/modules/security";
 const SEVERITY_OPTIONS = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"];
 const CATEGORY_OPTIONS = [
   "command_injection",
+  "code_execution",
   "data_exfiltration",
   "path_traversal",
   "sensitive_file_access",
   "network_abuse",
   "credential_exposure",
   "resource_abuse",
-  "code_execution",
+  "privilege_escalation",
+  "prompt_injection",
 ];
 const BUILTIN_TOOLS = [
   "execute_shell_command",
@@ -133,7 +135,10 @@ export function RuleModal({
         </Form.Item>
         <Form.Item label={t("security.rules.categoryLabel")} name="category">
           <Select
-            options={CATEGORY_OPTIONS.map((c) => ({ label: c, value: c }))}
+            options={CATEGORY_OPTIONS.map((c) => ({
+              label: t(`security.rules.categories.${c}`, { defaultValue: c }),
+              value: c,
+            }))}
           />
         </Form.Item>
         <Form.Item

--- a/console/src/pages/Settings/Security/components/RuleTable.tsx
+++ b/console/src/pages/Settings/Security/components/RuleTable.tsx
@@ -1,4 +1,12 @@
-import { Table, Tag, Switch, Button, Tooltip } from "@agentscope-ai/design";
+import { useMemo } from "react";
+import {
+  Table,
+  Tag,
+  Switch,
+  Button,
+  Tooltip,
+  Collapse,
+} from "@agentscope-ai/design";
 import { Space } from "antd";
 import { Eye, Pencil, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -23,6 +31,20 @@ interface RuleTableProps {
   onDeleteRule: (ruleId: string) => void;
 }
 
+function groupRulesByCategory(
+  rules: MergedRule[],
+): Record<string, MergedRule[]> {
+  const groups: Record<string, MergedRule[]> = {};
+  for (const rule of rules) {
+    const category = rule.category || "other";
+    if (!groups[category]) {
+      groups[category] = [];
+    }
+    groups[category].push(rule);
+  }
+  return groups;
+}
+
 export function RuleTable({
   rules,
   enabled,
@@ -34,6 +56,8 @@ export function RuleTable({
   const { t } = useTranslation();
   const { isDark } = useTheme();
   const darkBtnStyle = isDark ? { color: "rgba(255,255,255,0.75)" } : undefined;
+
+  const groupedRules = useMemo(() => groupRulesByCategory(rules), [rules]);
 
   const columns = [
     {
@@ -166,14 +190,44 @@ export function RuleTable({
     },
   ];
 
+  const categoryKeys = Object.keys(groupedRules);
+
+  const collapseItems = categoryKeys.map((category) => {
+    const categoryRules = groupedRules[category];
+    const enabledCount = categoryRules.filter((r) => !r.disabled).length;
+    const totalCount = categoryRules.length;
+    const categoryLabel =
+      t(`security.rules.categories.${category}`, { defaultValue: "" }) ||
+      category.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+    return {
+      key: category,
+      label: (
+        <span className={styles.collapseCategoryLabel}>
+          {categoryLabel}
+          <Tag style={{ marginLeft: 8 }}>
+            {enabledCount}/{totalCount}
+          </Tag>
+        </span>
+      ),
+      children: (
+        <Table
+          dataSource={categoryRules}
+          columns={columns}
+          rowKey="id"
+          pagination={false}
+          size="small"
+          className={styles.ruleTable}
+        />
+      ),
+    };
+  });
+
   return (
-    <Table
-      dataSource={rules}
-      columns={columns}
-      rowKey="id"
-      pagination={false}
-      size="small"
-      className={styles.ruleTable}
+    <Collapse
+      defaultActiveKey={categoryKeys}
+      items={collapseItems}
+      className={styles.ruleCollapse}
     />
   );
 }

--- a/console/src/pages/Settings/Security/components/ShellEvasionSection.tsx
+++ b/console/src/pages/Settings/Security/components/ShellEvasionSection.tsx
@@ -1,0 +1,70 @@
+import { Switch } from "@agentscope-ai/design";
+import { useTranslation } from "react-i18next";
+import styles from "../index.module.less";
+
+/**
+ * The 7 shell evasion check types defined in
+ * `shell_evasion_guardian.py` → `_CHECKS`.
+ */
+const SHELL_EVASION_CHECK_KEYS = [
+  "command_substitution",
+  "obfuscated_flags",
+  "backslash_escaped_whitespace",
+  "backslash_escaped_operators",
+  "newlines",
+  "comment_quote_desync",
+  "quoted_newline",
+] as const;
+
+interface ShellEvasionSectionProps {
+  checks: Record<string, boolean>;
+  onToggle: (checkName: string, checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function ShellEvasionSection({
+  checks,
+  onToggle,
+  disabled = false,
+}: ShellEvasionSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.shellEvasionSection}>
+      <div className={styles.shellEvasionGrid}>
+        {SHELL_EVASION_CHECK_KEYS.map((checkKey) => {
+          const isEnabled = checks[checkKey] !== false;
+          const nameKey = `security.shellEvasion.checks.${checkKey}.name`;
+          const descKey = `security.shellEvasion.checks.${checkKey}.description`;
+          const displayName =
+            t(nameKey, { defaultValue: "" }) ||
+            checkKey
+              .replace(/_/g, " ")
+              .replace(/\b\w/g, (c) => c.toUpperCase());
+          const displayDesc = t(descKey, { defaultValue: "" });
+
+          return (
+            <div key={checkKey} className={styles.shellEvasionItem}>
+              <div className={styles.shellEvasionItemInfo}>
+                <span className={styles.shellEvasionItemName}>
+                  {displayName}
+                </span>
+                {displayDesc && (
+                  <span className={styles.shellEvasionItemDesc}>
+                    {displayDesc}
+                  </span>
+                )}
+              </div>
+              <Switch
+                size="small"
+                checked={isEnabled}
+                onChange={(val) => onToggle(checkKey, val)}
+                disabled={disabled}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/console/src/pages/Settings/Security/components/ToolGuardTab.tsx
+++ b/console/src/pages/Settings/Security/components/ToolGuardTab.tsx
@@ -1,0 +1,151 @@
+import { Form, Switch, Button, Card, Select } from "@agentscope-ai/design";
+import { PlusCircleOutlined } from "@ant-design/icons";
+import { useTranslation } from "react-i18next";
+import type { MergedRule } from "../useToolGuard";
+import type { ToolGuardConfig } from "../../../../api/modules/security";
+import type { FormInstance } from "antd";
+import { RuleTable, ShellEvasionSection } from "./index";
+import styles from "../index.module.less";
+
+interface ToolGuardTabProps {
+  form: FormInstance;
+  config: ToolGuardConfig | null;
+  enabled: boolean;
+  setEnabled: (val: boolean) => void;
+  toolOptions: { label: string; value: string }[];
+  mergedRules: MergedRule[];
+  toggleRule: (ruleId: string, currentlyDisabled: boolean) => void;
+  onPreviewRule: (rule: MergedRule) => void;
+  onEditRule: (rule: MergedRule) => void;
+  onDeleteRule: (ruleId: string) => void;
+  openAddRule: () => void;
+  shellEvasionChecks: Record<string, boolean>;
+  toggleShellEvasionCheck: (checkName: string, checked: boolean) => void;
+}
+
+export function ToolGuardTab({
+  form,
+  config,
+  enabled,
+  setEnabled,
+  toolOptions,
+  mergedRules,
+  toggleRule,
+  onPreviewRule,
+  onEditRule,
+  onDeleteRule,
+  openAddRule,
+  shellEvasionChecks,
+  toggleShellEvasionCheck,
+}: ToolGuardTabProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.tabContent}>
+      <div className={styles.sectionConfigureContainer}>
+        <p className={styles.tabDescription}>
+          {t("security.toolGuardDescription")}
+        </p>
+
+        <Card className={styles.formCard}>
+          <Form
+            form={form}
+            layout="vertical"
+            className={styles.form}
+            initialValues={{
+              enabled: config?.enabled ?? true,
+              guarded_tools: config?.guarded_tools ?? [],
+              denied_tools: config?.denied_tools ?? [],
+            }}
+          >
+            <Form.Item
+              label={t("security.enabled")}
+              name="enabled"
+              valuePropName="checked"
+              tooltip={t("security.enabledTooltip")}
+            >
+              <Switch onChange={(val) => setEnabled(val)} />
+            </Form.Item>
+            <div className={styles.toolGuardRow}>
+              <Form.Item
+                label={t("security.guardedTools")}
+                name="guarded_tools"
+                tooltip={t("security.guardedToolsTooltip")}
+                style={{ marginBottom: 0 }}
+              >
+                <Select
+                  mode="tags"
+                  options={toolOptions}
+                  placeholder={t("security.guardedToolsPlaceholder")}
+                  disabled={!enabled}
+                  allowClear
+                  style={{ width: "100%" }}
+                />
+              </Form.Item>
+
+              <Form.Item
+                label={t("security.deniedTools")}
+                name="denied_tools"
+                tooltip={t("security.deniedToolsTooltip")}
+                style={{ marginBottom: 0 }}
+              >
+                <Select
+                  mode="tags"
+                  options={toolOptions}
+                  placeholder={t("security.deniedToolsPlaceholder")}
+                  disabled={!enabled}
+                  allowClear
+                  style={{ width: "100%" }}
+                />
+              </Form.Item>
+            </div>
+          </Form>
+        </Card>
+      </div>
+
+      <div className={styles.sectionContainer}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>{t("security.rules.title")}</h2>
+          <Button
+            type="primary"
+            icon={<PlusCircleOutlined />}
+            onClick={openAddRule}
+            disabled={!enabled}
+            size="middle"
+          >
+            {t("security.rules.add")}
+          </Button>
+        </div>
+
+        <Card className={styles.tableCard}>
+          <RuleTable
+            rules={mergedRules}
+            enabled={enabled}
+            onToggleRule={toggleRule}
+            onPreviewRule={onPreviewRule}
+            onEditRule={onEditRule}
+            onDeleteRule={onDeleteRule}
+          />
+        </Card>
+      </div>
+
+      <div className={styles.sectionContainer}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>
+            {t("security.shellEvasion.title")}
+          </h2>
+        </div>
+        <div className={styles.sectionConfigureContainer}>
+          <p className={styles.tabDescription}>
+            {t("security.shellEvasion.description")}
+          </p>
+          <ShellEvasionSection
+            checks={shellEvasionChecks}
+            onToggle={toggleShellEvasionCheck}
+            disabled={!enabled}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/console/src/pages/Settings/Security/components/index.ts
+++ b/console/src/pages/Settings/Security/components/index.ts
@@ -3,3 +3,5 @@ export * from "./RuleModal";
 export * from "./PreviewModal";
 export * from "./SkillScannerSection";
 export * from "./FileGuardSection";
+export * from "./ShellEvasionSection";
+export * from "./ToolGuardTab";

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -252,12 +252,12 @@
 }
 
 .sectionConfigureContainer {
-  padding: 0 16px;
+  padding: 0 16px 24px 16px;
 }
 
 .sectionContainer {
   .sectionHeader {
-    padding: 0 16px;
+    padding: 24px 16px 0 16px;
   }
 
   .tableCard {
@@ -401,6 +401,115 @@
   :global(.qwenpaw-table-tbody > tr > td) {
     padding-left: 16px !important;
     padding-right: 16px !important;
+  }
+}
+
+/* ---- Rule Collapse (category grouping) ---- */
+.ruleCollapse {
+  background: transparent;
+  border: none;
+
+  :global(.qwenpaw-collapse-item) {
+    margin-bottom: 12px;
+    border: 1px solid #e8e8e8;
+    border-radius: 8px !important;
+    overflow: hidden;
+  }
+
+  :global(.qwenpaw-collapse-header) {
+    font-weight: 600;
+    font-size: 14px;
+    padding: 12px 16px !important;
+    background: #fafafa;
+  }
+
+  :global(.qwenpaw-collapse-content-box) {
+    padding: 0 !important;
+  }
+}
+
+:global(.dark-mode) {
+  .ruleCollapse {
+    :global(.qwenpaw-collapse-item) {
+      border-color: rgba(255, 255, 255, 0.1);
+    }
+
+    :global(.qwenpaw-collapse-header) {
+      background: rgba(255, 255, 255, 0.04);
+    }
+  }
+}
+
+.collapseCategoryLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ---- Shell Evasion Checks ---- */
+.shellEvasionSection {
+  margin-top: 16px;
+}
+
+.shellEvasionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.shellEvasionItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  background: #fafafa;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: #d9d9d9;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  }
+}
+
+.shellEvasionItemInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  margin-right: 12px;
+}
+
+.shellEvasionItemName {
+  font-weight: 500;
+  font-size: 13px;
+  color: #333;
+}
+
+.shellEvasionItemDesc {
+  font-size: 12px;
+  color: #999;
+  line-height: 1.4;
+}
+
+:global(.dark-mode) {
+  .shellEvasionItem {
+    border-color: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.2);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    }
+  }
+
+  .shellEvasionItemName {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .shellEvasionItemDesc {
+    color: rgba(255, 255, 255, 0.45);
   }
 }
 

--- a/console/src/pages/Settings/Security/index.tsx
+++ b/console/src/pages/Settings/Security/index.tsx
@@ -1,19 +1,8 @@
-import { useState, useCallback } from "react";
-import {
-  Form,
-  Switch,
-  Button,
-  Card,
-  Select,
-  Tabs,
-} from "@agentscope-ai/design";
-import { useAppMessage } from "../../../hooks/useAppMessage";
-import { PlusCircleOutlined } from "@ant-design/icons";
+import { Button, Tabs } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
-import api from "../../../api";
-import { useToolGuard, type MergedRule } from "./useToolGuard";
+import { useSecurityPage } from "./useSecurityPage";
 import {
-  RuleTable,
+  ToolGuardTab,
   RuleModal,
   PreviewModal,
   SkillScannerSection,
@@ -22,186 +11,42 @@ import {
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
 
-const BUILTIN_TOOLS = [
-  "execute_shell_command",
-  "execute_python_code",
-  "browser_use",
-  "desktop_screenshot",
-  "view_image",
-  "read_file",
-  "write_file",
-  "edit_file",
-  "append_file",
-  "view_text_file",
-  "write_text_file",
-  "send_file_to_user",
-];
-
 function SecurityPage() {
   const { t } = useTranslation();
-  const [form] = Form.useForm();
-  const [editForm] = Form.useForm();
-  const [saving, setSaving] = useState(false);
-  const [activeTab, setActiveTab] = useState("toolGuard");
-
-  // FileGuard handlers exposed from child component
-  const [fileGuardHandlers, setFileGuardHandlers] = useState<{
-    save: () => Promise<void>;
-    reset: () => void;
-    saving: boolean;
-  } | null>(null);
-
-  const onFileGuardHandlersReady = useCallback(
-    (handlers: {
-      save: () => Promise<void>;
-      reset: () => void;
-      saving: boolean;
-    }) => {
-      setFileGuardHandlers(handlers);
-    },
-    [],
-  );
 
   const {
+    activeTab,
+    setActiveTab,
+    form,
     config,
-    customRules,
-    builtinRules,
     enabled,
     setEnabled,
+    toolOptions,
+    saving,
+    handleSave,
+    handleReset,
     mergedRules,
+    builtinRules,
+    customRules,
+    toggleRule,
+    deleteCustomRule,
+    openAddRule,
+    openEditRule,
+    shellEvasionChecks,
+    toggleShellEvasionCheck,
+    editModal,
+    setEditModal,
+    editingRule,
+    editForm,
+    handleEditSave,
+    previewRule,
+    setPreviewRule,
+    fileGuardHandlers,
+    onFileGuardHandlersReady,
     loading,
     error,
     fetchAll,
-    toggleRule,
-    deleteCustomRule,
-    addCustomRule,
-    updateCustomRule,
-    buildSaveBody,
-  } = useToolGuard();
-
-  // Modal states
-  const [editModal, setEditModal] = useState(false);
-  const [editingRule, setEditingRule] = useState<MergedRule | null>(null);
-  const [previewRule, setPreviewRule] = useState<MergedRule | null>(null);
-
-  const { message } = useAppMessage();
-
-  // Form handlers
-  const handleSave = useCallback(async () => {
-    try {
-      setSaving(true);
-      const values = await form.validateFields();
-      const guardedTools: string[] = values.guarded_tools ?? [];
-      const body = {
-        enabled: values.enabled,
-        guarded_tools: guardedTools.length > 0 ? guardedTools : null,
-        denied_tools: values.denied_tools ?? [],
-        custom_rules: customRules,
-        disabled_rules: Array.from(buildSaveBody().disabled_rules),
-      };
-      await api.updateToolGuard(body);
-      setEnabled(body.enabled);
-      message.success(t("security.saveSuccess"));
-    } catch (err) {
-      if (err instanceof Error && "errorFields" in err) {
-        return;
-      }
-      const errMsg =
-        err instanceof Error ? err.message : t("security.saveFailed");
-      message.error(errMsg);
-    } finally {
-      setSaving(false);
-    }
-  }, [customRules, buildSaveBody, form, t]);
-
-  const handleReset = useCallback(() => {
-    form.resetFields();
-    fetchAll();
-  }, [form, fetchAll]);
-
-  // Rule modal handlers
-  const openAddRule = useCallback(() => {
-    setEditingRule(null);
-    editForm.resetFields();
-    editForm.setFieldsValue({
-      severity: "HIGH",
-      category: "command_injection",
-      tools: [],
-      params: [],
-      patterns: "",
-      exclude_patterns: "",
-    });
-    setEditModal(true);
-  }, [editForm]);
-
-  const openEditRule = useCallback(
-    (rule: MergedRule) => {
-      setEditingRule(rule);
-      editForm.setFieldsValue({
-        ...rule,
-        patterns: rule.patterns.join("\n"),
-        exclude_patterns: rule.exclude_patterns.join("\n"),
-      });
-      setEditModal(true);
-    },
-    [editForm],
-  );
-
-  const handleEditSave = useCallback(async () => {
-    try {
-      const values = await editForm.validateFields();
-      const patterns = (values.patterns as string)
-        .split("\n")
-        .map((s: string) => s.trim())
-        .filter(Boolean);
-      const excludePatterns = ((values.exclude_patterns as string) || "")
-        .split("\n")
-        .map((s: string) => s.trim())
-        .filter(Boolean);
-
-      const rule = {
-        id: values.id,
-        tools: values.tools ?? [],
-        params: values.params ?? [],
-        category: values.category,
-        severity: values.severity,
-        patterns,
-        exclude_patterns: excludePatterns,
-        description: values.description || "",
-        remediation: values.remediation || "",
-      };
-
-      if (editingRule) {
-        updateCustomRule(editingRule.id, rule);
-      } else {
-        const allIds = [
-          ...builtinRules.map((r) => r.id),
-          ...customRules.map((r) => r.id),
-        ];
-        if (allIds.includes(rule.id)) {
-          message.error(t("security.rules.duplicateId"));
-          return;
-        }
-        addCustomRule(rule);
-      }
-      setEditModal(false);
-    } catch {
-      // validation failed
-    }
-  }, [
-    editingRule,
-    builtinRules,
-    customRules,
-    updateCustomRule,
-    addCustomRule,
-    editForm,
-    t,
-  ]);
-
-  const toolOptions = BUILTIN_TOOLS.map((name) => ({
-    label: name,
-    value: name,
-  }));
+  } = useSecurityPage();
 
   // Loading state
   if (loading) {
@@ -249,98 +94,21 @@ function SecurityPage() {
                 </span>
               ),
               children: (
-                <div className={styles.tabContent}>
-                  <div className={styles.sectionConfigureContainer}>
-                    <p className={styles.tabDescription}>
-                      {t("security.toolGuardDescription")}
-                    </p>
-
-                    <Card className={styles.formCard}>
-                      <Form
-                        form={form}
-                        layout="vertical"
-                        className={styles.form}
-                        initialValues={{
-                          enabled: config?.enabled ?? true,
-                          guarded_tools: config?.guarded_tools ?? [],
-                          denied_tools: config?.denied_tools ?? [],
-                        }}
-                      >
-                        <Form.Item
-                          label={t("security.enabled")}
-                          name="enabled"
-                          valuePropName="checked"
-                          tooltip={t("security.enabledTooltip")}
-                        >
-                          <Switch onChange={(val) => setEnabled(val)} />
-                        </Form.Item>
-                        <div className={styles.toolGuardRow}>
-                          <Form.Item
-                            label={t("security.guardedTools")}
-                            name="guarded_tools"
-                            tooltip={t("security.guardedToolsTooltip")}
-                            style={{ marginBottom: 0 }}
-                          >
-                            <Select
-                              mode="tags"
-                              options={toolOptions}
-                              placeholder={t(
-                                "security.guardedToolsPlaceholder",
-                              )}
-                              disabled={!enabled}
-                              allowClear
-                              style={{ width: "100%" }}
-                            />
-                          </Form.Item>
-
-                          <Form.Item
-                            label={t("security.deniedTools")}
-                            name="denied_tools"
-                            tooltip={t("security.deniedToolsTooltip")}
-                            style={{ marginBottom: 0 }}
-                          >
-                            <Select
-                              mode="tags"
-                              options={toolOptions}
-                              placeholder={t("security.deniedToolsPlaceholder")}
-                              disabled={!enabled}
-                              allowClear
-                              style={{ width: "100%" }}
-                            />
-                          </Form.Item>
-                        </div>
-                      </Form>
-                    </Card>
-                  </div>
-
-                  <div className={styles.sectionContainer}>
-                    <div className={styles.sectionHeader}>
-                      <h2 className={styles.sectionTitle}>
-                        {t("security.rules.title")}
-                      </h2>
-                      <Button
-                        type="primary"
-                        icon={<PlusCircleOutlined />}
-                        onClick={openAddRule}
-                        disabled={!enabled}
-                        size="middle"
-                      >
-                        {t("security.rules.add")}
-                      </Button>
-                    </div>
-
-                    <Card className={styles.tableCard}>
-                      <RuleTable
-                        rules={mergedRules}
-                        enabled={enabled}
-                        onToggleRule={toggleRule}
-                        onPreviewRule={setPreviewRule}
-                        onEditRule={openEditRule}
-                        onDeleteRule={deleteCustomRule}
-                      />
-                    </Card>
-                  </div>
-                </div>
+                <ToolGuardTab
+                  form={form}
+                  config={config}
+                  enabled={enabled}
+                  setEnabled={setEnabled}
+                  toolOptions={toolOptions}
+                  mergedRules={mergedRules}
+                  toggleRule={toggleRule}
+                  onPreviewRule={setPreviewRule}
+                  onEditRule={openEditRule}
+                  onDeleteRule={deleteCustomRule}
+                  openAddRule={openAddRule}
+                  shellEvasionChecks={shellEvasionChecks}
+                  toggleShellEvasionCheck={toggleShellEvasionCheck}
+                />
               ),
             },
             {

--- a/console/src/pages/Settings/Security/useSecurityPage.ts
+++ b/console/src/pages/Settings/Security/useSecurityPage.ts
@@ -1,0 +1,239 @@
+import { useState, useCallback } from "react";
+import { Form } from "@agentscope-ai/design";
+import { useAppMessage } from "../../../hooks/useAppMessage";
+import { useTranslation } from "react-i18next";
+import api from "../../../api";
+import { useToolGuard, type MergedRule } from "./useToolGuard";
+
+const BUILTIN_TOOLS = [
+  "execute_shell_command",
+  "execute_python_code",
+  "browser_use",
+  "desktop_screenshot",
+  "view_image",
+  "read_file",
+  "write_file",
+  "edit_file",
+  "append_file",
+  "view_text_file",
+  "write_text_file",
+  "send_file_to_user",
+];
+
+export function useSecurityPage() {
+  const { t } = useTranslation();
+  const [form] = Form.useForm();
+  const [editForm] = Form.useForm();
+  const [saving, setSaving] = useState(false);
+  const [activeTab, setActiveTab] = useState("toolGuard");
+
+  // FileGuard handlers exposed from child component
+  const [fileGuardHandlers, setFileGuardHandlers] = useState<{
+    save: () => Promise<void>;
+    reset: () => void;
+    saving: boolean;
+  } | null>(null);
+
+  const onFileGuardHandlersReady = useCallback(
+    (handlers: {
+      save: () => Promise<void>;
+      reset: () => void;
+      saving: boolean;
+    }) => {
+      setFileGuardHandlers(handlers);
+    },
+    [],
+  );
+
+  const {
+    config,
+    customRules,
+    builtinRules,
+    enabled,
+    setEnabled,
+    mergedRules,
+    shellEvasionChecks,
+    toggleShellEvasionCheck,
+    loading,
+    error,
+    fetchAll,
+    toggleRule,
+    deleteCustomRule,
+    addCustomRule,
+    updateCustomRule,
+    buildSaveBody,
+  } = useToolGuard();
+
+  // Modal states
+  const [editModal, setEditModal] = useState(false);
+  const [editingRule, setEditingRule] = useState<MergedRule | null>(null);
+  const [previewRule, setPreviewRule] = useState<MergedRule | null>(null);
+
+  const { message } = useAppMessage();
+
+  // Form handlers
+  const handleSave = useCallback(async () => {
+    try {
+      setSaving(true);
+      const values = await form.validateFields();
+      const guardedTools: string[] = values.guarded_tools ?? [];
+      const savedBody = buildSaveBody();
+      const body = {
+        enabled: values.enabled,
+        guarded_tools: guardedTools.length > 0 ? guardedTools : null,
+        denied_tools: values.denied_tools ?? [],
+        custom_rules: customRules,
+        disabled_rules: Array.from(savedBody.disabled_rules),
+        shell_evasion_checks: savedBody.shell_evasion_checks,
+      };
+      await api.updateToolGuard(body);
+      setEnabled(body.enabled);
+      message.success(t("security.saveSuccess"));
+    } catch (err) {
+      if (err instanceof Error && "errorFields" in err) {
+        return;
+      }
+      const errMsg =
+        err instanceof Error ? err.message : t("security.saveFailed");
+      message.error(errMsg);
+    } finally {
+      setSaving(false);
+    }
+  }, [customRules, buildSaveBody, form, t]);
+
+  const handleReset = useCallback(() => {
+    form.resetFields();
+    fetchAll();
+  }, [form, fetchAll]);
+
+  // Rule modal handlers
+  const openAddRule = useCallback(() => {
+    setEditingRule(null);
+    editForm.resetFields();
+    editForm.setFieldsValue({
+      severity: "HIGH",
+      category: "command_injection",
+      tools: [],
+      params: [],
+      patterns: "",
+      exclude_patterns: "",
+    });
+    setEditModal(true);
+  }, [editForm]);
+
+  const openEditRule = useCallback(
+    (rule: MergedRule) => {
+      setEditingRule(rule);
+      editForm.setFieldsValue({
+        ...rule,
+        patterns: rule.patterns.join("\n"),
+        exclude_patterns: rule.exclude_patterns.join("\n"),
+      });
+      setEditModal(true);
+    },
+    [editForm],
+  );
+
+  const handleEditSave = useCallback(async () => {
+    try {
+      const values = await editForm.validateFields();
+      const patterns = (values.patterns as string)
+        .split("\n")
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+      const excludePatterns = ((values.exclude_patterns as string) || "")
+        .split("\n")
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+
+      const rule = {
+        id: values.id,
+        tools: values.tools ?? [],
+        params: values.params ?? [],
+        category: values.category,
+        severity: values.severity,
+        patterns,
+        exclude_patterns: excludePatterns,
+        description: values.description || "",
+        remediation: values.remediation || "",
+      };
+
+      if (editingRule) {
+        updateCustomRule(editingRule.id, rule);
+      } else {
+        const allIds = [
+          ...builtinRules.map((r) => r.id),
+          ...customRules.map((r) => r.id),
+        ];
+        if (allIds.includes(rule.id)) {
+          message.error(t("security.rules.duplicateId"));
+          return;
+        }
+        addCustomRule(rule);
+      }
+      setEditModal(false);
+    } catch {
+      // validation failed
+    }
+  }, [
+    editingRule,
+    builtinRules,
+    customRules,
+    updateCustomRule,
+    addCustomRule,
+    editForm,
+    t,
+  ]);
+
+  const toolOptions = BUILTIN_TOOLS.map((name) => ({
+    label: name,
+    value: name,
+  }));
+
+  return {
+    // Tab state
+    activeTab,
+    setActiveTab,
+
+    // Tool Guard form
+    form,
+    config,
+    enabled,
+    setEnabled,
+    toolOptions,
+    saving,
+    handleSave,
+    handleReset,
+
+    // Rules
+    mergedRules,
+    builtinRules,
+    customRules,
+    toggleRule,
+    deleteCustomRule,
+    openAddRule,
+    openEditRule,
+
+    // Shell Evasion
+    shellEvasionChecks,
+    toggleShellEvasionCheck,
+
+    // Modals
+    editModal,
+    setEditModal,
+    editingRule,
+    editForm,
+    handleEditSave,
+    previewRule,
+    setPreviewRule,
+
+    // FileGuard
+    fileGuardHandlers,
+    onFileGuardHandlersReady,
+
+    // Loading / Error
+    loading,
+    error,
+    fetchAll,
+  };
+}

--- a/console/src/pages/Settings/Security/useToolGuard.ts
+++ b/console/src/pages/Settings/Security/useToolGuard.ts
@@ -15,6 +15,9 @@ export function useToolGuard() {
   const [builtinRules, setBuiltinRules] = useState<ToolGuardRule[]>([]);
   const [customRules, setCustomRules] = useState<ToolGuardRule[]>([]);
   const [disabledRules, setDisabledRules] = useState<Set<string>>(new Set());
+  const [shellEvasionChecks, setShellEvasionChecks] = useState<
+    Record<string, boolean>
+  >({});
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -32,6 +35,7 @@ export function useToolGuard() {
       setBuiltinRules(builtin);
       setCustomRules(cfg.custom_rules ?? []);
       setDisabledRules(new Set(cfg.disabled_rules ?? []));
+      setShellEvasionChecks(cfg.shell_evasion_checks ?? {});
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Failed to load security config";
@@ -94,6 +98,13 @@ export function useToolGuard() {
     })),
   ];
 
+  const toggleShellEvasionCheck = useCallback(
+    (checkName: string, checked: boolean) => {
+      setShellEvasionChecks((prev) => ({ ...prev, [checkName]: checked }));
+    },
+    [],
+  );
+
   const buildSaveBody = useCallback((): ToolGuardConfig => {
     return {
       enabled,
@@ -101,8 +112,9 @@ export function useToolGuard() {
       denied_tools: config?.denied_tools ?? [],
       custom_rules: customRules,
       disabled_rules: Array.from(disabledRules),
+      shell_evasion_checks: shellEvasionChecks,
     };
-  }, [enabled, config, customRules, disabledRules]);
+  }, [enabled, config, customRules, disabledRules, shellEvasionChecks]);
 
   return {
     config,
@@ -112,6 +124,8 @@ export function useToolGuard() {
     enabled,
     setEnabled,
     mergedRules,
+    shellEvasionChecks,
+    toggleShellEvasionCheck,
     loading,
     error,
     fetchAll,


### PR DESCRIPTION
## Description

1.The security configuration page collapses these detection rules according to type.

2.A new Shell Evasion Detection module has been added to control risk monitoring.

<img width="1496" height="1227" alt="sec" src="https://github.com/user-attachments/assets/3ea63d27-c738-4ac6-b4dd-1fd69ffbb590" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
