### PR TITLE
fix(qq): voice message type mapping and platform ASR support

### DIFF
--- a/src/qwenpaw/agents/utils/audio_transcription.py
+++ b/src/qwenpaw/agents/utils/audio_transcription.py
@@ -10,16 +10,10 @@ Transcription is only attempted when explicitly enabled via the
 """
 
 import asyncio
-import io
 import logging
-import os
 import shutil
-import tempfile
 import threading
-import wave
 from typing import List, Optional, Tuple
-
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -154,77 +148,6 @@ def check_local_whisper_available() -> dict:
 
 
 # ------------------------------------------------------------------
-# SILK format detection and conversion for QQ voice messages
-# ------------------------------------------------------------------
-
-
-def _is_silk_file(file_path: str) -> bool:
-    """Check if a file is in QQ SILK voice format.
-
-    QQ voice messages start with the bytes ``\\x02#!SILK_V3``.
-    The leading ``\\x02`` byte is part of the QQ protocol header and
-    must be included in the check.
-    """
-    try:
-        with open(file_path, "rb") as f:
-            header = f.read(10)
-        return header[:10] == b"\x02#!SILK_V3"
-    except Exception:
-        return False
-
-
-def _convert_silk_to_wav(silk_path: str) -> Optional[str]:
-    """Decode a QQ SILK voice file to a 16 kHz WAV file.
-
-    Returns the path to the temporary WAV file, or ``None`` on failure.
-    The caller is responsible for cleaning up the returned file.
-    """
-    try:
-        import pysilk as silk
-        from scipy.signal import resample_poly
-
-        # Decode SILK to PCM at 24 kHz
-        pcm_buffer = io.BytesIO()
-        with open(silk_path, "rb") as in_file:
-            silk.decode(in_file, pcm_buffer, 24000)
-
-        pcm_data = pcm_buffer.getvalue()
-        if not pcm_data:
-            logger.warning("SILK decode returned empty data for %s", silk_path)
-            return None
-
-        # Convert PCM bytes to numpy array (16-bit signed integers)
-        pcm_array = np.frombuffer(pcm_data, dtype=np.int16)
-
-        # Resample 24 kHz -> 16 kHz (ratio 24/16 = 3/2)
-        resampled = resample_poly(pcm_array, 2, 3)
-
-        # Write to temporary WAV file at 16 kHz
-        temp_wav = tempfile.NamedTemporaryFile(
-            suffix=".wav", delete=False
-        )
-        with wave.open(temp_wav.name, "wb") as wf:
-            wf.setnchannels(1)
-            wf.setsampwidth(2)  # 16-bit
-            wf.setframerate(16000)
-            wf.writeframes(resampled.astype(np.int16).tobytes())
-
-        logger.debug("Converted SILK %s -> WAV %s", silk_path, temp_wav.name)
-        return temp_wav.name
-
-    except ImportError:
-        logger.warning(
-            "pysilk or scipy not installed; cannot decode SILK file %s. "
-            "Install with: pip install pysilk scipy numpy",
-            silk_path,
-        )
-        return None
-    except Exception:
-        logger.exception("Failed to convert SILK to WAV for %s", silk_path)
-        return None
-
-
-# ------------------------------------------------------------------
 # Transcription backends
 # ------------------------------------------------------------------
 
@@ -233,24 +156,8 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
     """Transcribe using the locally installed ``openai-whisper`` library.
 
     Requires both ``ffmpeg`` and ``openai-whisper`` to be installed.
