### PR TITLE
fix(feishu): add no-op handlers for reaction events to silence 'processor not found' logs

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -1998,6 +1998,12 @@ class FeishuChannel(BaseChannel):
                     .register_p2_im_message_receive_v1(
                         self._on_message_sync,
                     )
+                    .register_p2_im_message_reaction_created_v1(
+                        lambda _evt: None,
+                    )
+                    .register_p2_im_message_reaction_deleted_v1(
+                        lambda _evt: None,
+                    )
                     .build()
                 )
                 self._ws_client = lark.ws.Client(


### PR DESCRIPTION
## Description
This PR fixes the verbose `processor not found` error logs that appear in the Feishu channel when emoji reaction events are received via WebSocket.

As noted in issue #3888, the Feishu API pushes all subscribed events to the WebSocket connection. Since only `p2_im_message_receive_v1` was registered, any reaction events (`im.message.reaction.created_v1` and `im.message.reaction.deleted_v1`) triggered unhandled exceptions in the event dispatcher.

## Fix
Registered no-op (`lambda _evt: None`) handlers for both reaction events in `src/qwenpaw/app/channels/feishu/channel.py`. This cleanly consumes the events and silences the logs without altering core message processing logic.

## Changes
- `src/qwenpaw/app/channels/feishu/channel.py`
  - Added `.register_p2_im_message_reaction_created_v1(lambda _evt: None)`
  - Added `.register_p2_im_message_reaction_deleted_v1(lambda _evt: None)`

Fixes #3888.