### PR TITLE
fix: toolsIcon

### DIFF
--- a/console/src/pages/Agent/Tools/index.module.less
+++ b/console/src/pages/Agent/Tools/index.module.less
@@ -163,6 +163,23 @@
   font-weight: 500;
   color: rgba(20, 20, 19, 0.88);
   line-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.toolIconFallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+  line-height: 1;
 }
 
 .statusContainer {

--- a/console/src/pages/Agent/Tools/index.tsx
+++ b/console/src/pages/Agent/Tools/index.tsx
@@ -12,6 +12,41 @@ import type { ToolInfo } from "../../../api/modules/tools";
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
 
+/** Stable background colours for the initial-letter fallback icon. */
+const ICON_PALETTE = [
+  "#f56a00",
+  "#7265e6",
+  "#ffbf00",
+  "#00a2ae",
+  "#87d068",
+  "#1890ff",
+  "#eb2f96",
+  "#722ed1",
+];
+
+function hashStringToIndex(value: string, mod: number): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % mod;
+}
+
+/** Renders the emoji icon or a coloured initial-letter badge as fallback. */
+function ToolIcon({ icon, name }: { icon: string; name: string }) {
+  if (icon) {
+    return <span>{icon}</span>;
+  }
+  const letter = name.charAt(0).toUpperCase();
+  const backgroundColor =
+    ICON_PALETTE[hashStringToIndex(name, ICON_PALETTE.length)];
+  return (
+    <span className={styles.toolIconFallback} style={{ backgroundColor }}>
+      {letter}
+    </span>
+  );
+}
+
 export default function ToolsPage() {
   const { t } = useTranslation();
   const {
@@ -70,7 +105,7 @@ export default function ToolsPage() {
               >
                 <div className={styles.cardHeader}>
                   <h3 className={styles.toolName}>
-                    {tool.icon} {tool.name}
+                    <ToolIcon icon={tool.icon} name={tool.name} /> {tool.name}
                   </h3>
                   <div className={styles.statusContainer}>
                     <span className={styles.statusDot} />

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -153,11 +153,13 @@ function useIMEComposition(isChatActive: () => boolean) {
 
     const handleCompositionEnd = () => {
       if (!isChatActive()) return;
-      // Use a slightly longer delay for Safari on macOS, which fires keydown
-      // after compositionend within the same event loop tick.
+      // Small delay for Safari on macOS, which fires keydown after
+      // compositionend within the same event loop tick.  Keep this as
+      // short as possible so fast typists who hit Space+Enter in quick
+      // succession are not blocked.
       setTimeout(() => {
         isComposingRef.current = false;
-      }, 200);
+      }, 50);
     };
 
     const suppressImeEnter = (e: KeyboardEvent) => {

--- a/console/src/pages/Settings/Backups/create/CreateBackupModal.tsx
+++ b/console/src/pages/Settings/Backups/create/CreateBackupModal.tsx
@@ -77,7 +77,7 @@ export default function CreateBackupModal({
           ? { style: { display: "none" } }
           : { disabled: !name.trim() }
       }
-      cancelText={runner.loading ? t("common.cancel") : undefined}
+      cancelText={t("common.cancel")}
       okText={t("common.confirm")}
       destroyOnHidden
       afterOpenChange={handleAfterOpenChange}

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -67,7 +67,7 @@ async def list_tools(
                 enabled=tool_config.enabled,
                 description=tool_config.description,
                 async_execution=tool_config.async_execution,
-                icon=tool_config.icon,
+                icon=tool_config.icon or "",
             ),
         )
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1334,12 +1334,22 @@ class ToolsConfig(BaseModel):
 
     @model_validator(mode="after")
     def _merge_default_tools(self):
-        """Ensure new code-defined tools are present in saved configs."""
-        for name, tc in _default_builtin_tools().items():
+        """Ensure new code-defined tools are present in saved configs.
+
+        Also normalises legacy entries whose ``icon`` is ``None`` so that
+        downstream serialisation (e.g. ``ToolInfo``) never receives a null
+        icon value.
+        """
+        defaults = _default_builtin_tools()
+        for name, tc in defaults.items():
             if name not in self.builtin_tools:
                 self.builtin_tools[name] = tc
             elif self.builtin_tools[name].icon is None:
                 self.builtin_tools[name].icon = tc.icon
+        # Normalise legacy/stale entries not in the current defaults
+        for name, tc in self.builtin_tools.items():
+            if name not in defaults and tc.icon is None:
+                tc.icon = ""
         return self
 
 


### PR DESCRIPTION
## Description

1. Missing tools icons should be standardized to their default values.

2. Fixed internationalization issues on the backup page.

3. Adjusted the chat input/send interval to 50ms.

Fixes  #3757

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
