### PR TITLE
perf: cache skill manifest reads to prevent FD exhaustion

### DIFF
--- a/src/qwenpaw/agents/skills_manager.py
+++ b/src/qwenpaw/agents/skills_manager.py
@@ -14,6 +14,7 @@ import tempfile
 import threading
 import time
 import zipfile
+from functools import lru_cache
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -1630,18 +1631,45 @@ def list_workspaces() -> list[dict[str, str]]:
     return workspaces
 
 
+@lru_cache(maxsize=256)
+def _read_file_text_cached(  # pylint: disable=unused-argument
+    path_str: str,
+    mtime_ns: int,
+) -> str:
+    """Return file text cached by *path + mtime*."""
+    return Path(path_str).read_text(encoding="utf-8")
+
+
+def _read_json_mtime_cached(
+    path: Path,
+    default: dict[str, Any],
+) -> dict[str, Any]:
+    """``_read_json_unlocked`` variant with mtime cache."""
+    if not path.exists():
+        return json.loads(json.dumps(default))
+    try:
+        mtime_ns = os.stat(path).st_mtime_ns
+        text = _read_file_text_cached(str(path), mtime_ns)
+        return json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("Malformed JSON in %s, resetting to default", path)
+        return json.loads(json.dumps(default))
+    except OSError:
+        return json.loads(json.dumps(default))
+
+
 def read_skill_manifest(
     workspace_dir: Path,
 ) -> dict[str, Any]:
-    """Return the cached workspace skill manifest."""
+    """Return the workspace skill manifest, cached by file mtime."""
     path = get_workspace_skill_manifest_path(workspace_dir)
-    return _read_json_unlocked(path, _default_workspace_manifest())
+    return _read_json_mtime_cached(path, _default_workspace_manifest())
 
 
 def read_skill_pool_manifest() -> dict[str, Any]:
-    """Return the cached pool skill manifest."""
+    """Return the pool skill manifest, cached by file mtime."""
     path = get_pool_skill_manifest_path()
-    return _read_json_unlocked(path, _default_pool_manifest())
+    return _read_json_mtime_cached(path, _default_pool_manifest())
 
 
 def resolve_effective_skills(


### PR DESCRIPTION
## Description

- Add mtime-based LRU cache for `read_skill_manifest()` and `read_skill_pool_manifest()` to avoid redundant file opens under concurrent load
- Replaces uncached `_read_json_unlocked()` calls with `_read_json_mtime_cached()` that uses `os.stat().st_mtime_ns` as cache key 

Fixes #3892

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
