### PR TITLE
skills: add built-in agent audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Your personal AI assistant — easy to install, deploy locally or in the cloud, 
 >
 > **Skills extension** — Built-in scheduling, PDF/Office processing, news digest, and more; custom skills auto-loaded, no lock-in. Skills determine what QwenPaw can do.
 >
+> **Agent runtime audit** — The built-in `agent_audit` skill helps diagnose wrapper regressions, stale memory contamination, hidden repair layers, and tool-discipline issues with evidence-first structured reports.
+>
 > **Multi-agent collaboration** — Create multiple independent agents, each with their own role; enable collaboration skills for inter-agent communication to tackle complex tasks together.
 >
 > **Multi-layer security** — Tool guard, file access control, skill security scanning to ensure safe operation.

--- a/src/qwenpaw/agents/skills/agent_audit-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/agent_audit-en/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: agent_audit
+description: "Evidence-first audit workflow for agent runtimes, wrappers, memory layers, tool routing, and delivery paths. Use when an agent becomes less reliable than the base model, skips tools, leaks stale memory, or mutates otherwise correct answers."
+metadata:
+  builtin_skill_version: "1.0"
+  qwenpaw:
+    emoji: "🩺"
+    requires: {}
+---
+
+# Agent Audit
+
+Audit the agent system itself, not the user's domain task.
+
+Use this skill when an assistant, wrapper, channel adapter, browser agent, or
+long-running runtime:
+
+- behaves worse than the underlying model
+- skips required tools
+- reuses stale session or memory evidence
+- mutates correct answers during retries, formatting, or transport
+- hides repair, retry, recap, or summarization layers
+- gives confident operational answers without current evidence
+
+## Core rule
+
+Work evidence-first and JSON-first.
+
+Do not jump directly to prose conclusions. Build the structured artifacts first,
+then render the user-facing diagnosis from those artifacts.
+
+Required artifacts, in order:
+
+1. `agent_check_scope.json`
+2. `evidence_pack.json`
+3. `failure_map.json`
+4. `agent_check_report.json`
+
+## Audit target
+
+Inspect the full agent stack:
+
+1. system prompt and role shaping
+2. session history injection
+3. long-term memory retrieval
+4. summaries or distillation
+5. active recall or recap layers
+6. tool routing and selection
+7. tool execution
+8. tool-output interpretation
+9. answer shaping
+10. platform rendering or transport
+11. fallback or repair loops
+12. persistence and stale state
+
+## Required working style
+
+- Prefer direct evidence: code, config, logs, payloads, DB rows, screenshots, and tests.
+- Treat a clean current state as insufficient when the reported failure was historical.
+- Prefer code and configuration fixes over prompt-only fixes.
+- Be explicit about confidence and contradictory evidence.
+- Do not blame the base model unless wrapper layers have been falsified.
+
+## References
+
+Read these references before or during the audit:
+
+- `references/report-schema.json`
+- `references/rubric.md`
+- `references/playbooks.md`
+- `references/advanced-playbooks.md`
+- `references/example-report.json`
+- `references/trigger-prompts.md`
+
+## Standard workflow
+
+1. Create `agent_check_scope.json`.
+2. Gather direct evidence into `evidence_pack.json`.
+3. Map failure modes in `failure_map.json`.
+4. Build `agent_check_report.json` from structured artifacts.
+5. Present severity-ranked findings first, then architecture diagnosis, then ordered fix plan.
+
+## Output rules
+
+- Lead with findings, not compliments.
+- Do not hide uncertainty.
+- Do not improvise a new theory after producing the report.
+- If the main problem is wrapper design, say so directly.
+- If the user asks for JSON, provide `agent_check_report.json`.
+
+## Example prompt
+
+Use `agent_audit` to inspect this agent runtime for wrapper regression and
+tool-discipline failures. Focus on stale evidence reuse, hidden repair layers,
+and whether tool requirements are enforced in code or only described in prompts.
+Build the JSON artifacts first, then give severity-ranked findings and a fix order.

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/advanced-playbooks.md
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/advanced-playbooks.md
@@ -1,0 +1,25 @@
+# Advanced Playbooks
+
+## false-confidence
+
+Use when the agent sounds decisive while evidence is weak or missing.
+
+## stale-evidence-replay
+
+Use when old outputs are repeated as if they were current.
+
+## fake-agentic-depth
+
+Use when the system looks more agentic but gets less reliable.
+
+## hidden-repair-brain
+
+Use when platform or fallback code silently spins up a second model pass.
+
+## memory-poisoning
+
+Use when assistant self-talk becomes durable knowledge.
+
+## protocol-decay
+
+Use when internal state is carried as prose instead of typed data.

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/example-report.json
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/example-report.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "high_risk",
+    "primary_failure_mode": "stale same-session evidence is being reused as if it were current truth",
+    "most_urgent_fix": "enforce code-level fresh probes for operational queries"
+  },
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Operational answers can bypass real inspection",
+      "symptom": "The agent gives confident system-state answers before tools run.",
+      "user_impact": "Users receive wrong operational facts with high confidence.",
+      "source_layer": "tool_selection",
+      "mechanism": "Tool usage is encouraged in prompt text but not always required by code.",
+      "root_cause": "Prompt-enforced discipline instead of code-enforced discipline.",
+      "evidence_refs": ["runtime.log:first_reply_without_tool", "tool-routing:gate"],
+      "confidence": 0.98,
+      "fix_type": "code",
+      "recommended_fix": "Introduce task classification plus mandatory probe execution before final answer generation."
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "session_history",
+      "to_layer": "tool_interpretation",
+      "conflict_type": "stale_state",
+      "note": "Old evidence is accepted as if it were fresh."
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "session_history",
+      "affected_layer": "tool_selection",
+      "artifact": "stale operational observation",
+      "failure_mode": "stale_state",
+      "note": "A previous observation survives long enough to bias current-turn tool routing."
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "Force fresh probes for system-state queries",
+      "why_now": "It removes the most damaging correctness failure immediately.",
+      "expected_effect": "Wrong operational answers drop sharply."
+    }
+  ]
+}

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/playbooks.md
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/playbooks.md
@@ -1,0 +1,37 @@
+# Playbooks
+
+## wrapper-regression
+
+Use when the base model seems strong but the wrapped agent behaves much worse.
+
+Focus on wrapper layering, duplicated context injection, hidden formatting or
+fallback layers, and answer degradation after orchestration.
+
+## memory-contamination
+
+Use when old topics or stale artifacts bleed into current turns.
+
+Focus on same-session artifact reentry, stale session reuse, weak memory
+admission criteria, and aggressive distillation cadence.
+
+## tool-discipline
+
+Use when the agent should have used a tool but did not, or when tool evidence
+was available but the conclusion drifted.
+
+Focus on code-enforced versus prompt-enforced tool requirements, preflight
+probes, tool-call skip paths, and stale evidence reuse.
+
+## rendering-transport
+
+Use when the answer seems correct internally but broken in delivery.
+
+Focus on transport payload shape assumptions, deterministic fallback behavior,
+and platform-layer mutations.
+
+## hidden-agent-layers
+
+Use when repair, retry, summarize, or recap loops are hidden in the stack.
+
+Focus on hidden repair agents, recap loops, maintenance-worker synthesis paths,
+and transport repair prompts.

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/report-schema.json
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/report-schema.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "critical | high_risk | unstable | acceptable | strong",
+    "primary_failure_mode": "string",
+    "most_urgent_fix": "string"
+  },
+  "scope": {
+    "target_name": "string",
+    "entrypoints": ["string"],
+    "channels": ["string"],
+    "model_stack": ["string"],
+    "time_window": "string",
+    "layers_to_audit": [
+      "system_prompt",
+      "session_history",
+      "long_term_memory",
+      "distillation",
+      "active_recall",
+      "tool_selection",
+      "tool_execution",
+      "tool_interpretation",
+      "answer_shaping",
+      "platform_rendering",
+      "fallback_loops",
+      "persistence"
+    ]
+  },
+  "evidence_pack": [
+    {
+      "kind": "code | log | db | config | screenshot | test",
+      "source": "string",
+      "location": "string",
+      "summary": "string",
+      "time_scope": "historical | current | mixed"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical | high | medium | low",
+      "title": "string",
+      "symptom": "string",
+      "user_impact": "string",
+      "source_layer": "string",
+      "mechanism": "string",
+      "root_cause": "string",
+      "evidence_refs": ["string"],
+      "confidence": 0.0,
+      "fix_type": "code | config | prompt_removal | architecture | data_cleanup",
+      "recommended_fix": "string"
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "string",
+      "to_layer": "string",
+      "conflict_type": "duplication | contradiction | stale_state | hidden_mutation | freeform_overwrite",
+      "note": "string"
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "string",
+      "affected_layer": "string",
+      "artifact": "string",
+      "failure_mode": "string",
+      "note": "string"
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "string",
+      "why_now": "string",
+      "expected_effect": "string"
+    }
+  ]
+}

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/rubric.md
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/rubric.md
@@ -1,0 +1,46 @@
+# Audit Rubric
+
+Use this rubric when producing `agent_check_report.json`.
+
+## 1. Context cleanliness
+
+- Is the same information injected through multiple layers?
+- Are model-generated summaries fed back as context?
+- Is session history carrying stale facts forward?
+- Are current-session artifacts re-entering the same turn?
+
+## 2. Tool discipline
+
+- Are tools merely available, or actually required in code?
+- Can the model skip tools and still answer?
+- Does the runtime bind final answers to current-turn evidence?
+
+## 3. Failure handling
+
+- Does a send or render failure trigger another hidden agent?
+- Is there a deterministic fallback path?
+- Are failures visible and attributable?
+
+## 4. Memory admission
+
+- Can assistant self-talk become long-term memory?
+- Are user corrections weighted more than assistant assertions?
+- Is there a stable-window or evidence gate before distillation?
+
+## 5. Answer shaping
+
+- Is the final response derived from structured evidence?
+- Does formatting add noise or rewrap already-correct answers?
+- Does platform rendering leak raw markdown or transform meaning unpredictably?
+
+## 6. Hidden agent layers
+
+- Are there hidden repair, retry, summarize, or recap agents?
+- Do these layers have explicit contracts and schemas?
+
+## Severity heuristics
+
+- `critical`: confidently wrong operational behavior
+- `high`: repeated corruption of otherwise good evidence
+- `medium`: correctness often survives, but the system is fragile
+- `low`: mostly maintainability or cosmetic concerns