-    If the input file is in QQ SILK format, it is automatically decoded
-    to WAV before transcription.
     Returns the transcribed text, or ``None`` on failure.
     """
-    # Auto-detect and convert QQ SILK voice format
-    wav_path = None
-    if _is_silk_file(file_path):
-        logger.debug("Detected QQ SILK format, converting to WAV...")
-        wav_path = _convert_silk_to_wav(file_path)
-        if wav_path is None:
-            logger.warning(
-                "SILK conversion failed for %s; "
-                "attempting transcription with original file anyway.",
-                file_path,
-            )
-        else:
-            file_path = wav_path
-
     status = check_local_whisper_available()
     if not status["available"]:
         missing = []
@@ -263,8 +170,6 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
             "Install the missing dependencies to use local transcription.",
             ", ".join(missing),
         )
-        if wav_path and os.path.exists(wav_path):
-            os.unlink(wav_path)
         return None
 
     def _run():
@@ -293,13 +198,6 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
             exc_info=True,
         )
         return None
-    finally:
-        # Clean up temporary WAV file created from SILK conversion
-        if wav_path and os.path.exists(wav_path):
-            try:
-                os.unlink(wav_path)
-            except Exception:
-                pass
 
 
 def _get_configured_provider_creds() -> Optional[Tuple[str, str]]:

--- a/src/qwenpaw/agents/utils/audio_transcription.py
+++ b/src/qwenpaw/agents/utils/audio_transcription.py
@@ -10,10 +10,16 @@ Transcription is only attempted when explicitly enabled via the
 """
 
 import asyncio
+import io
 import logging
+import os
 import shutil
+import tempfile
 import threading
+import wave
 from typing import List, Optional, Tuple
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +154,77 @@ def check_local_whisper_available() -> dict:
 
 
 # ------------------------------------------------------------------
+# SILK format detection and conversion for QQ voice messages
+# ------------------------------------------------------------------
+
+
+def _is_silk_file(file_path: str) -> bool:
+    """Check if a file is in QQ SILK voice format.
+
+    QQ voice messages start with the bytes ``\\x02#!SILK_V3``.
+    The leading ``\\x02`` byte is part of the QQ protocol header and
+    must be included in the check.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(10)
+        return header[:10] == b"\x02#!SILK_V3"
+    except Exception:
+        return False
+
+
+def _convert_silk_to_wav(silk_path: str) -> Optional[str]:
+    """Decode a QQ SILK voice file to a 16 kHz WAV file.
+
+    Returns the path to the temporary WAV file, or ``None`` on failure.
+    The caller is responsible for cleaning up the returned file.
+    """
+    try:
+        import pysilk as silk
+        from scipy.signal import resample_poly
+
+        # Decode SILK to PCM at 24 kHz
+        pcm_buffer = io.BytesIO()
+        with open(silk_path, "rb") as in_file:
+            silk.decode(in_file, pcm_buffer, 24000)
+
+        pcm_data = pcm_buffer.getvalue()
+        if not pcm_data:
+            logger.warning("SILK decode returned empty data for %s", silk_path)
+            return None
+
+        # Convert PCM bytes to numpy array (16-bit signed integers)
+        pcm_array = np.frombuffer(pcm_data, dtype=np.int16)
+
+        # Resample 24 kHz -> 16 kHz (ratio 24/16 = 3/2)
+        resampled = resample_poly(pcm_array, 2, 3)
+
+        # Write to temporary WAV file at 16 kHz
+        temp_wav = tempfile.NamedTemporaryFile(
+            suffix=".wav", delete=False
+        )
+        with wave.open(temp_wav.name, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)  # 16-bit
+            wf.setframerate(16000)
+            wf.writeframes(resampled.astype(np.int16).tobytes())
+
+        logger.debug("Converted SILK %s -> WAV %s", silk_path, temp_wav.name)
+        return temp_wav.name
+
+    except ImportError:
+        logger.warning(
+            "pysilk or scipy not installed; cannot decode SILK file %s. "
+            "Install with: pip install pysilk scipy numpy",
+            silk_path,
+        )
+        return None
+    except Exception:
+        logger.exception("Failed to convert SILK to WAV for %s", silk_path)
+        return None
+
+
+# ------------------------------------------------------------------
 # Transcription backends
 # ------------------------------------------------------------------
 
@@ -156,8 +233,24 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
     """Transcribe using the locally installed ``openai-whisper`` library.
 
     Requires both ``ffmpeg`` and ``openai-whisper`` to be installed.
