### PR TITLE
feat(channels/weixin): log send_text ok for ops visibility

### DIFF
--- a/src/qwenpaw/app/channels/weixin/channel.py
+++ b/src/qwenpaw/app/channels/weixin/channel.py
@@ -986,6 +986,12 @@ class WeixinChannel(BaseChannel):
                         errcode,
                         to_user_id,
                     )
+                    return
+            logger.info(
+                "weixin send_text ok: to_user_id=%s text_len=%s",
+                to_user_id,
+                len(text),
+            )
         except Exception:
             logger.exception("weixin _send_text_direct failed")
 


### PR DESCRIPTION
## Summary

- Add one INFO log line on the successful weixin \`send_text\` branch so operators can reconstruct "did the bot reply to this user?" from server logs alone.
- Format: \`weixin send_text ok: to_user_id=<id> text_len=<N>\`. Only the length is logged, not the text — message content stays out of server logs.
- Matches the level and shape of feishu's existing \`_send_message ok\` line (\`channels/feishu/channel.py\`), bringing weixin to parity for incident triage / post-mortem reconstruction.

## Type of Change

- Feature (observability)

## Component(s) Affected

- Channels — WeChat (\`src/qwenpaw/app/channels/weixin/channel.py\`, 6-line change)

## Motivation (concrete)

Running streetlight-control bots on wechat, we found server logs show every **incoming** message (\`weixin recv: from=… text_len=…\`) and every **rejected** send (\`weixin send_text rejected: …\`), but **successful** sends produce no log at all. That means a user-facing conversation is entirely invisible on the server side: you can see the question but not whether the bot answered. Ops asks "did user X see a reply at timestamp T?" and we can't tell from logs.

## Historical note — relationship to #3685

An earlier version of this INFO line existed in #3685 along with a 20-line DEBUG token-source diagnostics block and a non-dict response guard. Review feedback (rightly) flagged the whole bundle as over-engineered and it was removed as a package.

This PR re-adds **only the success INFO** — a single low-rate line for ops, not the fat debug block. Streetlight-style bots typically send at most a handful of messages per minute per user, so the log volume is trivial. No DEBUG block, no non-dict guard, no policy change.

## Privacy

- \`text_len\` only (no \`text\` content)
- \`to_user_id\` is already logged on the corresponding \`weixin recv\` line when the user sent us a message, so logging it on the reply adds no new identifier class
- No \`context_token\` / \`bot_token\` is touched (neither was in the earlier version either)

## Checklist

- [x] \`pre-commit run --files src/qwenpaw/app/channels/weixin/channel.py\` — all hooks pass (black, flake8, mypy, pylint, etc.)
- [x] \`pytest tests/unit/channels/test_weixin.py\` — 78 passed, 0 failed
- [x] No test changes required — this is a logging-only addition; no public behavior changed

## Local Verification Evidence

\`\`\`bash
\$ pre-commit run --files src/qwenpaw/app/channels/weixin/channel.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

\$ python -m pytest tests/unit/channels/test_weixin.py -q
78 passed, 2 warnings in 0.71s
\`\`\`

## Diff

6-line addition, no removals:

\`\`\`python
try:
    resp = await _client.send_text(to_user_id, text, context_token)
    if isinstance(resp, dict):
        ret = resp.get(\"ret\", 0)
        errcode = resp.get(\"errcode\", 0)
        if ret != 0 or errcode != 0:
            logger.warning(
                \"weixin send_text rejected: \"
                \"ret=%s errcode=%s to_user_id=%s\",
                ret, errcode, to_user_id,
            )
            return             # <-- new
    logger.info(              # <-- new
        \"weixin send_text ok: to_user_id=%s text_len=%s\",
        to_user_id, len(text),
    )
except Exception:
    logger.exception(\"weixin _send_text_direct failed\")
\`\`\`