### PR TITLE
feat(DingTalk): add cron_message_type for independent cron send mode

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -25,6 +25,7 @@ export interface DingTalkConfig extends BaseChannelConfig {
   client_id: string;
   client_secret: string;
   message_type: string;
+  cron_message_type: string;
   card_template_id: string;
   card_template_key: string;
   robot_code: string;

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -407,13 +407,29 @@ export function ChannelDrawer({
               />
             </Form.Item>
             <Form.Item
+              name="cron_message_type"
+              label="Cron Message Type"
+              tooltip="Message type for cron/scheduled task sends. Independent from the chat message type above."
+            >
+              <Select
+                options={[
+                  { label: "markdown", value: "markdown" },
+                  { label: "card", value: "card" },
+                ]}
+              />
+            </Form.Item>
+            <Form.Item
               noStyle
               shouldUpdate={(prev, cur) =>
-                prev.message_type !== cur.message_type
+                prev.message_type !== cur.message_type ||
+                prev.cron_message_type !== cur.cron_message_type
               }
             >
               {({ getFieldValue }) => {
-                if (getFieldValue("message_type") !== "card") return null;
+                const needsCard =
+                  getFieldValue("message_type") === "card" ||
+                  getFieldValue("cron_message_type") === "card";
+                if (!needsCard) return null;
                 return (
                   <>
                     <Form.Item

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -141,6 +141,7 @@ class DingTalkChannel(BaseChannel):
         client_secret: str,
         bot_prefix: str,
         message_type: str = "markdown",
+        cron_message_type: str = "markdown",
         card_template_id: str = "",
         card_template_key: str = "content",
         robot_code: str = "",
@@ -175,6 +176,9 @@ class DingTalkChannel(BaseChannel):
         self.client_secret = client_secret
         self.bot_prefix = bot_prefix
         self.message_type = (message_type or "markdown").strip().lower()
+        self.cron_message_type = (
+            (cron_message_type or "markdown").strip().lower()
+        )
         self.card_template_id = card_template_id or ""
         self.card_template_key = card_template_key or "content"
         self.robot_code = robot_code or self.client_id
@@ -247,6 +251,10 @@ class DingTalkChannel(BaseChannel):
             client_secret=os.getenv("DINGTALK_CLIENT_SECRET", ""),
             bot_prefix=os.getenv("DINGTALK_BOT_PREFIX", ""),
             message_type=os.getenv("DINGTALK_MESSAGE_TYPE", "markdown"),
+            cron_message_type=os.getenv(
+                "DINGTALK_CRON_MESSAGE_TYPE",
+                "markdown",
+            ),
             card_template_id=os.getenv("DINGTALK_CARD_TEMPLATE_ID", ""),
             card_template_key=os.getenv(
                 "DINGTALK_CARD_TEMPLATE_KEY",
@@ -288,6 +296,11 @@ class DingTalkChannel(BaseChannel):
             client_secret=config.client_secret or "",
             bot_prefix=config.bot_prefix or "",
             message_type=getattr(config, "message_type", "markdown"),
+            cron_message_type=getattr(
+                config,
+                "cron_message_type",
+                "markdown",
+            ),
             card_template_id=getattr(config, "card_template_id", ""),
             card_template_key=getattr(config, "card_template_key", "content"),
             robot_code=(
@@ -1805,6 +1818,62 @@ class DingTalkChannel(BaseChannel):
             len(text_parts),
             len(media_parts),
         )
+
+        # ---------- AI Card path (cron / proactive sends) ----------
+        if self._cron_ai_card_enabled() and body.strip():
+            params = await self._resolve_open_api_params_from_handle(
+                to_handle,
+                meta,
+            )
+            conversation_id = params["conversation_id"]
+            if conversation_id:
+                card_meta = {
+                    "conversation_id": conversation_id,
+                    "conversation_type": params["conversation_type"],
+                    "sender_staff_id": params["sender_staff_id"],
+                    "is_group": params["conversation_type"] == "group",
+                }
+                try:
+                    card = await self._create_ai_card(
+                        conversation_id,
+                        meta=card_meta,
+                        inbound=False,
+                        force=True,
+                    )
+                    if card:
+                        await self._stream_ai_card(
+                            card,
+                            body.strip(),
+                            finalize=True,
+                        )
+                        logger.info(
+                            "dingtalk send_content_parts: "
+                            "AI card sent ok, conversation_id=%s",
+                            conversation_id,
+                        )
+                        # Send media parts separately via Open API
+                        for i, part in enumerate(media_parts):
+                            logger.info(
+                                "dingtalk send_content_parts: "
+                                "sending media part %s/%s via Open API "
+                                "(AI card path) type=%s",
+                                i + 1,
+                                len(media_parts),
+                                getattr(part, "type", None),
+                            )
+                            await self._send_media_part_via_open_api(
+                                part,
+                                conversation_id=conversation_id,
+                                conversation_type=params["conversation_type"],
+                                sender_staff_id=params["sender_staff_id"],
+                            )
+                        return
+                except Exception:
+                    logger.exception(
+                        "dingtalk send_content_parts: AI card failed, "
+                        "falling back to webhook/Open API",
+                    )
+
         if session_webhook and (body.strip() or media_parts):
             text_ok = True
             if body.strip():
@@ -2791,6 +2860,14 @@ class DingTalkChannel(BaseChannel):
             and bool(self.robot_code)
         )
 
+    def _cron_ai_card_enabled(self) -> bool:
+        """Check if AI Card is enabled for cron/proactive sends."""
+        return (
+            self.cron_message_type == "card"
+            and bool(self.card_template_id)
+            and bool(self.robot_code)
+        )
+
     # ---- Emotion reaction helpers ----
 
     async def _send_emotion(
@@ -2907,16 +2984,20 @@ class DingTalkChannel(BaseChannel):
         conversation_id: str,
         meta: Optional[Dict[str, Any]] = None,
         inbound: bool = True,
+        force: bool = False,
     ) -> Optional[ActiveAICard]:
-        if not self._ai_card_enabled() or self._card_sdk is None:
+        if self._card_sdk is None or (
+            not force and not self._ai_card_enabled()
+        ):
             logger.warning(
                 "dingtalk create ai card skipped: enabled=%s sdk_ready=%s "
-                "message_type=%s has_template=%s has_robot=%s",
+                "message_type=%s has_template=%s has_robot=%s force=%s",
                 self._ai_card_enabled(),
                 self._card_sdk is not None,
                 self.message_type,
                 bool(self.card_template_id),
                 bool(self.robot_code),
+                force,
             )
             return None
         token = await self._get_access_token()

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -222,6 +222,7 @@ class DingTalkConfig(BaseChannelConfig):
     client_id: str = ""
     client_secret: str = ""
     message_type: str = "markdown"
+    cron_message_type: str = "markdown"
     card_template_id: str = ""
     card_template_key: str = "content"
     robot_code: str = ""


### PR DESCRIPTION
## Description

Added cron_message_type config to DingTalk channel, so users can control cron/scheduled task message format independently from chat. Supports "markdown" (default) and "card". Also added the corresponding selector in the console UI.

<img width="1423" height="700" alt="image" src="https://github.com/user-attachments/assets/d1db6bb2-cedc-4a53-8c7f-a470d40637b5" />


**Related Issue:** Fixes #3742 
**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
