### PR TITLE
fix(backup): restore secrets on Docker volume mount points

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -25,6 +25,7 @@ from ..constant import (
     DOCS_ENABLED,
     LOG_LEVEL_ENV,
     CORS_ORIGINS,
+    SECRET_DIR,
     WORKING_DIR,
     PROJECT_NAME,
 )
@@ -247,6 +248,16 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         logger.debug(
             "Telemetry collection skipped due to error",
             exc_info=True,
+        )
+
+    try:
+        from ..backup._utils.safe_swap import cleanup_stale_restore_artifacts
+
+        cleanup_stale_restore_artifacts(SECRET_DIR)
+    except Exception:
+        logger.exception(
+            "Failed to clean up stale restore artifacts in %s",
+            SECRET_DIR,
         )
 
     logger.debug("Checking for legacy config migration...")

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -25,7 +25,6 @@ from ..constant import (
     DOCS_ENABLED,
     LOG_LEVEL_ENV,
     CORS_ORIGINS,
-    SECRET_DIR,
     WORKING_DIR,
     PROJECT_NAME,
 )
@@ -229,6 +228,10 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     # Everything here must be lightweight so the server starts quickly.
     # ================================================================
 
+    from ..backup._utils.safe_swap import cleanup_startup_restore_artifacts
+
+    cleanup_startup_restore_artifacts()
+
     from .auth import auto_register_from_env
 
     auto_register_from_env()
@@ -248,16 +251,6 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         logger.debug(
             "Telemetry collection skipped due to error",
             exc_info=True,
-        )
-
-    try:
-        from ..backup._utils.safe_swap import cleanup_stale_restore_artifacts
-
-        cleanup_stale_restore_artifacts(SECRET_DIR)
-    except Exception:
-        logger.exception(
-            "Failed to clean up stale restore artifacts in %s",
-            SECRET_DIR,
         )
 
     logger.debug("Checking for legacy config migration...")

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -29,13 +29,14 @@ from ..constant import (
     PROJECT_NAME,
 )
 from ..__version__ import __version__
+from ..backup._utils.safe_swap import cleanup_startup_restore_artifacts
 from ..utils.logging import (
     setup_logger,
     add_project_file_handler,
     LOG_FILE_PATH,
 )
 from ..utils.system_info import summarize_python_environment
-from .auth import AuthMiddleware
+from .auth import AuthMiddleware, auto_register_from_env
 from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
 from .routers.approval import router as approval_router
@@ -228,11 +229,17 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     # Everything here must be lightweight so the server starts quickly.
     # ================================================================
 
-    from ..backup._utils.safe_swap import cleanup_startup_restore_artifacts
-
-    cleanup_startup_restore_artifacts()
-
-    from .auth import auto_register_from_env
+    try:
+        cleanup_startup_restore_artifacts()
+    except Exception as exc:
+        message = (
+            "QwenPaw startup failed because restore artifact cleanup did not "
+            "complete. Another restore or cleanup may still be running, or "
+            "a previous restore may need recovery before startup can safely "
+            "read restored files."
+        )
+        logger.error(message, exc_info=True)
+        raise RuntimeError(f"{message} Original error: {exc}") from exc
 
     auto_register_from_env()
 

--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -23,6 +23,7 @@ from .._utils.safe_swap import (
     commit_tmp,
     discard_tmp,
     extract_to_tmp,
+    restore_process_lock,
 )
 from ..models import BackupMeta, RestoreBackupRequest
 from ...config.config import AgentProfileRef
