### PR TITLE
fix(WeCom): keep placeholder stream alive to prevent stuck "Thinking..." 

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -59,6 +59,13 @@ _UPLOAD_CMD_FINISH = "aibot_upload_media_finish"
 _UPLOAD_CMDS = (_UPLOAD_CMD_INIT, _UPLOAD_CMD_CHUNK, _UPLOAD_CMD_FINISH)
 _UPLOAD_ACK_TIMEOUT = 30.0  # seconds to wait for each upload ack
 
+# Keepalive for "🤔 Thinking..." stream: refresh to avoid WeCom
+# server-side timeout; force-finish before the limit so later replies
+# can start a fresh stream_id (issue #3947).
+_PROCESSING_REFRESH_INTERVAL = 20.0
+_PROCESSING_MAX_DURATION = 120.0
+_PROCESSING_TEXT = "🤔 Thinking..."
+
 # Map ContentType → wecom msgtype used in send_message.
 _MEDIA_MSGTYPE: Dict[str, str] = {
     "image": "image",
@@ -632,15 +639,24 @@ class WecomChannel(BaseChannel):
                     await self._client.reply_stream(
                         frame,
                         stream_id=processing_stream_id,
-                        content="🤔 Thinking...",
+                        content=_PROCESSING_TEXT,
                         finish=False,
                     )
                 except Exception:
                     logger.debug("wecom failed to send processing indicator")
+                    processing_stream_id = ""
 
             session_id = self.resolve_session_id(sender_id, meta)
             if processing_stream_id:
                 meta["wecom_processing_stream_id"] = processing_stream_id
+                # Keep stream alive while agent is generating.
+                meta["wecom_keepalive_task"] = asyncio.create_task(
+                    self._keepalive_processing(
+                        frame,
+                        processing_stream_id,
+                        meta,
+                    ),
+                )
             native = {
                 "channel_id": self.channel,
                 "sender_id": sender_id,
@@ -942,6 +958,57 @@ class WecomChannel(BaseChannel):
                     chatid[:20],
                 )
 
+    async def _keepalive_processing(
+        self,
+        frame: Any,
+        stream_id: str,
+        meta: Dict[str, Any],
+        interval: float = _PROCESSING_REFRESH_INTERVAL,
+        max_duration: float = _PROCESSING_MAX_DURATION,
+    ) -> None:
+        """Refresh placeholder stream; force-finish at max_duration.
+
+        Prevents WeCom server from silently dropping the stream while
+        the agent is still running (issue #3947).
+        """
+        if not self._client:
+            return
+        elapsed = 0.0
+        try:
+            while elapsed + interval <= max_duration:
+                await asyncio.sleep(interval)
+                elapsed += interval
+                try:
+                    await self._client.reply_stream(
+                        frame,
+                        stream_id=stream_id,
+                        content=_PROCESSING_TEXT,
+                        finish=False,
+                    )
+                except Exception:
+                    logger.debug(
+                        "wecom keepalive refresh failed stream_id=%s",
+                        stream_id[:20],
+                    )
+            # Close stream so next reply can use a fresh stream_id.
+            try:
+                await self._client.reply_stream(
+                    frame,
+                    stream_id=stream_id,
+                    content=_PROCESSING_TEXT,
+                    finish=True,
+                )
+                logger.info(
+                    "wecom keepalive force-finished after %.0fs stream_id=%s",
+                    max_duration,
+                    stream_id[:20],
+                )
+            except Exception:
+                logger.debug("wecom keepalive force-finish failed")
+            meta.pop("wecom_processing_stream_id", None)
+        except asyncio.CancelledError:
+            return
+
     async def _send_text_via_frame(
         self,
         frame: Any,
@@ -1019,8 +1086,18 @@ class WecomChannel(BaseChannel):
         # Format markdown tables for WeCom compatibility
         body = format_markdown_tables(body)
 
-        # Use processing stream_id to overwrite "thinking..." indicator
-        # Only first reply uses it; subsequent replies get new stream_id
+        # Cancel keepalive before sending real reply to avoid racing
+        # finish=True on the same stream_id.
+        keepalive_task = m.pop("wecom_keepalive_task", None)
+        if keepalive_task is not None and not keepalive_task.done():
+            keepalive_task.cancel()
+            try:
+                await keepalive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        # Reuse processing stream_id on first chunk to overwrite the
+        # placeholder; empty if keepalive already force-finished it.
         processing_sid = m.pop("wecom_processing_stream_id", "")
 
         first_chunk = True

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -158,7 +158,7 @@ class WecomChannel(BaseChannel):
         self._ws_thread: Optional[threading.Thread] = None
 
         # Keepalive tasks keyed by stream_id (kept off `meta` so the
-        # payload stays JSON-serializable for tracing).
+        # payload stays JSON-serializable).
         self._keepalive_tasks: Dict[str, "asyncio.Task[None]"] = {}
 
         # message_id dedup (ordered dict, trimmed when over limit)
@@ -1091,11 +1091,9 @@ class WecomChannel(BaseChannel):
         # Format markdown tables for WeCom compatibility
         body = format_markdown_tables(body)
 
-        # Reuse processing stream_id on first chunk to overwrite the
-        # placeholder; cancel its keepalive task first to avoid racing
-        # finish=True on the same stream_id. If the task already
-        # force-finished (max_duration reached), it's gone from the
-        # dict and we should start with a fresh stream_id.
+        # Reuse placeholder stream_id on first chunk; cancel its
+        # keepalive task first to avoid racing finish=True. If task
+        # is already gone, it force-finished the stream, so start fresh.
         processing_sid = m.pop("wecom_processing_stream_id", "")
         keepalive_task = self._keepalive_tasks.pop(processing_sid, None)
         if keepalive_task is not None and not keepalive_task.done():
@@ -1105,7 +1103,6 @@ class WecomChannel(BaseChannel):
             except (asyncio.CancelledError, Exception):
                 pass
         elif keepalive_task is None and processing_sid:
-            # Task already self-finished the stream at max_duration.
             processing_sid = ""
 
         first_chunk = True

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -63,7 +63,7 @@ _UPLOAD_ACK_TIMEOUT = 30.0  # seconds to wait for each upload ack
 # server-side timeout; force-finish before the limit so later replies
 # can start a fresh stream_id (issue #3947).
 _PROCESSING_REFRESH_INTERVAL = 20.0
-_PROCESSING_MAX_DURATION = 120.0
+_PROCESSING_MAX_DURATION = 180.0
 _PROCESSING_TEXT = "🤔 Thinking..."
 
 # Map ContentType → wecom msgtype used in send_message.
@@ -156,6 +156,10 @@ class WecomChannel(BaseChannel):
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._ws_loop: Optional[asyncio.AbstractEventLoop] = None
         self._ws_thread: Optional[threading.Thread] = None
+
+        # Keepalive tasks keyed by stream_id (kept off `meta` so the
+        # payload stays JSON-serializable for tracing).
+        self._keepalive_tasks: Dict[str, "asyncio.Task[None]"] = {}
 
         # message_id dedup (ordered dict, trimmed when over limit)
         self._processed_message_ids: OrderedDict[str, None] = OrderedDict()
@@ -650,11 +654,12 @@ class WecomChannel(BaseChannel):
             if processing_stream_id:
                 meta["wecom_processing_stream_id"] = processing_stream_id
                 # Keep stream alive while agent is generating.
-                meta["wecom_keepalive_task"] = asyncio.create_task(
+                self._keepalive_tasks[
+                    processing_stream_id
+                ] = asyncio.create_task(
                     self._keepalive_processing(
                         frame,
                         processing_stream_id,
-                        meta,
                     ),
                 )
             native = {
@@ -962,7 +967,6 @@ class WecomChannel(BaseChannel):
         self,
         frame: Any,
         stream_id: str,
-        meta: Dict[str, Any],
         interval: float = _PROCESSING_REFRESH_INTERVAL,
         max_duration: float = _PROCESSING_MAX_DURATION,
     ) -> None:
@@ -1005,9 +1009,10 @@ class WecomChannel(BaseChannel):
                 )
             except Exception:
                 logger.debug("wecom keepalive force-finish failed")
-            meta.pop("wecom_processing_stream_id", None)
         except asyncio.CancelledError:
             return
+        finally:
+            self._keepalive_tasks.pop(stream_id, None)
 
     async def _send_text_via_frame(
         self,
@@ -1086,19 +1091,22 @@ class WecomChannel(BaseChannel):
         # Format markdown tables for WeCom compatibility
         body = format_markdown_tables(body)
 
-        # Cancel keepalive before sending real reply to avoid racing
-        # finish=True on the same stream_id.
-        keepalive_task = m.pop("wecom_keepalive_task", None)
+        # Reuse processing stream_id on first chunk to overwrite the
+        # placeholder; cancel its keepalive task first to avoid racing
+        # finish=True on the same stream_id. If the task already
+        # force-finished (max_duration reached), it's gone from the
+        # dict and we should start with a fresh stream_id.
+        processing_sid = m.pop("wecom_processing_stream_id", "")
+        keepalive_task = self._keepalive_tasks.pop(processing_sid, None)
         if keepalive_task is not None and not keepalive_task.done():
             keepalive_task.cancel()
             try:
                 await keepalive_task
             except (asyncio.CancelledError, Exception):
                 pass
-
-        # Reuse processing stream_id on first chunk to overwrite the
-        # placeholder; empty if keepalive already force-finished it.
-        processing_sid = m.pop("wecom_processing_stream_id", "")
+        elif keepalive_task is None and processing_sid:
+            # Task already self-finished the stream at max_duration.
+            processing_sid = ""
 
         first_chunk = True
         for chunk in split_text(body) if body else []:


### PR DESCRIPTION
## Description

### Why

WeCom drops a `stream_id` that isn't refreshed or finished in time.
After the `🤔 Thinking...` placeholder, we don't touch the stream
until the agent finishes, so the final `reply_stream(finish=True)`
gets silently discarded on long runs — users stay on `Thinking...`
and later messages are blocked.

### What

Added a keepalive task for the placeholder stream:

- Refresh every 20s to keep the stream alive.
- Force-finish at 180s so the real reply can use a fresh `stream_id`.
- Cancel the task before the real reply to avoid racing on the same
  `stream_id`.

**Related Issue:** Fixes #3947 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
