### PR TITLE
Console/chat performance

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1566,6 +1566,8 @@
       "placeholder": "Search messages...",
       "noResults": "No results found",
       "resultsCount": "Found {{count}} result(s)",
+      "searching": "Searching {{progress}}...",
+      "loading": "Loading...",
       "userMessage": "User",
       "assistantMessage": "Assistant",
       "titleMatch": "Title"

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1342,6 +1342,8 @@
       "placeholder": "メッセージを検索...",
       "noResults": "結果が見つかりません",
       "resultsCount": "{{count}} 件の結果が見つかりました",
+      "searching": "検索中 {{progress}}...",
+      "loading": "読み込み中...",
       "userMessage": "ユーザー",
       "assistantMessage": "アシスタント",
       "titleMatch": "タイトル"

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1357,6 +1357,8 @@
       "placeholder": "Поиск сообщений...",
       "noResults": "Результаты не найдены",
       "resultsCount": "Найдено {{count}} результат(ов)",
+      "searching": "Поиск {{progress}}...",
+      "loading": "Загрузка...",
       "userMessage": "Пользователь",
       "assistantMessage": "Ассистент",
       "titleMatch": "Название"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1429,6 +1429,8 @@
       "placeholder": "搜索消息...",
       "noResults": "未找到结果",
       "resultsCount": "找到 {{count}} 个结果",
+      "searching": "正在搜索 {{progress}}...",
+      "loading": "加载中...",
       "userMessage": "用户",
       "assistantMessage": "助手",
       "titleMatch": "标题"

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
@@ -173,8 +173,7 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
                   role: msg.role || "",
                   roleLabel: getRoleLabel(msg.role || "", t),
                   text: "",
-                  matchedText:
-                    start > 0 ? `...${matchedText}` : matchedText,
+                  matchedText: start > 0 ? `...${matchedText}` : matchedText,
                   timestamp: chatTimestamp,
                 });
               }
@@ -314,10 +313,10 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
                   progress: searchProgress,
                 })
               : loading
-                ? t("chat.search.loading")
-                : t("chat.search.resultsCount", {
-                    count: searchResults.length,
-                  })}
+              ? t("chat.search.loading")
+              : t("chat.search.resultsCount", {
+                  count: searchResults.length,
+                })}
           </Typography.Text>
         </div>
       )}

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
@@ -62,17 +62,21 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  /** Search progress text, e.g. "3/50" */
+  const [searchProgress, setSearchProgress] = useState("");
   const inputRef = useRef<InputRef>(null);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Monotonic id so slow list/getChat responses cannot overwrite a newer search. */
   const searchSeqRef = useRef(0);
 
-  // Clean up debounce timer on unmount to prevent memory leaks
+  // Clean up on unmount: clear timers and release result data
   useEffect(() => {
     return () => {
       if (searchTimeoutRef.current) {
         clearTimeout(searchTimeoutRef.current);
       }
+      setSearchResults([]);
+      setSearchQuery("");
     };
   }, []);
 
@@ -85,63 +89,52 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
     } else {
       setSearchQuery("");
       setSearchResults([]);
+      setSearchProgress("");
     }
   }, [open]);
 
