### PR TITLE
﻿fix(config): inherit acp in fallback agent profile

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1610,6 +1610,7 @@ def build_fallback_agent_profile_config(
             and config.agents.system_prompt_files
             else ["AGENTS.md", "SOUL.md", "PROFILE.md"]
         ),
+        acp=(config.acp if hasattr(config, "acp") and config.acp else None),
     )
 
 


### PR DESCRIPTION
## Description

`build_fallback_agent_profile_config()` builds a fallback `AgentProfileConfig` when `agent.json` is missing, but it was missing the `acp` field. This caused `_get_acp_service()` to fall back to `ACPConfig()` defaults, where `command="opencode"` is a bare name without a file extension. On Windows, `asyncio.create_subprocess_exec("opencode", ...)` raises `[WinError 2]` because `CreateProcess` cannot resolve a command without an extension (unlike cmd.exe which searches `%PATHEXT%`).

The fix adds `acp` inheritance from `config.json`, following the same pattern already used for `channels`, `mcp`, `tools`, and `security`.

**Security Considerations:** None — only inherits an existing config field that was already present in `config.json`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Delete `agent.json` from workspace directory
2. Start QwenPaw — `build_fallback_agent_profile_config` is called to generate a new fallback
3. Verify the generated profile contains `acp` config inherited from `config.json`
4. Call `delegate_external_agent(action="start", runner="opencode", message="hi")` — should succeed instead of raising `[WinError 2]`

Verified on Windows 11 with ACP agent `opencode` (command=`F:\nodejs\node.exe`).

## Local Verification Evidence

```bash
pre-commit run --all-files
# black: Passed (auto-formatted, committed)
# mypy: existing upstream errors in shutdown_cmd.py (unrelated to this change)
# all other hooks: Passed

pytest
# all tests passed
```

## Additional Notes

One-line change: `acp=(config.acp if hasattr(config, "acp") and config.acp else None),` added to `build_fallback_agent_profile_config()` in `src/qwenpaw/config/config.py`.