### PR TITLE
feat(feishu): introduce FeishuCardHandler and upgrade tool_guard approval to interactive buttons

### DIFF
--- a/src/qwenpaw/app/channels/feishu/card_handler.py
+++ b/src/qwenpaw/app/channels/feishu/card_handler.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+"""Feishu interactive-card handler.
+
+Dispatches all interactive-card work (both outbound rendering and
+inbound ``card.action.trigger`` callbacks) for :class:`FeishuChannel`.
+
+The lark_oapi SDK only allows **one** ``p2.card.action.trigger``
+callback per dispatcher (see ``EventDispatcherHandlerBuilder``), so we
+need a single entry-point on the Feishu side. Instead of growing
+``if/elif`` chains inside that entry-point, each card kind is described
+as a :class:`CardKind` record and registered into two lookup tables:
+
+* ``_by_message_type`` — for outbound: matches an outgoing event's
+  ``metadata.message_type`` to a ``render`` coroutine.
+* ``_by_action_type``  — for inbound: matches the ``type`` field in a
+  button's ``value`` to a ``handle`` callable.
+
+Adding a new card kind only needs:
+
+1. Build/parse helpers in :mod:`card_templates`.
+2. A private ``_send_*`` / ``_handle_*`` pair on this class.
+3. One ``self._register(CardKind(...))`` line in :meth:`_register_kinds`.
+
+The two public entry-points (:meth:`try_send_card_for_event`,
+:meth:`handle_card_action`) stay untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+)
+
+from .card_templates import (
+    TOOL_GUARD_ACTION_TYPE,
+    build_tool_guard_approval_card,
+    build_tool_guard_resolved_card,
+    build_tool_guard_toast,
+    parse_tool_guard_action_value,
+)
+
+try:
+    from lark_oapi.event.callback.model.p2_card_action_trigger import (
+        P2CardActionTrigger,
+        P2CardActionTriggerResponse,
+    )
+except ImportError:  # pragma: no cover - optional dependency
+    P2CardActionTrigger = None  # type: ignore[assignment]
+    P2CardActionTriggerResponse = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle avoidance
+    from .channel import FeishuChannel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Registry record
+# ---------------------------------------------------------------------
+
+# Outbound: given (to_handle, event, send_meta, meta) build + send the
+# card. Returns True if the card was sent so the caller can skip the
+# default text rendering.
+RenderFn = Callable[
+    [str, Any, Dict[str, Any], Dict[str, Any]],
+    Awaitable[bool],
+]
+
+# Inbound: given (event, action_value) produce the synchronous card
+# response for lark_oapi.
+HandleFn = Callable[[Any, Dict[str, Any]], "P2CardActionTriggerResponse"]
+
+
+@dataclass(frozen=True)
+class CardKind:
+    """Describes one kind of interactive card and its handlers."""
+
+    name: str          # human-readable tag for logs
+    message_type: str  # matches ``metadata.message_type`` (outbound)
+    action_type: str   # matches button ``value.type`` (inbound)
+    render: RenderFn
+    handle: HandleFn
+
+
+# ---------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------
+
+
+class FeishuCardHandler:
+    """Registry-based dispatcher for Feishu interactive cards.
+
+    Holds a back-reference to the owning :class:`FeishuChannel` so it
+    can piggyback on the channel's existing primitives
+    (``_send_message``, ``_get_receive_for_send``, the main event loop,
+    etc.) without duplicating state.
+    """
+
+    def __init__(self, channel: "FeishuChannel") -> None:
+        self._channel = channel
+        self._by_message_type: Dict[str, CardKind] = {}
+        self._by_action_type: Dict[str, CardKind] = {}
+        self._register_kinds()
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def _register(self, kind: CardKind) -> None:
+        """Install a card kind into both lookup tables."""
+        if kind.message_type in self._by_message_type:
+            logger.warning(
+                "feishu card: message_type %r already registered, overriding",
+                kind.message_type,
+            )
+        if kind.action_type in self._by_action_type:
+            logger.warning(
+                "feishu card: action_type %r already registered, overriding",
+                kind.action_type,
+            )
+        self._by_message_type[kind.message_type] = kind
+        self._by_action_type[kind.action_type] = kind
+
+    def _register_kinds(self) -> None:
+        """Register every built-in card kind.
+
+        New card kinds: add one ``self._register(CardKind(...))`` line
+        here and implement the render/handle pair below.
+        """
+        self._register(
+            CardKind(
+                name="tool_guard_approval",
+                message_type="tool_guard_approval",
+                action_type=TOOL_GUARD_ACTION_TYPE,
+                render=self._send_tool_guard_approval_card,
+                handle=self._handle_tool_guard_action,
+            ),
+        )
+
+    # ==================================================================
+    # Public entry-points (called by FeishuChannel)
+    # ==================================================================
+
+    async def try_send_card_for_event(
+        self,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> bool:
+        """Render ``event`` as an interactive card if any kind matches.
+
+        Returns ``True`` when a card was sent (the caller should then
+        skip the default text/post rendering), ``False`` otherwise.
+        """
+        meta = self._extract_meta(event)
+        if meta is None:
+            return False
+        kind = self._by_message_type.get(str(meta.get("message_type") or ""))
+        if kind is None:
+            return False
+        try:
+            return await kind.render(to_handle, event, send_meta, meta)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "feishu card render failed: kind=%s", kind.name,
+            )
+            return False
+
+    def handle_card_action(
+        self,
+        data: "P2CardActionTrigger",
+    ) -> "P2CardActionTriggerResponse":
+        """Sync entry for ``card.action.trigger`` (called from WS thread).
+
+        Must return a :class:`P2CardActionTriggerResponse` synchronously
+        so Feishu can use it to update the card UI.
+        """
+        # Guard against cross-instance dispatch: lark_oapi uses a single
+        # module-level loop variable that can be overwritten when
+        # multiple FeishuChannel instances coexist.
+        header = getattr(data, "header", None)
+        event_app_id = getattr(header, "app_id", None)
+        if event_app_id and event_app_id != self._channel.app_id:
+            return P2CardActionTriggerResponse({})
+
+        event = getattr(data, "event", None)
+        action = getattr(event, "action", None) if event else None
+        action_value = getattr(action, "value", None) if action else None
+        if not isinstance(action_value, dict):
+            return P2CardActionTriggerResponse({})
+
+        kind = self._by_action_type.get(str(action_value.get("type") or ""))
+        if kind is None:
+            return P2CardActionTriggerResponse({})
+
+        try:
+            return kind.handle(event, action_value)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "feishu card handle failed: kind=%s", kind.name,
+            )
+            return P2CardActionTriggerResponse({})
+
+    # ==================================================================
+    # tool-guard: outbound
+    # ==================================================================
+
+    async def _send_tool_guard_approval_card(
+        self,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        meta: Dict[str, Any],
+    ) -> bool:
+        if not meta.get("approval_request_id"):
+            return False
+        ch = self._channel
+        if not ch.enabled:
+            return False
+        recv = await ch._get_receive_for_send(to_handle, send_meta)
+        if not recv:
+            logger.warning(
+                "feishu approval card: no receive_id for to_handle=%s",
+                (to_handle or "")[:50],
+            )
+            return False
+        receive_id_type, receive_id = recv
+        body_text = self._extract_body_text(getattr(event, "content", None))
+        session_ctx = self._build_session_ctx(
+            to_handle=to_handle,
+            send_meta=send_meta,
+            receive_id=receive_id,
+            receive_id_type=receive_id_type,
+        )
+        content = build_tool_guard_approval_card(
+            request_id=str(meta.get("approval_request_id") or ""),
+            tool_name=str(meta.get("tool_name") or "tool"),
+            severity=str(meta.get("severity") or "medium"),
+            body_text=body_text,
+            session_ctx=session_ctx,
+        )
+        msg_id = await ch._send_message(
+            receive_id_type,
+            receive_id,
+            "interactive",
+            content,
+        )
+        if msg_id:
+            send_meta["_last_sent_message_id"] = msg_id
+            logger.info(
+                "feishu approval card sent: request_id=%s msg_id=%s",
+                str(meta.get("approval_request_id") or "")[:8],
+                msg_id[:24],
+            )
+            return True
+        logger.warning(
+            "feishu approval card send failed: request_id=%s",
+            str(meta.get("approval_request_id") or "")[:8],
+        )
+        return False
+
+    # ==================================================================
+    # tool-guard: inbound
+    # ==================================================================
+
+    def _handle_tool_guard_action(
+        self,
+        event: Any,
+        action_value: Dict[str, Any],
+    ) -> "P2CardActionTriggerResponse":
+        parsed = parse_tool_guard_action_value(action_value)
+        if not parsed:
+            return P2CardActionTriggerResponse({})
+
+        action = parsed["action"]
+        operator = getattr(event, "operator", None) if event else None
+        operator_open_id = (
+            getattr(operator, "open_id", None) if operator else None
+        ) or ""
+
+        ch = self._channel
+        loop = ch._loop
+
+        # Re-inject the user's decision as a ``/approval`` control
+        # command back into the channel queue, so the magic-command
+        # pipeline (ApprovalCommandHandler) is the single source of
+        # truth that talks to ApprovalService.  The card handler stays
+        # fully decoupled from approval business logic.
+        self._enqueue_approval_command(
+            action=action,
+            request_id=parsed["request_id"],
+            session_ctx=parsed.get("session_ctx") or {},
+            operator_open_id=operator_open_id,
+        )
+
+        tool_name = parsed.get("tool_name") or "tool"
+
+        # Resolve operator display name synchronously via the main loop.
+        # Fall back to the last 6 chars of open_id on lookup failure
+        # (e.g. missing contact permission or timeout).
+        operator_display = operator_open_id[-6:] if operator_open_id else ""
+        if operator_open_id and loop and loop.is_running():
+            try:
+                name = asyncio.run_coroutine_threadsafe(
+                    ch._get_user_name_by_open_id(operator_open_id),
+                    loop,
+                ).result(timeout=2)
+                if name:
+                    operator_display = name
+            except Exception:
+                pass  # keep fallback
+
+        resolved_card = build_tool_guard_resolved_card(
+            tool_name=tool_name,
+            action=action,
+            operator_display=operator_display,
+            body_text=parsed.get("body") or "",
+        )
+        toast = build_tool_guard_toast(action, tool_name)
+        try:
+            return P2CardActionTriggerResponse(
+                {
+                    "toast": toast,
+                    "card": {
+                        "type": "raw",
+                        "data": json.loads(resolved_card),
+                    },
+                },
+            )
+        except Exception:  # pragma: no cover
+            logger.exception("feishu card action: build response failed")
+            return P2CardActionTriggerResponse({"toast": toast})
+
+    def _enqueue_approval_command(
+        self,
+        *,
+        action: str,
+        request_id: str,
+        session_ctx: Dict[str, Any],
+        operator_open_id: str,
+    ) -> None:
+        """Inject ``/approval {action} {request_id}`` into channel queue.
+
+        Reconstructs a native-style payload (see ``FeishuChannel._on_message``)
+        from the session context embedded in the button value, so the
+        runner's command dispatcher picks it up and routes to
+        :class:`ApprovalCommandHandler`.  This is thread-safe: the
+        channel manager's enqueue callback hops onto the main loop via
+        ``loop.call_soon_threadsafe`` internally.
+        """
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            ContentType,
+            TextContent,
+        )
+
+        ch = self._channel
+        enqueue = getattr(ch, "_enqueue", None)
+        if enqueue is None:
+            logger.warning(
+                "feishu card action: channel enqueue not set, drop %s %s",
+                action,
+                request_id[:8],
+            )
+            return
+
+        sender_id = str(session_ctx.get("sender_id") or operator_open_id or "")
+        session_id = str(session_ctx.get("session_id") or "")
+        receive_id = str(session_ctx.get("receive_id") or "")
+        receive_id_type = str(session_ctx.get("receive_id_type") or "open_id")
+        chat_id = str(session_ctx.get("chat_id") or "")
+        chat_type = str(session_ctx.get("chat_type") or "p2p")
+        is_group = bool(session_ctx.get("is_group") or False)
+
+        command_text = f"/approval {action} {request_id}".strip()
+        content_parts = [
+            TextContent(type=ContentType.TEXT, text=command_text),
+        ]
+        meta: Dict[str, Any] = {
+            "feishu_sender_id": sender_id,
+            "feishu_chat_id": chat_id,
+            "feishu_chat_type": chat_type,
+            "feishu_receive_id": receive_id,
+            "feishu_receive_id_type": receive_id_type,
+            "is_group": is_group,
+            "from_card_action": True,
+        }
+        payload = {
+            "channel_id": ch.channel,
+            "sender_id": sender_id,
+            "user_id": sender_id,
+            "session_id": session_id,
+            "content_parts": content_parts,
+            "meta": meta,
+        }
+        try:
+            enqueue(payload)
+            logger.info(
+                "feishu card action enqueued: cmd=%s request=%s session=%s",
+                command_text,
+                request_id[:8],
+                session_id[:12],
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "feishu card action: enqueue command failed: %s %s",
+                action,
+                request_id[:8],
+            )
+
+    # ==================================================================
+    # Helpers
+    # ==================================================================
+
+    @staticmethod
+    def _build_session_ctx(
+        *,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+        receive_id: str,
+        receive_id_type: str,
+    ) -> Dict[str, Any]:
+        """Collect the routing info we need to re-inject a message later.
+
+        ``send_meta`` is the original inbound ``meta`` dict populated in
+        :meth:`FeishuChannel._on_message`, which already contains
+        ``feishu_sender_id`` / ``feishu_chat_id`` / ``feishu_chat_type``
+        / ``is_group`` etc.  We also derive ``session_id`` from
+        ``to_handle`` (``feishu:sw:<short_session_id>``) so the enqueued
+        command lands in the same debounce bucket as the original
+        conversation.
+        """
+        session_id = ""
+        handle = (to_handle or "").strip()
+        if handle.startswith("feishu:sw:"):
+            session_id = handle[len("feishu:sw:"):]
+        return {
+            "session_id": session_id,
+            "sender_id": str(send_meta.get("feishu_sender_id") or ""),
+            "receive_id": receive_id,
+            "receive_id_type": receive_id_type,
+            "chat_id": str(send_meta.get("feishu_chat_id") or ""),
+            "chat_type": str(send_meta.get("feishu_chat_type") or "p2p"),
+            "is_group": bool(send_meta.get("is_group") or False),
+        }
+
+    @staticmethod
+    def _extract_meta(event: Any) -> Optional[Dict[str, Any]]:
+        """Return the original ``Msg.metadata`` dict or ``None``.
+
+        ``Runner`` wraps the original ``Msg.metadata`` under a nested
+        ``metadata`` key when converting to ``Message``; unwrap it.
+        """
+        metadata = getattr(event, "metadata", None) or {}
+        if not isinstance(metadata, dict):
+            return None
+        inner = metadata.get("metadata")
+        meta = inner if isinstance(inner, dict) else metadata
+        return meta if isinstance(meta, dict) else None
+
+    @staticmethod
+    def _extract_body_text(content: Any) -> str:
+        """Flatten ``Message.content`` (``List[ContentPart]``) to plain text."""
+        if not content:
+            return ""
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return ""
+        parts = []
+        for c in content:
+            # TextContent objects have a ``.text`` attribute
+            if hasattr(c, "text") and c.text:
+                parts.append(c.text)
+            elif isinstance(c, dict) and c.get("type") == "text":
+                parts.append(c.get("text") or "")
+        return "".join(parts)
+
+
+__all__ = ["CardKind", "FeishuCardHandler"]

--- a/src/qwenpaw/app/channels/feishu/card_handler.py
+++ b/src/qwenpaw/app/channels/feishu/card_handler.py
@@ -83,9 +83,9 @@ HandleFn = Callable[[Any, Dict[str, Any]], "P2CardActionTriggerResponse"]
 class CardKind:
     """Describes one kind of interactive card and its handlers."""
 
-    name: str          # human-readable tag for logs
+    name: str  # human-readable tag for logs
     message_type: str  # matches ``metadata.message_type`` (outbound)
-    action_type: str   # matches button ``value.type`` (inbound)
+    action_type: str  # matches button ``value.type`` (inbound)
     render: RenderFn
     handle: HandleFn
 
@@ -103,6 +103,10 @@ class FeishuCardHandler:
     (``_send_message``, ``_get_receive_for_send``, the main event loop,
     etc.) without duplicating state.
     """