-  // Search across all sessions
+  // Search across all sessions — serial streaming to avoid memory explosion
   useEffect(() => {
-    // Bump first so clearing input or closing invalidates any in-flight search.
     const seq = ++searchSeqRef.current;
 
     if (!searchQuery.trim()) {
       setSearchResults([]);
+      setSearchProgress("");
       setLoading(false);
       return;
     }
 
-    // Debounce search
     if (searchTimeoutRef.current) {
       clearTimeout(searchTimeoutRef.current);
     }
 
     searchTimeoutRef.current = setTimeout(async () => {
       setLoading(true);
+      setSearchProgress("");
       try {
         const query = searchQuery.toLowerCase();
         const results: SearchResult[] = [];
 
-        // Get all chats from backend
         const chats = await chatApi.listChats();
         if (seq !== searchSeqRef.current) return;
 
-        // Fetch all chat histories in parallel using Promise.all
-        const chatHistories = await Promise.all(
-          chats
-            .filter((chat): chat is typeof chat & { id: string } => !!chat.id)
-            .map(async (chat) => {
-              try {
-                const history = await chatApi.getChat(chat.id);
-                return { chat, history };
-              } catch (err) {
-                console.warn(`Failed to load chat ${chat.id}:`, err);
-                return null;
-              }
-            }),
+        const validChats = chats.filter(
+          (chat): chat is typeof chat & { id: string } => !!chat.id,
         );
+        const totalChats = validChats.length;
 
-        if (seq !== searchSeqRef.current) return;
+        // Serial iteration: load one chat at a time, search, then discard
+        for (let chatIndex = 0; chatIndex < totalChats; chatIndex++) {
+          if (seq !== searchSeqRef.current) return;
 
-        // Search in each chat: title match + message body matches are independent
-        for (const item of chatHistories) {
-          if (!item) continue;
-          const { chat, history } = item;
+          const chat = validChats[chatIndex];
           const chatId = chat.id;
-          if (!chatId) continue;
-          const messages = history.messages || [];
           const chatName = chat.name || "New Chat";
           const chatTimestamp = chat.created_at;
 
-          // Title match: only match real titles, skip the default placeholder
+          setSearchProgress(`${chatIndex + 1}/${totalChats}`);
+
+          // Title match
           if (chat.name && chatName.toLowerCase().includes(query)) {
             results.push({
               chatId,
@@ -154,35 +147,62 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
             });
           }
 
-          // Message body matches
-          for (const msg of messages) {
-            const text = extractTextFromContent(msg.content);
-            const lowerText = text.toLowerCase();
-            if (lowerText.includes(query)) {
-              const matchIndex = lowerText.indexOf(query);
-              const contextLength = 80;
-              const start = Math.max(0, matchIndex - contextLength);
-              const end = Math.min(
-                text.length,
-                matchIndex + searchQuery.length + contextLength,
-              );
-              const matchedText = text.slice(start, end);
+          // Load this chat's messages, search, then let GC reclaim
+          try {
+            const history = await chatApi.getChat(chatId);
+            if (seq !== searchSeqRef.current) return;
 
-              results.push({
-                chatId,
-                chatName,
-                messageId: String(msg.id || ""),
-                role: msg.role || "",
-                roleLabel: getRoleLabel(msg.role || "", t),
-                text,
-                matchedText: start > 0 ? `...${matchedText}` : matchedText,
-                timestamp: chatTimestamp,
-              });
+            const messages = history.messages || [];
+            for (const msg of messages) {
+              const text = extractTextFromContent(msg.content);
+              const lowerText = text.toLowerCase();
+              if (lowerText.includes(query)) {
+                const matchIndex = lowerText.indexOf(query);
+                const contextLength = 80;
+                const start = Math.max(0, matchIndex - contextLength);
+                const end = Math.min(
+                  text.length,
+                  matchIndex + searchQuery.length + contextLength,
+                );
+                const matchedText = text.slice(start, end);
+
+                results.push({
+                  chatId,
+                  chatName,
+                  messageId: String(msg.id || ""),
+                  role: msg.role || "",
+                  roleLabel: getRoleLabel(msg.role || "", t),
+                  text: "",
+                  matchedText:
+                    start > 0 ? `...${matchedText}` : matchedText,
+                  timestamp: chatTimestamp,
+                });
+              }
             }
+            // history and messages go out of scope here — GC can reclaim
+          } catch (err) {
+            console.warn(`Failed to load chat ${chatId}:`, err);
+          }
+
+          // Flush intermediate results every 5 chats for progressive UX
+          if ((chatIndex + 1) % 5 === 0 || chatIndex === totalChats - 1) {
+            if (seq !== searchSeqRef.current) return;
+            const sorted = [...results].sort((a, b) => {
+              if (!a.timestamp && !b.timestamp) return 0;
+              if (!a.timestamp) return 1;
+              if (!b.timestamp) return -1;
+              return (
+                new Date(b.timestamp!).getTime() -
+                new Date(a.timestamp!).getTime()
+              );
+            });
+            setSearchResults(sorted);
           }
         }
 
-        // Sort by timestamp descending
+        if (seq !== searchSeqRef.current) return;
+
+        // Final sort and update
         results.sort((a, b) => {
           if (!a.timestamp && !b.timestamp) return 0;
           if (!a.timestamp) return 1;
@@ -192,7 +212,6 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
           );
         });
 
-        if (seq !== searchSeqRef.current) return;
         setSearchResults(results);
       } catch (err) {
         if (seq !== searchSeqRef.current) return;
@@ -201,6 +220,7 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
       } finally {
         if (seq === searchSeqRef.current) {
           setLoading(false);
+          setSearchProgress("");
         }
       }
     }, 300);
@@ -240,6 +260,7 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
     <Drawer
       open={open}
       onClose={onClose}
+      destroyOnClose
       placement="right"
       width={360}
       closable={false}
@@ -284,11 +305,19 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
         />
       </div>
 
-      {/* Results count */}
-      {searchQuery.trim() && !loading && (
+      {/* Results count / search progress */}
+      {searchQuery.trim() && (
         <div className={styles.resultsCount}>
           <Typography.Text type="secondary">
-            {t("chat.search.resultsCount", { count: searchResults.length })}
+            {loading && searchProgress
+              ? t("chat.search.searching", {
+                  progress: searchProgress,
+                })
+              : loading
+                ? t("chat.search.loading")
+                : t("chat.search.resultsCount", {
+                    count: searchResults.length,
+                  })}
           </Typography.Text>
         </div>
       )}
@@ -297,13 +326,13 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
       <div className={styles.listWrapper}>
         <div className={styles.topGradient} />
         <div className={styles.list}>
-          {loading ? (
+          {loading && searchResults.length === 0 ? (
             <div
               style={{ display: "flex", justifyContent: "center", padding: 40 }}
             >
               <Spin />
             </div>
-          ) : searchQuery.trim() && searchResults.length === 0 ? (
+          ) : searchQuery.trim() && !loading && searchResults.length === 0 ? (
             <Empty
               description={t("chat.search.noResults")}
               style={{ marginTop: 40 }}

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -287,10 +287,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         key: "rename",
         label: t("chat.contextMenu.rename", "Rename"),
         onClick: () =>
-          handleEditStart(
-            contextMenuSessionId,
-            session?.name || "New Chat",
-          ),
+          handleEditStart(contextMenuSessionId, session?.name || "New Chat"),
       },
       {
         key: "pin",

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Drawer } from "antd";
 import { IconButton } from "@agentscope-ai/design";
 import { SparkOperateRightLine } from "@agentscope-ai/icons";
@@ -13,7 +19,15 @@ import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
 import ChatSessionItem from "../ChatSessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
+import {
+  ContextMenu,
+  useContextMenu,
+  type ContextMenuItem,
+} from "../../../../components/ContextMenu";
 import styles from "./index.module.less";
+
+/** Number of sessions to render per page for progressive loading */
+const PAGE_SIZE = 50;
 
 /** Sessions from QwenPaw backend include extra fields beyond the runtime UI type */
 interface ExtendedChatSession extends IAgentScopeRuntimeWebUISession {
@@ -74,17 +88,42 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Current value of the rename input */
   const [editValue, setEditValue] = useState("");
 
+  /** Progressive rendering: only show the first N sessions, load more on scroll */
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  /** Shared context menu — only one instance instead of one per item */
+  const sharedContextMenu = useContextMenu();
+  const [contextMenuSessionId, setContextMenuSessionId] = useState<
+    string | null
+  >(null);
+
+  /** Reset visible count when drawer opens */
+  useEffect(() => {
+    if (props.open) {
+      setVisibleCount(PAGE_SIZE);
+    }
+  }, [props.open]);
+
+  /** Load more sessions when scrolling near the bottom */
+  const handleListScroll = useCallback(() => {
+    const listElement = listRef.current;
+    if (!listElement) return;
+    const { scrollTop, scrollHeight, clientHeight } = listElement;
+    if (scrollHeight - scrollTop - clientHeight < 200) {
+      setVisibleCount((prev) => prev + PAGE_SIZE);
+    }
+  }, []);
+
   /** Sessions sorted by pinned first, then by createdAt descending */
   const sortedSessions = useMemo(() => {
     return [...sessions].sort((a, b) => {
       const extA = a as ExtendedChatSession;
       const extB = b as ExtendedChatSession;
 
-      // Pinned items come first
       if (extA.pinned && !extB.pinned) return -1;
       if (!extA.pinned && extB.pinned) return 1;
 
-      // Then sort by createdAt descending
       const aTime = extA.createdAt;
       const bTime = extB.createdAt;
       if (!aTime && !bTime) return 0;
@@ -94,13 +133,19 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     });
   }, [sessions]);
 
+  /** Only render a slice of sorted sessions for progressive loading */
+  const visibleSessions = useMemo(
+    () => sortedSessions.slice(0, visibleCount),
+    [sortedSessions, visibleCount],
+  );
+
   /** Re-fetch session list from the backend and sync to context state */
   const refreshSessions = useCallback(async () => {
     const list = await sessionApi.getSessionList();
     setSessions(list);
   }, [setSessions]);
 
-  /** Open drawer → refresh session list (same deduped fetch as getSessionList). */
+  /** Open drawer → refresh session list */
   useEffect(() => {
     if (!props.open) return;
 
@@ -113,7 +158,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           setSessions(list);
         }
       } catch (error) {
-        // It's good practice to log errors.
         console.error("Failed to refresh session list:", error);
       }
     };
@@ -168,7 +212,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     setEditValue(value);
   }, []);
 
-  /** Submit rename: send a minimal patch so stale session fields cannot overwrite the title. */
+  /** Submit rename */
   const handleEditSubmit = useCallback(async () => {
     if (!editingSessionId) return;
 
@@ -218,10 +262,66 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     [sessions, refreshSessions],
   );
 
+  /** Show shared context menu for a specific session */
+  const handleItemContextMenu = useCallback(
+    (sessionId: string, event: React.MouseEvent) => {
+      setContextMenuSessionId(sessionId);
+      sharedContextMenu.show(event);
+    },
+    [sharedContextMenu],
+  );
+
+  /** Build context menu items for the currently right-clicked session */
+  const contextMenuItems: ContextMenuItem[] = useMemo(() => {
+    if (!contextMenuSessionId) return [];
+    const session = sessions.find((s) => s.id === contextMenuSessionId) as
+      | ExtendedChatSession
+      | undefined;
+    return [
+      {
+        key: "open",
+        label: t("chat.contextMenu.open", "Open"),
+        onClick: () => handleSessionClick(contextMenuSessionId),
+      },
+      {
+        key: "rename",
+        label: t("chat.contextMenu.rename", "Rename"),
+        onClick: () =>
+          handleEditStart(
+            contextMenuSessionId,
+            session?.name || "New Chat",
+          ),
+      },
+      {
+        key: "pin",
+        label: session?.pinned
+          ? t("chat.contextMenu.unpin", "Unpin")
+          : t("chat.contextMenu.pin", "Pin"),
+        onClick: () => handlePinToggle(contextMenuSessionId),
+      },
+      { key: "divider-1", label: "", divider: true },
+      {
+        key: "delete",
+        label: t("chat.contextMenu.delete", "Delete"),
+        danger: true,
+        onClick: () => handleDelete(contextMenuSessionId),
+      },
+    ];
+  }, [
+    contextMenuSessionId,
+    sessions,
+    t,
+    handleSessionClick,
+    handleEditStart,
+    handlePinToggle,
+    handleDelete,
+  ]);
+
   return (
     <Drawer
       open={props.open}
       onClose={props.onClose}
+      destroyOnClose
       placement="right"
       width={360}
       closable={false}
@@ -263,8 +363,8 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       {/* Session list */}
       <div className={styles.listWrapper}>
         <div className={styles.topGradient} />
-        <div className={styles.list}>
-          {sortedSessions.map((session) => {
+        <div className={styles.list} ref={listRef} onScroll={handleListScroll}>
+          {visibleSessions.map((session) => {
             const ext = session as ExtendedChatSession;
             const channelKey = ext.channel?.trim() || "";
             const channelLabel = channelKey
@@ -273,6 +373,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
             return (
               <ChatSessionItem
                 key={session.id}
+                sessionId={session.id!}
                 name={session.name || "New Chat"}
                 time={formatCreatedAt(ext.createdAt ?? null)}
                 channelKey={channelKey || undefined}
@@ -285,21 +386,29 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
                 editValue={
                   editingSessionId === session.id ? editValue : undefined
                 }
-                onClick={() => handleSessionClick(session.id!)}
-                onEdit={() =>
-                  handleEditStart(session.id!, session.name || "New Chat")
-                }
-                onDelete={() => handleDelete(session.id!)}
-                onPin={() => handlePinToggle(session.id!)}
+                onClick={handleSessionClick}
+                onEdit={handleEditStart}
+                onDelete={handleDelete}
+                onPin={handlePinToggle}
                 onEditChange={handleEditChange}
                 onEditSubmit={handleEditSubmit}
                 onEditCancel={handleEditCancel}
+                onContextMenu={handleItemContextMenu}
               />
             );
           })}
         </div>
         <div className={styles.bottomGradient} />
       </div>
+
+      {/* Shared context menu — single instance for all session items */}
+      <ContextMenu
+        visible={sharedContextMenu.visible}
+        x={sharedContextMenu.x}
+        y={sharedContextMenu.y}
+        items={contextMenuItems}
+        onClose={sharedContextMenu.hide}
+      />
     </Drawer>
   );
 };

--- a/console/src/pages/Chat/components/ChatSessionItem/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback } from "react";
 import { Input } from "antd";
 import { IconButton } from "@agentscope-ai/design";
 import {
@@ -9,15 +9,12 @@ import {
 } from "@agentscope-ai/icons";
 import { useTranslation } from "react-i18next";
 import { ChannelIcon } from "../../../Control/Channels/components";
-import {
-  ContextMenu,
-  useContextMenu,
-  type ContextMenuItem,
-} from "../../../../components/ContextMenu";
 import type { ChatStatus } from "../../../../api/types/chat";
 import styles from "./index.module.less";
 
 interface ChatSessionItemProps {
+  /** Unique session id — used to call back parent handlers without inline closures */
+  sessionId: string;
   /** Session display name */
   name: string;
   /** Pre-formatted creation time string */
@@ -36,26 +33,27 @@ interface ChatSessionItemProps {
   editValue?: string;
   /** Whether the chat is pinned */
   pinned?: boolean;
-  /** Click callback */
-  onClick?: () => void;
-  /** Edit button callback */
-  onEdit?: () => void;
-  /** Delete button callback */
-  onDelete?: () => void;
-  /** Pin button callback */
-  onPin?: () => void;
+  /** Click callback — receives sessionId */
+  onClick?: (sessionId: string) => void;
+  /** Edit button callback — receives (sessionId, currentName) */
+  onEdit?: (sessionId: string, currentName: string) => void;
+  /** Delete button callback — receives sessionId */
+  onDelete?: (sessionId: string) => void;
+  /** Pin button callback — receives sessionId */
+  onPin?: (sessionId: string) => void;
   /** Edit input value change callback */
   onEditChange?: (value: string) => void;
   /** Confirm edit callback (Enter key or blur) */
   onEditSubmit?: () => void;
   /** Cancel edit callback */
   onEditCancel?: () => void;
+  /** Context menu callback — parent manages a shared ContextMenu */
+  onContextMenu?: (sessionId: string, event: React.MouseEvent) => void;
   className?: string;
 }
 
 const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
   const { t } = useTranslation();
-  const contextMenu = useContextMenu();
 
   const inProgress =
     props.generating === true || props.chatStatus === "running";
@@ -63,34 +61,39 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
     ? t("chat.statusInProgress")
     : t("chat.statusIdle");
 
-  const contextMenuItems: ContextMenuItem[] = useMemo(
-    () => [
-      {
-        key: "open",
-        label: t("chat.contextMenu.open", "Open"),
-        onClick: props.onClick,
-      },
-      {
-        key: "rename",
-        label: t("chat.contextMenu.rename", "Rename"),
-        onClick: props.onEdit,
-      },
-      {
-        key: "pin",
-        label: props.pinned
-          ? t("chat.contextMenu.unpin", "Unpin")
-          : t("chat.contextMenu.pin", "Pin"),
-        onClick: props.onPin,
-      },
-      { key: "divider-1", label: "", divider: true },
-      {
-        key: "delete",
-        label: t("chat.contextMenu.delete", "Delete"),
-        danger: true,
-        onClick: props.onDelete,
-      },
-    ],
-    [t, props.onClick, props.onEdit, props.onPin, props.onDelete, props.pinned],
+  const handleClick = useCallback(() => {
+    props.onClick?.(props.sessionId);
+  }, [props.onClick, props.sessionId]);
+
+  const handleEdit = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      props.onEdit?.(props.sessionId, props.name);
+    },
+    [props.onEdit, props.sessionId, props.name],
+  );
+
+  const handleDelete = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      props.onDelete?.(props.sessionId);
+    },
+    [props.onDelete, props.sessionId],
+  );
+
+  const handlePin = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      props.onPin?.(props.sessionId);
+    },
+    [props.onPin, props.sessionId],
+  );
+
+  const handleContextMenu = useCallback(
+    (event: React.MouseEvent) => {
+      props.onContextMenu?.(props.sessionId, event);
+    },
+    [props.onContextMenu, props.sessionId],
   );
 
   const className = [
@@ -106,8 +109,8 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
   return (
     <div
       className={className}
-      onClick={props.editing ? undefined : props.onClick}
-      onContextMenu={props.editing ? undefined : contextMenu.show}
+      onClick={props.editing ? undefined : handleClick}
+      onContextMenu={props.editing ? undefined : handleContextMenu}
     >
       {/* Timeline indicator placeholder */}
       <div className={styles.iconPlaceholder} />
@@ -166,10 +169,7 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
           className={styles.pinButton}
           data-pinned={props.pinned}
           icon={props.pinned ? <SparkMarkFill /> : <SparkMarkLine />}
-          onClick={(e) => {
-            e.stopPropagation();
-            props.onPin?.();
-          }}
+          onClick={handlePin}
         />
       )}
       {/* Action buttons - edit and delete, only visible on hover */}
@@ -179,31 +179,18 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
             bordered={false}
             size="small"
             icon={<SparkEditLine />}
-            onClick={(e) => {
-              e.stopPropagation();
-              props.onEdit?.();
-            }}
+            onClick={handleEdit}
           />
           <IconButton
             bordered={false}
             size="small"
             icon={<SparkDeleteLine />}
-            onClick={(e) => {
-              e.stopPropagation();
-              props.onDelete?.();
-            }}
+            onClick={handleDelete}
           />
         </div>
       )}
-      <ContextMenu
-        visible={contextMenu.visible}
-        x={contextMenu.x}
-        y={contextMenu.y}
-        items={contextMenuItems}
-        onClose={contextMenu.hide}
-      />
     </div>
   );
 };
 
-export default ChatSessionItem;
+export default React.memo(ChatSessionItem);

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -296,16 +296,33 @@ function useMessageHistoryNavigation(
   const historyIndexRef = useRef<number>(-1);
   const draftRef = useRef<string>("");
 
+  /** Cached user messages to avoid re-computing on every keydown */
+  const userMessagesCacheRef = useRef<string[]>([]);
+  const cachedMessageCountRef = useRef<number>(0);
+
   const getUserMessagesWithText = useCallback((): string[] => {
     if (!chatRef.current?.messages?.getMessages) return [];
 
     const allMessages = chatRef.current.messages.getMessages();
     if (!Array.isArray(allMessages)) return [];
 
-    return allMessages
+    const currentCount = allMessages.length;
+    if (
+      userMessagesCacheRef.current.length > 0 &&
+      cachedMessageCountRef.current === currentCount
+    ) {
+      return userMessagesCacheRef.current;
+    }
+
+    const userMessages = allMessages
       .filter((msg) => msg.role === "user")
       .map((msg) => extractTextFromMessage(msg))
       .filter((text) => text.trim().length > 0);
+
+    userMessagesCacheRef.current = userMessages;
+    cachedMessageCountRef.current = currentCount;
+
+    return userMessages;
   }, [chatRef]);
 
   interface MessageResult {


### PR DESCRIPTION
## Description

1. Add `destroyOnClose` to `ChatSessionDrawer`, enabling paginated loading (PAGE_SIZE=50), automatic loading of more content upon scrolling to the bottom, and extracting it as a shared singleton for the parent component (1 instance).

2. Change `ChatSearchPanel` to a `for...of` loop for sequential loading, searching and discarding (only keeping matching fragments).

Add `destroyOnClose` and clear state upon unloading.

3. Add a message-based caching mechanism to `useMessageHistoryNavigation`, reducing continuous key presses from O(n) to O(1).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
