### PR TITLE
feat: agent local cache

### DIFF
--- a/console/src/api/authHeaders.ts
+++ b/console/src/api/authHeaders.ts
@@ -8,7 +8,7 @@ export function buildAuthHeaders(): Record<string, string> {
     headers.Authorization = `Bearer ${token}`;
   }
   try {
-    const agentStorage = sessionStorage.getItem("qwenpaw-agent-storage");
+    const agentStorage = localStorage.getItem("qwenpaw-agent-storage");
     if (agentStorage) {
       const parsed = JSON.parse(agentStorage);
       const selectedAgent = parsed?.state?.selectedAgent;

--- a/console/src/api/modules/workspace.ts
+++ b/console/src/api/modules/workspace.ts
@@ -5,7 +5,7 @@ import type { MdFileInfo, MdFileContent, DailyMemoryFile } from "../types";
 
 function getSelectedAgentId(): string {
   try {
-    const agentStorage = sessionStorage.getItem("qwenpaw-agent-storage");
+    const agentStorage = localStorage.getItem("qwenpaw-agent-storage");
     if (agentStorage) {
       const parsed = JSON.parse(agentStorage);
       const selectedAgent = parsed?.state?.selectedAgent;

--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -63,24 +63,24 @@ export const useAgentStore = create<AgentStore>()(
       storage: {
         getItem: (name) => {
           try {
-            const value = sessionStorage.getItem(name);
+            const value = localStorage.getItem(name);
             return value ? JSON.parse(value) : null;
           } catch (error) {
             console.error(`Failed to parse agent storage "${name}":`, error);
             // Remove corrupted data to prevent repeated errors
-            sessionStorage.removeItem(name);
+            localStorage.removeItem(name);
             return null;
           }
         },
         setItem: (name, value) => {
           try {
-            sessionStorage.setItem(name, JSON.stringify(value));
+            localStorage.setItem(name, JSON.stringify(value));
           } catch (error) {
             console.error(`Failed to save agent storage "${name}":`, error);
           }
         },
         removeItem: (name) => {
-          sessionStorage.removeItem(name);
+          localStorage.removeItem(name);
         },
       },
     },


### PR DESCRIPTION
## Description

The agent supports local caching, so opening the page still uses the agent from the last conversation.

Fixes #3540


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
