### PR TITLE
improve(deploy): enable runtime auto-initialization of config.json

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -89,8 +89,6 @@ COPY src ./src
 COPY --from=console-builder /app/console/dist/ ./src/qwenpaw/console/
 RUN pip install --no-cache-dir .
 
-# Init working dir with default config.json and HEARTBEAT.md (build time).
-RUN qwenpaw init --defaults --accept-security
 
 # QwenPaw app port (default 8088). Override at runtime with -e QWENPAW_PORT=3000.
 ENV QWENPAW_PORT=8088

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -2,6 +2,17 @@
 # Substitute QWENPAW_PORT in supervisord template and start supervisord.
 # Default port 8088; override at runtime with -e QWENPAW_PORT=3000.
 set -e
+
+# Auto-initialize if config.json is missing (bind mount with empty directory).
+if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
+  echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
+  echo "📦 Running initialization..."
+  qwenpaw init --defaults --accept-security
+  echo "✅ Initialization complete!"
+else
+  echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
+fi
+
 export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
 envsubst '${QWENPAW_PORT}' \
   < /etc/supervisor/conf.d/supervisord.conf.template \


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
