### PR TITLE
fix(tools): normalize missing builtin tool icons in API responses

### DIFF
--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -14,10 +14,12 @@ from fastapi import (
 )
 from pydantic import BaseModel, Field
 
+from ...config.config import BuiltinToolConfig
 from ..utils import schedule_agent_reload
 from ...config import load_config
 
 router = APIRouter(prefix="/tools", tags=["tools"])
+DEFAULT_TOOL_ICON = "🔧"
 
 
 class ToolInfo(BaseModel):
@@ -30,7 +32,21 @@ class ToolInfo(BaseModel):
         default=False,
         description="Whether to execute the tool asynchronously in background",
     )
-    icon: str = Field(default="🔧", description="Emoji icon for the tool")
+    icon: str = Field(
+        default=DEFAULT_TOOL_ICON,
+        description="Emoji icon for the tool",
+    )
+
+
+def _build_tool_info(tool_config: BuiltinToolConfig) -> ToolInfo:
+    """Normalize tool config into a stable API response."""
+    return ToolInfo(
+        name=tool_config.name,
+        enabled=tool_config.enabled,
+        description=tool_config.description,
+        async_execution=tool_config.async_execution,
+        icon=tool_config.icon or DEFAULT_TOOL_ICON,
+    )
 
 
 @router.get("", response_model=List[ToolInfo])
@@ -61,15 +77,7 @@ async def list_tools(
 
     tools_list = []
     for tool_config in builtin_tools.values():
-        tools_list.append(
-            ToolInfo(
-                name=tool_config.name,
-                enabled=tool_config.enabled,
-                description=tool_config.description,
-                async_execution=tool_config.async_execution,
-                icon=tool_config.icon,
-            ),
-        )
+        tools_list.append(_build_tool_info(tool_config))
 
     return tools_list
 
@@ -117,13 +125,7 @@ async def toggle_tool(
     schedule_agent_reload(request, workspace.agent_id)
 
     # Return immediately (optimistic update)
-    return ToolInfo(
-        name=tool_config.name,
-        enabled=tool_config.enabled,
-        description=tool_config.description,
-        async_execution=tool_config.async_execution,
-        icon=tool_config.icon,
-    )
+    return _build_tool_info(tool_config)
 
 
 @router.patch("/{tool_name}/async-execution", response_model=ToolInfo)
@@ -171,10 +173,4 @@ async def update_tool_async_execution(
     schedule_agent_reload(request, workspace.agent_id)
 
     # Return immediately (optimistic update)
-    return ToolInfo(
-        name=tool_config.name,
-        enabled=tool_config.enabled,
-        description=tool_config.description,
-        async_execution=tool_config.async_execution,
-        icon=tool_config.icon,
-    )
+    return _build_tool_info(tool_config)


### PR DESCRIPTION
## Description

Fixes a backward-compatibility bug where `GET /api/tools` could return `500 Internal Server Error` when legacy built-in tool config entries contain `icon = null`.

The root cause is that historical `~/.copaw` config data may still include stale tool entries such as `spawn_agent` with a null icon, while the `/api/tools` response model requires `icon` to be a string. This change adds API-layer normalization so missing icons fall back to a default value instead of crashing response validation.

**Related Issue:** Fixes #3757

**Security Considerations:** None known. This change only adds defensive normalization for legacy config data in the tools API response path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Use a runtime that loads legacy config from `~/.copaw`.
2. Ensure the config contains a stale built-in tool entry with `icon: null` such as `spawn_agent`.
3. Open the Tools page or call `GET /api/tools`.
4. Verify the API no longer returns `500` and instead returns a valid tools list with a fallback icon.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed

pytest
# Not run
```

## Additional Notes

This is a defensive compatibility fix rather than a root-cause migration fix. The API now tolerates legacy/stale config entries by normalizing missing icons to a default value, and the helper now uses an explicit `BuiltinToolConfig` type annotation for better IDE and static-analysis support.
