### PR TITLE
fix(console): use hybrid storage for per-tab agent selection

### DIFF
--- a/console/src/api/authHeaders.ts
+++ b/console/src/api/authHeaders.ts
@@ -8,7 +8,10 @@ export function buildAuthHeaders(): Record<string, string> {
     headers.Authorization = `Bearer ${token}`;
   }
   try {
-    const agentStorage = localStorage.getItem("qwenpaw-agent-storage");
+    // Read from sessionStorage first (per-tab agent), fall back to localStorage
+    const agentStorage =
+      sessionStorage.getItem("qwenpaw-agent-storage") ||
+      localStorage.getItem("qwenpaw-agent-storage");
     if (agentStorage) {
       const parsed = JSON.parse(agentStorage);
       const selectedAgent = parsed?.state?.selectedAgent;

--- a/console/src/api/modules/workspace.ts
+++ b/console/src/api/modules/workspace.ts
@@ -5,7 +5,10 @@ import type { MdFileInfo, MdFileContent, DailyMemoryFile } from "../types";
 
 function getSelectedAgentId(): string {
   try {
-    const agentStorage = localStorage.getItem("qwenpaw-agent-storage");
+    // Read from sessionStorage first (per-tab agent), fall back to localStorage
+    const agentStorage =
+      sessionStorage.getItem("qwenpaw-agent-storage") ||
+      localStorage.getItem("qwenpaw-agent-storage");
     if (agentStorage) {
       const parsed = JSON.parse(agentStorage);
       const selectedAgent = parsed?.state?.selectedAgent;

--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -2,6 +2,18 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { AgentSummary } from "../api/types/agents";
 
+/**
+ * Storage key used by both sessionStorage (per-tab state) and localStorage
+ * (cross-tab shared state).
+ */
+const STORAGE_KEY = "qwenpaw-agent-storage";
+
+/**
+ * localStorage key that remembers the last-used agent across browser sessions.
+ * New tabs read this to set their initial selectedAgent.
+ */
+const LAST_USED_AGENT_KEY = "qwenpaw-last-used-agent";
+
 interface AgentStore {
   selectedAgent: string;
   agents: AgentSummary[];
@@ -16,14 +28,50 @@ interface AgentStore {
   getLastChatId: (agentId: string) => string | undefined;
 }
 
+/**
+ * Determines the initial selectedAgent for this tab.
+ *
+ * Priority:
+ *  1. sessionStorage (returning to a tab that already picked an agent)
+ *  2. localStorage lastUsedAgent (new tab inherits the most recent choice)
+ *  3. "default"
+ */
+function getInitialSelectedAgent(): string {
+  try {
+    const sessionValue = sessionStorage.getItem(STORAGE_KEY);
+    if (sessionValue) {
+      const parsed = JSON.parse(sessionValue);
+      const agent = parsed?.state?.selectedAgent;
+      if (agent) return agent;
+    }
+  } catch {
+    /* ignore */
+  }
+  try {
+    const lastUsed = localStorage.getItem(LAST_USED_AGENT_KEY);
+    if (lastUsed) return lastUsed;
+  } catch {
+    /* ignore */
+  }
+  return "default";
+}
+
 export const useAgentStore = create<AgentStore>()(
   persist(
     (set, get) => ({
-      selectedAgent: "default",
+      selectedAgent: getInitialSelectedAgent(),
       agents: [],
       lastChatIdByAgent: {},
 
-      setSelectedAgent: (agentId) => set({ selectedAgent: agentId }),
+      setSelectedAgent: (agentId) => {
+        set({ selectedAgent: agentId });
+        // Persist to localStorage so new tabs inherit this choice
+        try {
+          localStorage.setItem(LAST_USED_AGENT_KEY, agentId);
+        } catch {
+          /* ignore */
+        }
+      },
 
       setAgents: (agents) => set({ agents }),
 
@@ -59,27 +107,42 @@ export const useAgentStore = create<AgentStore>()(
       getLastChatId: (agentId) => get().lastChatIdByAgent[agentId],
     }),
     {
-      name: "qwenpaw-agent-storage",
+      name: STORAGE_KEY,
       storage: {
         getItem: (name) => {
           try {
-            const value = localStorage.getItem(name);
-            return value ? JSON.parse(value) : null;
+            // Read per-tab state from sessionStorage
+            const value = sessionStorage.getItem(name);
+            if (value) return JSON.parse(value);
+          } catch {
+            /* ignore */
+          }
+          // Fall back to localStorage for shared data (agents list, etc.)
+          try {
+            const shared = localStorage.getItem(name);
+            return shared ? JSON.parse(shared) : null;
           } catch (error) {
             console.error(`Failed to parse agent storage "${name}":`, error);
-            // Remove corrupted data to prevent repeated errors
             localStorage.removeItem(name);
             return null;
           }
         },
         setItem: (name, value) => {
           try {
+            // Per-tab state (includes selectedAgent)
+            sessionStorage.setItem(name, JSON.stringify(value));
+          } catch {
+            /* ignore */
+          }
+          try {
+            // Shared state (agents list, lastChatIdByAgent)
             localStorage.setItem(name, JSON.stringify(value));
           } catch (error) {
             console.error(`Failed to save agent storage "${name}":`, error);
           }
         },
         removeItem: (name) => {
+          sessionStorage.removeItem(name);
           localStorage.removeItem(name);
         },
       },


### PR DESCRIPTION
## Description

A hybrid storage strategy simultaneously satisfies the requirements of "new tabs inheriting the last selection" and "multiple tabs operating independently":

Data Storage Location Reason

selectedAgent sessionStorage (per-tab) Each tab independently selects an agent, without interference.

lastUsedAgent localStorage (cross-tab) New tab/new browser session inherits the last selection.

agents list, lastChatIdByAgent dual write (sessionStorage + localStorage) Shared data remains consistent across tabs.

New tab initialization priority: sessionStorage → localStorage.lastUsedAgent → "default"

API request header reading priority: sessionStorage → localStorage (ensuring the agent of the current tab takes precedence)

Fixes #3852

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
