### PR TITLE
docs: polish ACP docs and add ACP doc link

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -115,6 +115,8 @@
     "stdioBufferLimitHelp": "Maximum stdio line buffer size in bytes for the ACP subprocess.",
     "stdioBufferLimitRequired": "Please enter a stdio buffer limit",
     "stdioBufferLimitMin": "Stdio buffer limit must be at least 1 byte",
+    "docs": "Setup Docs",
+    "docsHelp": "Open the ACP integration docs and jump to the \"How to configure external runners\" section",
     "notSet": "Not set",
     "configSaved": "ACP configuration saved",
     "configFailed": "Failed to save ACP configuration"

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1581,6 +1581,8 @@
     "stdioBufferLimitHelp": "ACP サブプロセスの stdio 1 行読み取りバッファの最大バイト数です。",
     "stdioBufferLimitRequired": "stdio バッファ上限を入力してください",
     "stdioBufferLimitMin": "stdio バッファ上限は 1 バイト以上である必要があります",
+    "docs": "設定ドキュメント",
+    "docsHelp": "ACP 統合ドキュメントを開き、「How to configure external runners」セクションへ移動します",
     "notSet": "未設定",
     "configSaved": "ACP 設定を保存しました",
     "configFailed": "ACP 設定の保存に失敗しました"

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1596,6 +1596,8 @@
     "stdioBufferLimitHelp": "Максимальный размер буфера чтения одной строки stdio для ACP-подпроцесса в байтах.",
     "stdioBufferLimitRequired": "Пожалуйста, укажите лимит буфера stdio",
     "stdioBufferLimitMin": "Лимит буфера stdio должен быть не меньше 1 байта",
+    "docs": "Документация",
+    "docsHelp": "Открыть документацию по ACP и перейти к разделу \"How to configure external runners\"",
     "notSet": "Не задано",
     "configSaved": "Конфигурация ACP сохранена",
     "configFailed": "Не удалось сохранить конфигурацию ACP"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -210,6 +210,8 @@
     "stdioBufferLimitHelp": "ACP 子进程 stdio 单行读取缓冲的最大字节数。",
     "stdioBufferLimitRequired": "请输入 stdio 缓冲上限",
     "stdioBufferLimitMin": "stdio 缓冲上限至少为 1 字节",
+    "docs": "配置文档",
+    "docsHelp": "打开 ACP 集成文档，并跳转到“如何配置外部 runner”章节",
     "notSet": "未设置",
     "configSaved": "ACP 配置已保存",
     "configFailed": "ACP 配置保存失败"

--- a/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
+++ b/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
@@ -7,6 +7,7 @@ import {
   Select,
   InputNumber,
 } from "@agentscope-ai/design";