+
+    # CardHandler is intentionally coupled with its owning FeishuChannel
+    # and shares its private primitives (_send_message / _loop / ...).
+    # pylint: disable=protected-access
 
     def __init__(self, channel: "FeishuChannel") -> None:
         self._channel = channel
@@ -170,7 +174,8 @@ class FeishuCardHandler:
             return await kind.render(to_handle, event, send_meta, meta)
         except Exception:  # pragma: no cover - defensive
             logger.exception(
-                "feishu card render failed: kind=%s", kind.name,
+                "feishu card render failed: kind=%s",
+                kind.name,
             )
             return False
 
@@ -205,7 +210,8 @@ class FeishuCardHandler:
             return kind.handle(event, action_value)
         except Exception:  # pragma: no cover - defensive
             logger.exception(
-                "feishu card handle failed: kind=%s", kind.name,
+                "feishu card handle failed: kind=%s",
+                kind.name,
             )
             return P2CardActionTriggerResponse({})
 
@@ -377,7 +383,7 @@ class FeishuCardHandler:
         receive_id_type = str(session_ctx.get("receive_id_type") or "open_id")
         chat_id = str(session_ctx.get("chat_id") or "")
         chat_type = str(session_ctx.get("chat_type") or "p2p")
-        is_group = bool(session_ctx.get("is_group") or False)
+        is_group = bool(session_ctx.get("is_group"))
 
         command_text = f"/approval {action} {request_id}".strip()
         content_parts = [
@@ -440,7 +446,7 @@ class FeishuCardHandler:
         session_id = ""
         handle = (to_handle or "").strip()
         if handle.startswith("feishu:sw:"):
-            session_id = handle[len("feishu:sw:"):]
+            session_id = handle[len("feishu:sw:") :]
         return {
             "session_id": session_id,
             "sender_id": str(send_meta.get("feishu_sender_id") or ""),
@@ -448,7 +454,7 @@ class FeishuCardHandler:
             "receive_id_type": receive_id_type,
             "chat_id": str(send_meta.get("feishu_chat_id") or ""),
             "chat_type": str(send_meta.get("feishu_chat_type") or "p2p"),
-            "is_group": bool(send_meta.get("is_group") or False),
+            "is_group": bool(send_meta.get("is_group")),
         }
 
     @staticmethod
@@ -467,7 +473,7 @@ class FeishuCardHandler:
 
     @staticmethod
     def _extract_body_text(content: Any) -> str:
-        """Flatten ``Message.content`` (``List[ContentPart]``) to plain text."""
+        """Flatten ``Message.content`` to plain text."""
         if not content:
             return ""
         if isinstance(content, str):

--- a/src/qwenpaw/app/channels/feishu/card_handler.py
+++ b/src/qwenpaw/app/channels/feishu/card_handler.py
@@ -98,14 +98,12 @@ class CardKind:
 class FeishuCardHandler:
     """Registry-based dispatcher for Feishu interactive cards.
 
-    Holds a back-reference to the owning :class:`FeishuChannel` so it
-    can piggyback on the channel's existing primitives
-    (``_send_message``, ``_get_receive_for_send``, the main event loop,
-    etc.) without duplicating state.
+    Holds a back-reference to the owning :class:`FeishuChannel` and
+    piggybacks on its primitives (``_send_message`` / ``_loop`` / ...)
+    without duplicating state.
     """
 
-    # CardHandler is intentionally coupled with its owning FeishuChannel
-    # and shares its private primitives (_send_message / _loop / ...).
+    # Tightly coupled with the owning FeishuChannel by design.
     # pylint: disable=protected-access
 
     def __init__(self, channel: "FeishuChannel") -> None:
@@ -295,11 +293,9 @@ class FeishuCardHandler:
         ch = self._channel
         loop = ch._loop
 
-        # Re-inject the user's decision as a ``/approval`` control
-        # command back into the channel queue, so the magic-command
-        # pipeline (ApprovalCommandHandler) is the single source of
-        # truth that talks to ApprovalService.  The card handler stays
-        # fully decoupled from approval business logic.
+        # Re-inject as ``/approval`` magic command so ApprovalCommandHandler
+        # stays the single source of truth; card handler keeps no business
+        # state of its own.
         self._enqueue_approval_command(
             action=action,
             request_id=parsed["request_id"],
@@ -309,9 +305,8 @@ class FeishuCardHandler:
 
         tool_name = parsed.get("tool_name") or "tool"
 
-        # Resolve operator display name synchronously via the main loop.
-        # Fall back to the last 6 chars of open_id on lookup failure
-        # (e.g. missing contact permission or timeout).
+        # Resolve operator display name on the main loop; fall back to
+        # the last 6 chars of open_id on lookup failure.
         operator_display = operator_open_id[-6:] if operator_open_id else ""
         if operator_open_id and loop and loop.is_running():
             try:
@@ -353,14 +348,11 @@ class FeishuCardHandler:
         session_ctx: Dict[str, Any],
         operator_open_id: str,
     ) -> None:
-        """Inject ``/approval {action} {request_id}`` into channel queue.
+        """Inject ``/approval {action} {request_id}`` into the channel queue.
 
-        Reconstructs a native-style payload (see ``FeishuChannel._on_message``)
-        from the session context embedded in the button value, so the
-        runner's command dispatcher picks it up and routes to
-        :class:`ApprovalCommandHandler`.  This is thread-safe: the
-        channel manager's enqueue callback hops onto the main loop via
-        ``loop.call_soon_threadsafe`` internally.
+        Rebuilds a native payload from ``session_ctx`` so the runner's
+        command dispatcher routes it to :class:`ApprovalCommandHandler`.
+        Thread-safe via the manager's enqueue callback.
         """
         from agentscope_runtime.engine.schemas.agent_schemas import (
             ContentType,
@@ -433,15 +425,11 @@ class FeishuCardHandler:
         receive_id: str,
         receive_id_type: str,
     ) -> Dict[str, Any]:
-        """Collect the routing info we need to re-inject a message later.
+        """Collect routing info needed to re-inject a message later.
 
-        ``send_meta`` is the original inbound ``meta`` dict populated in
-        :meth:`FeishuChannel._on_message`, which already contains
-        ``feishu_sender_id`` / ``feishu_chat_id`` / ``feishu_chat_type``
-        / ``is_group`` etc.  We also derive ``session_id`` from
-        ``to_handle`` (``feishu:sw:<short_session_id>``) so the enqueued
-        command lands in the same debounce bucket as the original
-        conversation.
+        ``session_id`` is derived from ``to_handle``
+        (``feishu:sw:<short_session_id>``) so the enqueued command
+        lands in the same debounce bucket as the original conversation.
         """
         session_id = ""
         handle = (to_handle or "").strip()

--- a/src/qwenpaw/app/channels/feishu/card_templates.py
+++ b/src/qwenpaw/app/channels/feishu/card_templates.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+"""Feishu interactive-card templates.
+
+Pure, side-effect-free helpers that build card JSON payloads and parse
+``card.action.trigger`` values. Grouped by card kind; when more card
+kinds are added (e.g. poll, form), put their builders + parsers here.
+
+Kept separate from :mod:`card_handler` so the templates are easy to
+unit-test and reuse without pulling in any channel-level dependency.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+# =====================================================================
+# Shared utilities
+# =====================================================================
+
+def _truncate(text: str, limit: int) -> str:
+    if not text:
+        return ""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+# =====================================================================
+# Tool-guard approval card
+# =====================================================================
+
+# Marker in ``CallBackAction.value`` that identifies tool-guard
+# approve/deny buttons; avoids clashing with other interactive cards.
+TOOL_GUARD_ACTION_TYPE = "tool_guard_approval"
+
+_TOOL_GUARD_SEVERITY_TEMPLATE = {
+    "critical": "red",
+    "high": "red",
+    "medium": "orange",
+    "low": "yellow",
+}
+
+
+def _tool_guard_severity_template(severity: str) -> str:
+    return _TOOL_GUARD_SEVERITY_TEMPLATE.get(
+        (severity or "").lower(),
+        "orange",
+    )
+
+
+def build_tool_guard_approval_card(
+    *,
+    request_id: str,
+    tool_name: str,
+    severity: str,
+    body_text: str,
+    session_ctx: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build the tool-guard approval card JSON string.
+
+    ``body_text`` is the pre-rendered, already-i18n'd message produced
+    by tool_guard_mixin; it is used verbatim as the markdown body.
+
+    Each button's ``value`` is echoed back in the
+    ``card.action.trigger`` event, so we embed ``request_id`` plus a
+    ``type`` marker and a snapshot of ``body_text`` (so the resolved
+    card can reconstruct the original content without any extra API
+    call on the WS thread).
+
+    ``session_ctx`` carries the originating chat's routing info
+    (session_id / sender_id / receive_id / chat_id / is_group ...).  It
+    is echoed back inside the button value so the inbound handler can
+    re-inject a ``/approval approve <id>`` message into the channel's
+    queue with the right context, instead of calling ApprovalService
+    directly.
+    """
+    text = body_text or ""
+    markdown_content = _truncate(text, 1800)
+    body_snapshot = _truncate(text, 1500)
+    ctx_snapshot = dict(session_ctx or {})
+    approve_value = {
+        "type": TOOL_GUARD_ACTION_TYPE,
+        "action": "approve",
+        "request_id": request_id,
+        "tool_name": tool_name,
+        "severity": severity or "medium",
+        "body": body_snapshot,
+        "session_ctx": ctx_snapshot,
+    }
+    deny_value = {**approve_value, "action": "deny"}
+
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "template": _tool_guard_severity_template(severity),
+            "title": {
+                "tag": "plain_text",
+                "content": "🛡️ Tool Approval Required",
+            },
+        },
+        "elements": [
+            {"tag": "markdown", "content": markdown_content},
+            {"tag": "hr"},
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {
+                            "tag": "plain_text",
+                            "content": "✅ Approve",
+                        },
+                        "type": "primary",
+                        "value": approve_value,
+                    },
+                    {
+                        "tag": "button",
+                        "text": {
+                            "tag": "plain_text",
+                            "content": "❌ Deny",
+                        },
+                        "type": "danger",
+                        "value": deny_value,
+                    },
+                ],
+            },
+        ],
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
+def build_tool_guard_resolved_card(
+    *,
+    tool_name: str,
+    action: str,
+    operator_display: str = "",
+    body_text: str = "",
+) -> str:
+    """Card that replaces the original one after a button click.
+
+    ``action`` is the raw button action string (``"approve"`` or
+    ``"deny"``); any other value is treated as an expired/unknown
+    fallback.  We keep this layer independent of the tool-guard enum
+    so templates stay pure-data.
+
+    The original approval body (``body_text``) is preserved so the
+    card keeps the full tool-guard context; only the button row is
+    replaced by a single status line.
+    """
+    by = f" by `{operator_display}`" if operator_display else ""
+    if action == "approve":
+        title = "✅ Approved"
+        template = "green"
+        status_line = f"Tool `{tool_name}` approved{by}."
+    elif action == "deny":
+        title = "🚫 Denied"
+        template = "red"
+        status_line = f"Tool `{tool_name}` denied{by}."
+    else:
+        title = "⌛ Expired"
+        template = "grey"
+        status_line = f"Approval for `{tool_name}` has expired."
+
+    elements: list = []
+    if body_text:
+        elements.append(
+            {"tag": "markdown", "content": _truncate(body_text, 1800)},
+        )
+        elements.append({"tag": "hr"})
+    elements.append({"tag": "markdown", "content": status_line})
+
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "template": template,
+            "title": {"tag": "plain_text", "content": title},
+        },
+        "elements": elements,
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
+def parse_tool_guard_action_value(
+    action_value: Any,
+) -> Optional[Dict[str, Any]]:
+    """Extract tool-guard action fields from a card.action.trigger payload.
+
+    Returns ``None`` if the value does not look like a tool-guard button.
+    """
+    if not isinstance(action_value, dict):
+        return None
+    if action_value.get("type") != TOOL_GUARD_ACTION_TYPE:
+        return None
+    action = str(action_value.get("action") or "").strip().lower()
+    request_id = str(action_value.get("request_id") or "").strip()
+    if not request_id or action not in ("approve", "deny"):
+        return None
+    raw_ctx = action_value.get("session_ctx")
+    session_ctx = raw_ctx if isinstance(raw_ctx, dict) else {}
+    return {
+        "action": action,
+        "request_id": request_id,
+        "tool_name": str(action_value.get("tool_name") or ""),
+        "severity": str(action_value.get("severity") or "medium"),
+        "body": str(action_value.get("body") or ""),
+        "session_ctx": session_ctx,
+    }
+
+
+def build_tool_guard_toast(
+    action: str,
+    tool_name: str,
+) -> Dict[str, Any]:
+    """Build a toast payload for the card.action.trigger response.
+
+    ``action`` is the raw button action string; unknown values fall
+    back to an expired/unknown warning.
+    """
+    if action == "approve":
+        return {
+            "type": "success",
+            "content": f"Approved tool {tool_name}",
+        }
+    if action == "deny":
+        return {
+            "type": "info",
+            "content": f"Denied tool {tool_name}",
+        }
+    return {
+        "type": "warning",
+        "content": "Approval request has expired",
+    }