--- a/src/qwenpaw/agents/skills/agent_audit-en/references/trigger-prompts.md
+++ b/src/qwenpaw/agents/skills/agent_audit-en/references/trigger-prompts.md
@@ -1,0 +1,11 @@
+# Trigger Prompts
+
+Use this skill when users ask:
+
+- Audit this agent runtime end to end
+- Why is this wrapped model worse than the base model?
+- Why does the assistant skip tools?
+- Why is memory polluting new turns?
+- Why do answers become worse after retries or formatting?
+- Diagnose hidden prompt conflicts in this assistant stack
+- Give me a severity-ranked audit of this agent wrapper

--- a/src/qwenpaw/agents/skills/agent_audit-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: agent_audit
+description: "面向 agent 运行时、包装层、记忆层、工具路由和交付链路的证据优先审计流程。当 agent 比基础模型更不可靠、跳过工具、复用陈旧记忆或在重试/渲染中改坏答案时使用。"
+metadata:
+  builtin_skill_version: "1.0"
+  qwenpaw:
+    emoji: "🩺"
+    requires: {}
+---
+
+# Agent Audit
+
+审计 agent 系统本身，而不是完成用户的业务任务。
+
+当助手、包装层、通道适配器、浏览器 agent 或长期运行的 runtime 出现以下问题时使用：
+
+- 表现比底层模型更差
+- 跳过本该使用的工具
+- 复用陈旧会话或记忆证据
+- 在重试、格式化或传输过程中把正确答案改坏
+- 隐藏了修复、重试、摘要或回顾层
+- 在没有当前证据的情况下自信回答运行状态
+
+## 核心规则
+
+证据优先，JSON 优先。
+
+不要直接写自由文本结论。先构造结构化产物，再从结构化产物渲染给用户看的诊断。
+
+必须按顺序构造：
+
+1. `agent_check_scope.json`
+2. `evidence_pack.json`
+3. `failure_map.json`
+4. `agent_check_report.json`
+
+## 审计对象
+
+审计完整 agent 栈：
+
+1. system prompt 与角色塑形
+2. 会话历史注入
+3. 长期记忆检索
+4. 摘要或蒸馏
+5. 主动回忆或 recap 层
+6. 工具路由与选择
+7. 工具执行
+8. 工具输出解释
+9. 最终答案塑形
+10. 平台渲染或传输
+11. fallback 或 repair loop
+12. 持久化与陈旧状态
+
+## 工作方式
+
+- 优先使用直接证据：代码、配置、日志、payload、数据库行、截图和测试。
+- 如果故障发生在历史窗口，不要只看当前干净状态。
+- 优先给代码和配置级修复，不要只给 prompt 补丁。
+- 明确置信度和反证。
+- 除非已经排除包装层问题，否则不要直接责怪基础模型。
+
+## 参考资料
+
+审计前或审计中阅读：
+
+- `references/report-schema.json`
+- `references/rubric.md`
+- `references/playbooks.md`
+- `references/advanced-playbooks.md`
+- `references/example-report.json`
+- `references/trigger-prompts.md`
+
+## 标准流程
+
+1. 创建 `agent_check_scope.json`。
+2. 收集直接证据到 `evidence_pack.json`。
+3. 在 `failure_map.json` 中映射失败模式。
+4. 从结构化产物生成 `agent_check_report.json`。
+5. 先输出按严重程度排序的 findings，再给架构诊断，最后给修复顺序。
+
+## 输出规则
+
+- 先给 findings，不要先夸。
+- 不要隐藏不确定性。
+- 生成报告后，不要再临场编一个新理论。
+- 如果主要问题是包装层设计，请直接说。
+- 如果用户要求 JSON，提供 `agent_check_report.json`。

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/advanced-playbooks.md
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/advanced-playbooks.md
@@ -1,0 +1,25 @@
+# Advanced Playbooks
+
+## false-confidence
+
+Use when the agent sounds decisive while evidence is weak or missing.
+
+## stale-evidence-replay
+
+Use when old outputs are repeated as if they were current.
+
+## fake-agentic-depth
+
+Use when the system looks more agentic but gets less reliable.
+
+## hidden-repair-brain
+
+Use when platform or fallback code silently spins up a second model pass.
+
+## memory-poisoning
+
+Use when assistant self-talk becomes durable knowledge.
+
+## protocol-decay
+
+Use when internal state is carried as prose instead of typed data.

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/example-report.json
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/example-report.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "high_risk",
+    "primary_failure_mode": "stale same-session evidence is being reused as if it were current truth",
+    "most_urgent_fix": "enforce code-level fresh probes for operational queries"
+  },
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Operational answers can bypass real inspection",
+      "symptom": "The agent gives confident system-state answers before tools run.",
+      "user_impact": "Users receive wrong operational facts with high confidence.",
+      "source_layer": "tool_selection",
+      "mechanism": "Tool usage is encouraged in prompt text but not always required by code.",
+      "root_cause": "Prompt-enforced discipline instead of code-enforced discipline.",
+      "evidence_refs": ["runtime.log:first_reply_without_tool", "tool-routing:gate"],
+      "confidence": 0.98,
+      "fix_type": "code",
+      "recommended_fix": "Introduce task classification plus mandatory probe execution before final answer generation."
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "session_history",
+      "to_layer": "tool_interpretation",
+      "conflict_type": "stale_state",
+      "note": "Old evidence is accepted as if it were fresh."
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "session_history",
+      "affected_layer": "tool_selection",
+      "artifact": "stale operational observation",
+      "failure_mode": "stale_state",
+      "note": "A previous observation survives long enough to bias current-turn tool routing."
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "Force fresh probes for system-state queries",
+      "why_now": "It removes the most damaging correctness failure immediately.",
+      "expected_effect": "Wrong operational answers drop sharply."
+    }
+  ]
+}

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/playbooks.md
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/playbooks.md
@@ -1,0 +1,37 @@
+# Playbooks
+
+## wrapper-regression
+
+Use when the base model seems strong but the wrapped agent behaves much worse.
+
+Focus on wrapper layering, duplicated context injection, hidden formatting or
+fallback layers, and answer degradation after orchestration.
+
+## memory-contamination
+
+Use when old topics or stale artifacts bleed into current turns.
+
+Focus on same-session artifact reentry, stale session reuse, weak memory
+admission criteria, and aggressive distillation cadence.
+
+## tool-discipline
+
+Use when the agent should have used a tool but did not, or when tool evidence
+was available but the conclusion drifted.
+
+Focus on code-enforced versus prompt-enforced tool requirements, preflight
+probes, tool-call skip paths, and stale evidence reuse.
+
+## rendering-transport
+
+Use when the answer seems correct internally but broken in delivery.
+
+Focus on transport payload shape assumptions, deterministic fallback behavior,
+and platform-layer mutations.
+
+## hidden-agent-layers
+
+Use when repair, retry, summarize, or recap loops are hidden in the stack.
+
+Focus on hidden repair agents, recap loops, maintenance-worker synthesis paths,
+and transport repair prompts.

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/report-schema.json
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/report-schema.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "agent-audit.report.v1",
+  "executive_verdict": {
+    "overall_health": "critical | high_risk | unstable | acceptable | strong",
+    "primary_failure_mode": "string",
+    "most_urgent_fix": "string"
+  },
+  "scope": {
+    "target_name": "string",
+    "entrypoints": ["string"],
+    "channels": ["string"],
+    "model_stack": ["string"],
+    "time_window": "string",
+    "layers_to_audit": [
+      "system_prompt",
+      "session_history",
+      "long_term_memory",
+      "distillation",
+      "active_recall",
+      "tool_selection",
+      "tool_execution",
+      "tool_interpretation",
+      "answer_shaping",
+      "platform_rendering",
+      "fallback_loops",
+      "persistence"
+    ]
+  },
+  "evidence_pack": [
+    {
+      "kind": "code | log | db | config | screenshot | test",
+      "source": "string",
+      "location": "string",
+      "summary": "string",
+      "time_scope": "historical | current | mixed"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "critical | high | medium | low",
+      "title": "string",
+      "symptom": "string",
+      "user_impact": "string",
+      "source_layer": "string",
+      "mechanism": "string",
+      "root_cause": "string",
+      "evidence_refs": ["string"],
+      "confidence": 0.0,
+      "fix_type": "code | config | prompt_removal | architecture | data_cleanup",
+      "recommended_fix": "string"
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "string",
+      "to_layer": "string",
+      "conflict_type": "duplication | contradiction | stale_state | hidden_mutation | freeform_overwrite",
+      "note": "string"
+    }
+  ],
+  "contamination_paths": [
+    {
+      "origin_layer": "string",
+      "affected_layer": "string",
+      "artifact": "string",
+      "failure_mode": "string",
+      "note": "string"
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "string",
+      "why_now": "string",
+      "expected_effect": "string"
+    }
+  ]
+}

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/rubric.md
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/rubric.md
@@ -1,0 +1,46 @@
+# Audit Rubric
+
+Use this rubric when producing `agent_check_report.json`.
+
+## 1. Context cleanliness
+
+- Is the same information injected through multiple layers?
+- Are model-generated summaries fed back as context?
+- Is session history carrying stale facts forward?
+- Are current-session artifacts re-entering the same turn?
+
+## 2. Tool discipline
+
+- Are tools merely available, or actually required in code?
+- Can the model skip tools and still answer?
+- Does the runtime bind final answers to current-turn evidence?
+
+## 3. Failure handling
+
+- Does a send or render failure trigger another hidden agent?
+- Is there a deterministic fallback path?
+- Are failures visible and attributable?
+
+## 4. Memory admission
+
+- Can assistant self-talk become long-term memory?
+- Are user corrections weighted more than assistant assertions?
+- Is there a stable-window or evidence gate before distillation?
+
+## 5. Answer shaping
+
+- Is the final response derived from structured evidence?
+- Does formatting add noise or rewrap already-correct answers?
+- Does platform rendering leak raw markdown or transform meaning unpredictably?
+
+## 6. Hidden agent layers
+
+- Are there hidden repair, retry, summarize, or recap agents?
+- Do these layers have explicit contracts and schemas?
+
+## Severity heuristics
+
+- `critical`: confidently wrong operational behavior
+- `high`: repeated corruption of otherwise good evidence
+- `medium`: correctness often survives, but the system is fragile
+- `low`: mostly maintainability or cosmetic concerns

