### PR TITLE
fix(chat): fix CodeMirror line wrapping in tool call input/output blocks

### DIFF
--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -1070,3 +1070,19 @@ html.dark-mode .ant-typography-secondary {
 html.dark-mode .debug-log-path strong {
   color: rgba(255, 255, 255, 0.85) !important;
 }
+
+[class*="tool-call-block-content"] .cm-content,
+[class*="tool-call-block-content"] .cm-line {
+  white-space: pre-wrap !important;
+  word-break: break-word !important;
+}
+
+[class*="tool-call-block-content"] .cm-content {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+[class*="tool-call-block-content"] {
+  max-height: 250px !important;
+  overflow-y: auto !important;
+}

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -1074,7 +1074,8 @@ html.dark-mode .debug-log-path strong {
 [class*="tool-call-block-content"] .cm-content,
 [class*="tool-call-block-content"] .cm-line {
   white-space: pre-wrap !important;
-  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+  word-break: normal !important;
 }
 
 [class*="tool-call-block-content"] .cm-content {


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

Description:                                                                            
 Add CSS override in console/src/styles/layout.css to fix long-line overflow in tool     
 call blocks. The @agentscope-ai/design CodeBlock component uses CodeMirror 6 with       
 white-space: pre, causing oversized JSON/text content to expand horizontally beyond           
 container bounds.                                                                       
                                                                                         
 Changes:                                                                                
 - Force white-space: pre-wrap and word-break: break-word on .cm-content / .cm-line      
 - Constrain .cm-content width to 100%                                                   
 - Cap block height at 250px with overflow-y: auto for scrollable content 

- Before:
<img width="972" height="488" alt="image" src="https://github.com/user-attachments/assets/5ec66a70-e961-4307-b6f7-a3398bc8b3a9" />

- After:
<img width="919" height="581" alt="image" src="https://github.com/user-attachments/assets/369c2541-d9a8-458c-a4a4-16ccf1d3e035" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
