### PR TITLE
fix(mcp): pass execution timeout to mcp client 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "QwenPaw is a **personal assistant** that runs in your own environ
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "agentscope==1.0.19",
+    "agentscope==1.0.19.post1",
     "agentscope-runtime==1.1.4",
     "httpx>=0.27.0",
     "packaging>=24.0",

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -491,6 +491,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 await self.toolkit.register_mcp_client(
                     client,
                     namesake_strategy=namesake_strategy,
+                    execution_timeout=client.timeout,
                 )
             except (ClosedResourceError, asyncio.CancelledError) as error:
                 if self._should_propagate_cancelled_error(error):
@@ -507,6 +508,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                         await self.toolkit.register_mcp_client(
                             recovered_client,
                             namesake_strategy=namesake_strategy,
+                            exeution_timeout=client.timeout,
                         )
                         continue
                     except asyncio.CancelledError as recover_error:

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -64,6 +64,7 @@ class StdIOStatefulClient(StatefulClientBase):
             "ignore",
             "replace",
         ] = "strict",
+        **kwargs,
     ) -> None:
         """Initialize the StdIO MCP client.
 
@@ -108,6 +109,8 @@ class StdIOStatefulClient(StatefulClientBase):
 
         # Tool cache
         self._cached_tools = None
+
+        self.timeout = kwargs.get("timeout")
 
     async def _run_lifecycle(self) -> None:
         """Run MCP client lifecycle in a dedicated task.


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
