### PR TITLE
feat(providers): add Unsloth Studio provider

### DIFF
--- a/console/src/pages/Settings/Models/components/providerIcon.ts
+++ b/console/src/pages/Settings/Models/components/providerIcon.ts
@@ -27,6 +27,8 @@ export const providerIcon = (provider: string) => {
       return "https://gw.alicdn.com/imgextra/i4/O1CN01aDHDeq1mgj7gbRkhi_!!6000000004984-2-tps-400-400.png";
     case "lmstudio":
       return "https://gw.alicdn.com/imgextra/i4/O1CN01Abv67y1jHaXLqikIJ_!!6000000004523-2-tps-200-200.png";
+    case "unsloth-studio":
+      return "https://cdn.jsdelivr.net/gh/unslothai/unsloth@main/images/unsloth_logo.png";
     case "siliconflow-cn":
     case "siliconflow-intl":
       return "https://img.alicdn.com/imgextra/i1/O1CN01TUkzVC1clAoPa2ix8_!!6000000003640-2-tps-520-520.png";

--- a/console/src/pages/Settings/Models/components/providerLetterIcon.tsx
+++ b/console/src/pages/Settings/Models/components/providerLetterIcon.tsx
@@ -15,6 +15,7 @@ const PROVIDER_LETTER_COLORS: Record<string, string> = {
   openai: "#10A37F",
   dashscope: "#6236FF",
   lmstudio: "#6C5CE7",
+  "unsloth-studio": "#FF6B35",
   "siliconflow-cn": "#5B5FC7",
   "siliconflow-intl": "#5B5FC7",
   "qwenpaw-local": "#FF7F16",

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -24,6 +24,7 @@ from .gemini_provider import GeminiProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
 from .lmstudio_provider import LMStudioProvider
+from .unsloth_studio_provider import UnslothStudioProvider
 from .provider import (
     ModelInfo,
     Provider,
@@ -696,6 +697,15 @@ PROVIDER_LMSTUDIO = LMStudioProvider(
     generate_kwargs={"max_tokens": None},
 )
 
+PROVIDER_UNSLOTH_STUDIO = UnslothStudioProvider(
+    id="unsloth-studio",
+    name="Unsloth Studio",
+    is_local=True,
+    require_api_key=False,
+    support_model_discovery=True,
+    generate_kwargs={"max_tokens": None},
+)
+
 PROVIDER_SILICONFLOW_CN = OpenAIProvider(
     id="siliconflow-cn",
     name="SiliconFlow (China)",
@@ -761,6 +771,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         self._add_builtin(PROVIDER_QWENPAW)
         self._add_builtin(PROVIDER_OLLAMA)
         self._add_builtin(PROVIDER_LMSTUDIO)
+        self._add_builtin(PROVIDER_UNSLOTH_STUDIO)
         self._add_builtin(PROVIDER_OPENROUTER)
         self._add_builtin(PROVIDER_MODELSCOPE)
         self._add_builtin(PROVIDER_DASHSCOPE)
@@ -1325,6 +1336,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             return GeminiProvider.model_validate(data)
         if provider_id == "ollama":
             return OllamaProvider.model_validate(data)
+        if provider_id == "unsloth-studio":
+            return UnslothStudioProvider.model_validate(data)
         return OpenAIProvider.model_validate(data)
 
     def save_active_model(self, active_model: ModelSlotConfig):

--- a/src/qwenpaw/providers/unsloth_studio_provider.py
+++ b/src/qwenpaw/providers/unsloth_studio_provider.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Unsloth Studio Provider implementation."""
+
+from typing import Any
+
+from agentscope.model import ChatModelBase
+from openai import AsyncOpenAI
+
+from qwenpaw.providers.openai_provider import OpenAIProvider
+
+
+class UnslothStudioProvider(OpenAIProvider):
+    """Provider implementation for Unsloth Studio
+    local LLM hosting platform."""
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        normalized_base_url = (base_url or "").rstrip("/")
+        if normalized_base_url.endswith("/v1"):
+            normalized_base_url = normalized_base_url[:-3].rstrip("/")
+        return normalized_base_url
+
+    def _openai_compatible_base_url(self) -> str:
+        return (
+            self._normalize_base_url(
+                self.base_url,  # type: ignore [has-type]
+            )
+            + "/v1"
+        )
+
+    def model_post_init(self, __context: Any) -> None:
+        if not self.base_url:  # type: ignore
+            self.base_url = "http://127.0.0.1:8888"
+        self.base_url = self._normalize_base_url(self.base_url)
+
+    def update_config(self, config: dict[str, Any]) -> None:
+        super().update_config(config)
+        self.base_url = self._normalize_base_url(self.base_url)
+
+    def _client(self, timeout: float = 5) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            base_url=self._openai_compatible_base_url(),
+            api_key=self.api_key,
+            timeout=timeout,
+        )
+
+    async def check_model_connection(
+        self,
+        model_id: str,
+        timeout: float = 5,
+    ) -> tuple[bool, str]:
+        """Check if a specific model is reachable/usable"""
+        models = await self.fetch_models(timeout=timeout)
+        if any(model.id == model_id for model in models):
+            return True, ""
+        return False, f"Model '{model_id}' not found"
+
+    def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
+        from .openai_chat_model_compat import (
+            OpenAIChatModelCompat,
+        )
+
+        return OpenAIChatModelCompat(
+            model_name=model_id,
+            stream=True,
+            api_key=self.api_key,
+            stream_tool_parsing=False,
+            client_kwargs={
+                "base_url": self._openai_compatible_base_url(),
+            },
+            generate_kwargs=self.get_effective_generate_kwargs(
+                model_id,
+            ),
+        )


### PR DESCRIPTION
## Summary

- Add built-in provider for [Unsloth Studio](https://unsloth.ai/) local LLM hosting platform
- Extends `OpenAIProvider` following the same pattern as Ollama and LM Studio
- Default endpoint: `http://127.0.0.1:8888` (configurable via settings)
- Supports model discovery, connection check, and streaming

## Changes

| File | Description |
|------|-------------|
| `src/qwenpaw/providers/unsloth_studio_provider.py` | New provider class with URL normalization and OpenAI-compatible client |
| `src/qwenpaw/providers/provider_manager.py` | Register built-in provider + deserialization mapping |
| `console/src/.../providerIcon.ts` | Unsloth logo icon |
| `console/src/.../providerLetterIcon.tsx` | Provider letter-avatar color |

## How it works

Unsloth Studio exposes an OpenAI-compatible API at `http://127.0.0.1:8888/v1`. The provider normalizes the base URL (strips/appends `/v1`), uses `AsyncOpenAI` for communication, and delegates streaming to `OpenAIChatModelCompat`.

```python
from openai import OpenAI
client = OpenAI(base_url="http://127.0.0.1:8888/v1", api_key="sk-unsloth-YOUR_KEY")
response = client.chat.completions.create(
    model="unsloth/Qwen3.6-35B-A3B-GGUF",
    messages=[{"role": "user", "content": "Hello"}],
    stream=True,
)
```

## Tested

- Model discovery (`GET /v1/models`)
- Non-streaming chat completions
- Streaming chat completions
- Provider registration and deserialization
- `OpenAIChatModelCompat` integration (stream + tool parsing)