### PR TITLE
feat(feishu): hint docs link on approval card when card.action.trigger is unsubscribed

### DIFF
--- a/src/qwenpaw/app/channels/feishu/card_templates.py
+++ b/src/qwenpaw/app/channels/feishu/card_templates.py
@@ -33,6 +33,13 @@ def _truncate(text: str, limit: int) -> str:
 # approve/deny buttons; avoids clashing with other interactive cards.
 TOOL_GUARD_ACTION_TYPE = "tool_guard_approval"
 
+# Docs anchor shown when the ``card.action.trigger`` event is not
+# subscribed and the buttons silently fail on click.
+_FEISHU_CALLBACK_CONFIG_DOC_URL = (
+    "https://qwenpaw.agentscope.io/docs/channels#feishu-callback-config"
+)
+
+
 _TOOL_GUARD_SEVERITY_TEMPLATE = {
     "critical": "red",
     "high": "red",
@@ -93,6 +100,15 @@ def build_tool_guard_approval_card(
         "elements": [
             {"tag": "markdown", "content": markdown_content},
             {"tag": "hr"},
+            {
+                "tag": "markdown",
+                "content": (
+                    "ⓘ <font color='orange'>**"
+                    "[Buttons not working?  Click here]"
+                    f"({_FEISHU_CALLBACK_CONFIG_DOC_URL})"
+                    "**</font>"
+                ),
+            },
             {
                 "tag": "action",
                 "actions": [

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -195,7 +195,21 @@ The Feishu channel receives messages via **WebSocket long connection** (no publi
 
 ![Result](https://img.alicdn.com/imgextra/i2/O1CN01fiMjkp24mN51TyWcI_!!6000000007433-2-tps-4082-2126.png)
 
-9. Under **App Versions** → **Version Management & Release**, **Create a version**, fill in basic info, **Save** and **Publish**
+<div id="feishu-callback-config"></div>
+
+9. Under **Events & Callbacks**, click **Callback configuration**, and choose **Receive events through persistent connection** as the subscription mode (no public IP needed)
+
+![WebSocket](https://img.alicdn.com/imgextra/i4/O1CN015r6kS71DLBxFDJQWe_!!6000000000199-2-tps-1671-848.png)
+
+10. Select **Add Callback**, search for **Card callback interaction**, and subscribe to **Card callback interaction** (`card.action.trigger`)
+
+![Receive](https://img.alicdn.com/imgextra/i3/O1CN017s7lz724GJMzKKKnC_!!6000000007363-2-tps-1685-855.png)
+
+![Click](https://img.alicdn.com/imgextra/i4/O1CN01CcGGmW1K0JCp7cQQV_!!6000000001101-2-tps-1679-847.png)
+
+![Result](https://img.alicdn.com/imgextra/i3/O1CN01V9kzMj1CbqkBnSI0x_!!6000000000100-2-tps-1682-847.png)
+
+11. Under **App Versions** → **Version Management & Release**, **Create a version**, fill in basic info, **Save** and **Publish**
 
 ![Create](https://img.alicdn.com/imgextra/i3/O1CN01mzOHs11cdO4MnZMcX_!!6000000003623-2-tps-4082-2126.png)
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -190,7 +190,21 @@
 
 ![result](https://img.alicdn.com/imgextra/i2/O1CN015GPfGr1BsxuoOXbYC_!!6000000000002-2-tps-4082-2126.png)
 
-9. 在「应用发布」的「版本管理与发布」中，**创建版本**，填写基础信息，**保存**并**发布**
+<div id="feishu-callback-config"></div>
+
+9. 在「事件与回调」中，点击「回调配置」，选择订阅方式为**长连接（WebSocket）** 模式（无需公网 IP）
+
+![websocket](https://img.alicdn.com/imgextra/i4/O1CN015r6kS71DLBxFDJQWe_!!6000000000199-2-tps-1671-848.png)
+
+10. 选择「添加回调」，搜索**卡片回传交互**，订阅**卡片回传交互**
+
+![reveive](https://img.alicdn.com/imgextra/i3/O1CN017s7lz724GJMzKKKnC_!!6000000007363-2-tps-1685-855.png)
+
+![click](https://img.alicdn.com/imgextra/i4/O1CN01CcGGmW1K0JCp7cQQV_!!6000000001101-2-tps-1679-847.png)
+
+![result](https://img.alicdn.com/imgextra/i3/O1CN01V9kzMj1CbqkBnSI0x_!!6000000000100-2-tps-1682-847.png)
+
+11. 在「应用发布」的「版本管理与发布」中，**创建版本**，填写基础信息，**保存**并**发布**
 
 ![create](https://img.alicdn.com/imgextra/i1/O1CN01zOqMGk1lhoREn9Lip_!!6000000004851-2-tps-4082-2126.png)
 


### PR DESCRIPTION
## Description

### What

Add an inline hint on the tool-guard approval card linking to the docs anchor that
walks through subscribing `card.action.trigger`. Without the subscription, Approve /
Deny buttons silently fail and Feishu's toast cannot be customized server-side.

### Changes

- `card_templates.py`: add an orange markdown note `ⓘ Buttons not working?  Click here`
  above the action row, linking to `/docs/channels#feishu-callback-config`.
- `channels.{zh,en}.md`: add steps 9 (Callback configuration, WebSocket) and 10
  (subscribe Card callback interaction); shift the original publish step to 11; add a
  `<div id="feishu-callback-config">` anchor before step 9.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
