### PR TITLE
fix(WeCom): strip @mention prefix in group chat for correct command detection

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -376,22 +376,24 @@ class WecomChannel(BaseChannel):
             if msgtype == "text":
                 text = (body.get("text") or {}).get("content", "").strip()
                 if text:
-                    # In group chat, strip leading/trailing @mention
+                    # In group chat, strip @mention only when it wraps a
+                    # slash command, to preserve normal conversation text.
                     if chat_type == "group":
                         text = re.sub(
-                            r"^@\S+\s*",
+                            r"^@\S+\s+(?=/)",
                             "",
                             text,
                         ).strip()
-                        text = re.sub(
-                            r"\s*@\S+$",
-                            "",
-                            text,
-                        ).strip()
-                        # If stripping @mention left nothing (bare @bot),
-                        # keep a placeholder so the message isn't dropped.
-                        if not text:
-                            text = "@"
+                        text = (
+                            re.sub(
+                                r"@\S+$",
+                                "",
+                                text,
+                            )
+                            if text.startswith("/")
+                            else text
+                        )
+                        text = text.strip()
                     text_parts.append(text)
 
             elif msgtype == "image":

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -18,6 +18,7 @@ import base64
 import hashlib
 import logging
 import os
+import re
 import sys
 import threading
 from collections import OrderedDict
@@ -375,6 +376,22 @@ class WecomChannel(BaseChannel):
             if msgtype == "text":
                 text = (body.get("text") or {}).get("content", "").strip()
                 if text:
+                    # In group chat, strip leading/trailing @mention
+                    if chat_type == "group":
+                        text = re.sub(
+                            r"^@\S+\s*",
+                            "",
+                            text,
+                        ).strip()
+                        text = re.sub(
+                            r"\s*@\S+$",
+                            "",
+                            text,
+                        ).strip()
+                        # If stripping @mention left nothing (bare @bot),
+                        # keep a placeholder so the message isn't dropped.
+                        if not text:
+                            text = "@"
                     text_parts.append(text)
 
             elif msgtype == "image":


### PR DESCRIPTION
## Description

### Changes:

- Strip leading `@Bot ` when followed by `/` (e.g. `@Bot /approval approve` → `/approval approve`)
- Strip trailing `@Bot` when message starts with `/` (e.g. `/stop@Bot` → `/stop`)
- Normal conversation text is unaffected

**Related Issue:** Fixes #3901 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