+    If the input file is in QQ SILK format, it is automatically decoded
+    to WAV before transcription.
     Returns the transcribed text, or ``None`` on failure.
     """
+    # Auto-detect and convert QQ SILK voice format
+    wav_path = None
+    if _is_silk_file(file_path):
+        logger.debug("Detected QQ SILK format, converting to WAV...")
+        wav_path = _convert_silk_to_wav(file_path)
+        if wav_path is None:
+            logger.warning(
+                "SILK conversion failed for %s; "
+                "attempting transcription with original file anyway.",
+                file_path,
+            )
+        else:
+            file_path = wav_path
+
     status = check_local_whisper_available()
     if not status["available"]:
         missing = []
@@ -170,6 +263,8 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
             "Install the missing dependencies to use local transcription.",
             ", ".join(missing),
         )
+        if wav_path and os.path.exists(wav_path):
+            os.unlink(wav_path)
         return None
 
     def _run():
@@ -198,6 +293,13 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
             exc_info=True,
         )
         return None
+    finally:
+        # Clean up temporary WAV file created from SILK conversion
+        if wav_path and os.path.exists(wav_path):
+            try:
+                os.unlink(wav_path)
+            except Exception:
+                pass
 
 
 def _get_configured_provider_creds() -> Optional[Tuple[str, str]]:

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1856,8 +1856,24 @@ class QQChannel(BaseChannel):
     @staticmethod
     def _content_type_to_media_type(
         content_type: Any,
+        source_path: str = "",
     ) -> Optional[int]:
-        """Map ContentType to QQ rich-media file_type integer."""
+        """Map ContentType to QQ rich-media file_type integer.
+
+        Distinguishes between voice messages and regular files based on
+        file extension:
+        - Voice messages (.amr, .silk, .slk) -> _MEDIA_TYPE_AUDIO (3)
+        - Regular audio files (.mp3, .wav, .m4a, etc.) -> _MEDIA_TYPE_FILE (4)
+        - Other files -> _MEDIA_TYPE_FILE (4)
+        """
+        # QQ voice message formats
+        _VOICE_EXTS = {".amr", ".silk", ".slk"}
+
+        if source_path:
+            ext = Path(source_path).suffix.lower()
+            if ext in _VOICE_EXTS:
+                return _MEDIA_TYPE_AUDIO
+
         mapping = {
             ContentType.IMAGE: _MEDIA_TYPE_IMAGE,
             ContentType.VIDEO: _MEDIA_TYPE_VIDEO,
@@ -2035,7 +2051,7 @@ class QQChannel(BaseChannel):
         token: str,
     ) -> None:
         """Upload + send rich media for c2c or group scenarios."""
-        media_type = self._content_type_to_media_type(content_type)
+        media_type = self._content_type_to_media_type(content_type, source_path=url or local_path or "")
         if media_type is None:
             logger.warning(
                 "qq _send_media_c2c_or_group: unknown content_type=%s",

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1228,28 +1228,37 @@ class QQChannel(BaseChannel):
         for att in attachments:
             url = att.get("url", "")
             file_name = att.get("filename", "")
-            
+
             # QQ Voice Message ASR Support
             # Check if attachment is a voice message and has ASR text.
             att_type = att.get("content_type", att.get("type", ""))
             file_ext = Path(file_name).suffix.lower()
-            is_voice = (
-                att_type == "voice"
-                or file_ext in {".amr", ".silk", ".slk"}
-            )
-            
+            is_voice = att_type == "voice" or file_ext in {
+                ".amr",
+                ".silk",
+                ".slk",
+            }
+
             if is_voice:
                 asr_text = att.get("asr_refer_text", "")
                 if asr_text:
-                    # Use platform-side ASR text directly, skipping audio download.
+                    # Use platform-side ASR text directly,
+                    # skipping audio download.
                     parts.append(
-                        TextContent(type=ContentType.TEXT, text=asr_text)
+                        TextContent(type=ContentType.TEXT, text=asr_text),
                     )
                     continue
+                # No ASR text available: prefer the pre-converted WAV URL so
+                # the transcription pipeline can process it without needing
+                # SILK decoding.  Fall back to the original AMR/SILK URL.
+                voice_wav_url = att.get("voice_wav_url", "")
+                if voice_wav_url:
+                    url = voice_wav_url
+                    file_name = file_name.rsplit(".", 1)[0] + ".wav"
 
             if not url:
                 continue
-            
+
             resolved = self._resolve_attachment_type(
                 att_type,
                 file_name,
@@ -2067,7 +2076,10 @@ class QQChannel(BaseChannel):
         token: str,
     ) -> None:
         """Upload + send rich media for c2c or group scenarios."""
-        media_type = self._content_type_to_media_type(content_type, source_path=url or local_path or "")
+        media_type = self._content_type_to_media_type(
+            content_type,
+            source_path=url or local_path or "",
+        )
         if media_type is None:
             logger.warning(
                 "qq _send_media_c2c_or_group: unknown content_type=%s",

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1228,12 +1228,28 @@ class QQChannel(BaseChannel):
         for att in attachments:
             url = att.get("url", "")
             file_name = att.get("filename", "")
+            
+            # QQ Voice Message ASR Support
+            # Check if attachment is a voice message and has ASR text.
+            att_type = att.get("content_type", att.get("type", ""))
+            file_ext = Path(file_name).suffix.lower()
+            is_voice = (
+                att_type == "voice"
+                or file_ext in {".amr", ".silk", ".slk"}
+            )
+            
+            if is_voice:
+                asr_text = att.get("asr_refer_text", "")
+                if asr_text:
+                    # Use platform-side ASR text directly, skipping audio download.
+                    parts.append(
+                        TextContent(type=ContentType.TEXT, text=asr_text)
+                    )
+                    continue
+
             if not url:
                 continue
-            att_type = att.get(
-                "content_type",
-                att.get("type", ""),
-            )
+            
             resolved = self._resolve_attachment_type(
                 att_type,
                 file_name,


### PR DESCRIPTION
## 📋 Summary

This PR fixes two issues related to QQ voice messages:

1. **Audio message type mapping** — Distinguishes between QQ voice messages (`.amr/.silk/.slk`) and regular audio files (`.mp3/.wav/.m4a`) so they are sent as voice bubbles instead of file cards.

2. **Platform-side ASR fallback** — Extracts `asr_refer_text` from the QQ voice attachment payload for automatic transcription. When ASR text is absent, falls back to `voice_wav_url` (QQ's pre-converted WAV format) instead of raw AMR/SILK, ensuring transcription works without additional format conversion.

---

## 📝 Changes

### `src/qwenpaw/app/channels/qq/channel.py`

| Function | Change |
|----------|--------|
| `_parse_qq_attachments()` | Extracts `asr_refer_text` from voice attachments; falls back to `voice_wav_url` when ASR text is unavailable |
| `_content_type_to_media_type()` | Accepts `source_path` parameter to distinguish voice messages from regular audio files based on extension |

### Mapping Rules

| File Type | Extensions | QQ Media Type | Display |
|-----------|-----------|---------------|---------|
| Voice messages | `.amr`, `.silk`, `.slk` | `_MEDIA_TYPE_AUDIO` (3) | Voice bubble |
| Regular audio | `.mp3`, `.wav`, `.m4a`, etc. | `_MEDIA_TYPE_FILE` (4) | File card |

---

## 🧹 Cleanup

- Removed all custom SILK detection/conversion logic
- Removed `pysilk` / `scipy` / `numpy` dependencies
- No longer modifies `audio_transcription.py`

---

## 🔗 Related Issues

- Fixes silent bug where all audio was sent as file attachments
- Addresses voice interaction needs mentioned in #3293
- Follows the same pattern as WeCom (`voice.content`) and WeiXin (`voice_item.text_item.text`)