### PR TITLE
Fix(Provider): Fix warning when adding  a model

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1059,6 +1059,7 @@
     "modelNamePlaceholder": "e.g. GPT-4o, Gemini 2.0 Flash",
     "modelAdded": "Model \"{{name}}\" added",
     "modelAddFailed": "Failed to add model",
+    "modelAlreadyExists": "Model ID \"{{id}}\" already exists",
     "autoDiscoverModelsSuccess": "Auto discovery complete. Added {{count}} models",
     "autoDiscoverModelsNoNew": "Auto discovery complete. No new models were added",
     "autoDiscoverModelsFailed": "Failed to auto discover models",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -872,6 +872,7 @@
     "modelNamePlaceholder": "例: GPT-4o, Gemini 2.0 Flash",
     "modelAdded": "モデル \"{{name}}\" を追加しました",
     "modelAddFailed": "モデルの追加に失敗しました",
+    "modelAlreadyExists": "モデル ID \"{{id}}\" は既に存在します",
     "autoDiscoverModelsSuccess": "自動検出が完了しました。{{count}} 件のモデルを追加しました",
     "autoDiscoverModelsNoNew": "自動検出が完了しました。新しいモデルは追加されませんでした",
     "autoDiscoverModelsFailed": "モデルの自動検出に失敗しました",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -872,6 +872,7 @@
     "modelNamePlaceholder": "например: GPT-4o, Gemini 2.0 Flash",
     "modelAdded": "Модель «{{name}}» добавлена",
     "modelAddFailed": "Не удалось добавить модель",
+    "modelAlreadyExists": "Модель с ID \"{{id}}\" уже существует",
     "autoDiscoverModelsSuccess": "Автообнаружение завершено. Добавлено моделей: {{count}}",
     "autoDiscoverModelsNoNew": "Автообнаружение завершено. Новых моделей не найдено",
     "autoDiscoverModelsFailed": "Не удалось автоматически обнаружить модели",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -922,6 +922,7 @@
     "modelNamePlaceholder": "例如 GPT-4o, Gemini 2.0 Flash",
     "modelAdded": "模型 \"{{name}}\" 已添加",
     "modelAddFailed": "添加模型失败",
