### PR TITLE
fix(console): keep Chat mounted when navigating to other pages

### DIFF
--- a/console/src/layouts/MainLayout/index.tsx
+++ b/console/src/layouts/MainLayout/index.tsx
@@ -82,6 +82,10 @@ export default function MainLayout() {
       : "chat";
   }
 
+  // Keep Chat component always mounted to preserve session/task state.
+  // Use CSS display to show/hide instead of unmounting via Routes.
+  const isChatActive = currentPath === "/" || currentPath.startsWith("/chat");
+
   return (
     <Layout className={styles.mainLayout}>
       <Header />
@@ -99,43 +103,62 @@ export default function MainLayout() {
                   />
                 }
               >
-                <Routes>
-                  <Route path="/" element={<Navigate to="/chat" replace />} />
-                  <Route path="/chat/*" element={<Chat />} />
-                  <Route path="/channels" element={<ChannelsPage />} />
-                  <Route path="/sessions" element={<SessionsPage />} />
-                  <Route path="/cron-jobs" element={<CronJobsPage />} />
-                  <Route path="/heartbeat" element={<HeartbeatPage />} />
-                  <Route path="/skills" element={<SkillsPage />} />
-                  <Route path="/skill-pool" element={<SkillPoolPage />} />
-                  <Route path="/tools" element={<ToolsPage />} />
-                  <Route path="/mcp" element={<MCPPage />} />
-                  <Route path="/acp" element={<ACPPage />} />
-                  <Route path="/ACP" element={<Navigate to="/acp" replace />} />
-                  <Route path="/workspace" element={<WorkspacePage />} />
-                  <Route path="/agents" element={<AgentsPage />} />
-                  <Route path="/models" element={<ModelsPage />} />
-                  <Route path="/environments" element={<EnvironmentsPage />} />
-                  <Route path="/agent-config" element={<AgentConfigPage />} />
-                  <Route path="/security" element={<SecurityPage />} />
-                  <Route path="/token-usage" element={<TokenUsagePage />} />
-                  <Route path="/agent-stats" element={<AgentStatsPage />} />
-                  <Route
-                    path="/voice-transcription"
-                    element={<VoiceTranscriptionPage />}
-                  />
-                  <Route path="/debug" element={<DebugPage />} />
-                  <Route path="/backups" element={<BackupsPage />} />
+                {/* Chat is always mounted; hidden via display:none when inactive */}
+                <div
+                  style={{
+                    display: isChatActive ? "contents" : "none",
+                  }}
+                >
+                  <Chat />
+                </div>
 
-                  {/* Plugin routes — dynamically injected at runtime */}
-                  {pluginRoutes.map((route) => (
+                {/* Other pages rendered only when chat is not active */}
+                {!isChatActive && (
+                  <Routes>
+                    <Route path="/channels" element={<ChannelsPage />} />
+                    <Route path="/sessions" element={<SessionsPage />} />
+                    <Route path="/cron-jobs" element={<CronJobsPage />} />
+                    <Route path="/heartbeat" element={<HeartbeatPage />} />
+                    <Route path="/skills" element={<SkillsPage />} />
+                    <Route path="/skill-pool" element={<SkillPoolPage />} />
+                    <Route path="/tools" element={<ToolsPage />} />
+                    <Route path="/mcp" element={<MCPPage />} />
+                    <Route path="/acp" element={<ACPPage />} />
                     <Route
-                      key={route.path}
-                      path={route.path}
-                      element={<route.component />}
+                      path="/ACP"
+                      element={<Navigate to="/acp" replace />}
                     />
-                  ))}
-                </Routes>
+                    <Route path="/workspace" element={<WorkspacePage />} />
+                    <Route path="/agents" element={<AgentsPage />} />
+                    <Route path="/models" element={<ModelsPage />} />
+                    <Route
+                      path="/environments"
+                      element={<EnvironmentsPage />}
+                    />
+                    <Route
+                      path="/agent-config"
+                      element={<AgentConfigPage />}
+                    />
+                    <Route path="/security" element={<SecurityPage />} />
+                    <Route path="/token-usage" element={<TokenUsagePage />} />
+                    <Route path="/agent-stats" element={<AgentStatsPage />} />
+                    <Route
+                      path="/voice-transcription"
+                      element={<VoiceTranscriptionPage />}
+                    />
+                    <Route path="/debug" element={<DebugPage />} />
+                    <Route path="/backups" element={<BackupsPage />} />
+
+                    {/* Plugin routes dynamically injected at runtime */}
+                    {pluginRoutes.map((route) => (
+                      <Route
+                        key={route.path}
+                        path={route.path}
+                        element={<route.component />}
+                      />
+                    ))}
+                  </Routes>
+                )}
               </Suspense>
             </ChunkErrorBoundary>
           </div>


### PR DESCRIPTION
## Problem  When navigating away from chat page (e.g. to /cron-jobs for scheduled tasks, or /sessions, /settings etc.) and navigating back, the Chat component is completely unmounted and remounted, causing:  1. **Active task lost** - any running agent task is cancelled 2. **Chat session lost** - all messages disappear 3. **User has to start over** - no way to recover the previous conversation  ## Root Cause  MainLayout uses React Router `<Routes>` to render different pages:  ```tsx <Routes>   <Route path=/chat/* element={<Chat />} />   <Route path=/cron-jobs element={<CronJobsPage />} />   ... </Routes> ```  When navigating to `/cron-jobs`, React Router unmounts `<Chat />` entirely. When navigating back, a completely new `<Chat />` instance is mounted, losing all internal state (messages, session selection, running tasks).  ## Solution  Keep the Chat component **always mounted** but hidden via CSS when not active:  ```tsx // Chat always mounted, hidden via display:none when inactive const isChatActive = currentPath === / || currentPath.startsWith(/chat);  <div style={{ display: isChatActive ? contents : none }}>   <Chat /> </div>  // Other pages only rendered when chat is not active {!isChatActive && (   <Routes>     <Route path=/cron-jobs element={<CronJobsPage />} />     ...   </Routes> )} ```  This preserves all Chat internal state (messages, session, running tasks) when navigating to other pages and back.  ## Changes  - `console/src/layouts/MainLayout/index.tsx`   - Always render `<Chat />` wrapped in a display toggle div   - Conditionally render other page `<Routes>` only when not on chat   - Uses `display: contents` when active (no extra wrapper in DOM), `display: none` when inactive