### PR TITLE
fix(pack): add discord.py to conda-unpack affected packages

### DIFF
--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -27,7 +27,7 @@ ENV_PREFIX = "qwenpaw_pack_"
 # See: issue.md and https://github.com/conda/conda-pack/issues/154
 CONDA_UNPACK_AFFECTED_PACKAGES = [
     "huggingface_hub",  # file_download.py, _local_folder.py use Windows long path prefix
-    "discord.py",       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted (#3677)
+    "discord.py",       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted
 ]
 
 

--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -27,6 +27,7 @@ ENV_PREFIX = "qwenpaw_pack_"
 # See: issue.md and https://github.com/conda/conda-pack/issues/154
 CONDA_UNPACK_AFFECTED_PACKAGES = [
     "huggingface_hub",  # file_download.py, _local_folder.py use Windows long path prefix
+    "discord.py",       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted (#3677)
 ]
 
 

--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -18,7 +18,7 @@ $NsiPath = Join-Path $PackDir "desktop.nsi"
 # See: issue.md, scripts/pack/WINDOWS_FIX.md
 $CondaUnpackAffectedPackages = @(
   "huggingface_hub"  # Uses Windows extended-length path prefix (\\?\)
-  "discord.py"       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted (#3677)
+  "discord.py"       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted
 )
 
 New-Item -ItemType Directory -Force -Path $Dist | Out-Null

--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -18,6 +18,7 @@ $NsiPath = Join-Path $PackDir "desktop.nsi"
 # See: issue.md, scripts/pack/WINDOWS_FIX.md
 $CondaUnpackAffectedPackages = @(
   "huggingface_hub"  # Uses Windows extended-length path prefix (\\?\)
+  "discord.py"       # ARG_NAME_SUBREGEX contains \\?\* which gets corrupted (#3677)
 )
 
 New-Item -ItemType Directory -Force -Path $Dist | Out-Null

--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -117,6 +117,10 @@ if (Test-Path $CondaUnpack) {
     if ($LASTEXITCODE -ne 0) {
       throw "CRITICAL: huggingface_hub still has import errors after reinstall. See issue.md"
     }
+    & $pythonExe -c "import discord; print('✓ discord.py import OK')"
+    if ($LASTEXITCODE -ne 0) {
+      throw "CRITICAL: discord.py still has import errors after reinstall."
+    }
     Write-Host "[build_win] ✓ conda-unpack corruption fixed successfully."
   } else {
     Write-Host "[build_win] WARN: wheels_cache not found at $WheelsCache" -ForegroundColor Yellow


### PR DESCRIPTION
## Description

Add discord.py to CONDA_UNPACK_AFFECTED_PACKAGES in build_common.py and build_win.ps1. On Windows, conda-unpack corrupts the backslash escape \\?\* in discord/app_commands/commands.py, turning the valid regex (?:\\?\*) into (?:*), which causes re.error: nothing to repeat at import time and prevents the Discord channel from initializing. Reinstalling the package from cached wheels after conda-unpack restores the correct source files.

**Related Issue:** Fixes #3677 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