+import { LinkOutlined } from "@ant-design/icons";
 import type { FormInstance } from "antd";
 import { useTranslation } from "react-i18next";
 import {
@@ -14,6 +15,8 @@ import {
   type ACPAgentConfig,
   type ACPToolParseMode,
 } from "../../../../api/types";
+import { getWebsiteLang } from "../../../../layouts/constants";
+import styles from "../../../Control/Channels/index.module.less";
 
 interface ACPDrawerProps {
   open: boolean;
@@ -31,6 +34,18 @@ const TOOL_PARSE_MODE_OPTIONS: { value: ACPToolParseMode; label: string }[] = [
   { value: "update_detail", label: "update_detail" },
   { value: "call_detail", label: "call_detail" },
 ];
+
+const ACP_DOC_SECTION_HASH = {
+  zh: "如何配置外部-runner",
+  en: "How-to-configure-external-runners",
+} as const;
+
+function getACPDocsUrl(lang: string): string {
+  const websiteLang = getWebsiteLang(lang);
+  const hash =
+    websiteLang === "zh" ? ACP_DOC_SECTION_HASH.zh : ACP_DOC_SECTION_HASH.en;
+  return `https://qwenpaw.agentscope.io/docs/acp-integration?lang=${websiteLang}#${hash}`;
+}
 
 export function parseArgsText(value: unknown): string[] {
   return String(value || "")
@@ -90,7 +105,7 @@ export function ACPDrawer({
   onClose,
   onSubmit,
 }: ACPDrawerProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   return (
     <Drawer
@@ -182,6 +197,26 @@ export function ACPDrawer({
         >
           <Input.TextArea autoSize={{ minRows: 4, maxRows: 8 }} />
         </Form.Item>
+
+        <div className={styles.formTopActions}>
+          <Button
+            type="text"
+            size="small"
+            icon={<LinkOutlined />}
+            onClick={() =>
+              window.open(
+                getACPDocsUrl(i18n.language),
+                "_blank",
+                "noopener,noreferrer",
+              )
+            }
+            title={t("acp.docsHelp")}
+            className={styles.dingtalkDocBtn}
+            style={{ color: "#FF7F16" }}
+          >
+            {t("acp.docs")}
+          </Button>
+        </div>
 
         <Form.Item
           name="trusted"

--- a/website/public/docs/acp-integration.en.md
+++ b/website/public/docs/acp-integration.en.md
@@ -2,99 +2,18 @@
 
 QwenPaw supports **ACP (Agent Client Protocol)** in two complementary ways:
 
-1. **QwenPaw as an ACP Server** — external clients connect to QwenPaw over ACP
-2. **QwenPaw using ACP as a Tool** — QwenPaw connects to external ACP runners and collaborates with them as delegated agents
+1. **QwenPaw using ACP as a Tool**: QwenPaw connects to external ACP runners and uses them as delegated collaborators
+2. **QwenPaw as an ACP Server**: external clients connect to QwenPaw over ACP
 
-This page explains both modes and when to use each one.
-
----
-
-## QwenPaw as ACP Server
-
-In this mode, QwenPaw exposes itself as an [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) compliant agent server over stdio JSON-RPC. External clients — such as [Zed](https://zed.dev), [OpenCode](https://github.com/nicholasgasior/opencode), or any ACP-compatible editor — can connect to QwenPaw via the `qwenpaw acp` CLI command and interact with it programmatically.
-
-### Quick Start
-
-```bash
-# Start QwenPaw as an ACP agent
-qwenpaw acp
-
-# Use a specific agent profile
-qwenpaw acp --agent mybot
-
-# Use a custom workspace directory
-qwenpaw acp --workspace /path/to/workspace
-
-# Enable debug logging to stderr
-qwenpaw acp --debug
-```
-
-The process communicates over stdin/stdout using the ACP JSON-RPC protocol. stderr is used for logging.
-
-### Supported ACP Methods
-
-| Method              | Description                                                  |
-| ------------------- | ------------------------------------------------------------ |
-| `initialize`        | Handshake — returns agent capabilities and version info      |
-| `new_session`       | Create a new conversation session                            |
-| `load_session`      | Load/attach to an existing session by ID                     |
-| `resume_session`    | Resume a previously closed session                           |
-| `list_sessions`     | List active sessions, optionally filtered by `cwd`           |
-| `close_session`     | Close and clean up a session                                 |
-| `prompt`            | Send a user message and stream back agent responses          |
-| `set_session_model` | Switch the active LLM model (format: `provider_id:model_id`) |
-| `set_config_option` | Toggle session config options (e.g. Tool Guard on/off)       |
-| `cancel`            | Cancel an in-progress prompt                                 |
-
-### Streaming Updates
-
-During a `prompt` call, the agent streams real-time updates back to the client via `session_update` notifications:
-
-| Update Type           | When                                       |
-| --------------------- | ------------------------------------------ |
-| `agent_message_chunk` | Agent text response (streaming)            |
-| `agent_thought_chunk` | Agent internal reasoning / system messages |
-| `tool_call`           | Tool invocation started                    |
-| `tool_call_update`    | Tool execution completed with output       |
-
-### Capabilities Declared
-
-The agent declares the following capabilities during `initialize`:
-
-```json
-{
-  "load_session": true,
-  "session_capabilities": {
-    "close": {},
-    "list": {},
-    "resume": {}
-  }
-}
-```
-
-### Session Config Options
-
-When a new session is created, the agent returns config options that the client can change via `set_config_option`:
-
-| Config ID | Type   | Category | Default   | Options                                                                                       |
-| --------- | ------ | -------- | --------- | --------------------------------------------------------------------------------------------- |
-| `mode`    | select | `mode`   | `default` | `default` — Normal mode with Tool Guard enabled; `bypassPermissions` — Skip tool guard checks |
-
-### Configuration
-
-The ACP agent resolves its configuration in the following order:
-
-1. **CLI arguments** — `--agent` and `--workspace` take highest priority
-2. **WORKING_DIR config** — reads `agents.active_agent` from the `config.json` inside `WORKING_DIR` (default `~/.qwenpaw`, or `~/.copaw` for legacy installations; overridable via `QWENPAW_WORKING_DIR` env var)
-3. **Defaults** — falls back to agent ID `"default"` and workspace directory `WORKING_DIR/workspaces/default/`
+This page explains both modes and the scenarios each one fits best.
 
 ---
 
 ## QwenPaw using ACP as a Tool
 
-QwenPaw can also use ACP in the opposite direction: instead of being the server that external clients connect to, it can act as an **ACP client / orchestrator** that connects to **configured and enabled external ACP runners** and brings them into the current session as delegated collaboration capabilities.
+In this mode, QwenPaw acts as an **ACP client / orchestrator**, connecting to **configured and enabled external ACP runners** and bringing them into the current session as delegated collaboration capabilities.
 
-The actual entry point for this mode is the built-in tool `delegate_external_agent`. It is intended for scenarios where QwenPaw needs to collaborate with other ACP-capable external agent runtimes. In the source code, the built-in runner set includes `opencode`, `qwen_code`, `claude_code`, and `codex`. For more ACP-compatible agents, see the official ACP agent list and integration guide: <https://agentclientprotocol.com/get-started/agents>. In other words, QwenPaw does not directly talk to arbitrary external agents by default — it talks to runners that have been registered in ACP configuration and are available to the current agent.
+The actual entry point for this mode is the built-in tool `delegate_external_agent`. It is intended for scenarios where QwenPaw needs to collaborate with other ACP-capable external agent runtimes, such as the built-in examples `opencode`, `qwen_code`, `claude_code`, and `codex`. For more ACP-compatible agents, see the official ACP agent list and integration guide: <https://agentclientprotocol.com/get-started/agents>. In other words, QwenPaw does not directly talk to arbitrary external agents. It talks to runners that have been registered in ACP configuration, and it starts, continues, responds to, and closes delegated collaboration sessions through them.
 
 ### What this mode does
 
@@ -103,17 +22,17 @@ In this mode, QwenPaw uses the built-in `delegate_external_agent` tool to:
 - start a session with an external ACP runner
 - send follow-up messages to that runner
 - respond to permission requests raised by that runner
-- close the delegated session when work is complete
+- close the delegated session when the work is complete
 
-Conceptually, this allows QwenPaw to treat an external agent as a cooperative tool-like capability, while QwenPaw remains the primary orchestrator of the main conversation.
+Conceptually, this lets QwenPaw treat an external agent as a collaborative, tool-like capability while keeping QwenPaw as the primary orchestrator of the main conversation.
 
 ### How to configure external runners
 
-Before using an external runner, make sure you have installed an ACP-compatible external agent and completed any required login or API key setup so it can be started and used normally from the command line. You can refer to the official ACP agent list here: <https://agentclientprotocol.com/get-started/agents>.
+Before using an external runner, make sure you have installed an ACP-compatible external agent and completed any required login or API key setup so it can be launched and used normally from the command line. You can refer to the official ACP agent list here: <https://agentclientprotocol.com/get-started/agents>.
 
 ![qwen](https://gw.alicdn.com/imgextra/i1/O1CN017f6aVo1tWpstPL4GK_!!6000000005910-2-tps-1226-408.png)
 
-Once the command-line side is ready, you can either configure a custom agent in QwenPaw or use one of the built-in agents for collaboration.
+Once the command-line side is ready, you can configure a custom runner in QwenPaw or collaborate with one of the built-in runners directly.
 
 External runners must be configured and enabled on the **Workspace → ACP** page before they can be used by `delegate_external_agent`.
 
@@ -129,19 +48,23 @@ The current ACP configuration UI supports these fields for each runner:
 
 Specifically:
 
-- `command` and `args` define how the external runner process is launched;
+- `command` and `args` define the command and arguments used to launch the external runner;
 - `env` passes environment variables;
-- `tool_parse_mode` and `stdio_buffer_limit_bytes` control ACP output parsing and stdio buffering behavior.
+- `tool_parse_mode` and `stdio_buffer_limit_bytes` control ACP output parsing and stdio buffering behavior. In most cases, the default values are fine and do not need to be changed.
 
-The source code ships with these built-in runner examples: `opencode`, `qwen_code`, `claude_code`, and `codex`. You can also add custom runners on the ACP page as long as they can run via ACP and are configured correctly.
+On Linux/macOS, `command` is usually the command that starts the external agent in ACP mode, such as `opencode` or `qwen`, or the command that launches the corresponding ACP plugin, such as `npx`. Put the remaining flags and arguments in `args`, such as `--acp` or `-y`. Each argument must be entered on its own line. The source code ships with these built-in runner examples: `opencode`, `qwen_code`, `claude_code`, and `codex`. You can also add custom runners on the ACP page as long as they can run via ACP and are configured correctly.
 
-![config](https://gw.alicdn.com/imgextra/i3/O1CN01QQjKIv1jAibICuR7Q_!!6000000004508-2-tps-1224-480.png)
+![config_mac](https://gw.alicdn.com/imgextra/i3/O1CN01QQjKIv1jAibICuR7Q_!!6000000004508-2-tps-1224-480.png)
 
-After that, enable the `delegate_external_agent` tool in the toolbar.
+On Windows, after confirming the external agent can be launched normally from the command line, set `command` to `cmd` and put `/c` as the first line in `args`, followed by the actual command and its arguments, again one per line. Example:
+
+![config_win](https://gw.alicdn.com/imgextra/i3/O1CN01BDYXdk22Zt4726sHa_!!6000000007135-2-tps-1608-792.png)
+
+After configuration, enable the `delegate_external_agent` tool in the toolbar.
 
 ![config](https://gw.alicdn.com/imgextra/i4/O1CN01XS6D6W1Yzap02Jnjk_!!6000000003130-2-tps-1224-700.png)
 
-You can then specify in the conversation which external agent you want to collaborate with.
+You can then explicitly specify which external agent you want to collaborate with in the conversation.
 
 ![comm](https://gw.alicdn.com/imgextra/i3/O1CN01LpUJWZ1QOTniYDnrP_!!6000000001966-2-tps-1986-946.png)
 
@@ -155,7 +78,7 @@ A typical delegated ACP workflow looks like this:
 4. If the external runner raises a permission request, first let the user choose from the options shown in the UI, then call `delegate_external_agent(action="respond", runner="...", message="<exact option id>")` to resume execution. Here, `message` must be the **exact option id** returned by that permission request.
 5. After the delegated work is complete, call `delegate_external_agent(action="close", runner="...")` to close the runner session.
 
-You can pass task prompts such as “analyze the current working directory structure” or “write your self-introduction into a markdown file” in `start` or `message`, but the underlying flow always maps to the same four actions: `start`, `message`, `respond`, and `close`.
+You can pass task prompts such as "analyze the current working directory structure" or "write your self-introduction into a Markdown file" in `start` or `message`, but the underlying flow always maps to the same four actions: `start`, `message`, `respond`, and `close`.
 
 ### Supported delegated actions
 
@@ -185,39 +108,120 @@ This keeps delegated ACP execution aligned with the same user-controlled safety 
 Use this mode when:
 
 - you want QwenPaw to collaborate with another agent runtime
-- you have a specialized external ACP-compatible runner for a certain class of tasks
-- you want to keep QwenPaw as the main orchestrator while delegating part of the work outward
+- you have a specialized ACP-compatible external runner for a certain class of tasks
+- you want QwenPaw to remain the primary orchestrator while delegating part of the work outward
 
 ### ACP Tool vs MCP
 
-ACP-as-Tool and MCP solve different problems:
+ACP as a Tool and MCP solve different problems:
 
 - **MCP** connects QwenPaw to external services and tool servers
-- **ACP as Tool** connects QwenPaw to an external **agent** runtime
+- **ACP as a Tool** connects QwenPaw to an external **agent** runtime
 
 If you need APIs, databases, filesystems, or service integrations, use **MCP**.
-If you need agent-to-agent collaboration, use **ACP as Tool**.
+If you need agent-to-agent collaboration, use **ACP as a Tool**.
+
+---
+
+## QwenPaw as an ACP Server
+
+In this mode, QwenPaw exposes itself as an [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) compliant agent service over stdio JSON-RPC. External clients, such as [Zed](https://zed.dev), [OpenCode](https://github.com/nicholasgasior/opencode), or any ACP-compatible editor, can connect to QwenPaw via the `qwenpaw acp` command and interact with it programmatically.
+
+### Quick Start
+
+```bash
+# Start QwenPaw as an ACP agent
+qwenpaw acp
+
+# Use a specific agent profile
+qwenpaw acp --agent mybot
+
+# Use a custom workspace directory
+qwenpaw acp --workspace /path/to/workspace
+
+# Enable debug logging to stderr
+qwenpaw acp --debug
+```
+
+The process communicates over stdin/stdout using the ACP JSON-RPC protocol. stderr is used for logging.
+
+### Supported ACP Methods
+
+| Method              | Description                                                  |
+| ------------------- | ------------------------------------------------------------ |
+| `initialize`        | Handshake that returns agent capabilities and version info   |
+| `new_session`       | Create a new conversation session                            |
+| `load_session`      | Load or attach to an existing session by ID                  |
+| `resume_session`    | Resume a previously closed session                           |
+| `list_sessions`     | List active sessions, optionally filtered by `cwd`           |
+| `close_session`     | Close and clean up a session                                 |
+| `prompt`            | Send a user message and stream back agent responses          |
+| `set_session_model` | Switch the active LLM model, using `provider_id:model_id`    |
+| `set_config_option` | Toggle session config options, such as the Tool Guard switch |
+| `cancel`            | Cancel an in-progress `prompt`                               |
+
+### Streaming Updates
+
+During a `prompt` call, the agent streams real-time updates back to the client via `session_update` notifications:
+
+| Update Type           | When                                        |
+| --------------------- | ------------------------------------------- |
+| `agent_message_chunk` | Agent text response (streaming)             |
+| `agent_thought_chunk` | Agent internal reasoning or system messages |
+| `tool_call`           | Tool invocation started                     |
+| `tool_call_update`    | Tool execution completed with output        |
+
+### Declared Capabilities
+
+The agent declares the following capabilities during `initialize`:
+
+```json
+{
+  "load_session": true,
+  "session_capabilities": {
+    "close": {},
+    "list": {},
+    "resume": {}
+  }
+}
+```
+
+### Session Config Options
+
+When a new session is created, the agent returns config options that the client can change via `set_config_option`:
+
+| Config ID | Type   | Category | Default   | Options                                                                                     |
+| --------- | ------ | -------- | --------- | ------------------------------------------------------------------------------------------- |
+| `mode`    | select | `mode`   | `default` | `default`: normal mode with Tool Guard enabled; `bypassPermissions`: skip tool guard checks |
+
+### Configuration
+
+The ACP agent resolves its configuration in the following order:
+
+1. **CLI arguments**: `--agent` and `--workspace` take highest priority
+2. **WORKING_DIR config**: read `agents.active_agent` from `config.json` inside `WORKING_DIR` (default `~/.qwenpaw`, or `~/.copaw` for legacy installations; overridable via the `QWENPAW_WORKING_DIR` environment variable)
+3. **Defaults**: fall back to agent ID `"default"` and workspace directory `WORKING_DIR/workspaces/default/`
 
 ---
 
 ## ACP Server vs ACP Tool
 
-| Aspect               | QwenPaw as ACP Server                         | QwenPaw using ACP as Tool                              |
+| Aspect               | QwenPaw as an ACP Server                      | QwenPaw using ACP as a Tool                            |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------ |
 | QwenPaw's role       | Server / target agent                         | Client / orchestrator                                  |
-| Connection direction | External client connects to QwenPaw           | QwenPaw connects to external runner                    |
+| Connection direction | External client connects to QwenPaw           | QwenPaw connects to an external runner                 |
 | Main purpose         | Let editors or external clients drive QwenPaw | Let QwenPaw delegate work to another agent             |
-| Typical entry point  | `qwenpaw acp`                                 | Delegation tool + ACP runner config                    |
+| Typical entry point  | `qwenpaw acp`                                 | Delegation tool + ACP runner configuration             |
 | Best for             | Editor integration, programmatic control      | Multi-agent collaboration, external specialist runners |
 
 ---
 
 ## Summary
 
-ACP in QwenPaw is not just one feature — it supports both directions:
+ACP in QwenPaw is not just one feature. It supports both directions:
 
 - **Expose QwenPaw outward** as an ACP server
 - **Reach outward from QwenPaw** to external ACP agents as delegated tools
 
 If you are integrating QwenPaw into another client, start with **ACP Server**.
-If you want QwenPaw to coordinate with another agent runtime, use **ACP as Tool**.
+If you want QwenPaw to coordinate with another agent runtime, use **ACP as a Tool**.

--- a/website/public/docs/acp-integration.zh.md
+++ b/website/public/docs/acp-integration.zh.md
@@ -2,99 +2,18 @@
 
 QwenPaw 对 **ACP（Agent Client Protocol）** 提供两种互补的支持方式：
 
-1. **QwenPaw 作为 ACP Server** —— 外部客户端通过 ACP 连接到 QwenPaw
-2. **QwenPaw 将 ACP 作为 Tool 使用** —— QwenPaw 连接外部 ACP runner，并把它作为委托协作能力来使用
+1. **QwenPaw 将 ACP 作为 Tool 使用**：QwenPaw 连接外部 ACP runner，并将其作为委托协作能力使用
+2. **QwenPaw 作为 ACP Server**：外部客户端通过 ACP 连接到 QwenPaw
 
 本页会同时介绍这两种模式，以及各自适合的使用场景。
 
 ---
 
-## QwenPaw as ACP Server
-
-在这种模式下，QwenPaw 会通过 stdio JSON-RPC 将自己暴露为一个符合 [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) 规范的智能体服务。外部客户端（如 [Zed](https://zed.dev)、[OpenCode](https://github.com/nicholasgasior/opencode) 或任何兼容 ACP 的编辑器）可以通过 `qwenpaw acp` 命令连接 QwenPaw，并以编程方式与之交互。
-
-### 快速开始
-
-```bash
-# 启动 QwenPaw 作为 ACP 智能体
-qwenpaw acp
-
-# 使用指定的智能体配置
-qwenpaw acp --agent mybot
-
-# 使用自定义工作区目录
-qwenpaw acp --workspace /path/to/workspace
-
-# 启用调试日志（输出到 stderr）
-qwenpaw acp --debug
-```
-
-进程通过 stdin/stdout 使用 ACP JSON-RPC 协议通信，stderr 用于日志输出。
-
-### 支持的 ACP 方法
-
-| 方法                | 说明                                              |
-| ------------------- | ------------------------------------------------- |
-| `initialize`        | 握手——返回智能体能力和版本信息                    |
-| `new_session`       | 创建新的会话                                      |
-| `load_session`      | 按 ID 加载/接入已有会话                           |
-| `resume_session`    | 恢复之前关闭的会话                                |
-| `list_sessions`     | 列出活跃会话，可按 `cwd` 过滤                     |
-| `close_session`     | 关闭并清理会话                                    |
-| `prompt`            | 发送用户消息，流式返回智能体响应                  |
-| `set_session_model` | 切换活跃 LLM 模型（格式：`provider_id:model_id`） |
-| `set_config_option` | 切换会话配置选项（如 Tool Guard 开关）            |
-| `cancel`            | 取消正在进行的 prompt                             |
-
-### 流式更新
-
-在 `prompt` 调用过程中，智能体通过 `session_update` 通知向客户端实时推送更新：
-
-| 更新类型              | 触发时机                |
-| --------------------- | ----------------------- |
-| `agent_message_chunk` | 智能体文本响应（流式）  |
-| `agent_thought_chunk` | 智能体内部推理/系统消息 |
-| `tool_call`           | 工具调用开始            |
-| `tool_call_update`    | 工具执行完成并返回结果  |
-
-### 声明的能力
-
-智能体在 `initialize` 阶段声明以下能力：
-
-```json
-{
-  "load_session": true,
-  "session_capabilities": {
-    "close": {},
-    "list": {},
-    "resume": {}
-  }
-}
-```
-
-### 会话配置选项
-
-创建新会话时，智能体会返回可通过 `set_config_option` 切换的配置选项：
-
-| 配置 ID | 类型   | 类别   | 默认值    | 可选值                                                                        |
-| ------- | ------ | ------ | --------- | ----------------------------------------------------------------------------- |
-| `mode`  | select | `mode` | `default` | `default` — 正常模式，启用 Tool Guard；`bypassPermissions` — 跳过工具安全检查 |
-
-### 配置
-
-ACP 智能体按以下优先级解析配置：
-
-1. **CLI 参数** —— `--agent` 和 `--workspace` 优先级最高
-2. **WORKING_DIR 配置** —— 从 `WORKING_DIR` 内的 `config.json` 中读取 `agents.active_agent`（默认 `~/.qwenpaw`，旧版安装为 `~/.copaw`；可通过 `QWENPAW_WORKING_DIR` 环境变量覆盖）
-3. **默认值** —— 回退到智能体 ID `"default"` 和工作区目录 `WORKING_DIR/workspaces/default/`
-
----
-
 ## QwenPaw 将 ACP 作为 Tool 使用
 
-QwenPaw 也可以反过来使用 ACP：不是自己作为 server 被外部客户端连接，而是作为 **ACP client / orchestrator** 去连接**已配置并启用的外部 ACP runner**，并把它们作为委托协作能力接入当前会话。
+在这种模式下，QwenPaw 会作为 **ACP client / orchestrator**，连接**已配置并启用的外部 ACP runner**，并将它们接入当前会话，作为委托协作能力使用。
 
-这类能力的实际调用入口是内置工具 `delegate_external_agent`。它适用于你希望 QwenPaw 与其他支持 ACP 的外部 agent/runtime 协作的场景，例如源码中默认内置的 `opencode`、`qwen_code`、`claude_code`、`codex`。这些 agent 可参考 ACP 官方的 Agent 列表与接入说明：<https://agentclientprotocol.com/get-started/agents>。换句话说，QwenPaw 不是“直接和任意外部 agent 交互”，而是通过 ACP 配置中已注册的 runner，在会话内发起、继续、响应和关闭一次委托式协作。
+这类能力的实际调用入口是内置工具 `delegate_external_agent`。它适用于你希望 QwenPaw 与其他支持 ACP 的外部 agent runtime 协作的场景，例如源码中默认内置的 `opencode`、`qwen_code`、`claude_code`、`codex`。这些 agent 可参考 ACP 官方的 Agent 列表与接入说明：<https://agentclientprotocol.com/get-started/agents>。换句话说，QwenPaw 不是“直接和任意外部 agent 交互”，而是通过 ACP 配置中已注册的 runner，在会话内发起、继续、响应和关闭一次委托式协作。
 
 ### 这种模式能做什么
 
@@ -109,11 +28,11 @@ QwenPaw 也可以反过来使用 ACP：不是自己作为 server 被外部客户
 
 ### 如何配置外部 runner
 
-在使用外部 runner 之前，请先安装一个支持 ACP 协议的外部 agent，并完成登录或 API Key 等必要配置，确保它可以在命令行中正常启动和使用。可参考 ACP 官方提供的 agent 列表：<https://agentclientprotocol.com/get-started/agents>。
+在使用外部 runner 之前，请先安装一个支持 ACP 协议的外部 agent，并完成登录、API Key 等必要配置，确保它可以在命令行中正常启动和使用。可参考 ACP 官方提供的 agent 列表：<https://agentclientprotocol.com/get-started/agents>。
 
 ![qwen](https://gw.alicdn.com/imgextra/i1/O1CN01XtTTNP1IuyyyKi5ZS_!!6000000000954-2-tps-1196-664.png)
 
-完成命令行侧准备后，你可以在 QwenPaw 中配置自定义 agent，或直接使用内置 agent 与其协作。
+命令行侧准备完成后，你可以在 QwenPaw 中配置自定义 runner，或直接使用内置 runner 与其协作。
 
 外部 runner 需要先在 **Workspace → ACP** 页面中完成配置并启用，之后才能被 `delegate_external_agent` 调用。
 
@@ -129,13 +48,17 @@ QwenPaw 也可以反过来使用 ACP：不是自己作为 server 被外部客户
 
 其中：
 
-- `command` 与 `args` 用于定义外部 runner 的启动方式；
+- `command` 与 `args` 用于定义外部 runner 的启动命令及参数；
 - `env` 用于传递环境变量；
-- `tool_parse_mode` 与 `stdio_buffer_limit_bytes` 用于控制 ACP 输出解析方式以及 stdio 缓冲行为。
+- `tool_parse_mode` 与 `stdio_buffer_limit_bytes` 用于控制 ACP 输出解析方式及 stdio 缓冲行为。通常保持默认值即可，一般不需要修改。
 
-源码中默认内置了这些 runner 示例：`opencode`、`qwen_code`、`claude_code`、`codex`。你也可以在 ACP 页面中添加自定义 runner，只要它能够以 ACP 方式运行并被正确配置即可。
+对于 Linux/macOS，`command` 一般填写外部 agent 以 ACP 模式启动时使用的命令，例如 `opencode`、`qwen`，或者相应 ACP 插件的启动命令，例如 `npx`；`args` 则填写后续参数，例如 `--acp`、`-y` 等。**注意每个参数都需要单独占一行**。源码中默认内置了这些 runner 示例：`opencode`、`qwen_code`、`claude_code`、`codex`。你也可以在 ACP 页面中添加自定义 runner，只要它能够以 ACP 方式运行并被正确配置即可。
 
-![config](https://gw.alicdn.com/imgextra/i3/O1CN01pskmLt29VwyFGhO1r_!!6000000008074-2-tps-1224-472.png)
+![config_mac](https://gw.alicdn.com/imgextra/i3/O1CN01pskmLt29VwyFGhO1r_!!6000000008074-2-tps-1224-472.png)
+
+对于 Windows，在确保外部 agent 可以在命令行中正常启动和使用后，`command` 字段填写 `cmd`，`args` 的第一行填写 `/c`，后续再逐行填写真正要执行的命令及参数。**注意每个参数都需要单独占一行**。示例如下：
+
+![config_win](https://gw.alicdn.com/imgextra/i3/O1CN01BDYXdk22Zt4726sHa_!!6000000007135-2-tps-1608-792.png)
 
 配置完成后，在工具栏中启用 `delegate_external_agent` 工具。
 
@@ -155,7 +78,7 @@ QwenPaw 也可以反过来使用 ACP：不是自己作为 server 被外部客户
 4. 如果外部 runner 发起权限请求，先由用户从界面展示的选项中做出选择，再调用 `delegate_external_agent(action="respond", runner="...", message="<exact option id>")` 恢复执行。这里的 `message` 必须是权限请求中返回的**精确 option id**。
 5. 委托任务完成后，调用 `delegate_external_agent(action="close", runner="...")` 关闭该 runner 会话。
 
-你也可以在 `start` 或 `message` 时传入类似“请分析当前工作目录结构”或“请把你的自我介绍写入一个 markdown 文件”这样的任务说明，但底层流程始终对应上述四种 action：`start`、`message`、`respond`、`close`。
+你也可以在 `start` 或 `message` 时传入类似“请分析当前工作目录结构”或“请把你的自我介绍写入一个 Markdown 文件”这样的任务说明，但底层流程始终对应上述四种 action：`start`、`message`、`respond`、`close`。
 
 ### 支持的委托动作
 
@@ -197,6 +120,87 @@ ACP as Tool 和 MCP 解决的问题并不相同：
 
 如果你需要接入 API、数据库、文件系统或服务能力，优先使用 **MCP**。
 如果你需要 agent 与 agent 之间的协作，优先使用 **ACP as Tool**。
+
+---
+
+## QwenPaw as ACP Server
+
+在这种模式下，QwenPaw 会通过 stdio JSON-RPC 将自己暴露为一个符合 [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/python-sdk) 规范的智能体服务。外部客户端，如 [Zed](https://zed.dev)、[OpenCode](https://github.com/nicholasgasior/opencode) 或任何兼容 ACP 的编辑器，都可以通过 `qwenpaw acp` 命令连接到 QwenPaw，并以编程方式与之交互。
+
+### 快速开始
+
+```bash
+# 启动 QwenPaw 作为 ACP 智能体
+qwenpaw acp
+
+# 使用指定的智能体配置
+qwenpaw acp --agent mybot
+
+# 使用自定义工作区目录
+qwenpaw acp --workspace /path/to/workspace
+
+# 启用调试日志（输出到 stderr）
+qwenpaw acp --debug
+```
+
+进程通过 stdin/stdout 使用 ACP JSON-RPC 协议通信，stderr 用于日志输出。
+
+### 支持的 ACP 方法
+
+| 方法                | 说明                                             |
+| ------------------- | ------------------------------------------------ |
+| `initialize`        | 握手，返回智能体能力和版本信息                   |
+| `new_session`       | 创建新的会话                                     |
+| `load_session`      | 按 ID 加载或接入已有会话                         |
+| `resume_session`    | 恢复之前关闭的会话                               |
+| `list_sessions`     | 列出活跃会话，可按 `cwd` 过滤                    |
+| `close_session`     | 关闭并清理会话                                   |
+| `prompt`            | 发送用户消息，并流式返回智能体响应               |
+| `set_session_model` | 切换活跃 LLM 模型，格式为 `provider_id:model_id` |
+| `set_config_option` | 切换会话配置选项，例如 Tool Guard 开关           |
+| `cancel`            | 取消正在进行的 `prompt`                          |
+
+### 流式更新
+
+在 `prompt` 调用过程中，智能体会通过 `session_update` 通知向客户端实时推送更新：
+
+| 更新类型              | 触发时机                 |
+| --------------------- | ------------------------ |
+| `agent_message_chunk` | 智能体文本响应（流式）   |
+| `agent_thought_chunk` | 智能体内部推理或系统消息 |
+| `tool_call`           | 工具调用开始             |
+| `tool_call_update`    | 工具执行完成并返回结果   |
+
+### 声明的能力
+
+智能体会在 `initialize` 阶段声明以下能力：
+
+```json
+{
+  "load_session": true,
+  "session_capabilities": {
+    "close": {},
+    "list": {},
+    "resume": {}
+  }
+}
+```
+
+### 会话配置选项
+
+创建新会话时，智能体会返回可通过 `set_config_option` 切换的配置项：
+
+| 配置 ID | 类型   | 类别   | 默认值    | 可选值                                                                      |
+| ------- | ------ | ------ | --------- | --------------------------------------------------------------------------- |
+| `mode`  | select | `mode` | `default` | `default`：正常模式，启用 Tool Guard；`bypassPermissions`：跳过工具安全检查 |
+
+### 配置
+
+ACP 智能体按以下优先级解析配置：
+
+1. **CLI 参数**：`--agent` 和 `--workspace` 优先级最高
+2. **WORKING_DIR 配置**：从 `WORKING_DIR` 内的 `config.json` 中读取 `agents.active_agent`（默认 `~/.qwenpaw`，旧版安装为 `~/.copaw`；可通过 `QWENPAW_WORKING_DIR` 环境变量覆盖）
+3. **默认值**：回退到智能体 ID `"default"` 和工作区目录 `WORKING_DIR/workspaces/default/`
 
 ---
 


### PR DESCRIPTION
## Description

polish ACP docs and add ACP doc link in ACP config page
<img width="202" height="212" alt="image" src="https://github.com/user-attachments/assets/01dcc11d-9158-475b-91b7-31e2322d4dda" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