+    "modelAlreadyExists": "模型 ID \"{{id}}\" 已存在",
     "autoDiscoverModelsSuccess": "自动发现完成，新增 {{count}} 个模型",
     "autoDiscoverModelsNoNew": "自动发现完成，未新增模型",
     "autoDiscoverModelsFailed": "自动发现模型失败",

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -313,6 +313,15 @@ export function RemoteModelManageModal({
       const values = await form.validateFields();
       const id = values.id.trim();
       const name = values.name?.trim() || id;
+      const modelAlreadyExists = [
+        ...(provider.models ?? []),
+        ...(provider.extra_models ?? []),
+      ].some((model) => model.id === id);
+
+      if (modelAlreadyExists) {
+        message.warning(t("models.modelAlreadyExists", { id }));
+        return;
+      }
 
       // Step 1: Test the model connection first
       setSaving(true);

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -316,7 +316,7 @@ export function RemoteModelManageModal({
       const modelAlreadyExists = [
         ...(provider.models ?? []),
         ...(provider.extra_models ?? []),
-      ].some((model) => model.id === id);
+      ].some((model) => model.id.trim() === id);
 
       if (modelAlreadyExists) {
         message.warning(t("models.modelAlreadyExists", { id }));

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -196,15 +196,15 @@ class Provider(ProviderInfo, ABC):
     def update_config(self, config: Dict) -> None:
         """Update provider configuration with the given dictionary."""
         if "name" in config and config["name"] is not None:
-            self.name = str(config["name"])
+            self.name = str(config["name"]).strip()
         if (
             not self.freeze_url
             and "base_url" in config
             and config["base_url"] is not None
         ):
-            self.base_url = str(config["base_url"])
+            self.base_url = str(config["base_url"]).strip()
         if "api_key" in config and config["api_key"] is not None:
-            self.api_key = str(config["api_key"])
+            self.api_key = str(config["api_key"]).strip()
         if (
             self.is_custom
             and "chat_model" in config

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -170,9 +170,11 @@ class Provider(ProviderInfo, ABC):
         timeout: float = 10,  # pylint: disable=unused-argument
     ) -> tuple[bool, str]:
         """Add a model to the provider's model list."""
-        if model_info.id in {
-            model.id for model in self.models + self.extra_models
-        }:
+        model_info.id = model_info.id.strip()
+        if any(
+            model.id.strip() == model_info.id
+            for model in self.models + self.extra_models
+        ):
             return False, f"Model '{model_info.id}' already exists"
         if target == "extra_models":
             self.extra_models.append(model_info)
@@ -188,8 +190,11 @@ class Provider(ProviderInfo, ABC):
         timeout: float = 10,  # pylint: disable=unused-argument
     ) -> tuple[bool, str]:
         """Delete a model from the provider's model list."""
+        model_id = model_id.strip()
         self.extra_models = [
-            model for model in self.extra_models if model.id != model_id
+            model
+            for model in self.extra_models
+            if model.id.strip() != model_id
         ]
         return True, ""
 

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1048,7 +1048,15 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             raise ProviderError(
                 message=f"Provider '{provider_id}' not found.",
             )
-        await provider.add_model(model_info)
+        added, error_message = await provider.add_model(model_info)
+        if not added:
+            raise ProviderError(
+                message=error_message,
+                details={
+                    "provider_id": provider_id,
+                    "model_id": model_info.id,
+                },
+            )
 
         # Save provider config to appropriate location
         is_plugin = provider_id in self.plugin_providers

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -422,6 +422,32 @@ async def test_activate_provider_invalid_model_raises(
         await manager.activate_model("openai", "not-exists")
 
 
+async def test_add_model_to_provider_duplicate_id_raises(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    model_info = ModelInfo(id="custom-duplicate", name="Custom Duplicate")
+
+    provider = await manager.add_model_to_provider("openai", model_info)
+
+    assert [m.id for m in provider.extra_models].count("custom-duplicate") == 1
+
+    with pytest.raises(ProviderError, match="already exists"):
+        await manager.add_model_to_provider("openai", model_info)
+
+    reloaded = ProviderManager()
+    reloaded_provider = reloaded.get_provider("openai")
+
+    assert reloaded_provider is not None
+    assert reloaded_provider.extra_models is not None
+    assert (
+        [m.id for m in reloaded_provider.extra_models].count(
+            "custom-duplicate",
+        )
+        == 1
+    )
+
+
 def test_save_provider_skip_if_exists_does_not_overwrite(
     isolated_secret_dir,
 ) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -440,12 +440,9 @@ async def test_add_model_to_provider_duplicate_id_raises(
 
     assert reloaded_provider is not None
     assert reloaded_provider.extra_models is not None
-    assert (
-        [m.id for m in reloaded_provider.extra_models].count(
-            "custom-duplicate",
-        )
-        == 1
-    )
+    assert [m.id for m in reloaded_provider.extra_models].count(
+        "custom-duplicate",
+    ) == 1
 
 
 def test_save_provider_skip_if_exists_does_not_overwrite(


### PR DESCRIPTION
## Description

This pull request adds robust duplicate model ID detection and handling when adding models, both in the UI and backend, and improves input sanitization for provider configurations. It also introduces new user-facing messages in multiple languages and adds a unit test to ensure duplicate models cannot be added.

**Duplicate model ID handling:**

* The add model flow in `RemoteModelManageModal.tsx` now checks for existing model IDs and warns the user if a duplicate is detected, preventing the addition.
* The backend (`provider_manager.py` and provider classes) now returns an error if a model with the same ID already exists, raising a `ProviderError` with details.

**Internationalization:**

* Added the `modelAlreadyExists` message to English, Japanese, Russian, and Chinese locale files for UI feedback on duplicate model IDs. [[1]](diffhunk://#diff-70ef29eeac20307853ba5eaaba3ff471bfd559dc74ceed759bebbb3ac38cc29bR1062) [[2]](diffhunk://#diff-bb4f6d5f4efb1d3e9abdf897f75babc3ca22a2f57f248fd1d5cdf4d3535a5d54R875) [[3]](diffhunk://#diff-951dbaf31168d36150806995d2a815bac2ad91f708b8a796ae3d812ade9da4abR875) [[4]](diffhunk://#diff-02dadf2a6969295b987f93599c04ce4d7947ae756edc57ef2eff4e9066a6c0dcR925)

**Input sanitization:**

* The `update_config` method in `provider.py` now trims whitespace from `name`, `base_url`, and `api_key` fields to prevent subtle bugs.

**Testing:**

* Added a unit test to verify that attempting to add a model with a duplicate ID raises an error and does not add multiple copies.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
