### PR TITLE
refactor(chat): dedupe repeated model API requests when opening /chat page

### DIFF
--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -72,11 +72,7 @@ export const providerApi = {
       method: "PUT",
       body: JSON.stringify(body),
     }).then((result) => {
-      const key = buildActiveModelQuery({
-        scope: body.scope,
-        agent_id: body.agent_id,
-      });
-      activeModelPromises.delete(key);
+      activeModelPromises.clear();
       return result;
     }),
 

--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -71,6 +71,13 @@ export const providerApi = {
     request<ActiveModelsInfo>("/models/active", {
       method: "PUT",
       body: JSON.stringify(body),
+    }).then((result) => {
+      const key = buildActiveModelQuery({
+        scope: body.scope,
+        agent_id: body.agent_id,
+      });
+      activeModelPromises.delete(key);
+      return result;
     }),
 
   /* ---- Custom provider CRUD ---- */

--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -38,8 +38,17 @@ function buildActiveModelQuery(params?: GetActiveModelsRequest): string {
   return `/models/active?${searchParams.toString()}`;
 }
 
+let listProvidersPromise: Promise<ProviderInfo[]> | null = null;
+const activeModelPromises = new Map<string, Promise<ActiveModelsInfo>>();
+
 export const providerApi = {
-  listProviders: () => request<ProviderInfo[]>("/models"),
+  listProviders: () => {
+    if (listProvidersPromise) return listProvidersPromise;
+    listProvidersPromise = request<ProviderInfo[]>("/models").finally(() => {
+      listProvidersPromise = null;
+    });
+    return listProvidersPromise;
+  },
 
   configureProvider: (providerId: string, body: ProviderConfigRequest) =>
     request<ProviderInfo>(`/models/${encodeURIComponent(providerId)}/config`, {
@@ -47,8 +56,16 @@ export const providerApi = {
       body: JSON.stringify(body),
     }),
 
-  getActiveModels: (params?: GetActiveModelsRequest) =>
-    request<ActiveModelsInfo>(buildActiveModelQuery(params)),
+  getActiveModels: (params?: GetActiveModelsRequest) => {
+    const key = buildActiveModelQuery(params);
+    const cached = activeModelPromises.get(key);
+    if (cached) return cached;
+    const promise = request<ActiveModelsInfo>(key).finally(() => {
+      activeModelPromises.delete(key);
+    });
+    activeModelPromises.set(key, promise);
+    return promise;
+  },
 
   setActiveLlm: (body: ModelSlotRequest) =>
     request<ActiveModelsInfo>("/models/active", {


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

### Problem
Opening the `/chat` page triggered duplicate GET requests:
- `GET /api/models` (×3, pulling 25KB response per request)
- `GET /api/models/active?scope=effective&agent_id=default` (×3)
This happened because multiple components (`ModelSelector`, `useMultimodalCapabilities`) mount simultaneously and fire the same requests without coordination.
### Fix
Cache in-flight promises for `listProviders` and `getActiveModels` inside `providerApi`. If a request with the same key is already pending, return the existing promise instead of starting a new one. The cache is cleared on `finally`, so subsequent calls after completion still fetch fresh data.

- Before:
  - GET /api/models — 3 requests per page load
  - GET /api/models/active — 3 requests per page load
- After:
  - Both endpoints — 1 request per page load

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
