### PR TITLE
fix(backup): improve error logging with exception details and stack traces

### DIFF
--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -321,7 +321,7 @@ def _commit_and_finalize(
             commit_tmp(d)
             committed.append(d)
             logger.info("Committed restore for %s", d)
-    except Exception as exc:
+    except Exception:
         remaining = [d for d in staged_dirs if d not in set(committed)]
         for d in remaining:
             discard_tmp(d)

--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -325,12 +325,11 @@ def _commit_and_finalize(
         remaining = [d for d in staged_dirs if d not in set(committed)]
         for d in remaining:
             discard_tmp(d)
-        logger.error(
-            "Phase 2 commit failed after committing %d/%d dirs: %s. "
+        logger.exception(
+            "Phase 2 commit failed after committing %d/%d dirs. "
             "Committed (already live): %s. Discarded (rolled back): %s.",
             len(committed),
             len(staged_dirs),
-            exc,
             committed,
             remaining,
         )

--- a/src/qwenpaw/backup/_ops/restore_helpers.py
+++ b/src/qwenpaw/backup/_ops/restore_helpers.py
@@ -100,7 +100,8 @@ def rewrite_agent_workspace_dir(dst: Path, aid: str) -> None:
     except Exception as exc:
         tmp_path.unlink(missing_ok=True)
         logger.warning(
-            "Failed to rewrite workspace_dir in agent.json for agent '%s': %s: %s",
+            "Failed to rewrite workspace_dir in agent.json"
+            " for agent '%s': %s: %s",
             aid,
             type(exc).__name__,
             exc,

--- a/src/qwenpaw/backup/_ops/restore_helpers.py
+++ b/src/qwenpaw/backup/_ops/restore_helpers.py
@@ -97,11 +97,13 @@ def rewrite_agent_workspace_dir(dst: Path, aid: str) -> None:
             json.dump(agent_data, f, ensure_ascii=False, indent=2)
         os.replace(tmp_path, agent_json_path)
         logger.debug("Rewrote workspace_dir in agent.json for agent '%s'", aid)
-    except Exception:
+    except Exception as exc:
         tmp_path.unlink(missing_ok=True)
         logger.warning(
-            "Failed to rewrite workspace_dir in agent.json for agent '%s'",
+            "Failed to rewrite workspace_dir in agent.json for agent '%s': %s: %s",
             aid,
+            type(exc).__name__,
+            exc,
         )
 
 
@@ -148,9 +150,8 @@ def handle_master_key_conflict(
         bak_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(current_master_key, bak)
         return bak
-    except OSError as exc:
-        logger.error(
-            "Failed to back up current master_key before restore: %s",
-            exc,
+    except OSError:
+        logger.exception(
+            "Failed to back up current master_key before restore",
         )
         return None

--- a/src/qwenpaw/backup/_ops/storage.py
+++ b/src/qwenpaw/backup/_ops/storage.py
@@ -44,8 +44,13 @@ def _list_sync() -> list[BackupMeta]:
                     results.append(
                         BackupMeta.model_validate_json(meta_json),
                     )
-        except Exception:
-            logger.warning("Skipping invalid backup file: %s", f.name)
+        except Exception as exc:
+            logger.warning(
+                "Skipping invalid backup file: %s: %s: %s",
+                f.name,
+                type(exc).__name__,
+                exc,
+            )
     results.sort(key=lambda s: s.created_at, reverse=True)
     return results
 
@@ -98,15 +103,22 @@ def _detail_sync(backup_id: str) -> BackupDetail | None:
                     name = data.get("name")
                     if isinstance(name, str) and name:
                         stats[aid]["name"] = name
-                except Exception:
+                except Exception as exc:
                     logger.debug(
-                        "Failed to read agent name from %s in backup %s",
+                        "Failed to read agent name from %s in backup %s: %s: %s",
                         json_path,
                         backup_id,
+                        type(exc).__name__,
+                        exc,
                     )
             return BackupDetail(**meta.model_dump(), workspace_stats=stats)
-    except Exception:
-        logger.warning("Failed to read backup: %s", backup_id)
+    except Exception as exc:
+        logger.warning(
+            "Failed to read backup: %s: %s: %s",
+            backup_id,
+            type(exc).__name__,
+            exc,
+        )
         return None
 
 

--- a/src/qwenpaw/backup/_ops/storage.py
+++ b/src/qwenpaw/backup/_ops/storage.py
@@ -105,7 +105,8 @@ def _detail_sync(backup_id: str) -> BackupDetail | None:
                         stats[aid]["name"] = name
                 except Exception as exc:
                     logger.debug(
-                        "Failed to read agent name from %s in backup %s: %s: %s",
+                        "Failed to read agent name from %s"
+                        " in backup %s: %s: %s",
                         json_path,
                         backup_id,
                         type(exc).__name__,

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -98,12 +98,11 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
                 base_dir,
                 _RESTORE_OLD_SUFFIX,
             )
-        except OSError as exc:
-            logger.error(
-                "Failed to recover %s from %s: %s",
+        except OSError:
+            logger.exception(
+                "Failed to recover %s from %s",
                 base_dir,
                 _RESTORE_OLD_SUFFIX,
-                exc,
             )
             # Keep .restore_old intact to avoid data loss; abort cleanup.
             return
@@ -117,12 +116,11 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
                 _RESTORE_TMP_SUFFIX,
                 tmp,
             )
-        except OSError as exc:
-            logger.error(
-                "Failed to remove stale %s %s: %s",
+        except OSError:
+            logger.exception(
+                "Failed to remove stale %s %s",
                 _RESTORE_TMP_SUFFIX,
                 tmp,
-                exc,
             )
 
     # Scenario 3: interrupted cleanup.
@@ -134,12 +132,11 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
                 _RESTORE_OLD_SUFFIX,
                 old,
             )
-        except OSError as exc:
-            logger.error(
-                "Failed to remove stale %s %s: %s",
+        except OSError:
+            logger.exception(
+                "Failed to remove stale %s %s",
                 _RESTORE_OLD_SUFFIX,
                 old,
-                exc,
             )
 
 
@@ -203,11 +200,10 @@ def _swap_directories(dst: Path, tmp_dst: Path, old_dst: Path) -> None:
                     dst,
                     old_dst,
                 )
-            except OSError as rollback_exc:
-                logger.error(
-                    "Rollback of %s failed: %s — original data is in %s",
+            except OSError:
+                logger.exception(
+                    "Rollback of %s failed — original data is in %s",
                     dst,
-                    rollback_exc,
                     old_dst,
                 )
         raise
@@ -280,9 +276,8 @@ def discard_tmp(dst: Path) -> None:
         if tmp_dst.exists():
             try:
                 shutil.rmtree(tmp_dst)
-            except OSError as exc:
-                logger.error(
-                    "Failed to discard staging directory %s: %s",
+            except OSError:
+                logger.exception(
+                    "Failed to discard staging directory %s",
                     tmp_dst,
-                    exc,
                 )

--- a/src/qwenpaw/backup/orchestration.py
+++ b/src/qwenpaw/backup/orchestration.py
@@ -129,12 +129,10 @@ async def execute_restore(
             "execute_restore finished successfully: backup_id=%s",
             backup_id,
         )
-    except Exception as exc:
-        logger.error(
-            "execute_restore failed for backup_id=%s: %s",
+    except Exception:
+        logger.exception(
+            "execute_restore failed for backup_id=%s",
             backup_id,
-            exc,
-            exc_info=True,
         )
         raise
     finally:

--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -96,7 +96,16 @@ class PlainFormatter(logging.Formatter):
 
         prefix = f"{record.levelname} | {full_path}:{record.lineno}"
         formatted_time = self.formatTime(record, self.datefmt)
-        return f"{formatted_time} | {prefix} | {record.getMessage()}"
+        msg = f"{formatted_time} | {prefix} | {record.getMessage()}"
+
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            msg = msg + "\n" + record.exc_text
+        if record.stack_info:
+            msg = msg + "\n" + self.formatStack(record.stack_info)
+
+        return msg
 
 
 class SuppressPathAccessLogFilter(logging.Filter):


### PR DESCRIPTION
## Description

This PR contains two related logging fixes:

### Commit 1 — Backup/restore module: improve exception log messages

In the backup/restore module, `except` blocks that called `logger.warning` or `logger.error` were missing the exception details — the log message only contained identifiers (file name, backup ID, agent ID) but not the actual error type or message. This made it impossible to diagnose failures from logs alone.

**Changes:**
- For `logger.warning` / `logger.debug` calls (which do **not** attach a traceback automatically): bind `exc` and include `type(exc).__name__: exc` in the format string so the error is visible in the message
- For `logger.exception` calls: remove the redundant `type(exc).__name__` / `exc` arguments that were duplicating what the traceback already shows; keep only the contextual identifiers (backup ID, agent ID, etc.)
- Replace `logger.error(..., exc_info=True)` with `logger.exception(...)` (idiomatic equivalent) in `safe_swap.discard_tmp`
- Reformat two overlong lines in `storage.py` to stay within the 79-column project limit
- Files changed: `backup/_ops/create.py`, `backup/_ops/restore.py`, `backup/_ops/restore_helpers.py`, `backup/_ops/storage.py`, `backup/_utils/safe_swap.py`, `backup/orchestration.py`

### Commit 2 — Fix `PlainFormatter` silently dropping exception tracebacks

**Root cause discovered while reviewing the first commit against a real log file:**

`PlainFormatter` (used by the file handler in `utils/logging.py`) overrides `format()` and calls `record.getMessage()` directly. `getMessage()` only returns the log message text — it does **not** append `exc_info` (the exception type, message, and traceback). As a result, **every `logger.exception()` and `logger.error(..., exc_info=True)` call across the entire codebase produced no traceback in the log file**, making the file handler silently less useful than the console handler (`ColorFormatter`, which correctly calls `super().format(record)`).

The fix mirrors the standard `logging.Formatter.format()` pipeline: after building the main message line, call `self.formatException(record.exc_info)` and `self.formatStack(record.stack_info)` and append the results, exactly as the base class does.

**Impact:** 100+ `logger.exception()` call sites across channels (DingTalk, Feishu, QQ, WeChat, Telegram, etc.), agents, runners, and backup modules will now correctly write full tracebacks to the log file.

**Related Issue:** N/A

**Security Considerations:** None — logging-only change, no behavior or data flow modified.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

N/A — no channel changes.

## Testing

Both changes are purely in logging calls; no functional logic was altered.

**Verified `logger.exception()` writes traceback to file with the `PlainFormatter` fix:**

```python
import logging, sys
from qwenpaw.utils.logging import PlainFormatter

handler = logging.StreamHandler(sys.stdout)
handler.setFormatter(PlainFormatter("%(asctime)s | %(message)s", "%Y-%m-%d %H:%M:%S"))
logger = logging.getLogger("test"); logger.addHandler(handler); logger.setLevel(logging.DEBUG)

try:
    raise ValueError("disk quota exceeded")
except Exception:
    logger.exception("Backup creation failed for %s", "backup-123")

# Output:
# 2026-04-27 19:54:03 | ERROR | <string>:9 | Backup creation failed for backup-123
# Traceback (most recent call last):
#   File "<string>", line 7, in <module>
# ValueError: disk quota exceeded
```

Existing tests pass (`pytest`).

## Additional Notes

`logger.exception(msg)` is exactly equivalent to `logger.error(msg, exc_info=True)` — it logs at ERROR level and automatically attaches the current exception traceback **provided the formatter handles `exc_info`**. The `PlainFormatter` bug meant this guarantee was silently broken for all file-based logging.
