### PR TITLE
fix(qq): reconnect on recoverable websocket socket aborts

### DIFF
--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -71,6 +71,7 @@ RECONNECT_DELAYS = [1, 2, 5, 10, 30, 60]
 RATE_LIMIT_DELAY = 60
 QUICK_DISCONNECT_THRESHOLD = 5
 MAX_QUICK_DISCONNECT_COUNT = 3
+_RECOVERABLE_WS_WINERRORS = frozenset({10053, 10054, 10060})
 
 DEFAULT_API_BASE = "https://api.sgroup.qq.com"
 TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken"
@@ -203,6 +204,22 @@ class QQApiError(RuntimeError):
         self.status = status
         self.data = data
         super().__init__(f"API {path} {status}: {data}")
+
+
+def _is_recoverable_ws_os_error(exc: OSError) -> bool:
+    """Return True for socket errors that should trigger reconnect.
+
+    On Windows, transient remote/local disconnects often surface as plain
+    ``OSError`` subclasses such as ``ConnectionAbortedError`` with WinError
+    10053, which should be treated the same as a closed WebSocket.
+    """
+
+    if isinstance(
+        exc,
+        (ConnectionAbortedError, ConnectionResetError, BrokenPipeError),
+    ):
+        return True
+    return getattr(exc, "winerror", None) in _RECOVERABLE_WS_WINERRORS
 
 
 def _sanitize_qq_text(text: str) -> tuple[str, bool]:
@@ -1667,8 +1684,12 @@ class QQChannel(BaseChannel):
                     break
         except websocket.WebSocketConnectionClosedException:
             pass
-        except OSError:
-            if not self._stop_event.is_set():
+        except OSError as e:
+            if self._stop_event.is_set():
+                pass
+            elif _is_recoverable_ws_os_error(e):
+                logger.warning("qq ws connection lost, reconnecting: %s", e)
+            else:
                 raise
         except Exception as e:
             logger.exception("qq ws loop: %s", e)

--- a/tests/unit/channels/test_qq.py
+++ b/tests/unit/channels/test_qq.py
@@ -1778,7 +1778,10 @@ class TestWSConnectOnce:
         assert result is False
 
     def test_recoverable_os_error_reconnects(self, qq_channel):
-        """Should reconnect on recoverable socket aborts like WinError 10053."""
+        """Should reconnect on recoverable socket aborts.
+
+        Covers Windows-style WinError 10053 disconnects.
+        """
         from qwenpaw.app.channels.qq.channel import _WSState
 
         qq_channel._get_access_token_sync = MagicMock(return_value="token123")

--- a/tests/unit/channels/test_qq.py
+++ b/tests/unit/channels/test_qq.py
@@ -1777,6 +1777,32 @@ class TestWSConnectOnce:
 
         assert result is False
 
+    def test_recoverable_os_error_reconnects(self, qq_channel):
+        """Should reconnect on recoverable socket aborts like WinError 10053."""
+        from qwenpaw.app.channels.qq.channel import _WSState
+
+        qq_channel._get_access_token_sync = MagicMock(return_value="token123")
+
+        state = _WSState()
+
+        err = ConnectionAbortedError(10053, "Software caused connection abort")
+        mock_ws = MagicMock()
+        mock_ws.recv.side_effect = err
+
+        mock_websocket = MagicMock()
+        mock_websocket.create_connection.return_value = mock_ws
+        mock_websocket.WebSocketConnectionClosedException = Exception
+
+        with patch(
+            "qwenpaw.app.channels.qq.channel._get_channel_url_sync",
+            return_value="wss://gateway",
+        ):
+            result = qq_channel._ws_connect_once(state, mock_websocket)
+
+        assert result is True
+        assert state.reconnect_attempts == 1
+        mock_ws.close.assert_called_once()
+
 
 class TestDownloadQQFile:
     """Tests for _download_qq_file function."""

--- a/tests/unit/channels/test_qq.py
+++ b/tests/unit/channels/test_qq.py
@@ -1777,35 +1777,6 @@ class TestWSConnectOnce:
 
         assert result is False
 
-    def test_recoverable_os_error_reconnects(self, qq_channel):
-        """Should reconnect on recoverable socket aborts.
-
-        Covers Windows-style WinError 10053 disconnects.
-        """
-        from qwenpaw.app.channels.qq.channel import _WSState
-
-        qq_channel._get_access_token_sync = MagicMock(return_value="token123")
-
-        state = _WSState()
-
-        err = ConnectionAbortedError(10053, "Software caused connection abort")
-        mock_ws = MagicMock()
-        mock_ws.recv.side_effect = err
-
-        mock_websocket = MagicMock()
-        mock_websocket.create_connection.return_value = mock_ws
-        mock_websocket.WebSocketConnectionClosedException = Exception
-
-        with patch(
-            "qwenpaw.app.channels.qq.channel._get_channel_url_sync",
-            return_value="wss://gateway",
-        ):
-            result = qq_channel._ws_connect_once(state, mock_websocket)
-
-        assert result is True
-        assert state.reconnect_attempts == 1
-        mock_ws.close.assert_called_once()
-
 
 class TestDownloadQQFile:
     """Tests for _download_qq_file function."""


### PR DESCRIPTION
## Summary
Treat recoverable QQ WebSocket socket aborts as reconnectable instead of fatal thread errors.

## Type of Change
- Bug fix

## Component(s) Affected
- Channels
- Tests

## What changed
- treat recoverable `OSError` cases such as WinError 10053/10054/10060 as reconnectable
- preserve the fast-stop behavior added for explicit channel shutdown
- remove the extra regression test per maintainer review

## Why
On Windows, transient QQ socket drops can surface as plain `OSError` subclasses. The current logic re-raises those errors, which stops the QQ WS thread instead of letting the existing reconnect loop resume the session.

## Testing
- `pre-commit run --files tests/unit/channels/test_qq.py`
- `pytest tests/unit/channels/test_qq.py -q`

## Local Verification Evidence
- `pre-commit run --files tests/unit/channels/test_qq.py`
  - Result: passed
- `pytest tests/unit/channels/test_qq.py -q`
  - Result: `116 passed, 1 warning`

## Checklist
- [x] Relevant tests passed locally
- [x] Review follow-up applied
- [x] No documentation update needed for this bug fix
