### PR TITLE
fix(context): prevent context loss when tool result exceeds reserve limit

### DIFF
--- a/src/qwenpaw/agents/context/as_msg_handler.py
+++ b/src/qwenpaw/agents/context/as_msg_handler.py
@@ -340,14 +340,14 @@ class AsMsgHandler:
                 stat.total_tokens for stat in msg_stats[-keep_count:]
             )
 
-            if keep_tokens > context_compact_reserve:
-                # Exceeds reserve limit, stop expanding
-                break
-
             if self.validate_tool_ids_alignment(messages[-keep_count:]):
                 # Valid slice, update best (keeps maximum valid)
                 best_keep_count = keep_count
                 best_keep_tokens = keep_tokens
+
+            if keep_tokens > context_compact_reserve:
+                # Exceeds reserve limit, stop expanding
+                break
 
         # Build final split based on best_keep_count
         messages_to_keep = (


### PR DESCRIPTION
## Description

This PR fixes a critical context management bug where the agent enters an infinite loop because it repeatedly loses conversation context after a tool call.

### Root Cause
In `src/qwenpaw/agents/context/as_msg_handler.py`, the `context_check` method validates conversation history slices to determine how many recent messages to keep (`messages_to_keep`). 

The original logic checks the token limit **before** validating tool ID alignment:

```python
            if keep_tokens > context_compact_reserve:
                break # <--- FATAL: Breaks loop before validating alignment

            if self.validate_tool_ids_alignment(messages[-keep_count:]):
                best_keep_count = keep_count
```

**The Bug:**
If the token count of a message slice exceeds `context_compact_reserve` (e.g., when a tool result is large), the loop breaks immediately. If the alignment hasn't been validated yet for this slice size (e.g., `keep_count=1` fails validation, `keep_count=2` exceeds limit), `best_keep_count` remains 0. This results in `messages_to_keep` being an empty list `[]`.

The agent receives an empty context (reset to just System Prompt), causing it to "re-discover" the user's last intent and call the same tool again, creating an infinite loop.

### The Fix
Swap the order of operations: Validate alignment first, then check the token limit.

```python
            if self.validate_tool_ids_alignment(messages[-keep_count:]):
                best_keep_count = keep_count

            if keep_tokens > context_compact_reserve:
                break
```

This ensures that if a slice is valid (e.g., a complete Tool Use + Tool Result pair), it is captured in `best_keep_count` before the token check breaks the loop. Even if the pair slightly exceeds the reserve limit, we preserve the context instead of clearing it.

### Verification

#### Local CI Verification
- **pre-commit (target file):** ✅ All checks passed
  - mypy: Passed
  - black: Passed
  - flake8: Passed
  - pylint: Passed
- **pytest (context module):** ✅ 5/5 tests passed
  - `test_tool_use_result_pair_aligned_when_both_fit`
  - `test_tool_use_result_pair_excluded_when_result_too_large`
  - `test_partial_tool_result_kept_with_tool_use`
  - `test_multiple_tool_pairs_in_same_message`
  - `test_reverse_dependency_tool_use_needs_tool_result`

#### Local Simulation
Created `reproduce_sync_race.py` to simulate the race condition:
- **Original Logic:** Returns 0 kept messages (Context Lost)
- **Fixed Logic:** Returns 2 kept messages (Context Saved)

See Issue #3893 for detailed logs and evidence of the context sync race condition.

Fixes #3893