--- a/src/qwenpaw/agents/skills/agent_audit-zh/references/trigger-prompts.md
+++ b/src/qwenpaw/agents/skills/agent_audit-zh/references/trigger-prompts.md
@@ -1,0 +1,11 @@
+# Trigger Prompts
+
+Use this skill when users ask:
+
+- Audit this agent runtime end to end
+- Why is this wrapped model worse than the base model?
+- Why does the assistant skip tools?
+- Why is memory polluting new turns?
+- Why do answers become worse after retries or formatting?
+- Diagnose hidden prompt conflicts in this assistant stack
+- Give me a severity-ranked audit of this agent wrapper

--- a/tests/unit/skills/test_agent_audit_skill.py
+++ b/tests/unit/skills/test_agent_audit_skill.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_DIR = REPO_ROOT / "src" / "qwenpaw" / "agents" / "skills"
+
+
+def test_agent_audit_english_skill_contract():
+    skill_dir = SKILLS_DIR / "agent_audit-en"
+    skill_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    schema = json.loads((skill_dir / "references" / "report-schema.json").read_text())
+    example = json.loads((skill_dir / "references" / "example-report.json").read_text())
+
+    assert "name: agent_audit" in skill_text
+    assert "agent_check_scope.json" in skill_text
+    assert "evidence_pack.json" in skill_text
+    assert "failure_map.json" in skill_text
+    assert "agent_check_report.json" in skill_text
+    assert schema["schema_version"] == "agent-audit.report.v1"
+    assert "contamination_paths" in schema
+    assert "contamination_paths" in example
+
+
+def test_agent_audit_chinese_skill_contract():
+    skill_dir = SKILLS_DIR / "agent_audit-zh"
+    skill_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    schema = json.loads((skill_dir / "references" / "report-schema.json").read_text())
+
+    assert "name: agent_audit" in skill_text
+    assert "agent_check_scope.json" in skill_text
+    assert "evidence_pack.json" in skill_text
+    assert "failure_map.json" in skill_text
+    assert "agent_check_report.json" in skill_text
+    assert schema["schema_version"] == "agent-audit.report.v1"
+    assert "contamination_paths" in schema


