### PR TITLE
fix(chat): migrate deprecated antd v5 APIs to eliminate console warnings 

### DIFF
--- a/console/src/components/AgentSelector/index.tsx
+++ b/console/src/components/AgentSelector/index.tsx
@@ -93,7 +93,7 @@ export default function AgentSelector({
             : selectedAgent
         }
         placement="right"
-        overlayInnerStyle={{ background: "rgba(0,0,0,0.75)", color: "#fff" }}
+        styles={{ root: { background: "rgba(0,0,0,0.75)", color: "#fff" } }}
       >
         <div className={styles.agentSelectorCollapsed}>
           <Bot size={18} strokeWidth={2} />
@@ -119,12 +119,12 @@ export default function AgentSelector({
         className={styles.agentSelector}
         placeholder={t("agent.selectAgent")}
         optionLabelProp="label"
-        popupClassName={styles.agentSelectorDropdown}
-        onDropdownVisibleChange={setDropdownOpen}
+        classNames={{ popup: { root: styles.agentSelectorDropdown } }}
+        onOpenChange={setDropdownOpen}
         suffixIcon={
           dropdownOpen ? <SparkUpLine size={20} /> : <SparkDownLine size={20} />
         }
-        dropdownRender={(menu) => (
+        popupRender={(menu) => (
           <>
             <div className={styles.dropdownHeader}>
               <span className={styles.dropdownHeaderTitle}>

--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -60,7 +60,7 @@ export default function LanguageSwitcher() {
     <Dropdown
       menu={{ items, selectedKeys: [currentLangKey] }}
       placement="bottomRight"
-      overlayClassName={styles.languageDropdown}
+      classNames={{ root: styles.languageDropdown }}
     >
       <Button icon={LIGHT_ICON[currentLangKey]} type="text" />
     </Dropdown>

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -437,9 +437,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                 key={item.key}
                 title={item.label}
                 placement="right"
-                overlayInnerStyle={{
-                  background: "rgba(0,0,0,0.75)",
-                  color: "#fff",
+                styles={{
+                  root: {
+                    background: "rgba(0,0,0,0.75)",
+                    color: "#fff",
+                  },
                 }}
               >
                 <button

--- a/console/src/pages/Agent/Skills/components/SkillsToolbar.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillsToolbar.tsx
@@ -46,11 +46,11 @@ export function SkillsToolbar({
           value={searchTags}
           onChange={onTagsChange}
           open={filterOpen}
-          onDropdownVisibleChange={onFilterOpenChange}
+          onOpenChange={onFilterOpenChange}
           allowClear
           maxTagCount="responsive"
           notFoundContent={<></>}
-          dropdownRender={() =>
+          popupRender={() =>
             allTags.length > 0 ? (
               <SkillFilterDropdown
                 allTags={allTags}

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -247,7 +247,7 @@ export default function ModelSelector() {
     <Dropdown
       open={open}
       onOpenChange={handleOpenChange}
-      dropdownRender={() => dropdownContent}
+      popupRender={() => dropdownContent}
       trigger={["click"]}
       placement="bottomLeft"
     >

--- a/console/src/pages/Control/CronJobs/components/columns.tsx
+++ b/console/src/pages/Control/CronJobs/components/columns.tsx
@@ -228,7 +228,7 @@ export const createColumns = (
               </div>
             }
             placement="topLeft"
-            overlayInnerStyle={{ maxWidth: 400 }}
+            styles={{ root: { maxWidth: 400 } }}
           >
             <code className={styles.codeLink}>{truncatedText}</code>
           </Tooltip>

--- a/console/src/pages/Settings/SkillPool/index.tsx
+++ b/console/src/pages/Settings/SkillPool/index.tsx
@@ -188,11 +188,11 @@ function SkillPoolPage() {
                 value={pool.searchTags}
                 onChange={pool.setSearchTags}
                 open={pool.filterOpen}
-                onDropdownVisibleChange={pool.setFilterOpen}
+                onOpenChange={pool.setFilterOpen}
                 allowClear
                 maxTagCount="responsive"
                 notFoundContent={<></>}
-                dropdownRender={() =>
+                popupRender={() =>
                   pool.allTags.length > 0 ? (
                     <SkillFilterDropdown
                       allTags={pool.allTags}


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

Removes 5 of 11 warnings on `/chat/` page. 

Replaces deprecated antd APIs with modern equivalents across the console frontend to clean up DevTools warnings.

Changes include:                                                                                     
     - `overlayInnerStyle` → `styles` (Tooltip)                                                           
     - `overlayClassName` → `classNames` (Dropdown)                                                       
     - `popupClassName` → `classNames.popup.root` (Select)                                                
     - `onDropdownVisibleChange` → `onOpenChange` (Select)                                                
     - `dropdownRender` → `popupRender` (Select, Dropdown) 


Note: `ThemeToggleButton`'s `overlayClassName` is retained since antd v5.29.1 Dropdown does not yet expose `classNames` in its type definition, requiring antd v6.x for fixes. （`Warning: [antd: Tooltip] `overlayClassName` is deprecated. Please use `classNames={{ root: "" }}` instead.`）

- Fixed the following warning messages in devtool console:

<img width="938" height="454" alt="image" src="https://github.com/user-attachments/assets/7aaf16b4-ff5d-41bc-a3c6-1aa684026afc" />



**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
