### PR TITLE
fix(agent-tools): add safe default timeout for delegate_external_agent

### DIFF
--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -433,7 +433,7 @@ async def delegate_external_agent(
     runner: str,
     message: str = "",
     cwd: str = "",
-    max_runtime: Optional[float] = None,
+    max_runtime: float = 60.0,  # Default timeout to prevent infinite hangs
 ) -> ToolResponse | AsyncGenerator[ToolResponse, None]:
     # pylint: disable=too-many-return-statements
     """
@@ -474,13 +474,13 @@ async def delegate_external_agent(
             is empty, a default `hi` is sent.
         cwd (`str`):
             Working directory for the agent. Defaults to the current workspace.
-        max_runtime (`float | None`):
-            Optional max runtime in seconds for a single ACP turn. `None`
-            means no timeout is applied. When the limit is reached, the tool
-            sends ACP cancel for the current turn but keeps the ACP session
-            open, so you can continue later with
-            `delegate_external_agent(action="message", runner=..., `
-            `message="continue")`.
+        max_runtime (`float`, default=60.0):
+            **Maximum runtime in seconds for a single ACP turn.** 
+            This parameter prevents infinite hangs if the external agent fails to respond.
+            Default is 60.0 seconds. Increase this value for complex tasks that require more time.
+            When the limit is reached, the tool sends an ACP cancel signal but keeps the session open,
+            allowing continuation with `delegate_external_agent(action="message", runner=..., message="continue")`.
+            **Note: Always ensure a reasonable timeout is set to avoid indefinite waiting.**
 
     Returns:
         `AsyncGenerator[ToolResponse, None]`:
@@ -494,9 +494,12 @@ async def delegate_external_agent(
     runner_name = str(runner or "").strip()
     message_text = str(message or "")
     try:
-        timeout_seconds = None if max_runtime is None else float(max_runtime)
+        timeout_seconds = float(max_runtime)
     except (TypeError, ValueError):
         return response_text("Error: max_runtime must be a number in seconds.")
+
+    if timeout_seconds <= 0:
+        return response_text("Error: max_runtime must be greater than 0.")
 
     validation_error = _validate_action_inputs(
         action_name=action_name,
@@ -505,8 +508,6 @@ async def delegate_external_agent(
     )
     if validation_error:
         return response_text(validation_error)
-    if timeout_seconds is not None and timeout_seconds <= 0:
-        return response_text("Error: max_runtime must be greater than 0.")
 
     if action_name == "close":
         try:

--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -475,12 +475,17 @@ async def delegate_external_agent(
         cwd (`str`):
             Working directory for the agent. Defaults to the current workspace.
         max_runtime (`float`, default=60.0):
-            **Maximum runtime in seconds for a single ACP turn.** 
-            This parameter prevents infinite hangs if the external agent fails to respond.
-            Default is 60.0 seconds. Increase this value for complex tasks that require more time.
-            When the limit is reached, the tool sends an ACP cancel signal but keeps the session open,
-            allowing continuation with `delegate_external_agent(action="message", runner=..., message="continue")`.
-            **Note: Always ensure a reasonable timeout is set to avoid indefinite waiting.**
+            **Maximum runtime in seconds for a single ACP turn.**
+            Prevents infinite hangs if the external agent fails
+            to respond. Default is 60.0 seconds. Increase for
+            complex tasks that require more time.
+            When the limit is reached, the tool sends an ACP
+            cancel signal but keeps the session open, allowing
+            continuation with ``delegate_external_agent(
+            action="message", runner=...,
+            message="continue")``.
+            **Note: Always set a reasonable timeout to avoid
+            indefinite waiting.**
 
     Returns:
         `AsyncGenerator[ToolResponse, None]`:


### PR DESCRIPTION
## Problem - The `max_runtime` parameter defaults to `None`, causing **infinite waits** when LLMs omit it from tool calls - Tool docstring marks it as 'Optional', which leads LLMs to skip providing the parameter - No safety mechanism exists for slow or unresponsive ACP agents, causing sessions to hang indefinitely  ## Root Cause Analysis When external agents call `delegate_external_agent(action="start", runner="qwen_code", message="...")` without specifying `max_runtime`: 1. Parameter resolves to `None` 2. Timeout logic is skipped (deadline=None) 3. ACP prompt waits forever if the external agent doesn't respond  Users reported sessions getting stuck with no way to recover except manual intervention.  ## Solution This PR implements three key changes:  ### 1. Safe Default Value ```python # Before max_runtime: Optional[float] = None  # ❌ No timeout protection  # After   max_runtime: float = 60.0  # ✅ Default 60-second safety net ```  ### 2. Clear Documentation Updated docstring removes 'Optional' ambiguity and emphasizes: - Purpose: prevents infinite hangs - Default value: 60.0 seconds - Recommendation: always set reasonable timeout for complex tasks  ### 3. Simplified Validation Removed unnecessary `None` handling code paths since the parameter now always has a valid numeric default.  ## Impact ✅ **Backward Compatible**: Existing explicit `max_runtime` values continue unchanged   ✅ **Immediate Safety**: All new calls get 60-second protection by default   ✅ **Flexible**: Complex tasks can override with higher values (e.g., 180.0, 300.0)   ✅ **No Breaking Changes**: Only affects behavior when parameter was omitted  ## Testing Recommendations - Test simple queries (should complete within 60s or timeout gracefully) - Test complex tasks with custom higher timeouts - Verify timeout messages appear correctly after interruption - Ensure ACP session remains open for continuation  ## Related This fix addresses the issue where users experienced frozen sessions when delegating to external agents without understanding the importance of timeout parameters.