--- a/src/qwenpaw/app/channels/feishu/card_templates.py
+++ b/src/qwenpaw/app/channels/feishu/card_templates.py
@@ -58,21 +58,13 @@ def build_tool_guard_approval_card(
 ) -> str:
     """Build the tool-guard approval card JSON string.
 
-    ``body_text`` is the pre-rendered, already-i18n'd message produced
-    by tool_guard_mixin; it is used verbatim as the markdown body.
+    ``body_text`` is the pre-rendered markdown body produced by
+    tool_guard_mixin and used verbatim.
 
-    Each button's ``value`` is echoed back in the
-    ``card.action.trigger`` event, so we embed ``request_id`` plus a
-    ``type`` marker and a snapshot of ``body_text`` (so the resolved
-    card can reconstruct the original content without any extra API
-    call on the WS thread).
-
-    ``session_ctx`` carries the originating chat's routing info
-    (session_id / sender_id / receive_id / chat_id / is_group ...).  It
-    is echoed back inside the button value so the inbound handler can
-    re-inject a ``/approval approve <id>`` message into the channel's
-    queue with the right context, instead of calling ApprovalService
-    directly.
+    A snapshot of ``body_text`` plus ``session_ctx`` (session_id /
+    sender_id / receive_id / chat_id / ...) is embedded in each button's
+    ``value``, so the inbound handler can rebuild the resolved card and
+    re-inject a ``/approval`` command without any extra API call.
     """
     text = body_text or ""
     markdown_content = _truncate(text, 1800)
