### PR TITLE
fix(console): sync new agent language with console UI

### DIFF
--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -14,7 +14,7 @@ import { reorderAgents } from "./reorder";
 import styles from "./index.module.less";
 
 export default function AgentsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { agents, loading, deleteAgent, toggleAgent, loadAgents, setAgents } =
     useAgents();
   const { selectedAgent, setSelectedAgent } = useAgentStore();
@@ -132,6 +132,7 @@ export default function AgentsPage() {
       } else {
         const result = await agentsApi.createAgent({
           ...payload,
+          language: i18n.language,
           skill_names: selectedSkills,
         });
         message.success(`${t("agent.createSuccess")} (ID: ${result.id})`);

--- a/src/qwenpaw/agents/utils/__init__.py
+++ b/src/qwenpaw/agents/utils/__init__.py
@@ -49,6 +49,8 @@ from .setup_utils import (
     copy_md_files,
     copy_template_md_files,
     copy_workspace_md_files,
+    get_supported_agent_languages,
+    normalize_agent_language,
 )
 
 # Token counting
@@ -88,6 +90,9 @@ __all__ = [
     "copy_md_files",
     "copy_template_md_files",
     "copy_workspace_md_files",
+    # Setup utilities
+    "get_supported_agent_languages",
+    "normalize_agent_language",
     # Token counting
     "get_token_counter",
     # Tool message utilities

--- a/src/qwenpaw/agents/utils/__init__.py
+++ b/src/qwenpaw/agents/utils/__init__.py
@@ -49,7 +49,6 @@ from .setup_utils import (
     copy_md_files,
     copy_template_md_files,
     copy_workspace_md_files,
-    get_supported_agent_languages,
     normalize_agent_language,
 )
 
@@ -91,7 +90,6 @@ __all__ = [
     "copy_template_md_files",
     "copy_workspace_md_files",
     # Setup utilities
-    "get_supported_agent_languages",
     "normalize_agent_language",
     # Token counting
     "get_token_counter",

--- a/src/qwenpaw/agents/utils/setup_utils.py
+++ b/src/qwenpaw/agents/utils/setup_utils.py
@@ -8,6 +8,8 @@ import logging
 import shutil
 from pathlib import Path
 
+from ...constant import SUPPORTED_AGENT_LANGUAGES
+
 logger = logging.getLogger(__name__)
 
 _TEMPLATE_OVERRIDE_FILENAMES = {
@@ -17,24 +19,10 @@ _TEMPLATE_OVERRIDE_FILENAMES = {
     "SOUL.md",
 }
 
-_MD_FILES_ROOT = Path(__file__).resolve().parent.parent / "md_files"
-
-
-def get_supported_agent_languages() -> set[str]:
-    """Return the set of languages that have agent MD file directories."""
-    if not _MD_FILES_ROOT.is_dir():
-        return {"en"}
-    return {
-        d.name
-        for d in _MD_FILES_ROOT.iterdir()
-        if d.is_dir() and not d.name.startswith(".") and any(d.glob("*.md"))
-    }
-
 
 def normalize_agent_language(language: str) -> str:
     """Map *language* to a supported agent language"""
-    supported = get_supported_agent_languages()
-    if language in supported:
+    if language in SUPPORTED_AGENT_LANGUAGES:
         return language
     return "en"
 

--- a/src/qwenpaw/agents/utils/setup_utils.py
+++ b/src/qwenpaw/agents/utils/setup_utils.py
@@ -17,6 +17,27 @@ _TEMPLATE_OVERRIDE_FILENAMES = {
     "SOUL.md",
 }
 
+_MD_FILES_ROOT = Path(__file__).resolve().parent.parent / "md_files"
+
+
+def get_supported_agent_languages() -> set[str]:
+    """Return the set of languages that have agent MD file directories."""
+    if not _MD_FILES_ROOT.is_dir():
+        return {"en"}
+    return {
+        d.name
+        for d in _MD_FILES_ROOT.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and any(d.glob("*.md"))
+    }
+
+
+def normalize_agent_language(language: str) -> str:
+    """Map *language* to a supported agent language"""
+    supported = get_supported_agent_languages()
+    if language in supported:
+        return language
+    return "en"
+
 
 def copy_md_files(
     language: str,

--- a/src/qwenpaw/app/routers/agent.py
+++ b/src/qwenpaw/app/routers/agent.py
@@ -13,11 +13,8 @@ from ...config import (
 from ...config.config import load_agent_config, save_agent_config
 from ...agents.memory.agent_md_manager import AgentMdManager
 from ...agents.templates import get_workspace_md_template_id
-from ...agents.utils import (
-    copy_workspace_md_files,
-    get_supported_agent_languages,
-)
-from ...constant import BUILTIN_QA_AGENT_ID
+from ...agents.utils import copy_workspace_md_files
+from ...constant import BUILTIN_QA_AGENT_ID, SUPPORTED_AGENT_LANGUAGES
 from ..agent_context import get_agent_for_request
 
 router = APIRouter(prefix="/agent", tags=["agent"])
@@ -221,7 +218,7 @@ async def put_agent_language(
     Update agent language and optionally re-copy MD files to agent workspace.
     """
     language = (body.get("language") or "").strip().lower()
-    valid = get_supported_agent_languages()
+    valid = SUPPORTED_AGENT_LANGUAGES
     if language not in valid:
         raise HTTPException(
             status_code=400,

--- a/src/qwenpaw/app/routers/agent.py
+++ b/src/qwenpaw/app/routers/agent.py
@@ -13,7 +13,10 @@ from ...config import (
 from ...config.config import load_agent_config, save_agent_config
 from ...agents.memory.agent_md_manager import AgentMdManager
 from ...agents.templates import get_workspace_md_template_id
-from ...agents.utils import copy_workspace_md_files
+from ...agents.utils import (
+    copy_workspace_md_files,
+    get_supported_agent_languages,
+)
 from ...constant import BUILTIN_QA_AGENT_ID
 from ..agent_context import get_agent_for_request
 
@@ -218,7 +221,7 @@ async def put_agent_language(
     Update agent language and optionally re-copy MD files to agent workspace.
     """
     language = (body.get("language") or "").strip().lower()
-    valid = {"zh", "en", "ru"}
+    valid = get_supported_agent_languages()
     if language not in valid:
         raise HTTPException(
             status_code=400,

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -347,6 +347,7 @@ async def create_agent(
         skill_names=(
             request.skill_names if request.skill_names is not None else []
         ),
+        language=request.language,
     )
 
     agent_ref = AgentProfileRef(
@@ -704,6 +705,7 @@ def _initialize_agent_workspace(
     workspace_dir: Path,
     skill_names: list[str] | None = None,
     md_template_id: str | None = None,
+    language: str | None = None,
 ) -> None:
     """Initialize agent workspace with only explicitly requested skills."""
     from ...config import load_config as load_global_config
@@ -713,7 +715,8 @@ def _initialize_agent_workspace(
     get_workspace_skills_dir(workspace_dir).mkdir(exist_ok=True)
 
     config = load_global_config()
-    language = config.agents.language or "zh"
+    if not language:
+        language = config.agents.language or "zh"
 
     _apply_workspace_md_templates(
         workspace_dir,

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -29,7 +29,7 @@ from ...config.config import (
 )
 from ...config.utils import load_config, save_config
 from ...agents.memory.agent_md_manager import AgentMdManager
-from ...agents.utils import copy_workspace_md_files
+from ...agents.utils import copy_workspace_md_files, normalize_agent_language
 from ...agents.skills_manager import SkillPoolService, get_workspace_skills_dir
 from ..multi_agent_manager import MultiAgentManager
 from ...constant import WORKING_DIR
@@ -74,7 +74,7 @@ class CreateAgentRequest(BaseModel):
     name: str
     description: str = ""
     workspace_dir: str | None = None
-    language: str = "en"
+    language: str | None = None
     skill_names: list[str] | None = None
     active_model: ModelSlotConfig | None = None
 
@@ -329,12 +329,16 @@ async def create_agent(
         ToolsConfig,
     )
 
+    language = normalize_agent_language(
+        request.language or config.agents.language or "en",
+    )
+
     agent_config = AgentProfileConfig(
         id=new_id,
         name=request.name,
         description=request.description,
         workspace_dir=str(workspace_dir),
-        language=request.language,
+        language=language,
         channels=ChannelConfig(),
         mcp=MCPConfig(),
         heartbeat=HeartbeatConfig(),
@@ -347,7 +351,7 @@ async def create_agent(
         skill_names=(
             request.skill_names if request.skill_names is not None else []
         ),
-        language=request.language,
+        language=language,
     )
 
     agent_ref = AgentProfileRef(

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -122,9 +122,25 @@ JOBS_FILE = EnvVarLoader.get_str("QWENPAW_JOBS_FILE", "jobs.json")
 
 CHATS_FILE = EnvVarLoader.get_str("QWENPAW_CHATS_FILE", "chats.json")
 
+
 # Builtin Q&A helper profile.  agent_id keeps "QwenPaw" prefix for existing
 # workspaces and agent.json; do not rename.
-SUPPORTED_AGENT_LANGUAGES: frozenset[str] = frozenset({"en", "zh", "ru"})
+def _discover_agent_languages() -> frozenset[str]:
+    md_root = Path(__file__).resolve().parent / "agents" / "md_files"
+    if md_root.is_dir():
+        langs = {
+            d.name
+            for d in md_root.iterdir()
+            if d.is_dir()
+            and not d.name.startswith(".")
+            and any(d.glob("*.md"))
+        }
+        if langs:
+            return frozenset(langs)
+    return frozenset({"en", "zh", "ru"})
+
+
+SUPPORTED_AGENT_LANGUAGES: frozenset[str] = _discover_agent_languages()
 
 BUILTIN_QA_AGENT_ID = "QwenPaw_QA_Agent_0.2"
 BUILTIN_QA_AGENT_NAME = "QA Agent"

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -124,6 +124,8 @@ CHATS_FILE = EnvVarLoader.get_str("QWENPAW_CHATS_FILE", "chats.json")
 
 # Builtin Q&A helper profile.  agent_id keeps "QwenPaw" prefix for existing
 # workspaces and agent.json; do not rename.
+SUPPORTED_AGENT_LANGUAGES: frozenset[str] = frozenset({"en", "zh", "ru"})
+
 BUILTIN_QA_AGENT_ID = "QwenPaw_QA_Agent_0.2"
 BUILTIN_QA_AGENT_NAME = "QA Agent"
 # Default skills when the builtin QA workspace is first created only.

--- a/tests/unit/app/test_agents_ordering.py
+++ b/tests/unit/app/test_agents_ordering.py
@@ -154,7 +154,7 @@ async def test_create_agent_appends_new_id_to_order(monkeypatch, tmp_path):
     monkeypatch.setattr(
         agents_router,
         "_initialize_agent_workspace",
-        lambda workspace_dir, skill_names=None, md_template_id=None: None,
+        lambda workspace_dir, skill_names=None, md_template_id=None, language=None: None,  # noqa: E501  # pylint: disable=line-too-long
     )
     monkeypatch.setattr(
         agents_router,


### PR DESCRIPTION
## Description

- Console now sends `i18n.language` when creating an agent so the workspace matches the user's UI language
- Introduce `get_supported_agent_languages()` that dynamically reads available `md_files/<lang>/` directories, replacing hardcoded `{"zh", "en", "ru"}` sets
- Introduce `normalize_agent_language()` to map unsupported languages to `"en"` fallback
- `PUT /agent/language` validation now uses the dynamic language set

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
