### PR TITLE
feat(ACP): add ACP agent rename and delete in WebUI

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -100,6 +100,7 @@
     "agentKey": "Agent Key",
     "agentKeyRequired": "Please enter an agent key",
     "agentKeyInvalid": "Agent key can only contain letters, numbers, underscores, and hyphens",
+    "agentKeyExists": "This agent key already exists",
     "enabled": "Enabled",
     "command": "Command",
     "commandRequired": "Please enter a command",
@@ -119,7 +120,11 @@
     "docsHelp": "Open the ACP integration docs and jump to the \"How to configure external runners\" section",
     "notSet": "Not set",
     "configSaved": "ACP configuration saved",
-    "configFailed": "Failed to save ACP configuration"
+    "configFailed": "Failed to save ACP configuration",
+    "deleteTitle": "Delete {{name}}",
+    "deleteConfirm": "Delete this ACP agent? This action cannot be undone.",
+    "deleteSuccess": "ACP agent deleted",
+    "deleteFailed": "Failed to delete ACP agent"
   },
   "voiceTranscription": {
     "title": "Voice Transcription",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1606,6 +1606,7 @@
     "agentKey": "Agent Key",
     "agentKeyRequired": "Agent Key を入力してください",
     "agentKeyInvalid": "Agent Key には英字、数字、アンダースコア、ハイフンのみ使用できます",
+    "agentKeyExists": "この Agent Key は既に存在します",
     "enabled": "有効",
     "command": "コマンド",
     "commandRequired": "コマンドを入力してください",
@@ -1625,7 +1626,11 @@
     "docsHelp": "ACP 統合ドキュメントを開き、「How to configure external runners」セクションへ移動します",
     "notSet": "未設定",
     "configSaved": "ACP 設定を保存しました",
-    "configFailed": "ACP 設定の保存に失敗しました"
+    "configFailed": "ACP 設定の保存に失敗しました",
+    "deleteTitle": "{{name}} を削除",
+    "deleteConfirm": "この ACP Agent を削除しますか？この操作は元に戻せません。",
+    "deleteSuccess": "ACP Agent を削除しました",
+    "deleteFailed": "ACP Agent の削除に失敗しました"
   },
   "backup": {
     "title": "バックアップ",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1621,6 +1621,7 @@
     "agentKey": "Ключ агента",
     "agentKeyRequired": "Пожалуйста, введите ключ агента",
     "agentKeyInvalid": "Ключ агента может содержать только буквы, цифры, подчёркивания и дефисы",
+    "agentKeyExists": "Этот ключ агента уже существует",
     "enabled": "Включено",
     "command": "Команда",
     "commandRequired": "Пожалуйста, введите команду",
@@ -1640,7 +1641,11 @@
     "docsHelp": "Открыть документацию по ACP и перейти к разделу \"How to configure external runners\"",
     "notSet": "Не задано",
     "configSaved": "Конфигурация ACP сохранена",
-    "configFailed": "Не удалось сохранить конфигурацию ACP"
+    "configFailed": "Не удалось сохранить конфигурацию ACP",
+    "deleteTitle": "Удалить {{name}}",
+    "deleteConfirm": "Удалить этот ACP агент? Это действие нельзя отменить.",
+    "deleteSuccess": "ACP агент удалён",
+    "deleteFailed": "Не удалось удалить ACP агент"
   },
   "backup": {
     "title": "Резервные копии",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -195,6 +195,7 @@
     "agentKey": "Agent Key",
     "agentKeyRequired": "请输入 Agent Key",
     "agentKeyInvalid": "Agent Key 只能包含字母、数字、下划线和连字符",
+    "agentKeyExists": "该 Agent Key 已存在",
     "enabled": "启用",
     "command": "命令",
     "commandRequired": "请输入命令",
@@ -214,7 +215,11 @@
     "docsHelp": "打开 ACP 集成文档，并跳转到“如何配置外部 runner”章节",
     "notSet": "未设置",
     "configSaved": "ACP 配置已保存",
-    "configFailed": "ACP 配置保存失败"
+    "configFailed": "ACP 配置保存失败",
+    "deleteTitle": "删除 {{name}}",
+    "deleteConfirm": "确定删除该 ACP Agent 吗？此操作不可撤销。",
+    "deleteSuccess": "ACP Agent 已删除",
+    "deleteFailed": "ACP Agent 删除失败"
   },
   "skills": {
     "title": "技能",

--- a/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
+++ b/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
@@ -25,8 +25,11 @@ interface ACPDrawerProps {
   form: FormInstance<Record<string, unknown>>;
   saving: boolean;
   initialValues?: ACPAgentConfig;
+  canEditKey?: boolean;
+  canDelete?: boolean;
   onClose: () => void;
   onSubmit: (values: Record<string, unknown>) => void;
+  onDelete?: () => void;
 }
 
 const TOOL_PARSE_MODE_OPTIONS: { value: ACPToolParseMode; label: string }[] = [
@@ -102,8 +105,11 @@ export function ACPDrawer({
   form,
   saving,
   initialValues,
+  canEditKey = false,
+  canDelete = false,
   onClose,
   onSubmit,
+  onDelete,
 }: ACPDrawerProps) {
   const { t, i18n } = useTranslation();
 
@@ -120,11 +126,24 @@ export function ACPDrawer({
       onClose={onClose}
       width={520}
       footer={
-        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-          <Button onClick={onClose}>{t("common.cancel")}</Button>
-          <Button type="primary" loading={saving} onClick={() => form.submit()}>
-            {t("common.save")}
-          </Button>
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <div>
+            {canDelete ? (
+              <Button danger onClick={onDelete}>
+                {t("common.delete")}
+              </Button>
+            ) : null}
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+            <Button onClick={onClose}>{t("common.cancel")}</Button>
+            <Button
+              type="primary"
+              loading={saving}
+              onClick={() => form.submit()}
+            >
+              {t("common.save")}
+            </Button>
+          </div>
         </div>
       }
       destroyOnClose
@@ -138,20 +157,15 @@ export function ACPDrawer({
         <Form.Item
           name="agentKey"
           label={t("acp.agentKey")}
-          hidden={!isCreateMode}
-          rules={
-            isCreateMode
-              ? [
-                  { required: true, message: t("acp.agentKeyRequired") },
-                  {
-                    pattern: /^[A-Za-z0-9_-]+$/,
-                    message: t("acp.agentKeyInvalid"),
-                  },
-                ]
-              : []
-          }
+          rules={[
+            { required: true, message: t("acp.agentKeyRequired") },
+            {
+              pattern: /^[A-Za-z0-9_-]+$/,
+              message: t("acp.agentKeyInvalid"),
+            },
+          ]}
         >
-          <Input placeholder="my_custom_runner" />
+          <Input placeholder="my_custom_runner" disabled={!canEditKey} />
         </Form.Item>
 
         <Form.Item

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Form } from "@agentscope-ai/design";
+import { Button, Form, Modal } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
 import api from "../../../api";
@@ -100,6 +100,7 @@ function ACPPage() {
     setDrawerOpen(true);
     form.setFieldsValue({
       ...config,
+      agentKey: key,
       argsText: stringifyArgs(config?.args),
       envText: stringifyEnv(config?.env),
       stdio_buffer_limit_bytes:
@@ -133,12 +134,15 @@ function ACPPage() {
   };
 
   const handleSubmit = async (values: Record<string, unknown>) => {
-    const targetKey = isCreateMode
-      ? String(values.agentKey || "").trim()
-      : activeKey;
+    const targetKey = String(values.agentKey || activeKey || "").trim();
     if (!targetKey) return;
     const existingConfig: Partial<ACPAgentConfig> =
       (!isCreateMode && activeKey ? agents[activeKey] : undefined) || {};
+
+    if ((isCreateMode || targetKey !== activeKey) && agents[targetKey]) {
+      message.error(t("acp.agentKeyExists"));
+      return;
+    }
 
     const updatedConfig: ACPAgentConfig = {
       ...existingConfig,
@@ -158,7 +162,16 @@ function ACPPage() {
 
     setSaving(true);
     try {
-      await api.updateACPAgentConfig(targetKey, updatedConfig);
+      if (isCreateMode || targetKey !== activeKey) {
+        const nextAgents = { ...agents };
+        if (!isCreateMode && activeKey) {
+          delete nextAgents[activeKey];
+        }
+        nextAgents[targetKey] = updatedConfig;
+        await api.updateACPConfig({ agents: nextAgents });
+      } else {
+        await api.updateACPAgentConfig(targetKey, updatedConfig);
+      }
       await fetchACP();
       setDrawerOpen(false);
       message.success(
@@ -170,6 +183,32 @@ function ACPPage() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleDelete = () => {
+    if (!activeKey || isBuiltinACPAgent(activeKey)) return;
+
+    Modal.confirm({
+      title: t("acp.deleteTitle", { name: activeKey }),
+      content: t("acp.deleteConfirm"),
+      okText: t("common.delete"),
+      cancelText: t("common.cancel"),
+      okButtonProps: { danger: true },
+      async onOk() {
+        try {
+          const nextAgents = { ...agents };
+          delete nextAgents[activeKey];
+          await api.updateACPConfig({ agents: nextAgents });
+          await fetchACP();
+          handleClose();
+          message.success(t("acp.deleteSuccess"));
+        } catch (error) {
+          console.error("❌ Failed to delete ACP config:", error);
+          message.error(t("acp.deleteFailed"));
+          throw error;
+        }
+      },
+    });
   };
 
   const FILTER_TABS: { key: FilterType; label: string }[] = [
@@ -229,8 +268,11 @@ function ACPPage() {
         form={form}
         saving={saving}
         initialValues={activeKey ? agents[activeKey] : undefined}
+        canEditKey={isCreateMode || !isBuiltinACPAgent(activeKey || "")}
+        canDelete={!isCreateMode && !isBuiltinACPAgent(activeKey || "")}
         onClose={handleClose}
         onSubmit={handleSubmit}
+        onDelete={handleDelete}
       />
     </div>
   );


### PR DESCRIPTION
## Description

Add rename and delete support for custom ACP agents in the console ACP configuration page.

This PR keeps the change scoped to the frontend and reuses the existing ACP config APIs:

- Custom ACP agents can now edit their `Agent Key` from the ACP drawer.
- Custom ACP agents can now be deleted from the ACP drawer with confirmation.
- Built-in ACP agents keep their names read-only and do not expose delete actions, because backend defaults are merged back into ACP config.
- Rename/delete operations use the existing full-config update API instead of adding new backend endpoints.
- ACP locale strings are added for `zh`, `en`, `ja`, and `ru`.

**Related Issue:** fixes https://github.com/agentscope-ai/QwenPaw/issues/3835

**Security Considerations:** No new permission or credential handling. The change only edits ACP configuration keys and entries through existing authenticated config APIs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

N/A. This PR changes the console ACP configuration UI, not a channel implementation or channel contract.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

From `console/`:

```bash
 npm run format
```

## Local Verification Evidence

```bash
npx tsc -b --noEmit
# passed

npx prettier --check src/pages/Agent/ACP/index.tsx src/pages/Agent/ACP/components/ACPDrawer.tsx src/locales/zh.json src/locales/en.json src/locales/ja.json src/locales/ru.json
# Checking formatting...
# All matched files use Prettier code style!

npm run format:check
# tsc -b --noEmit passed
# prettier --check . failed on existing console/dist generated assets
```

## Additional Notes

The implementation intentionally does not add backend delete or rename endpoints. ACP agent names are map keys, so the frontend performs custom-agent rename/delete by submitting the next `agents` map through the existing `PUT /config/acp` API.
