### PR TITLE
fix(DingTalk): stop exposing local file paths in DingTalk messages

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -740,15 +740,6 @@ class DingTalkChannel(BaseChannel):
             None,
         )
 
-    @staticmethod
-    def _is_base64_url(url: str) -> bool:
-        """True when *url* is a ``data:…;base64,`` URI."""
-        return (
-            isinstance(url, str)
-            and url.startswith("data:")
-            and "base64," in url
-        )
-
     def _parts_to_single_text(
         self,
         parts: List[OutgoingContentPart],

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -754,11 +754,8 @@ class DingTalkChannel(BaseChannel):
         parts: List[OutgoingContentPart],
         bot_prefix: str = "",
     ) -> str:
-        """Build one reply text from parts.
-
-        Base64 data-URIs are replaced with a short
-        placeholder to avoid exceeding DingTalk's
-        message size limit.
+        """
+        Build one reply text from parts.
         """
         text_parts: List[str] = []
         for p in parts:
@@ -767,32 +764,6 @@ class DingTalkChannel(BaseChannel):
                 text_parts.append(p.text or "")
             elif t == ContentType.REFUSAL and getattr(p, "refusal", None):
                 text_parts.append(p.refusal or "")
-            elif t == ContentType.IMAGE and getattr(p, "image_url", None):
-                url = p.image_url
-                if self._is_base64_url(url):
-                    text_parts.append("[Image]")
-                else:
-                    text_parts.append(f"[Image: {url}]")
-            elif t == ContentType.VIDEO and getattr(p, "video_url", None):
-                url = p.video_url
-                if self._is_base64_url(url):
-                    text_parts.append("[Video]")
-                else:
-                    text_parts.append(f"[Video: {url}]")
-            elif t == ContentType.FILE and (
-                getattr(p, "file_url", None) or getattr(p, "file_id", None)
-            ):
-                url_or_id = getattr(p, "file_url", None) or getattr(
-                    p,
-                    "file_id",
-                    None,
-                )
-                if self._is_base64_url(url_or_id or ""):
-                    text_parts.append("[File]")
-                else:
-                    text_parts.append(f"[File: {url_or_id}]")
-            elif t == ContentType.AUDIO and getattr(p, "data", None):
-                text_parts.append("[Audio]")
         body = "\n".join(text_parts) if text_parts else ""
         if bot_prefix and body:
             body = bot_prefix + "  " + body
@@ -1907,33 +1878,11 @@ class DingTalkChannel(BaseChannel):
                 ):
                     self._reply_sync(m, SENT_VIA_WEBHOOK)
                 return
-            # Open API unavailable: append text placeholders so the user
-            # is at least aware of the attachments.
-            for p in media_parts:
-                pt = getattr(p, "type", None)
-                if pt == ContentType.IMAGE and getattr(
-                    p,
-                    "image_url",
-                    None,
-                ):
-                    body += f"\n[Image: {p.image_url}]"
-                elif pt == ContentType.FILE and (
-                    getattr(p, "file_url", None) or getattr(p, "file_id", None)
-                ):
-                    furl = getattr(p, "file_url", None) or getattr(
-                        p,
-                        "file_id",
-                        None,
-                    )
-                    body += f"\n[File: {furl}]"
-                elif pt == ContentType.VIDEO and getattr(
-                    p,
-                    "video_url",
-                    None,
-                ):
-                    body += f"\n[Video: {p.video_url}]"
-                elif pt == ContentType.AUDIO and getattr(p, "data", None):
-                    body += "\n[Audio]"
+            logger.warning(
+                "dingtalk send_content_parts: no webhook and no "
+                "conversation_id, skipping %s media part(s)",
+                len(media_parts),
+            )
 
         if (
             m.get("reply_loop") is not None

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -1077,7 +1077,7 @@ class TestDingTalkPartsToText:
         assert "I cannot" in result
 
     def test_parts_to_single_text_with_image(self, dingtalk_channel):
-        """Should format image content."""
+        """Media parts should be skipped (delivered separately)."""
         from qwenpaw.app.channels.base import ImageContent, ContentType
 
         parts = [
@@ -1086,8 +1086,7 @@ class TestDingTalkPartsToText:
 
         result = dingtalk_channel._parts_to_single_text(parts)
 
-        assert "[Image:" in result
-        assert "http://img.jpg" in result
+        assert result == ""
 
     def test_parts_to_single_text_empty_list(self, dingtalk_channel):
         """Should handle empty parts list."""


### PR DESCRIPTION
## Description

Remove media placeholder text (e.g. [File: /local/path]) from _parts_to_single_text so local file paths are no longer leaked in markdown and AI Card messages. Also cleaned up unreachable fallback code in send_content_parts and removed the now-unused _is_base64_url method.

Updated related unit test.

**Related Issue:** Fixes #3760 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
