### PR TITLE
feat(WeCom): add share_session_in_group toggle for group chats

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -89,6 +89,7 @@ export interface WecomConfig extends BaseChannelConfig {
   secret: string;
   media_dir?: string;
   welcome_text?: string;
+  share_session_in_group?: boolean;
   max_reconnect_attempts?: number;
 }
 

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -993,6 +993,14 @@ export function ChannelDrawer({
             >
               <Input placeholder={t("channels.welcomeTextPlaceholder")} />
             </Form.Item>
+            <Form.Item
+              name="share_session_in_group"
+              label={t("channels.onebotShareSessionInGroup")}
+              valuePropName="checked"
+              tooltip={t("channels.onebotShareSessionInGroupTooltip")}
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -106,7 +106,7 @@ class WecomChannel(BaseChannel):
         bot_prefix: str = "",
         media_dir: str = "",
         welcome_text: str = "",
-        share_session_in_group: bool = False,
+        share_session_in_group: bool = True,
         workspace_dir: Path | None = None,
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
@@ -181,7 +181,7 @@ class WecomChannel(BaseChannel):
             media_dir=os.getenv("WECOM_MEDIA_DIR", ""),
             share_session_in_group=os.getenv(
                 "WECOM_SHARE_SESSION_IN_GROUP",
-                "0",
+                "1",
             )
             == "1",
             on_reply_sent=on_reply_sent,
@@ -214,7 +214,7 @@ class WecomChannel(BaseChannel):
             media_dir=getattr(config, "media_dir", None) or "",
             welcome_text=getattr(config, "welcome_text", "") or "",
             share_session_in_group=bool(
-                getattr(config, "share_session_in_group", False),
+                getattr(config, "share_session_in_group", True),
             ),
             workspace_dir=workspace_dir,
             on_reply_sent=on_reply_sent,
@@ -654,9 +654,9 @@ class WecomChannel(BaseChannel):
             native = {
                 "channel_id": self.channel,
                 "sender_id": sender_id,
-                # Group chats: isolate per member by default
-                # (user_id=sender_id); when share_session_in_group is
-                # True, use "group" so all members share one chat.
+                # Group chats: all members share one chat by default
+                # (user_id="group"); when share_session_in_group is
+                # False, use sender_id so each member is isolated.
                 # session_id stays group-level for reply routing.
                 "user_id": (
                     "group"

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -106,6 +106,7 @@ class WecomChannel(BaseChannel):
         bot_prefix: str = "",
         media_dir: str = "",
         welcome_text: str = "",
+        share_session_in_group: bool = False,
         workspace_dir: Path | None = None,
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
@@ -133,6 +134,7 @@ class WecomChannel(BaseChannel):
         self.secret = secret
         self.bot_prefix = bot_prefix
         self.welcome_text = welcome_text
+        self.share_session_in_group = share_session_in_group
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None
         )
@@ -177,6 +179,11 @@ class WecomChannel(BaseChannel):
             secret=os.getenv("WECOM_SECRET", ""),
             bot_prefix=os.getenv("WECOM_BOT_PREFIX", ""),
             media_dir=os.getenv("WECOM_MEDIA_DIR", ""),
+            share_session_in_group=os.getenv(
+                "WECOM_SHARE_SESSION_IN_GROUP",
+                "0",
+            )
+            == "1",
             on_reply_sent=on_reply_sent,
             dm_policy=os.getenv("WECOM_DM_POLICY", "open"),
             group_policy=os.getenv("WECOM_GROUP_POLICY", "open"),
@@ -206,6 +213,9 @@ class WecomChannel(BaseChannel):
             bot_prefix=getattr(config, "bot_prefix", "") or "",
             media_dir=getattr(config, "media_dir", None) or "",
             welcome_text=getattr(config, "welcome_text", "") or "",
+            share_session_in_group=bool(
+                getattr(config, "share_session_in_group", False),
+            ),
             workspace_dir=workspace_dir,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
@@ -644,7 +654,15 @@ class WecomChannel(BaseChannel):
             native = {
                 "channel_id": self.channel,
                 "sender_id": sender_id,
-                "user_id": sender_id,
+                # Group chats: isolate per member by default
+                # (user_id=sender_id); when share_session_in_group is
+                # True, use "group" so all members share one chat.
+                # session_id stays group-level for reply routing.
+                "user_id": (
+                    "group"
+                    if (is_group and self.share_session_in_group)
+                    else sender_id
+                ),
                 "session_id": session_id,
                 "content_parts": content_parts,
                 "meta": meta,

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -644,9 +644,7 @@ class WecomChannel(BaseChannel):
             native = {
                 "channel_id": self.channel,
                 "sender_id": sender_id,
-                # Group chats use a non-empty placeholder to prevent
-                # Runner.stream_query from overwriting it with session_id.
-                "user_id": "group" if is_group else sender_id,
+                "user_id": sender_id,
                 "session_id": session_id,
                 "content_parts": content_parts,
                 "meta": meta,

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -309,6 +309,9 @@ class WecomConfig(BaseChannelConfig):
     secret: str = ""
     media_dir: Optional[str] = None
     welcome_text: str = ""
+    # If True, all group members share one chat; default isolates
+    # each member into their own chat.
+    share_session_in_group: bool = False
     max_reconnect_attempts: int = -1
 
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -309,9 +309,9 @@ class WecomConfig(BaseChannelConfig):
     secret: str = ""
     media_dir: Optional[str] = None
     welcome_text: str = ""
-    # If True, all group members share one chat; default isolates
-    # each member into their own chat.
-    share_session_in_group: bool = False
+    # If True (default), all group members share one chat; set to
+    # False to isolate each member into their own chat.
+    share_session_in_group: bool = True
     max_reconnect_attempts: int = -1
 
 


### PR DESCRIPTION
## Description

dds a new `share_session_in_group` config toggle for the WeCom
channel to control group-chat conversation scope:

- false (default): each member gets an isolated chat
  (user_id = sender_id), so the bot can tell senders apart.
- true: all members share one chat (user_id = "group"), i.e. the
  previous behavior.

session_id stays group-level either way so replies still route back
to the group. The toggle is exposed in the Console channel drawer.

**Related Issue:** Fixes #3621 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