### PR DESCRIPTION
## Summary
- add a built-in `agent_audit` skill in both English and Chinese
- include structured references for playbooks, advanced playbooks, rubric guidance, report schema, trigger prompts, and example report data
- add unit tests that validate the new skill contract and schema shape
- mention the agent runtime audit capability in the README

## What this adds
This PR adds a reusable built-in skill for diagnosing agent runtime failures in QwenPaw.

The skill is designed for cases such as:
- wrapper regression
- tool-discipline failures
- stale memory contamination
- hidden repair or retry layers
- rendering / transport mutation

It asks the agent to build structured audit artifacts before writing a final diagnosis:
1. `agent_check_scope.json`
2. `evidence_pack.json`
3. `failure_map.json`
4. `agent_check_report.json`

The references include:
- standard playbooks
- advanced playbooks
- an audit rubric
- a report schema
- an example structured report
- trigger prompt examples

## Why this fits QwenPaw
QwenPaw is driven by Skills, and this capability fits naturally as a built-in skill rather than a core runtime change. It gives users and developers an evidence-first way to inspect the agent stack when behavior regresses because of memory, tool routing, wrapper logic, or delivery layers.

## Verification
I ran the following locally:

```bash
cd /tmp/qwenpaw-agent-audit && uv venv .venv --python 3.12
cd /tmp/qwenpaw-agent-audit && uv pip install pytest
cd /tmp/qwenpaw-agent-audit && .venv/bin/python -m pytest tests/unit/skills/test_agent_audit_skill.py -q
cd /tmp/qwenpaw-agent-audit && .venv/bin/python -m py_compile tests/unit/skills/test_agent_audit_skill.py
```

Results:
- `2 passed`
- `py_compile` passed
