### PR TITLE
fix: localStorage

### DIFF
--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -37,6 +37,7 @@ interface AgentStore {
  *  3. "default"
  */
 function getInitialSelectedAgent(): string {
+  // 1. sessionStorage: returning to a tab that already picked an agent
   try {
     const sessionValue = sessionStorage.getItem(STORAGE_KEY);
     if (sessionValue) {
@@ -47,9 +48,21 @@ function getInitialSelectedAgent(): string {
   } catch {
     /* ignore */
   }
+  // 2. Dedicated localStorage key (written by setSelectedAgent)
   try {
     const lastUsed = localStorage.getItem(LAST_USED_AGENT_KEY);
     if (lastUsed) return lastUsed;
+  } catch {
+    /* ignore */
+  }
+  // 3. Shared localStorage state (written by persist middleware)
+  try {
+    const shared = localStorage.getItem(STORAGE_KEY);
+    if (shared) {
+      const parsed = JSON.parse(shared);
+      const agent = parsed?.state?.selectedAgent;
+      if (agent) return agent;
+    }
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Description

Add a third-level fallback to getInitialSelectedAgent(), which reads selectedAgent from qwenpaw-agent-storage in localStorage to ensure that the correct value can be obtained from the shared storage of the persist middleware even if qwenpaw-last-used-agent is outdated.

All reads prioritize sessionStorage → localStorage fallback, while writes are written to both locations simultaneously. `qwenpaw-last-used-agent` is an additional dedicated key used to quickly retrieve the last used agent when initializing a new tab.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
