### PR TITLE
feat: sessionList right-click functionality

### DIFF
--- a/console/src/components/ContextMenu/index.module.less
+++ b/console/src/components/ContextMenu/index.module.less
@@ -1,0 +1,116 @@
+.contextMenu {
+  position: fixed;
+  z-index: 10000;
+  background: #ffffff;
+  border: 1px solid #e8ecf1;
+  border-radius: 8px;
+  box-shadow:
+    0 6px 24px rgba(0, 0, 0, 0.1),
+    0 2px 8px rgba(0, 0, 0, 0.06);
+  padding: 4px 0;
+  min-width: 160px;
+  animation: contextMenuFadeIn 0.12s ease-out;
+}
+
+@keyframes contextMenuFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  user-select: none;
+
+  &:hover {
+    background: #f5f5f5;
+  }
+
+  &.danger {
+    color: #ff4d4f;
+
+    &:hover {
+      background: #fff2f0;
+    }
+  }
+
+  &.disabled {
+    color: #bbb;
+    cursor: not-allowed;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+}
+
+.menuIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  font-size: 14px;
+}
+
+.menuLabel {
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.divider {
+  height: 1px;
+  background: #f0f0f0;
+  margin: 4px 0;
+}
+
+/* ─── Dark Mode ──────────────────────────────────────────────────────────── */
+:global(.dark-mode) {
+  .contextMenu {
+    background: #2a2a2a;
+    border-color: #3a3a3a;
+    box-shadow:
+      0 6px 24px rgba(0, 0, 0, 0.35),
+      0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .menuItem {
+    color: rgba(255, 255, 255, 0.85);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    &.danger {
+      color: #ff6b6b;
+
+      &:hover {
+        background: rgba(255, 77, 79, 0.1);
+      }
+    }
+
+    &.disabled {
+      color: #555;
+
+      &:hover {
+        background: transparent;
+      }
+    }
+  }
+
+  .divider {
+    background: #3a3a3a;
+  }
+}

--- a/console/src/components/ContextMenu/index.tsx
+++ b/console/src/components/ContextMenu/index.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+import styles from "./index.module.less";
+
+export interface ContextMenuItem {
+  key: string;
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  danger?: boolean;
+  disabled?: boolean;
+  divider?: boolean;
+  onClick?: () => void;
+}
+
+export interface ContextMenuProps {
+  visible: boolean;
+  x: number;
+  y: number;
+  items: ContextMenuItem[];
+  onClose: () => void;
+}
+
+export function ContextMenu({
+  visible,
+  x,
+  y,
+  items,
+  onClose,
+}: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const adjustPosition = useCallback(() => {
+    if (!menuRef.current || !visible) return;
+    const menu = menuRef.current;
+    const rect = menu.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let adjustedX = x;
+    let adjustedY = y;
+
+    if (x + rect.width > viewportWidth) {
+      adjustedX = viewportWidth - rect.width - 8;
+    }
+    if (y + rect.height > viewportHeight) {
+      adjustedY = viewportHeight - rect.height - 8;
+    }
+
+    menu.style.left = `${Math.max(8, adjustedX)}px`;
+    menu.style.top = `${Math.max(8, adjustedY)}px`;
+  }, [x, y, visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    // Adjust position after render
+    requestAnimationFrame(adjustPosition);
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleScroll = () => onClose();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("scroll", handleScroll, true);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", onClose);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("scroll", handleScroll, true);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", onClose);
+    };
+  }, [visible, onClose, adjustPosition]);
+
+  if (!visible) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className={styles.contextMenu}
+      style={{ left: x, top: y }}
+    >
+      {items.map((item) => {
+        if (item.divider) {
+          return <div key={item.key} className={styles.divider} />;
+        }
+        return (
+          <div
+            key={item.key}
+            className={`${styles.menuItem} ${
+              item.danger ? styles.danger : ""
+            } ${item.disabled ? styles.disabled : ""}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (item.disabled) return;
+              item.onClick?.();
+              onClose();
+            }}
+          >
+            {item.icon && <span className={styles.menuIcon}>{item.icon}</span>}
+            <span className={styles.menuLabel}>{item.label}</span>
+          </div>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}
+
+/** Hook to manage context menu state */
+export function useContextMenu() {
+  const [state, setState] = React.useState({
+    visible: false,
+    x: 0,
+    y: 0,
+  });
+
+  const show = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setState({ visible: true, x: event.clientX, y: event.clientY });
+  }, []);
+
+  const hide = useCallback(() => {
+    setState((prev) => ({ ...prev, visible: false }));
+  }, []);
+
+  return { ...state, show, hide };
+}

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1558,6 +1558,13 @@
       "userMessage": "User",
       "assistantMessage": "Assistant",
       "titleMatch": "Title"
+    },
+    "contextMenu": {
+      "open": "Open",
+      "rename": "Rename",
+      "pin": "Pin",
+      "unpin": "Unpin",
+      "delete": "Delete"
     }
   },
   "security": {

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1339,6 +1339,13 @@
       "userMessage": "ユーザー",
       "assistantMessage": "アシスタント",
       "titleMatch": "タイトル"
+    },
+    "contextMenu": {
+      "open": "開く",
+      "rename": "名前を変更",
+      "pin": "ピン留め",
+      "unpin": "ピン留め解除",
+      "delete": "削除"
     }
   },
   "security": {

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1354,6 +1354,13 @@
       "userMessage": "Пользователь",
       "assistantMessage": "Ассистент",
       "titleMatch": "Название"
+    },
+    "contextMenu": {
+      "open": "Открыть",
+      "rename": "Переименовать",
+      "pin": "Закрепить",
+      "unpin": "Открепить",
+      "delete": "Удалить"
     }
   },
   "security": {

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1421,6 +1421,13 @@
       "userMessage": "用户",
       "assistantMessage": "助手",
       "titleMatch": "标题"
+    },
+    "contextMenu": {
+      "open": "打开",
+      "rename": "重命名",
+      "pin": "置顶",
+      "unpin": "取消置顶",
+      "delete": "删除"
     }
   },
   "security": {

--- a/console/src/pages/Chat/components/ChatSessionItem/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionItem/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Input } from "antd";
 import { IconButton } from "@agentscope-ai/design";
 import {
@@ -9,6 +9,11 @@ import {
 } from "@agentscope-ai/icons";
 import { useTranslation } from "react-i18next";
 import { ChannelIcon } from "../../../Control/Channels/components";
+import {
+  ContextMenu,
+  useContextMenu,
+  type ContextMenuItem,
+} from "../../../../components/ContextMenu";
 import type { ChatStatus } from "../../../../api/types/chat";
 import styles from "./index.module.less";
 
@@ -50,12 +55,43 @@ interface ChatSessionItemProps {
 
 const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
   const { t } = useTranslation();
+  const contextMenu = useContextMenu();
 
   const inProgress =
     props.generating === true || props.chatStatus === "running";
   const statusAriaLabel = inProgress
     ? t("chat.statusInProgress")
     : t("chat.statusIdle");
+
+  const contextMenuItems: ContextMenuItem[] = useMemo(
+    () => [
+      {
+        key: "open",
+        label: t("chat.contextMenu.open", "Open"),
+        onClick: props.onClick,
+      },
+      {
+        key: "rename",
+        label: t("chat.contextMenu.rename", "Rename"),
+        onClick: props.onEdit,
+      },
+      {
+        key: "pin",
+        label: props.pinned
+          ? t("chat.contextMenu.unpin", "Unpin")
+          : t("chat.contextMenu.pin", "Pin"),
+        onClick: props.onPin,
+      },
+      { key: "divider-1", label: "", divider: true },
+      {
+        key: "delete",
+        label: t("chat.contextMenu.delete", "Delete"),
+        danger: true,
+        onClick: props.onDelete,
+      },
+    ],
+    [t, props.onClick, props.onEdit, props.onPin, props.onDelete, props.pinned],
+  );
 
   const className = [
     styles.chatSessionItem,
@@ -71,6 +107,7 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
     <div
       className={className}
       onClick={props.editing ? undefined : props.onClick}
+      onContextMenu={props.editing ? undefined : contextMenu.show}
     >
       {/* Timeline indicator placeholder */}
       <div className={styles.iconPlaceholder} />
@@ -158,6 +195,13 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
           />
         </div>
       )}
+      <ContextMenu
+        visible={contextMenu.visible}
+        x={contextMenu.x}
+        y={contextMenu.y}
+        items={contextMenuItems}
+        onClose={contextMenu.hide}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description
SessionList right-click on an item in the left-hand conversation list and select: Delete, Specify, Edit, Open.

[
<img width="2556" height="1225" alt="2333333" src="https://github.com/user-attachments/assets/cc632887-3708-4739-ad6d-ddd636f88e43" />
](url)

Fixes #3752
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
