### PR TITLE
fix(approval): /approve shorthand ignores request_id argument

### DIFF
--- a/src/qwenpaw/app/runner/control_commands/approval_handler.py
+++ b/src/qwenpaw/app/runner/control_commands/approval_handler.py
@@ -309,11 +309,15 @@ class ApproveCommandHandler(BaseControlCommandHandler):
         Returns:
             Response text from approval handler
         """
-        # Transform args: set action to approve
-        context.args = {
-            **context.args,
-            "action": "approve",
-        }
+        raw_args = context.args.get("_raw_args", "").strip()
+        parts = raw_args.split(maxsplit=1)
+
+        new_args = {"action": "approve"}
+
+        if parts:
+            new_args["request_id"] = parts[0]
+
+        context.args = new_args
 
         # Delegate to approval handler
         return await self._approval_handler._handle_approve(context)


### PR DESCRIPTION
## Description

`/approve <request_id>` silently ignored the request_id and always approved the queue head. The handler now extracts request_id from `_raw_args`, matching `DenyCommandHandler`'s existing pattern.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