@@ -358,6 +359,11 @@ def _commit_and_finalize(
 
 
 def _restore_sync(backup_id: str, req: RestoreBackupRequest) -> None:
+    with restore_process_lock():
+        _restore_sync_locked(backup_id, req)
+
+
+def _restore_sync_locked(backup_id: str, req: RestoreBackupRequest) -> None:
     zp = zip_path(backup_id)
     if not zp.is_file():
         raise FileNotFoundError(f"Backup not found: {backup_id}")

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -67,7 +67,8 @@ def is_rename_blocked(exc: OSError) -> bool:
 def should_skip_zip_member(filename: str, prefix: str) -> bool:
     """Return True when a ZIP member would overwrite restore internals."""
     rel_path = filename[len(prefix) :]
-    if not any(part in RESERVED_NAMES for part in Path(rel_path).parts):
+    parts = Path(rel_path).parts
+    if not parts or parts[0] not in RESERVED_NAMES:
         return False
     logger.warning("Skipping reserved restore path in backup: %s", filename)
     return True

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -112,7 +112,7 @@ def swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
     except Exception:
         logger.exception("Mount-point content swap failed for %s", dst)
         try:
-            recover_mount_point_swap(dst, tmp_dst.name.removeprefix(dst.name))
+            recover_mount_point_swap(dst, tmp_dst)
         except Exception:
             logger.exception(
                 "Immediate recovery failed after mount-point swap error "
@@ -136,19 +136,19 @@ def _swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
     _cleanup_artifacts(dst, tmp_dst)
 
 
-def recover_mount_point_swap(dst: Path, restore_tmp_suffix: str) -> None:
+def recover_mount_point_swap(dst: Path, tmp_dst: Path) -> None:
     """Recover a crashed mount-point fallback swap, if one is present.
 
     ``committed`` means the new content is already complete, so recovery only
     cleans artifacts.  ``installing_new`` means the new content may be partial,
     so recovery removes partial new children and restores old content.
-    ``evacuating_old`` or a missing/invalid state is treated conservatively:
-    move back any old children that had already been evacuated.
+    ``evacuating_old`` or an invalid state is treated conservatively: move back
+    any old children that had already been evacuated.  Markerless old-content
+    directories are left untouched because they are not proven restore state.
     """
     old_dir = dst / OLD_CONTENT_DIR_NAME
     marker = dst / STATE_FILE_NAME
     tmp_marker = dst / STATE_TMP_FILE_NAME
-    tmp_dst = dst.with_name(dst.name + restore_tmp_suffix)
 
     if not (old_dir.exists() or marker.exists() or tmp_marker.exists()):
         return

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -153,6 +153,14 @@ def recover_mount_point_swap(dst: Path, restore_tmp_suffix: str) -> None:
     if not (old_dir.exists() or marker.exists() or tmp_marker.exists()):
         return
 
+    if old_dir.exists() and not (marker.exists() or tmp_marker.exists()):
+        logger.warning(
+            "Leaving possible restore content directory untouched because "
+            "no restore state marker exists: %s",
+            old_dir,
+        )
+        return
+
     state = _read_state(dst)
     try:
         if state == STATE_COMMITTED:

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""Mount-point fallback for backup restore directory swaps.
+
+The normal restore path renames the destination directory away and then renames
+the staged directory into place.  That is the best path for ordinary
+directories, but it fails for Docker volume mount points because the OS refuses
+to rename the mount directory itself (typically ``EBUSY`` on Linux).
+
+This module keeps the mount directory stable and swaps only its children:
+
+1. ``evacuating_old``: move existing children into ``.qwenpaw_restore_old``.
+2. ``installing_new``: move staged children from the sibling ``.restore_tmp``.
+3. ``committed``: new contents are live; only cleanup remains.
+
+The state file lets startup cleanup decide whether to roll back to old content
+or finish cleanup after a crash.  The fallback is intentionally isolated here
+so ``safe_swap.py`` can remain focused on the normal rename protocol.
+"""
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+OLD_CONTENT_DIR_NAME = ".qwenpaw_restore_old"
+STATE_FILE_NAME = ".qwenpaw_restore_state"
+STATE_TMP_FILE_NAME = ".qwenpaw_restore_state.tmp"
+
+STATE_EVACUATING_OLD = "evacuating_old"
+STATE_INSTALLING_NEW = "installing_new"
+STATE_COMMITTED = "committed"
+
+RESERVED_NAMES = frozenset(
+    {
+        OLD_CONTENT_DIR_NAME,
+        STATE_FILE_NAME,
+        STATE_TMP_FILE_NAME,
+    },
+)
+
+_VALID_STATES = frozenset(
+    {
+        STATE_EVACUATING_OLD,
+        STATE_INSTALLING_NEW,
+        STATE_COMMITTED,
+    },
+)
+
+
+def is_mount_point(path: Path) -> bool:
+    """Return True when *path* is a filesystem mount point."""
+    try:
+        return os.path.ismount(path)
+    except OSError:
+        return False
+
+
+def is_rename_blocked(exc: OSError) -> bool:
+    """Return True for errors that mean directory rename cannot be used."""
+    return exc.errno in (errno.EBUSY, errno.EXDEV)
+
+
+def should_skip_zip_member(filename: str, prefix: str) -> bool:
+    """Return True when a ZIP member would overwrite restore internals."""
+    rel_path = filename[len(prefix) :]
+    if not any(part in RESERVED_NAMES for part in Path(rel_path).parts):
+        return False
+    logger.warning("Skipping reserved restore path in backup: %s", filename)
+    return True
+
+
+def prepare_destination_for_swap(
+    dst: Path,
+    tmp_dst: Path,
+    old_dst: Path,
+) -> tuple[bool, bool]:
+    """Prepare *dst* for normal rename swap, or handle mount fallback.
+
+    Returns ``(handled, renamed_to_old)``.  ``handled`` means the mount-point
+    content swap already completed and the caller should return.
+    """
+    if not dst.exists():
+        return False, False
+
+    if is_mount_point(dst):
+        swap_mount_point_contents(dst, tmp_dst)
+        return True, False
+
+    try:
+        dst.rename(old_dst)
+        return False, True
+    except OSError as exc:
+        if not is_rename_blocked(exc):
+            raise
+        logger.debug(
+            "Falling back to content swap for non-renamable %s",
+            dst,
+        )
+        swap_mount_point_contents(dst, tmp_dst)
+        return True, False
+
+
+def swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
+    """Replace mount-point contents without renaming the mount directory."""
+    try:
+        _swap_mount_point_contents(dst, tmp_dst)
+    except Exception:
+        logger.exception("Mount-point content swap failed for %s", dst)
+        try:
+            recover_mount_point_swap(dst, tmp_dst.name.removeprefix(dst.name))
+        except Exception:
+            logger.exception(
+                "Immediate recovery failed after mount-point swap error "
+                "for %s",
+                dst,
+            )
+        raise
+
+
+def _swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
+    """Implementation of mount-point content swap."""
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    _write_state(dst, STATE_EVACUATING_OLD)
+    old_dir.mkdir(exist_ok=True)
+    _move_children(dst, old_dir, excluded_names=RESERVED_NAMES)
+
+    _write_state(dst, STATE_INSTALLING_NEW)
+    _move_children(tmp_dst, dst, excluded_names=RESERVED_NAMES)
+
+    _write_state(dst, STATE_COMMITTED)
+    _cleanup_artifacts(dst, tmp_dst)
+
+
+def recover_mount_point_swap(dst: Path, restore_tmp_suffix: str) -> None:
+    """Recover a crashed mount-point fallback swap, if one is present.
+
+    ``committed`` means the new content is already complete, so recovery only
+    cleans artifacts.  ``installing_new`` means the new content may be partial,
+    so recovery removes partial new children and restores old content.
+    ``evacuating_old`` or a missing/invalid state is treated conservatively:
+    move back any old children that had already been evacuated.
+    """
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    marker = dst / STATE_FILE_NAME
+    tmp_marker = dst / STATE_TMP_FILE_NAME
+    tmp_dst = dst.with_name(dst.name + restore_tmp_suffix)
+
+    if not (old_dir.exists() or marker.exists() or tmp_marker.exists()):
+        return
+
+    state = _read_state(dst)
+    try:
+        if state == STATE_COMMITTED:
+            _cleanup_artifacts(dst, tmp_dst)
+            logger.warning(
+                "Completed cleanup for committed restore of %s",
+                dst,
+            )
+            return
+
+        if state == STATE_INSTALLING_NEW:
+            _rollback_installing_new(
+                dst,
+                tmp_dst,
+                old_dir,
+                marker,
+                tmp_marker,
+            )
+            return
+
+        _restore_old_content(dst)
+        if tmp_dst.exists():
+            shutil.rmtree(tmp_dst)
+        marker.unlink(missing_ok=True)
+        tmp_marker.unlink(missing_ok=True)
+        logger.warning(
+            "Rolled back interrupted restore preparation for %s",
+            dst,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to recover mount-point restore artifacts for %s "
+            "(state=%r, old_dir=%s, tmp_dir=%s)",
+            dst,
+            state,
+            old_dir,
+            tmp_dst,
+        )
+        raise
+
+
+def _rollback_installing_new(
+    dst: Path,
+    tmp_dst: Path,
+    old_dir: Path,
+    marker: Path,
+    tmp_marker: Path,
+) -> None:
+    restored = False
+    if old_dir.exists():
+        _remove_children(dst, excluded_names=RESERVED_NAMES)
+        _restore_old_content(dst)
+        restored = True
+    else:
+        logger.error(
+            "Cannot roll back partial restore of %s: %s is missing",
+            dst,
+            old_dir,
+        )
+
+    if tmp_dst.exists():
+        shutil.rmtree(tmp_dst)
+    marker.unlink(missing_ok=True)
+    tmp_marker.unlink(missing_ok=True)
+    if restored:
+        logger.warning("Rolled back partial restore of %s", dst)
+
+
+def _write_state(dst: Path, state: str) -> None:
+    marker = dst / STATE_FILE_NAME
+    tmp_marker = dst / STATE_TMP_FILE_NAME
+    try:
+        tmp_marker.write_text(state, encoding="utf-8")
+        with open(tmp_marker, "r+b") as handle:
+            os.fsync(handle.fileno())
+        os.replace(tmp_marker, marker)
+
+        try:
+            fd = os.open(dst, os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass
+    except OSError as exc:
+        logger.error(
+            "Failed to write restore state %r for %s via %s: %s",
+            state,
+            dst,
+            tmp_marker,
+            exc,
+        )
+        raise
+
+
+def _read_state(dst: Path) -> str | None:
+    marker = dst / STATE_FILE_NAME
+    try:
+        state = marker.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        if marker.exists():
+            logger.warning(
+                "Could not read restore state from %s: %s",
+                marker,
+                exc,
+            )
+        return None
+    if state in _VALID_STATES:
+        return state
+    logger.warning("Ignoring unknown restore state %r in %s", state, marker)
+    return None
+
+
+def _cleanup_artifacts(dst: Path, tmp_dst: Path) -> None:
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    if old_dir.exists():
+        shutil.rmtree(old_dir)
+    if tmp_dst.exists():
+        shutil.rmtree(tmp_dst)
+    (dst / STATE_TMP_FILE_NAME).unlink(missing_ok=True)
+    (dst / STATE_FILE_NAME).unlink(missing_ok=True)
+
+
+def _restore_old_content(dst: Path) -> None:
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    if old_dir.exists():
+        _move_children(old_dir, dst)
+        shutil.rmtree(old_dir)
+
+
+def _move_children(
+    src: Path,
+    dst: Path,
+    *,
+    excluded_names: frozenset[str] = frozenset(),
+) -> None:
+    dst.mkdir(parents=True, exist_ok=True)
+    for child in list(src.iterdir()):
+        if child.name in excluded_names:
+            continue
+        shutil.move(str(child), str(dst / child.name))
+
+
+def _remove_children(
+    path: Path,
+    *,
+    excluded_names: frozenset[str] = frozenset(),
+) -> None:
+    if not path.exists():
+        return
+    for child in list(path.iterdir()):
+        if child.name in excluded_names:
+            continue
+        _remove_path(child)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -55,7 +55,7 @@ _VALID_STATES = frozenset(
 class SwapPreparation(Enum):
     """Result of preparing a restore destination for commit."""
 
-    READY_TO_INSTALL = "ready_to_install"
+    DST_NOT_EXISTS = "dst_not_exists"
     ORIGINAL_MOVED_TO_OLD = "original_moved_to_old"
     CONTENT_SWAP_COMPLETED = "content_swap_completed"
 
@@ -93,7 +93,7 @@ def prepare_destination_for_swap(
     completed and the caller should return.
     """
     if not dst.exists():
-        return SwapPreparation.READY_TO_INSTALL
+        return SwapPreparation.DST_NOT_EXISTS
 
     if is_mount_point(dst):
         swap_mount_point_contents(dst, tmp_dst)

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -22,6 +22,7 @@ import errno
 import logging
 import os
 import shutil
+from enum import Enum
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,14 @@ _VALID_STATES = frozenset(
 )
 
 
+class SwapPreparation(Enum):
+    """Result of preparing a restore destination for commit."""
+
+    READY_TO_INSTALL = "ready_to_install"
+    ORIGINAL_MOVED_TO_OLD = "original_moved_to_old"
+    CONTENT_SWAP_COMPLETED = "content_swap_completed"
+
+
 def is_mount_point(path: Path) -> bool:
     """Return True when *path* is a filesystem mount point."""
     try:
@@ -77,22 +86,22 @@ def prepare_destination_for_swap(
     dst: Path,
     tmp_dst: Path,
     old_dst: Path,
-) -> tuple[bool, bool]:
+) -> SwapPreparation:
     """Prepare *dst* for normal rename swap, or handle mount fallback.
 
-    Returns ``(handled, renamed_to_old)``.  ``handled`` means the mount-point
-    content swap already completed and the caller should return.
+    ``CONTENT_SWAP_COMPLETED`` means the mount-point content swap already
+    completed and the caller should return.
     """
     if not dst.exists():
-        return False, False
+        return SwapPreparation.READY_TO_INSTALL
 
     if is_mount_point(dst):
         swap_mount_point_contents(dst, tmp_dst)
-        return True, False
+        return SwapPreparation.CONTENT_SWAP_COMPLETED
 
     try:
         dst.rename(old_dst)
-        return False, True
+        return SwapPreparation.ORIGINAL_MOVED_TO_OLD
     except OSError as exc:
         if not is_rename_blocked(exc):
             raise
@@ -101,7 +110,7 @@ def prepare_destination_for_swap(
             dst,
         )
         swap_mount_point_contents(dst, tmp_dst)
-        return True, False
+        return SwapPreparation.CONTENT_SWAP_COMPLETED
 
 
 def swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -124,8 +124,14 @@ def swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
 def _swap_mount_point_contents(dst: Path, tmp_dst: Path) -> None:
     """Implementation of mount-point content swap."""
     old_dir = dst / OLD_CONTENT_DIR_NAME
+    if old_dir.exists():
+        raise RuntimeError(
+            "Reserved restore directory exists before restore starts: "
+            f"{old_dir}",
+        )
+
     _write_state(dst, STATE_EVACUATING_OLD)
-    old_dir.mkdir(exist_ok=True)
+    old_dir.mkdir()
     _move_children(dst, old_dir, excluded_names=RESERVED_NAMES)
 
     _write_state(dst, STATE_INSTALLING_NEW)

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -152,10 +152,9 @@ def recover_mount_point_swap(dst: Path, tmp_dst: Path) -> None:
     directories are left untouched because they are not proven restore state.
     """
     old_dir = dst / OLD_CONTENT_DIR_NAME
-    has_marker = (
-        (dst / STATE_FILE_NAME).exists()
-        or (dst / STATE_TMP_FILE_NAME).exists()
-    )
+    has_marker = (dst / STATE_FILE_NAME).exists() or (
+        dst / STATE_TMP_FILE_NAME
+    ).exists()
 
     if not (old_dir.exists() or has_marker):
         return

--- a/src/qwenpaw/backup/_utils/_mount_swap.py
+++ b/src/qwenpaw/backup/_utils/_mount_swap.py
@@ -64,13 +64,12 @@ def is_rename_blocked(exc: OSError) -> bool:
     return exc.errno in (errno.EBUSY, errno.EXDEV)
 
 
-def should_skip_zip_member(filename: str, prefix: str) -> bool:
-    """Return True when a ZIP member would overwrite restore internals."""
-    rel_path = filename[len(prefix) :]
+def should_skip_restore_internal_path(rel_path: str) -> bool:
+    """Return True when a relative restore path targets internals."""
     parts = Path(rel_path).parts
     if not parts or parts[0] not in RESERVED_NAMES:
         return False
-    logger.warning("Skipping reserved restore path in backup: %s", filename)
+    logger.warning("Skipping reserved restore path in backup: %s", rel_path)
     return True
 
 
@@ -147,13 +146,15 @@ def recover_mount_point_swap(dst: Path, tmp_dst: Path) -> None:
     directories are left untouched because they are not proven restore state.
     """
     old_dir = dst / OLD_CONTENT_DIR_NAME
-    marker = dst / STATE_FILE_NAME
-    tmp_marker = dst / STATE_TMP_FILE_NAME
+    has_marker = (
+        (dst / STATE_FILE_NAME).exists()
+        or (dst / STATE_TMP_FILE_NAME).exists()
+    )
 
-    if not (old_dir.exists() or marker.exists() or tmp_marker.exists()):
+    if not (old_dir.exists() or has_marker):
         return
 
-    if old_dir.exists() and not (marker.exists() or tmp_marker.exists()):
+    if old_dir.exists() and not has_marker:
         logger.warning(
             "Leaving possible restore content directory untouched because "
             "no restore state marker exists: %s",
@@ -172,20 +173,11 @@ def recover_mount_point_swap(dst: Path, tmp_dst: Path) -> None:
             return
 
         if state == STATE_INSTALLING_NEW:
-            _rollback_installing_new(
-                dst,
-                tmp_dst,
-                old_dir,
-                marker,
-                tmp_marker,
-            )
+            _rollback_installing_new(dst, tmp_dst)
             return
 
         _restore_old_content(dst)
-        if tmp_dst.exists():
-            shutil.rmtree(tmp_dst)
-        marker.unlink(missing_ok=True)
-        tmp_marker.unlink(missing_ok=True)
+        _remove_tmp_and_state_markers(dst, tmp_dst)
         logger.warning(
             "Rolled back interrupted restore preparation for %s",
             dst,
@@ -205,10 +197,8 @@ def recover_mount_point_swap(dst: Path, tmp_dst: Path) -> None:
 def _rollback_installing_new(
     dst: Path,
     tmp_dst: Path,
-    old_dir: Path,
-    marker: Path,
-    tmp_marker: Path,
 ) -> None:
+    old_dir = dst / OLD_CONTENT_DIR_NAME
     restored = False
     if old_dir.exists():
         _remove_children(dst, excluded_names=RESERVED_NAMES)
@@ -221,10 +211,7 @@ def _rollback_installing_new(
             old_dir,
         )
 
-    if tmp_dst.exists():
-        shutil.rmtree(tmp_dst)
-    marker.unlink(missing_ok=True)
-    tmp_marker.unlink(missing_ok=True)
+    _remove_tmp_and_state_markers(dst, tmp_dst)
     if restored:
         logger.warning("Rolled back partial restore of %s", dst)
 
@@ -279,6 +266,10 @@ def _cleanup_artifacts(dst: Path, tmp_dst: Path) -> None:
     old_dir = dst / OLD_CONTENT_DIR_NAME
     if old_dir.exists():
         shutil.rmtree(old_dir)
+    _remove_tmp_and_state_markers(dst, tmp_dst)
+
+
+def _remove_tmp_and_state_markers(dst: Path, tmp_dst: Path) -> None:
     if tmp_dst.exists():
         shutil.rmtree(tmp_dst)
     (dst / STATE_TMP_FILE_NAME).unlink(missing_ok=True)

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -45,6 +45,12 @@ import threading
 import zipfile
 from pathlib import Path
 
+from ._mount_swap import (
+    prepare_destination_for_swap,
+    recover_mount_point_swap,
+    should_skip_zip_member,
+)
+
 logger = logging.getLogger(__name__)
 
 _RESTORE_TMP_SUFFIX = ".restore_tmp"
@@ -139,6 +145,8 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
                 old,
             )
 
+    recover_mount_point_swap(base_dir, _RESTORE_TMP_SUFFIX)
+
 
 def _extract_zip_to(
     zf: zipfile.ZipFile,
@@ -155,6 +163,9 @@ def _extract_zip_to(
         if info.is_dir() or not info.filename.startswith(prefix):
             continue
         rel = info.filename[len(prefix) :]
+
+        if should_skip_zip_member(info.filename, prefix):
+            continue
 
         # Zip Slip guard: validate the *logical* destination path.
         if not (base_resolved / rel).resolve().is_relative_to(base_resolved):
@@ -182,10 +193,13 @@ def _swap_directories(dst: Path, tmp_dst: Path, old_dst: Path) -> None:
             f"commit_tmp called without a valid staging directory: {tmp_dst}",
         )
 
-    renamed_to_old = False
-    if dst.exists():
-        dst.rename(old_dst)
-        renamed_to_old = True
+    handled, renamed_to_old = prepare_destination_for_swap(
+        dst,
+        tmp_dst,
+        old_dst,
+    )
+    if handled:
+        return
 
     try:
         tmp_dst.rename(dst)

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -40,10 +40,15 @@ the entire phase-1, phase-2+3, or cleanup operation.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import threading
+import time
 import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import BinaryIO
 
 from ._mount_swap import (
     prepare_destination_for_swap,
@@ -55,6 +60,11 @@ logger = logging.getLogger(__name__)
 
 _RESTORE_TMP_SUFFIX = ".restore_tmp"
 _RESTORE_OLD_SUFFIX = ".restore_old"
+_RESTORE_LOCK_FILE = ".qwenpaw_restore.lock"
+_LOCK_REGION_SIZE = 1
+_LOCK_RETRY_INTERVAL_SECONDS = 0.1
+_LOCK_TIMEOUT_SECONDS_ENV = "QWENPAW_RESTORE_LOCK_TIMEOUT_SECONDS"
+_LOCK_TIMEOUT_SECONDS = 3600.0
 
 # Per-destination threading locks.  The dict itself is guarded by _LOCKS_GUARD.
 _LOCKS: dict[str, threading.Lock] = {}
@@ -66,6 +76,89 @@ def _lock_for(dst: Path) -> threading.Lock:
     key = str(dst.resolve())
     with _LOCKS_GUARD:
         return _LOCKS.setdefault(key, threading.Lock())
+
+
+@contextmanager
+def restore_process_lock() -> Iterator[None]:
+    """Serialise restore and restore-cleanup work across processes."""
+    from ...constant import WORKING_DIR
+
+    lock_path = WORKING_DIR / _RESTORE_LOCK_FILE
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+b") as handle:
+        _acquire_file_lock(handle, lock_path)
+        try:
+            yield
+        finally:
+            _release_file_lock(handle)
+
+
+def _acquire_file_lock(handle: BinaryIO, lock_path: Path) -> None:
+    deadline = time.monotonic() + _restore_lock_timeout_seconds()
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        if handle.read(_LOCK_REGION_SIZE) == b"":
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        while time.monotonic() < deadline:
+            try:
+                msvcrt.locking(
+                    handle.fileno(),
+                    msvcrt.LK_NBLCK,
+                    _LOCK_REGION_SIZE,
+                )
+                break
+            except OSError:
+                time.sleep(_LOCK_RETRY_INTERVAL_SECONDS)
+        else:
+            raise TimeoutError(
+                f"Timed out waiting for restore lock: {lock_path}",
+            )
+        return
+
+    import fcntl
+
+    while time.monotonic() < deadline:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except OSError:
+            time.sleep(_LOCK_RETRY_INTERVAL_SECONDS)
+    else:
+        raise TimeoutError(
+            f"Timed out waiting for restore lock: {lock_path}",
+        )
+
+
+def _restore_lock_timeout_seconds() -> float:
+    raw = os.environ.get(_LOCK_TIMEOUT_SECONDS_ENV)
+    if not raw:
+        return _LOCK_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return _LOCK_TIMEOUT_SECONDS
+    return max(value, 1.0)
+
+
+def _release_file_lock(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(
+            handle.fileno(),
+            msvcrt.LK_UNLCK,
+            _LOCK_REGION_SIZE,
+        )
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def cleanup_stale_restore_artifacts(base_dir: Path) -> None:
@@ -122,8 +215,9 @@ def _dedupe_paths(paths: list[Path]) -> list[Path]:
 
 def cleanup_startup_restore_artifacts() -> None:
     """Recover interrupted restores before startup reads restored content."""
-    for target in _startup_restore_targets():
-        cleanup_stale_restore_artifacts(target)
+    with restore_process_lock():
+        for target in _startup_restore_targets():
+            cleanup_stale_restore_artifacts(target)
 
 
 def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -182,7 +182,10 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
                 old,
             )
 
-    recover_mount_point_swap(base_dir, _RESTORE_TMP_SUFFIX)
+    recover_mount_point_swap(
+        base_dir,
+        base_dir.with_name(base_dir.name + _RESTORE_TMP_SUFFIX),
+    )
 
 
 def _extract_zip_to(

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -89,6 +89,43 @@ def cleanup_stale_restore_artifacts(base_dir: Path) -> None:
         _cleanup_stale_restore_artifacts_locked(base_dir)
 
 
+def _startup_restore_targets() -> list[Path]:
+    """Return restore targets that may be loaded during app startup."""
+    from ...config import load_config
+    from ...config.utils import get_config_path
+    from ...constant import SECRET_DIR, WORKING_DIR
+
+    targets = [
+        SECRET_DIR,
+        WORKING_DIR / "skill_pool",
+    ]
+    config = load_config(get_config_path())
+    for profile in config.agents.profiles.values():
+        targets.append(Path(profile.workspace_dir).expanduser())
+    return _dedupe_paths(targets)
+
+
+def _dedupe_paths(paths: list[Path]) -> list[Path]:
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        try:
+            key = str(path.resolve())
+        except OSError:
+            key = str(path.absolute())
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+    return deduped
+
+
+def cleanup_startup_restore_artifacts() -> None:
+    """Recover interrupted restores before startup reads restored content."""
+    for target in _startup_restore_targets():
+        cleanup_stale_restore_artifacts(target)
+
+
 def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
     """Implementation of cleanup_stale_restore_artifacts (caller holds
     lock)."""

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -172,8 +172,8 @@ def cleanup_stale_restore_artifacts(base_dir: Path) -> None:
        → crash between the two renames in phase 2.  Rename .restore_old
          back to recover original data, then remove any orphaned .restore_tmp.
 
-    2. markerless ``.restore_tmp`` exists
-       -> left untouched; it may be active staging from another process.
+    2. ``.restore_tmp`` exists, ``base_dir`` exists
+       -> crash during phase 1 (extraction); drop the incomplete tmp dir.
 
     3. ``.restore_old`` exists, ``base_dir`` exists
        → crash during phase 3 (rmtree of old); drop the obsolete old dir.
@@ -225,7 +225,6 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
     lock)."""
     tmp = base_dir.with_name(base_dir.name + _RESTORE_TMP_SUFFIX)
     old = base_dir.with_name(base_dir.name + _RESTORE_OLD_SUFFIX)
-    had_old = old.exists()
 
     # Scenario 1: original data saved in .restore_old; recover it first.
     if old.exists() and not base_dir.exists():
@@ -245,27 +244,19 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
             # Keep .restore_old intact to avoid data loss; abort cleanup.
             return
 
-    # Scenario 2: incomplete extraction from a proven interrupted swap.
+    # Scenario 2: incomplete extraction.
     if tmp.exists():
-        if had_old:
-            try:
-                shutil.rmtree(tmp)
-                logger.warning(
-                    "Removed stale %s artifact: %s",
-                    _RESTORE_TMP_SUFFIX,
-                    tmp,
-                )
-            except OSError:
-                logger.exception(
-                    "Failed to remove stale %s %s",
-                    _RESTORE_TMP_SUFFIX,
-                    tmp,
-                )
-        else:
-            logger.debug(
-                "Leaving possible active restore staging untouched because "
-                "no %s artifact exists: %s",
-                _RESTORE_OLD_SUFFIX,
+        try:
+            shutil.rmtree(tmp)
+            logger.warning(
+                "Removed stale %s artifact: %s",
+                _RESTORE_TMP_SUFFIX,
+                tmp,
+            )
+        except OSError:
+            logger.exception(
+                "Failed to remove stale %s %s",
+                _RESTORE_TMP_SUFFIX,
                 tmp,
             )
 

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -79,8 +79,8 @@ def cleanup_stale_restore_artifacts(base_dir: Path) -> None:
        → crash between the two renames in phase 2.  Rename .restore_old
          back to recover original data, then remove any orphaned .restore_tmp.
 
-    2. ``.restore_tmp`` exists, ``base_dir`` exists
-       → crash during phase 1 (extraction); drop the incomplete tmp dir.
+    2. markerless ``.restore_tmp`` exists
+       -> left untouched; it may be active staging from another process.
 
     3. ``.restore_old`` exists, ``base_dir`` exists
        → crash during phase 3 (rmtree of old); drop the obsolete old dir.
@@ -131,6 +131,7 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
     lock)."""
     tmp = base_dir.with_name(base_dir.name + _RESTORE_TMP_SUFFIX)
     old = base_dir.with_name(base_dir.name + _RESTORE_OLD_SUFFIX)
+    had_old = old.exists()
 
     # Scenario 1: original data saved in .restore_old; recover it first.
     if old.exists() and not base_dir.exists():
@@ -150,19 +151,27 @@ def _cleanup_stale_restore_artifacts_locked(base_dir: Path) -> None:
             # Keep .restore_old intact to avoid data loss; abort cleanup.
             return
 
-    # Scenario 2: incomplete extraction.
+    # Scenario 2: incomplete extraction from a proven interrupted swap.
     if tmp.exists():
-        try:
-            shutil.rmtree(tmp)
-            logger.warning(
-                "Removed stale %s artifact: %s",
-                _RESTORE_TMP_SUFFIX,
-                tmp,
-            )
-        except OSError:
-            logger.exception(
-                "Failed to remove stale %s %s",
-                _RESTORE_TMP_SUFFIX,
+        if had_old:
+            try:
+                shutil.rmtree(tmp)
+                logger.warning(
+                    "Removed stale %s artifact: %s",
+                    _RESTORE_TMP_SUFFIX,
+                    tmp,
+                )
+            except OSError:
+                logger.exception(
+                    "Failed to remove stale %s %s",
+                    _RESTORE_TMP_SUFFIX,
+                    tmp,
+                )
+        else:
+            logger.debug(
+                "Leaving possible active restore staging untouched because "
+                "no %s artifact exists: %s",
+                _RESTORE_OLD_SUFFIX,
                 tmp,
             )
 

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 from ._mount_swap import (
+    SwapPreparation,
     prepare_destination_for_swap,
     recover_mount_point_swap,
     should_skip_restore_internal_path,
@@ -332,19 +333,23 @@ def _swap_directories(dst: Path, tmp_dst: Path, old_dst: Path) -> None:
             f"commit_tmp called without a valid staging directory: {tmp_dst}",
         )
 
-    handled, renamed_to_old = prepare_destination_for_swap(
+    preparation = prepare_destination_for_swap(
         dst,
         tmp_dst,
         old_dst,
     )
-    if handled:
+    if preparation is SwapPreparation.CONTENT_SWAP_COMPLETED:
         return
 
     try:
         tmp_dst.rename(dst)
     except OSError:
         # Roll back: restore original data if we moved it away.
-        if renamed_to_old and old_dst.exists() and not dst.exists():
+        if (
+            preparation is SwapPreparation.ORIGINAL_MOVED_TO_OLD
+            and old_dst.exists()
+            and not dst.exists()
+        ):
             try:
                 old_dst.rename(dst)
                 logger.warning(

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -64,7 +64,7 @@ _RESTORE_LOCK_FILE = ".qwenpaw_restore.lock"
 _LOCK_REGION_SIZE = 1
 _LOCK_RETRY_INTERVAL_SECONDS = 0.1
 _LOCK_TIMEOUT_SECONDS_ENV = "QWENPAW_RESTORE_LOCK_TIMEOUT_SECONDS"
-_LOCK_TIMEOUT_SECONDS = 3600.0
+_LOCK_TIMEOUT_SECONDS = 300.0
 
 # Per-destination threading locks.  The dict itself is guarded by _LOCKS_GUARD.
 _LOCKS: dict[str, threading.Lock] = {}
@@ -114,9 +114,7 @@ def _acquire_file_lock(handle: BinaryIO, lock_path: Path) -> None:
             except OSError:
                 time.sleep(_LOCK_RETRY_INTERVAL_SECONDS)
         else:
-            raise TimeoutError(
-                f"Timed out waiting for restore lock: {lock_path}",
-            )
+            _raise_restore_lock_timeout(lock_path)
         return
 
     import fcntl
@@ -128,9 +126,16 @@ def _acquire_file_lock(handle: BinaryIO, lock_path: Path) -> None:
         except OSError:
             time.sleep(_LOCK_RETRY_INTERVAL_SECONDS)
     else:
-        raise TimeoutError(
-            f"Timed out waiting for restore lock: {lock_path}",
-        )
+        _raise_restore_lock_timeout(lock_path)
+
+
+def _raise_restore_lock_timeout(lock_path: Path) -> None:
+    raise TimeoutError(
+        "Timed out waiting to acquire restore lock after "
+        f"{_restore_lock_timeout_seconds():g}s: {lock_path}. "
+        "Another restore or startup cleanup may still be running; "
+        f"set {_LOCK_TIMEOUT_SECONDS_ENV} to wait longer.",
+    )
 
 
 def _restore_lock_timeout_seconds() -> float:

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -188,7 +188,7 @@ def _startup_restore_targets() -> list[Path]:
     from ...config.utils import get_config_path
     from ...constant import WORKING_DIR
 
-    # SECRET_DIR is recovered in load_envs_into_environ before envs.json is read.
+    # SECRET_DIR is recovered before load_envs_into_environ reads envs.json.
     targets = [
         WORKING_DIR / "skill_pool",
     ]

--- a/src/qwenpaw/backup/_utils/safe_swap.py
+++ b/src/qwenpaw/backup/_utils/safe_swap.py
@@ -53,7 +53,7 @@ from typing import BinaryIO
 from ._mount_swap import (
     prepare_destination_for_swap,
     recover_mount_point_swap,
-    should_skip_zip_member,
+    should_skip_restore_internal_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -186,10 +186,10 @@ def _startup_restore_targets() -> list[Path]:
     """Return restore targets that may be loaded during app startup."""
     from ...config import load_config
     from ...config.utils import get_config_path
-    from ...constant import SECRET_DIR, WORKING_DIR
+    from ...constant import WORKING_DIR
 
+    # SECRET_DIR is recovered in load_envs_into_environ before envs.json is read.
     targets = [
-        SECRET_DIR,
         WORKING_DIR / "skill_pool",
     ]
     config = load_config(get_config_path())
@@ -298,7 +298,7 @@ def _extract_zip_to(
             continue
         rel = info.filename[len(prefix) :]
 
-        if should_skip_zip_member(info.filename, prefix):
+        if should_skip_restore_internal_path(rel):
             continue
 
         # Zip Slip guard: validate the *logical* destination path.

--- a/src/qwenpaw/envs/store.py
+++ b/src/qwenpaw/envs/store.py
@@ -253,10 +253,12 @@ def load_envs_into_environ() -> dict[str, str]:
     """
     from qwenpaw.backup._utils.safe_swap import (
         cleanup_stale_restore_artifacts,
+        restore_process_lock,
     )
 
-    cleanup_stale_restore_artifacts(_BOOTSTRAP_SECRET_DIR)
-    envs = load_envs()
+    with restore_process_lock():
+        cleanup_stale_restore_artifacts(_BOOTSTRAP_SECRET_DIR)
+        envs = load_envs()
     bootstrap_envs = {
         key: value
         for key, value in envs.items()

--- a/src/qwenpaw/envs/store.py
+++ b/src/qwenpaw/envs/store.py
@@ -251,6 +251,11 @@ def load_envs_into_environ() -> dict[str, str]:
         Full persisted mapping from envs.json, including protected keys
         that are intentionally not injected into ``os.environ``.
     """
+    from qwenpaw.backup._utils.safe_swap import (
+        cleanup_stale_restore_artifacts,
+    )
+
+    cleanup_stale_restore_artifacts(_BOOTSTRAP_SECRET_DIR)
     envs = load_envs()
     bootstrap_envs = {
         key: value

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -25,6 +25,7 @@ from qwenpaw.backup._utils._mount_swap import (
 from qwenpaw.backup._utils import _mount_swap
 from qwenpaw.backup._utils.safe_swap import (
     cleanup_stale_restore_artifacts,
+    cleanup_startup_restore_artifacts,
     commit_tmp,
     extract_to_tmp,
 )
@@ -248,6 +249,39 @@ def test_cleanup_finishes_committed_state(work_tmp_path: Path) -> None:
     assert not old_dir.exists()
     assert not _tmp_dir(dst).exists()
     assert not (dst / STATE_FILE_NAME).exists()
+
+
+def test_startup_cleanup_recovers_all_restore_targets(
+    work_tmp_path: Path,
+) -> None:
+    targets = [
+        work_tmp_path / "secrets",
+        work_tmp_path / "skill_pool",
+        work_tmp_path / "workspace",
+    ]
+    for target in targets:
+        target.mkdir()
+        old_dir = target / OLD_CONTENT_DIR_NAME
+        old_dir.mkdir()
+        (old_dir / "old.txt").write_text("old", encoding="utf-8")
+        (target / "new-partial.txt").write_text("new", encoding="utf-8")
+        (target / STATE_FILE_NAME).write_text(
+            STATE_INSTALLING_NEW,
+            encoding="utf-8",
+        )
+        _tmp_dir(target).mkdir()
+
+    with patch(
+        "qwenpaw.backup._utils.safe_swap._startup_restore_targets",
+        return_value=targets,
+    ):
+        cleanup_startup_restore_artifacts()
+
+    for target in targets:
+        assert _snapshot(target) == {"old.txt": "old"}
+        assert not (target / OLD_CONTENT_DIR_NAME).exists()
+        assert not _tmp_dir(target).exists()
+        assert not (target / STATE_FILE_NAME).exists()
 
 
 def test_reserved_restore_names_are_not_extracted(

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+"""Tests for backup restore directory swapping."""
+from __future__ import annotations
+
+import errno
+import io
+import shutil
+import uuid
+import zipfile
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.backup._utils._mount_swap import (
+    OLD_CONTENT_DIR_NAME,
+    RESERVED_NAMES,
+    STATE_COMMITTED,
+    STATE_EVACUATING_OLD,
+    STATE_FILE_NAME,
+    STATE_INSTALLING_NEW,
+    STATE_TMP_FILE_NAME,
+)
+from qwenpaw.backup._utils import _mount_swap
+from qwenpaw.backup._utils.safe_swap import (
+    cleanup_stale_restore_artifacts,
+    commit_tmp,
+    extract_to_tmp,
+)
+
+_RESTORE_TMP_SUFFIX = ".restore_tmp"
+
+
+def _make_zip(entries: dict[str, str]) -> zipfile.ZipFile:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    buffer.seek(0)
+    return zipfile.ZipFile(buffer, "r")
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): path.read_text(encoding="utf-8")
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _tmp_dir(dst: Path) -> Path:
+    return dst.with_name(dst.name + _RESTORE_TMP_SUFFIX)
+
+
+@pytest.fixture(name="work_tmp_path")
+def _work_tmp_path() -> Iterator[Path]:
+    root = Path.cwd() / ".safe_swap_test_tmp"
+    path = root / uuid.uuid4().hex
+    path.mkdir(parents=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+        try:
+            root.rmdir()
+        except OSError:
+            pass
+
+
+def test_normal_directory_uses_rename_swap(work_tmp_path: Path) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old", encoding="utf-8")
+
+    zf = _make_zip({"data/secrets/new.txt": "new"})
+    with patch(
+        "qwenpaw.backup._utils._mount_swap.is_mount_point",
+        return_value=False,
+    ), patch(
+        "qwenpaw.backup._utils._mount_swap.swap_mount_point_contents",
+    ) as mount_swap:
+        extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+        commit_tmp(dst)
+
+    mount_swap.assert_not_called()
+    assert _snapshot(dst) == {"new.txt": "new"}
+    assert not _tmp_dir(dst).exists()
+    assert not dst.with_name("secrets.restore_old").exists()
+
+
+def test_mount_point_swap_replaces_contents(work_tmp_path: Path) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old", encoding="utf-8")
+    (dst / "nested").mkdir()
+    (dst / "nested" / "old.txt").write_text("old nested", encoding="utf-8")
+
+    zf = _make_zip(
+        {
+            "data/secrets/new.txt": "new",
+            "data/secrets/nested/new.txt": "new nested",
+        },
+    )
+    with patch(
+        "qwenpaw.backup._utils._mount_swap.is_mount_point",
+        return_value=True,
+    ):
+        extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+        commit_tmp(dst)
+
+    assert _snapshot(dst) == {
+        "nested/new.txt": "new nested",
+        "new.txt": "new",
+    }
+    assert not (dst / OLD_CONTENT_DIR_NAME).exists()
+    assert not (dst / STATE_FILE_NAME).exists()
+    assert not _tmp_dir(dst).exists()
+
+
+def test_ebusy_rename_falls_back_to_mount_point_swap(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old", encoding="utf-8")
+
+    original_rename = Path.rename
+
+    def rename_or_ebusy(self: Path, target: Path) -> Path:
+        if self == dst:
+            raise OSError(errno.EBUSY, "Device or resource busy")
+        return original_rename(self, target)
+
+    zf = _make_zip({"data/secrets/new.txt": "new"})
+    with patch(
+        "qwenpaw.backup._utils._mount_swap.is_mount_point",
+        return_value=False,
+    ), patch.object(Path, "rename", rename_or_ebusy):
+        extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+        commit_tmp(dst)
+
+    assert _snapshot(dst) == {"new.txt": "new"}
+
+
+def test_mount_point_swap_failure_restores_old_contents(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old", encoding="utf-8")
+
+    zf = _make_zip({"data/secrets/new.txt": "new"})
+    original_move_children = getattr(_mount_swap, "_move_children")
+    move_calls = 0
+
+    def move_or_fail(*args, **kwargs):
+        nonlocal move_calls
+        move_calls += 1
+        if move_calls == 2:
+            raise OSError("simulated install failure")
+        return original_move_children(*args, **kwargs)
+
+    with patch(
+        "qwenpaw.backup._utils._mount_swap.is_mount_point",
+        return_value=True,
+    ), patch(
+        "qwenpaw.backup._utils._mount_swap._move_children",
+        move_or_fail,
+    ), pytest.raises(
+        OSError,
+        match="simulated install failure",
+    ):
+        extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+        commit_tmp(dst)
+
+    assert _snapshot(dst) == {"old.txt": "old"}
+    assert not (dst / OLD_CONTENT_DIR_NAME).exists()
+    assert not (dst / STATE_FILE_NAME).exists()
+    assert not _tmp_dir(dst).exists()
+
+
+def test_cleanup_rolls_back_evacuating_old_state(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    old_dir.mkdir()
+    (old_dir / "old-a.txt").write_text("old a", encoding="utf-8")
+    (dst / "old-b.txt").write_text("old b", encoding="utf-8")
+    (dst / STATE_FILE_NAME).write_text(
+        STATE_EVACUATING_OLD,
+        encoding="utf-8",
+    )
+    _tmp_dir(dst).mkdir()
+    (_tmp_dir(dst) / "new.txt").write_text("new", encoding="utf-8")
+
+    cleanup_stale_restore_artifacts(dst)
+
+    assert _snapshot(dst) == {
+        "old-a.txt": "old a",
+        "old-b.txt": "old b",
+    }
+    assert not old_dir.exists()
+    assert not _tmp_dir(dst).exists()
+    assert not (dst / STATE_FILE_NAME).exists()
+
+
+def test_cleanup_rolls_back_installing_new_state(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    old_dir.mkdir()
+    (old_dir / "old.txt").write_text("old", encoding="utf-8")
+    (dst / "new-partial.txt").write_text("new", encoding="utf-8")
+    (dst / STATE_FILE_NAME).write_text(
+        STATE_INSTALLING_NEW,
+        encoding="utf-8",
+    )
+    _tmp_dir(dst).mkdir()
+    (_tmp_dir(dst) / "new-rest.txt").write_text("new", encoding="utf-8")
+
+    cleanup_stale_restore_artifacts(dst)
+
+    assert _snapshot(dst) == {"old.txt": "old"}
+    assert not old_dir.exists()
+    assert not _tmp_dir(dst).exists()
+    assert not (dst / STATE_FILE_NAME).exists()
+
+
+def test_cleanup_finishes_committed_state(work_tmp_path: Path) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    old_dir.mkdir()
+    (old_dir / "old.txt").write_text("old", encoding="utf-8")
+    (dst / "new.txt").write_text("new", encoding="utf-8")
+    (dst / STATE_FILE_NAME).write_text(STATE_COMMITTED, encoding="utf-8")
+    _tmp_dir(dst).mkdir()
+
+    cleanup_stale_restore_artifacts(dst)
+    cleanup_stale_restore_artifacts(dst)
+
+    assert _snapshot(dst) == {"new.txt": "new"}
+    assert not old_dir.exists()
+    assert not _tmp_dir(dst).exists()
+    assert not (dst / STATE_FILE_NAME).exists()
+
+
+def test_reserved_restore_names_are_not_extracted(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    entries = {
+        f"data/secrets/{STATE_FILE_NAME}": "state",
+        f"data/secrets/{STATE_TMP_FILE_NAME}": "state tmp",
+        f"data/secrets/{OLD_CONTENT_DIR_NAME}/payload.txt": "old",
+        "data/secrets/legit.txt": "legit",
+    }
+
+    zf = _make_zip(entries)
+    extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+
+    tmp_dst = _tmp_dir(dst)
+    assert _snapshot(tmp_dst) == {"legit.txt": "legit"}
+    for reserved_name in RESERVED_NAMES:
+        assert not (tmp_dst / reserved_name).exists()

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -251,6 +251,25 @@ def test_cleanup_finishes_committed_state(work_tmp_path: Path) -> None:
     assert not (dst / STATE_FILE_NAME).exists()
 
 
+def test_cleanup_leaves_markerless_old_content_dir_untouched(
+    work_tmp_path: Path,
+) -> None:
+    dst = work_tmp_path / "secrets"
+    dst.mkdir()
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    old_dir.mkdir()
+    (old_dir / "payload.txt").write_text("keep", encoding="utf-8")
+    (dst / "live.txt").write_text("live", encoding="utf-8")
+
+    cleanup_stale_restore_artifacts(dst)
+
+    assert _snapshot(dst) == {
+        f"{OLD_CONTENT_DIR_NAME}/payload.txt": "keep",
+        "live.txt": "live",
+    }
+    assert old_dir.exists()
+
+
 def test_startup_cleanup_recovers_all_restore_targets(
     work_tmp_path: Path,
 ) -> None:

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -259,6 +259,9 @@ def test_reserved_restore_names_are_not_extracted(
         f"data/secrets/{STATE_FILE_NAME}": "state",
         f"data/secrets/{STATE_TMP_FILE_NAME}": "state tmp",
         f"data/secrets/{OLD_CONTENT_DIR_NAME}/payload.txt": "old",
+        f"data/secrets/nested/{STATE_FILE_NAME}/payload.txt": "nested state",
+        f"data/secrets/nested/{STATE_TMP_FILE_NAME}": "nested state tmp",
+        f"data/secrets/nested/{OLD_CONTENT_DIR_NAME}/payload.txt": "nested old",
         "data/secrets/legit.txt": "legit",
     }
 
@@ -266,6 +269,11 @@ def test_reserved_restore_names_are_not_extracted(
     extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
 
     tmp_dst = _tmp_dir(dst)
-    assert _snapshot(tmp_dst) == {"legit.txt": "legit"}
+    assert _snapshot(tmp_dst) == {
+        "legit.txt": "legit",
+        f"nested/{OLD_CONTENT_DIR_NAME}/payload.txt": "nested old",
+        f"nested/{STATE_FILE_NAME}/payload.txt": "nested state",
+        f"nested/{STATE_TMP_FILE_NAME}": "nested state tmp",
+    }
     for reserved_name in RESERVED_NAMES:
         assert not (tmp_dst / reserved_name).exists()

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -261,7 +261,9 @@ def test_reserved_restore_names_are_not_extracted(
         f"data/secrets/{OLD_CONTENT_DIR_NAME}/payload.txt": "old",
         f"data/secrets/nested/{STATE_FILE_NAME}/payload.txt": "nested state",
         f"data/secrets/nested/{STATE_TMP_FILE_NAME}": "nested state tmp",
-        f"data/secrets/nested/{OLD_CONTENT_DIR_NAME}/payload.txt": "nested old",
+        (
+            f"data/secrets/nested/{OLD_CONTENT_DIR_NAME}/payload.txt"
+        ): "nested old",
         "data/secrets/legit.txt": "legit",
     }
 

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -251,6 +251,32 @@ def test_cleanup_leaves_markerless_old_content_dir_untouched(
     assert old_dir.exists()
 
 
+def test_mount_point_restore_rejects_existing_markerless_old_dir(
+    secrets_dir: Path,
+) -> None:
+    dst = secrets_dir
+    old_dir = dst / OLD_CONTENT_DIR_NAME
+    old_dir.mkdir()
+    (old_dir / "payload.txt").write_text("keep", encoding="utf-8")
+    (dst / "live.txt").write_text("live", encoding="utf-8")
+
+    zf = _make_zip({"data/secrets/new.txt": "new"})
+    with patch(
+        "qwenpaw.backup._utils._mount_swap.is_mount_point",
+        return_value=True,
+    ), pytest.raises(RuntimeError, match="Reserved restore directory exists"):
+        extract_to_tmp(zf, "data/secrets/", dst, zip_slip_base=dst)
+        commit_tmp(dst)
+
+    assert _snapshot(dst) == {
+        f"{OLD_CONTENT_DIR_NAME}/payload.txt": "keep",
+        "live.txt": "live",
+    }
+    assert _snapshot(_tmp_dir(dst)) == {"new.txt": "new"}
+    assert not (dst / STATE_FILE_NAME).exists()
+    assert not (dst / STATE_TMP_FILE_NAME).exists()
+
+
 def test_startup_cleanup_recovers_all_restore_targets(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -51,8 +51,8 @@ def _tmp_dir(dst: Path) -> Path:
     return dst.with_name(dst.name + _RESTORE_TMP_SUFFIX)
 
 
-@pytest.fixture
-def secrets_dir(tmp_path: Path) -> Path:
+@pytest.fixture(name="secrets_dir")
+def _secrets_dir(tmp_path: Path) -> Path:
     dst = tmp_path / "secrets"
     dst.mkdir()
     return dst

--- a/tests/unit/backup/test_safe_swap.py
+++ b/tests/unit/backup/test_safe_swap.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import errno
 import io
-import shutil
-import uuid
 import zipfile
-from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -54,24 +51,15 @@ def _tmp_dir(dst: Path) -> Path:
     return dst.with_name(dst.name + _RESTORE_TMP_SUFFIX)
 
 
-@pytest.fixture(name="work_tmp_path")
-def _work_tmp_path() -> Iterator[Path]:
-    root = Path.cwd() / ".safe_swap_test_tmp"
-    path = root / uuid.uuid4().hex
-    path.mkdir(parents=True)
-    try:
-        yield path
-    finally:
-        shutil.rmtree(path, ignore_errors=True)
-        try:
-            root.rmdir()
-        except OSError:
-            pass
-
-
-def test_normal_directory_uses_rename_swap(work_tmp_path: Path) -> None:
-    dst = work_tmp_path / "secrets"
+@pytest.fixture
+def secrets_dir(tmp_path: Path) -> Path:
+    dst = tmp_path / "secrets"
     dst.mkdir()
+    return dst
+
+
+def test_normal_directory_uses_rename_swap(secrets_dir: Path) -> None:
+    dst = secrets_dir
     (dst / "old.txt").write_text("old", encoding="utf-8")
 
     zf = _make_zip({"data/secrets/new.txt": "new"})
@@ -90,9 +78,8 @@ def test_normal_directory_uses_rename_swap(work_tmp_path: Path) -> None:
     assert not dst.with_name("secrets.restore_old").exists()
 
 
-def test_mount_point_swap_replaces_contents(work_tmp_path: Path) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+def test_mount_point_swap_replaces_contents(secrets_dir: Path) -> None:
+    dst = secrets_dir
     (dst / "old.txt").write_text("old", encoding="utf-8")
     (dst / "nested").mkdir()
     (dst / "nested" / "old.txt").write_text("old nested", encoding="utf-8")
@@ -120,10 +107,9 @@ def test_mount_point_swap_replaces_contents(work_tmp_path: Path) -> None:
 
 
 def test_ebusy_rename_falls_back_to_mount_point_swap(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     (dst / "old.txt").write_text("old", encoding="utf-8")
 
     original_rename = Path.rename
@@ -145,10 +131,9 @@ def test_ebusy_rename_falls_back_to_mount_point_swap(
 
 
 def test_mount_point_swap_failure_restores_old_contents(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     (dst / "old.txt").write_text("old", encoding="utf-8")
 
     zf = _make_zip({"data/secrets/new.txt": "new"})
@@ -182,10 +167,9 @@ def test_mount_point_swap_failure_restores_old_contents(
 
 
 def test_cleanup_rolls_back_evacuating_old_state(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     old_dir = dst / OLD_CONTENT_DIR_NAME
     old_dir.mkdir()
     (old_dir / "old-a.txt").write_text("old a", encoding="utf-8")
@@ -209,10 +193,9 @@ def test_cleanup_rolls_back_evacuating_old_state(
 
 
 def test_cleanup_rolls_back_installing_new_state(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     old_dir = dst / OLD_CONTENT_DIR_NAME
     old_dir.mkdir()
     (old_dir / "old.txt").write_text("old", encoding="utf-8")
@@ -232,9 +215,8 @@ def test_cleanup_rolls_back_installing_new_state(
     assert not (dst / STATE_FILE_NAME).exists()
 
 
-def test_cleanup_finishes_committed_state(work_tmp_path: Path) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+def test_cleanup_finishes_committed_state(secrets_dir: Path) -> None:
+    dst = secrets_dir
     old_dir = dst / OLD_CONTENT_DIR_NAME
     old_dir.mkdir()
     (old_dir / "old.txt").write_text("old", encoding="utf-8")
@@ -252,10 +234,9 @@ def test_cleanup_finishes_committed_state(work_tmp_path: Path) -> None:
 
 
 def test_cleanup_leaves_markerless_old_content_dir_untouched(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     old_dir = dst / OLD_CONTENT_DIR_NAME
     old_dir.mkdir()
     (old_dir / "payload.txt").write_text("keep", encoding="utf-8")
@@ -271,12 +252,11 @@ def test_cleanup_leaves_markerless_old_content_dir_untouched(
 
 
 def test_startup_cleanup_recovers_all_restore_targets(
-    work_tmp_path: Path,
+    tmp_path: Path,
 ) -> None:
     targets = [
-        work_tmp_path / "secrets",
-        work_tmp_path / "skill_pool",
-        work_tmp_path / "workspace",
+        tmp_path / "skill_pool",
+        tmp_path / "workspace",
     ]
     for target in targets:
         target.mkdir()
@@ -304,10 +284,9 @@ def test_startup_cleanup_recovers_all_restore_targets(
 
 
 def test_reserved_restore_names_are_not_extracted(
-    work_tmp_path: Path,
+    secrets_dir: Path,
 ) -> None:
-    dst = work_tmp_path / "secrets"
-    dst.mkdir()
+    dst = secrets_dir
     entries = {
         f"data/secrets/{STATE_FILE_NAME}": "state",
         f"data/secrets/{STATE_TMP_FILE_NAME}": "state tmp",


### PR DESCRIPTION
## Description

This PR fixes backup restore for deployments where `SECRET_DIR` is mounted directly as a Docker volume, for example `/app/working.secret`. Linux refuses to rename mount points, so the previous safe-swap commit step failed with `EBUSY` when restoring secrets.

The normal rename-based swap remains the default path. When the restore target is a mount point, or the first destination rename reports `EBUSY`/`EXDEV`, restore now falls back to a marker-protected content swap in `_mount_swap.py`. Startup also runs stale restore cleanup for `SECRET_DIR` before core managers initialize, so interrupted mount-point restores are recovered before secrets are read.

**Related Issue:** Fixes #3827

**Security Considerations:** This touches secret restore handling. The fallback uses reserved marker names, skips those names during extraction, logs state write/recovery failures, and attempts immediate rollback if the mount-point content swap fails so agents do not restart against partially restored secrets.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit` locally on the files changed by this PR and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Ran the focused backup safe-swap tests on Windows:

```bash
.\.venv\Scripts\python.exe -m pytest tests\unit\backup\test_safe_swap.py -q -p no:cacheprovider
```

## Local Verification Evidence

```bash
$env:PRE_COMMIT_HOME = (Join-Path $env:TEMP 'qwenpaw-precommit-cache-codex-3827')
.\.venv\Scripts\python.exe -m pre_commit run --files src/qwenpaw/app/_app.py src/qwenpaw/backup/_utils/_mount_swap.py src/qwenpaw/backup/_utils/safe_swap.py tests/unit/backup/__init__.py tests/unit/backup/test_safe_swap.py
# check python ast: Passed
# fix python encoding pragma: Passed
# detect private key: Passed
# trim trailing whitespace: Passed
# Add trailing commas: Passed
# mypy: Passed
# black: Passed
# flake8: Passed
# pylint: Passed

.\.venv\Scripts\python.exe -m pytest tests\unit\backup\test_safe_swap.py -q -p no:cacheprovider
# 8 passed in 1.94s
```

## Additional Notes

- The fallback is isolated in `src/qwenpaw/backup/_utils/_mount_swap.py`; `safe_swap.py` keeps the existing rename-based protocol as the ordinary path.
- Direct pushes to upstream branches are restricted, so this draft PR is opened from the fork branch.