### PR TITLE
feat(DingTalk): support markdown format for DingTalk Open API messages

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -952,9 +952,17 @@ class DingTalkChannel(BaseChannel):
             len(text),
         )
 
+        if len(text) > 3500:
+            msg_key = "sampleText"
+            msg_param = json.dumps({"content": text})
+        else:
+            norm = dingtalk_markdown.normalize_dingtalk_markdown(text)
+            msg_key = "sampleMarkdown"
+            msg_param = json.dumps({"title": f"💬{norm[:10]}...", "text": norm})
+
         return await self._send_robot_message(
-            msg_key="sampleText",
-            msg_param=json.dumps({"content": text}),
+            msg_key=msg_key,
+            msg_param=msg_param,
             conversation_id=conversation_id,
             is_group=is_group,
             sender_staff_id=sender_staff_id,


### PR DESCRIPTION
## Description

The Open API path (_send_via_open_api) was hardcoded to use sampleText, causing cron/proactive push messages to always render as plain text. Updated the logic to use sampleMarkdown when the message is under 3,500 characters, falling back to sampleText for longer messages — consistent with the existing sessionWebhook behavior.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
