### PR TITLE
fix(timezone): normalize non-standard timezone names

### DIFF
--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -17,6 +17,7 @@ from ...config import (
     ToolGuardRuleConfig,
 )
 from ..channels.registry import BUILTIN_CHANNEL_KEYS
+from ...config.timezone import normalize_tz
 from ...config.config import (
     AgentsLLMRoutingConfig,
     ConsoleConfig,
@@ -612,10 +613,16 @@ async def put_user_timezone(
     tz = body.get("timezone", "").strip()
     if not tz:
         raise HTTPException(status_code=400, detail="timezone is required")
+    resolved = normalize_tz(tz)
+    if resolved is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid IANA timezone: {tz!r}",
+        )
     config = load_config()
-    config.user_timezone = tz
+    config.user_timezone = resolved
     save_config(config)
-    return {"timezone": tz}
+    return {"timezone": resolved}
 
 
 # ── Security / Tool Guard ────────────────────────────────────────────

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from qwenpaw.config.timezone import normalize_tz
 from qwenpaw.config.utils import load_config
 
 from .service_manager import ServiceDescriptor, ServiceManager
@@ -276,7 +277,10 @@ class Workspace:
                     "channel_manager": ws._service_manager.services.get(
                         "channel_manager",
                     ),
-                    "timezone": load_config().user_timezone or "UTC",
+                    "timezone": normalize_tz(
+                        load_config().user_timezone or "UTC",
+                    )
+                    or "UTC",
                     "agent_id": ws.agent_id,
                 },
                 start_method="start",

--- a/src/qwenpaw/config/timezone.py
+++ b/src/qwenpaw/config/timezone.py
@@ -8,14 +8,62 @@ utils.py.  Uses only the standard library; always returns a valid string
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+_NON_STANDARD_ALIASES: dict[str, str] = {
+    "Asia/Beijing": "Asia/Shanghai",
+    "Asia/Calcutta": "Asia/Kolkata",
+    "Asia/Saigon": "Asia/Ho_Chi_Minh",
+    "Asia/Katmandu": "Asia/Kathmandu",
+    "Asia/Rangoon": "Asia/Yangon",
+    "Asia/Thimbu": "Asia/Thimphu",
+    "Asia/Ujung_Pandang": "Asia/Makassar",
+    "Asia/Ulan_Bator": "Asia/Ulaanbaatar",
+    "Pacific/Samoa": "Pacific/Pago_Pago",
+    "Pacific/Ponape": "Pacific/Pohnpei",
+    "Pacific/Truk": "Pacific/Chuuk",
+    "Atlantic/Faeroe": "Atlantic/Faroe",
+    "Europe/Kiev": "Europe/Kyiv",
+    "PRC": "Asia/Shanghai",
+}
 
 
 def _is_iana(name: Optional[str]) -> bool:
     """Return True if *name* looks like an IANA tz id."""
     return bool(name and "/" in name)
+
+
+def normalize_tz(name: str) -> Optional[str]:
+    """Validate and normalize a timezone name.
+
+    Returns a valid IANA name, or ``None`` if *name* cannot be resolved.
+    Handles IANA backward-compatible links (via ``ZoneInfo``) as well as
+    non-standard names used by certain Linux distributions.
+    """
+    if not name:
+        return None
+    # Prefer our alias table first so that deprecated / non-standard
+    # names (even those accepted by ZoneInfo backward links) are
+    # mapped to canonical modern identifiers.
+    alias = _NON_STANDARD_ALIASES.get(name)
+    if alias:
+        try:
+            ZoneInfo(alias)
+            return alias
+        except (ZoneInfoNotFoundError, KeyError, ValueError):
+            pass
+    try:
+        ZoneInfo(name)
+        return name
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        pass
+    return None
 
 
 def detect_system_timezone() -> str:
@@ -42,9 +90,21 @@ def _detect_system_timezone_inner() -> str:  # noqa: R0911
             _probe_timedatectl,
         ]
     for probe in probes:
-        result = probe()
-        if result is not None:
-            return result
+        raw = probe()
+        if raw is not None:
+            normalized = normalize_tz(raw)
+            if normalized is not None:
+                if normalized != raw:
+                    logger.info(
+                        "Mapped non-standard timezone %r → %r",
+                        raw,
+                        normalized,
+                    )
+                return normalized
+            logger.debug(
+                "Probe returned invalid timezone %r, skipping",
+                raw,
+            )
     return "UTC"
 
 


### PR DESCRIPTION
## Description

- Fix startup crash on systems reporting non-standard timezone names (e.g. `Asia/Beijing` on Deepin 25), which caused `ZoneInfoNotFoundError` and made the entire app return 500 errors
- Add `normalize_tz()` with ZoneInfo validation and a mapping table for 13 known non-standard timezone aliases
- Add defensive fallback in CronManager construction and input validation on `PUT /user-timezone` API

Fixes #3818

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