@@ -138,14 +130,12 @@ def build_tool_guard_resolved_card(
 ) -> str:
     """Card that replaces the original one after a button click.
 
-    ``action`` is the raw button action string (``"approve"`` or
-    ``"deny"``); any other value is treated as an expired/unknown
-    fallback.  We keep this layer independent of the tool-guard enum
-    so templates stay pure-data.
+    ``action`` is the raw button action string (``"approve"`` /
+    ``"deny"``); any other value falls back to an expired/unknown
+    state.  Kept free of the tool-guard enum so templates stay pure-data.
 
-    The original approval body (``body_text``) is preserved so the
-    card keeps the full tool-guard context; only the button row is
-    replaced by a single status line.
+    ``body_text`` (the original approval body) is preserved; only the
+    button row is replaced by a single status line.
     """
     by = f" by `{operator_display}`" if operator_display else ""
     if action == "approve":

--- a/src/qwenpaw/app/channels/feishu/card_templates.py
+++ b/src/qwenpaw/app/channels/feishu/card_templates.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 # Shared utilities
 # =====================================================================
 
+
 def _truncate(text: str, limit: int) -> str:
     if not text:
         return ""

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -66,6 +66,7 @@ from .utils import (
     sender_display_string,
     short_session_id_from_full_id,
 )
