### PR TITLE
fix(WeCom): avoid double reconnect race and cross-loop disconnect

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -1247,8 +1247,9 @@ class WecomChannel(BaseChannel):
         self._client.on("message", self._on_message_sync)
         self._client.on("event.enter_chat", self._on_enter_chat_sync)
 
-        # Patch SDK heartbeat to trigger reconnect on pong timeout.
-        # Use ensure_future so reconnect survives heartbeat task cancel.
+        # On pong timeout just close the ws; let SDK's _receive_loop
+        # ConnectionClosed branch handle stop_heartbeat + reconnect,
+        # to avoid double _schedule_reconnect race (issue #2757).
         ws_mgr = self._client._ws_manager
         _original_send_heartbeat = ws_mgr._send_heartbeat
 
@@ -1256,14 +1257,9 @@ class WecomChannel(BaseChannel):
             if ws_mgr._missed_pong_count >= ws_mgr._max_missed_pong:
                 logger.warning(
                     "wecom heartbeat: no pong for %d pings, "
-                    "triggering reconnect",
+                    "closing ws to trigger reconnect",
                     ws_mgr._missed_pong_count,
                 )
-                # Schedule reconnect BEFORE _stop_heartbeat() because
-                # it cancels the current task; any await after that
-                # would raise CancelledError.
-                asyncio.ensure_future(ws_mgr._schedule_reconnect())
-                ws_mgr._stop_heartbeat()
                 if ws_mgr._ws:
                     try:
                         await ws_mgr._ws.close()
@@ -1315,9 +1311,16 @@ class WecomChannel(BaseChannel):
     async def stop(self) -> None:
         if not self.enabled:
             return
-        if self._client:
+        # disconnect() uses asyncio.ensure_future() internally which
+        # binds to the current loop; schedule it on _ws_loop so the
+        # ws is operated on its own loop (issue #2757).
+        if (
+            self._client
+            and self._ws_loop is not None
+            and self._ws_loop.is_running()
+        ):
             try:
-                self._client.disconnect()
+                self._ws_loop.call_soon_threadsafe(self._client.disconnect)
             except Exception:
                 pass
         if self._ws_loop is not None:

--- a/tests/unit/channels/test_wecom.py
+++ b/tests/unit/channels/test_wecom.py
@@ -1322,13 +1322,21 @@ class TestWecomChannelLifecycle:
 
     @pytest.mark.asyncio
     async def test_stop_cleans_up(self, wecom_channel, mock_ws_client):
-        """stop should clean up resources."""
+        """stop should schedule disconnect on ws_loop and clear client."""
         wecom_channel._client = mock_ws_client
         wecom_channel._ws_thread = MagicMock()
+        mock_ws_loop = MagicMock()
+        mock_ws_loop.is_running.return_value = True
+        wecom_channel._ws_loop = mock_ws_loop
 
         await wecom_channel.stop()
 
-        mock_ws_client.disconnect.assert_called_once()
+        # disconnect is scheduled on the ws loop (not called directly)
+        # to avoid cross-loop errors during daemon reload (issue #2757).
+        mock_ws_loop.call_soon_threadsafe.assert_any_call(
+            mock_ws_client.disconnect,
+        )
+        mock_ws_loop.call_soon_threadsafe.assert_any_call(mock_ws_loop.stop)
         assert wecom_channel._client is None
 
 


### PR DESCRIPTION
## Description

### What

- Heartbeat pong-timeout branch now only closes the ws; let SDK's
  `_receive_loop` `ConnectionClosed` handle stop_heartbeat + reconnect.
- `stop()` schedules `client.disconnect()` on `_ws_loop` via
  `call_soon_threadsafe`.

### Why

- The old patch scheduled its own reconnect **and** closed the ws,
  which made `_receive_loop` schedule a second reconnect. Two parallel
  reconnect tasks cleaned up each other's new connection, trapping the
  client in a zombie "attempt 1" state.
- `client.disconnect()` uses `asyncio.ensure_future()` internally and
  binds to the caller's loop. Calling it from the main loop scheduled
  `_async_disconnect` on the wrong loop while `ws` lives on `_ws_loop`,
  causing `wecom WebSocket thread failed` on daemon reload.

**Related Issue:** Fixes #2757 #3937 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
