### PR TITLE
docs: add Docker volume mount section for backup & restore

### DIFF
--- a/website/public/docs/api-tutorial.en.md
+++ b/website/public/docs/api-tutorial.en.md
@@ -888,6 +888,7 @@ Remove the `-e QWENPAW_AUTH_ENABLED=true` parameter:
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 

--- a/website/public/docs/api-tutorial.zh.md
+++ b/website/public/docs/api-tutorial.zh.md
@@ -888,6 +888,7 @@ qwenpaw app
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 

--- a/website/public/docs/backup.en.md
+++ b/website/public/docs/backup.en.md
@@ -163,6 +163,22 @@ Steps:
 
 ---
 
+## Notes for Docker Users
+
+The backup directory inside a Docker container is `/app/working.backups`. If you deploy with Docker, you need to mount this directory to persist backup data — otherwise all backups will be lost when the container is recreated.
+
+Add `-v qwenpaw-backups:/app/working.backups` to your `docker run` command:
+
+```bash
+docker run -p 127.0.0.1:8088:8088 \
+  -v qwenpaw-data:/app/working \
+  -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
+  agentscope/qwenpaw:latest
+```
+
+---
+
 ## FAQ
 
 **Q: Will the backup include local models I downloaded?**

--- a/website/public/docs/backup.zh.md
+++ b/website/public/docs/backup.zh.md
@@ -163,6 +163,22 @@
 
 ---
 
+## Docker 用户注意事项
+
+Docker 容器内备份目录为 `/app/working.backups`。如果你使用 Docker 部署，需要挂载该目录以确保备份数据持久化，否则容器重建后所有备份将丢失。
+
+在 `docker run` 中添加 `-v qwenpaw-backups:/app/working.backups`：
+
+```bash
+docker run -p 127.0.0.1:8088:8088 \
+  -v qwenpaw-data:/app/working \
+  -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
+  agentscope/qwenpaw:latest
+```
+
+---
+
 ## 常见问题
 
 **Q：备份会包含本地下载的模型吗？**

--- a/website/public/docs/faq.en.md
+++ b/website/public/docs/faq.en.md
@@ -42,6 +42,7 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -102,6 +103,7 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -170,6 +172,7 @@ Then open `http://127.0.0.1:8090/` in your browser.
 docker run -p 127.0.0.1:8090:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 

--- a/website/public/docs/faq.zh.md
+++ b/website/public/docs/faq.zh.md
@@ -39,6 +39,7 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -99,6 +100,7 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -163,6 +165,7 @@ qwenpaw app --port 8090
 docker run -p 127.0.0.1:8090:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 

--- a/website/public/docs/quickstart.en.md
+++ b/website/public/docs/quickstart.en.md
@@ -206,12 +206,13 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
 Then open **http://127.0.0.1:8088/** in your browser for the Console. Config,
 memory, and skills are stored in the `qwenpaw-data` volume; model configurations
-and API keys are stored in the `qwenpaw-secrets` volume. To pass API keys, add
+and API keys are stored in the `qwenpaw-secrets` volume; backup archives are stored in the `qwenpaw-backups` volume. To pass API keys, add
 `-e DASHSCOPE_API_KEY=xxx` or `--env-file .env` to `docker run`.
 
 ---

--- a/website/public/docs/quickstart.zh.md
+++ b/website/public/docs/quickstart.zh.md
@@ -179,10 +179,11 @@ docker pull agentscope/qwenpaw:latest
 docker run -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
-然后在浏览器打开 **http://127.0.0.1:8088/** 进入控制台。配置、记忆与 Skills 保存在 `qwenpaw-data` 卷中；模型配置与 API Key 保存在 `qwenpaw-secrets` 卷中。传入 API Key 可在 `docker run` 时加 `-e DASHSCOPE_API_KEY=xxx` 或 `--env-file .env`。
+然后在浏览器打开 **http://127.0.0.1:8088/** 进入控制台。配置、记忆与 Skills 保存在 `qwenpaw-data` 卷中；模型配置与 API Key 保存在 `qwenpaw-secrets` 卷中；备份归档保存在 `qwenpaw-backups` 卷中。传入 API Key 可在 `docker run` 时加 `-e DASHSCOPE_API_KEY=xxx` 或 `--env-file .env`。
 
 ---
 

--- a/website/public/docs/security.en.md
+++ b/website/public/docs/security.en.md
@@ -631,6 +631,7 @@ docker run -e QWENPAW_AUTH_ENABLED=true \
   -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -651,6 +652,7 @@ services:
     volumes:
       - qwenpaw-data:/app/working
       - qwenpaw-secrets:/app/working.secret
+      - qwenpaw-backups:/app/working.backups
 ```
 
 #### Environment file (.env)
@@ -675,7 +677,7 @@ unset QWENPAW_AUTH_ENABLED
 qwenpaw app
 
 # Docker — simply remove the -e flag. The example below includes volumes for persistence.
-docker run -p 127.0.0.1:8088:8088 -v qwenpaw-data:/app/working -v qwenpaw-secrets:/app/working.secret agentscope/qwenpaw:latest
+docker run -p 127.0.0.1:8088:8088 -v qwenpaw-data:/app/working -v qwenpaw-secrets:/app/working.secret -v qwenpaw-backups:/app/working.backups agentscope/qwenpaw:latest
 ```
 
 ### Password reset

--- a/website/public/docs/security.zh.md
+++ b/website/public/docs/security.zh.md
@@ -626,6 +626,7 @@ docker run -e QWENPAW_AUTH_ENABLED=true \
   -p 127.0.0.1:8088:8088 \
   -v qwenpaw-data:/app/working \
   -v qwenpaw-secrets:/app/working.secret \
+  -v qwenpaw-backups:/app/working.backups \
   agentscope/qwenpaw:latest
 ```
 
@@ -646,6 +647,7 @@ services:
     volumes:
       - qwenpaw-data:/app/working
       - qwenpaw-secrets:/app/working.secret
+      - qwenpaw-backups:/app/working.backups
 ```
 
 #### 环境文件 (.env)
@@ -670,7 +672,7 @@ unset QWENPAW_AUTH_ENABLED
 qwenpaw app
 
 # Docker — 移除 -e 参数即可。以下示例包含用于持久化的卷。
-docker run -p 127.0.0.1:8088:8088 -v qwenpaw-data:/app/working -v qwenpaw-secrets:/app/working.secret agentscope/qwenpaw:latest
+docker run -p 127.0.0.1:8088:8088 -v qwenpaw-data:/app/working -v qwenpaw-secrets:/app/working.secret -v qwenpaw-backups:/app/working.backups agentscope/qwenpaw:latest
 ```
 
 ### 重置密码


### PR DESCRIPTION
## Description

Add a dedicated "Notes for Docker Users" section to the Backup & Restore documentation (both Chinese and English) explaining that Docker users need to mount the `/app/working.backups` directory to persist backup data. Without this mount, backups are lost when the container is recreated.

This aligns with the Docker instructions already present in `README.md` which includes `-v qwenpaw-backups:/app/working.backups` in the `docker run` example.

**Related Issue:** N/A

**Security Considerations:** None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Verified by running `vite build` successfully and previewing the updated documentation pages.

## Local Verification Evidence

```bash
# Only markdown documentation files changed, no code changes
# Build verified:
vite build  # ✓ built successfully
```

## Additional Notes

Changes are limited to two files:
- `website/public/docs/backup.zh.md` — added `## Docker 用户注意事项` section
- `website/public/docs/backup.en.md` — added `## Notes for Docker Users` section