+from .card_handler import FeishuCardHandler
 
 
 # Compatibility for setuptools>=82 where pkg_resources may be absent.
@@ -129,7 +130,6 @@ try:
         GetMessageResourceRequest,
         P2ImMessageReceiveV1,
     )
-
     import lark_oapi.ws.client as _ws_mod
 
     _ws_mod.loop = _EventLoopProxy()
@@ -255,6 +255,10 @@ class FeishuChannel(BaseChannel):
         # open_id -> nickname (from Contact API) for sender display
         self._nickname_cache: Dict[str, str] = {}
         self._nickname_cache_lock = asyncio.Lock()
+
+        # All interactive-card logic (outbound rendering + inbound
+        # card.action.trigger dispatch) lives in the card handler.
+        self._card_handler = FeishuCardHandler(self)
 
     @classmethod
     def from_env(
@@ -1924,6 +1928,31 @@ class FeishuChannel(BaseChannel):
         if last_msg_id:
             await self._add_reaction(last_msg_id, "DONE")
 
+    # ------------------------------------------------------------------
+    # Interactive cards (tool_guard approval, etc.)
+    # ------------------------------------------------------------------
+
+    async def on_event_message_completed(  # type: ignore[override]
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Render card-flagged events via the card handler; else default."""
+        if await self._card_handler.try_send_card_for_event(
+            to_handle,
+            event,
+            send_meta,
+        ):
+            return
+        await super().on_event_message_completed(
+            request,
+            to_handle,
+            event,
+            send_meta,
+        )
+
     async def send(
         self,
         to_handle: str,
@@ -2003,6 +2032,9 @@ class FeishuChannel(BaseChannel):
                     )
                     .register_p2_im_message_reaction_deleted_v1(
                         lambda _evt: None,
+                    )
+                    .register_p2_card_action_trigger(
+                        self._card_handler.handle_card_action,
                     )
                     .build()
                 )


### PR DESCRIPTION
## Summary

Upgrade tool_guard approval on Feishu from a text-command flow (users typed `/approval approve <id>`) to a one-click interactive card, and add `FeishuCardHandler` as the single dispatch point for all Feishu interactive cards — designed to host future card kinds (polls, forms, ops confirmation, etc.) without further changes to `FeishuChannel`.

## What's Added

### Tool-guard approval as an interactive card

Approval requests on Feishu are now delivered as an interactive card with **Approve / Deny** buttons. Operators no longer need to copy the request id and type `/approval approve <id>` — one click resolves the request, and the card itself is replaced by a status line showing the outcome and operator.

### `FeishuCardHandler` — extensible card dispatch layer

A registry-based handler that owns both outbound card rendering and inbound `card.action.trigger` callbacks. Each card kind is described by a `CardKind` record and registered into two lookup tables (by outbound `message_type` and by inbound button `action_type`).

Adding a new card kind is a three-step, data-only change:
1. Add `build_xxx_card` / `parse_xxx_action_value` in `card_templates.py`
2. Add a `_send_xxx_card` / `_handle_xxx_action` pair on the handler
3. Add one `self._register(CardKind(...))` line in `_register_kinds()`

The two public entry points stay untouched, and the registry naturally works around the lark_oapi limitation of one `p2.card.action.trigger` callback per dispatcher.

### `card_templates.py` — pure-data template layer

A side-effect-free module for building card JSON and parsing button values. No dependency on business code, so templates are easy to unit-test and reuse.

### Magic-command injection under the hood

Button clicks are not wired directly to `ApprovalService`. Instead, the handler reconstructs a `/approval <action> <request_id>` payload from the session context embedded in the button value and enqueues it back onto the channel queue. `ApprovalCommandHandler` then becomes the single source of truth for approval semantics — the card handler itself stays fully decoupled from `ApprovalService`.

<img width="635" height="680" alt="image" src="https://github.com/user-attachments/assets/5e7e1b04-b8e3-4fd6-b84f-0f1e070ccdb4" />

after approve
<img width="692" height="793" alt="image" src="https://github.com/user-attachments/assets/f07e6af2-3cb7-4241-ad38-885267d31a55" />

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
