### PR TITLE
fix(skill):  resilient loading for migrated or malformed skill & skill pool entries

### DIFF
--- a/console/src/api/modules/skill.ts
+++ b/console/src/api/modules/skill.ts
@@ -102,7 +102,13 @@ async function _uploadZip(
   });
 
   if (!response.ok) {
-    throw new Error(await response.text());
+    const text = await response.text();
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      // Format like request.ts so parseErrorDetail() can extract structured fields
+      throw new Error(`${response.status} ${response.statusText} - ${text}`);
+    }
+    throw new Error(text || `Request failed: ${response.status}`);
   }
 
   return await response.json();

--- a/console/src/utils/error.ts
+++ b/console/src/utils/error.ts
@@ -1,11 +1,24 @@
 export function parseErrorDetail(error: unknown): Record<string, any> | null {
   if (!(error instanceof Error)) return null;
-  const idx = error.message.indexOf(" - ");
-  if (idx === -1) return null;
-  try {
-    const parsed = JSON.parse(error.message.slice(idx + 3));
-    return parsed?.detail || parsed;
-  } catch {
-    return null;
+  const msg = error.message;
+  // Try " - " separator first (from request.ts formatted errors)
+  const idx = msg.indexOf(" - ");
+  if (idx !== -1) {
+    try {
+      const parsed = JSON.parse(msg.slice(idx + 3));
+      return parsed?.detail || parsed;
+    } catch {
+      // fall through to raw JSON attempt
+    }
   }
+  // Fallback: try parsing the entire message as JSON
+  try {
+    const parsed = JSON.parse(msg);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed?.detail || parsed;
+    }
+  } catch {
+    // not JSON
+  }
+  return null;
 }

--- a/src/qwenpaw/agents/skills_manager.py
+++ b/src/qwenpaw/agents/skills_manager.py
@@ -505,8 +505,8 @@ def _read_json_unlocked(path: Path, default: dict[str, Any]) -> dict[str, Any]:
         return json.loads(json.dumps(default))
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        logger.warning("Malformed JSON in %s, resetting to default", path)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        logger.warning("Cannot read JSON from %s, resetting to default", path)
         return json.loads(json.dumps(default))
 
 
@@ -1460,39 +1460,47 @@ def reconcile_pool_manifest() -> dict[str, Any]:
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
-            existing = skills.get(skill_name, {})
-            source, protected = _classify_pool_skill_source(
-                skill_name,
-                skill_dir,
-                existing,
-                builtin_names,
-            )
-            has_config = "config" in existing
-            config = existing.get("config") if has_config else None
-            existing_tags = existing.get("tags")
-            skills[skill_name] = _build_skill_metadata(
-                skill_name,
-                skill_dir,
-                source=source,
-                protected=protected,
-            )
-            if source == "builtin" or _is_pool_builtin_entry(existing):
-                language = _resolve_pool_builtin_language(
+            try:
+                existing = skills.get(skill_name, {})
+                source, protected = _classify_pool_skill_source(
                     skill_name,
-                    existing or skills[skill_name],
-                    registry,
-                    preferred_language=pref,
+                    skill_dir,
+                    existing,
+                    builtin_names,
                 )
-                if language:
-                    skills[skill_name]["builtin_language"] = language
-                    if language in (registry.get(skill_name) or {}):
-                        skills[skill_name]["builtin_source_name"] = registry[
-                            skill_name
-                        ][language].source_name
-            if has_config:
-                skills[skill_name]["config"] = config
-            if existing_tags is not None:
-                skills[skill_name]["tags"] = existing_tags
+                has_config = "config" in existing
+                config = existing.get("config") if has_config else None
+                existing_tags = existing.get("tags")
+                new_entry = _build_skill_metadata(
+                    skill_name,
+                    skill_dir,
+                    source=source,
+                    protected=protected,
+                )
+                if source == "builtin" or _is_pool_builtin_entry(existing):
+                    language = _resolve_pool_builtin_language(
+                        skill_name,
+                        existing or new_entry,
+                        registry,
+                        preferred_language=pref,
+                    )
+                    if language:
+                        new_entry["builtin_language"] = language
+                        if language in (registry.get(skill_name) or {}):
+                            new_entry["builtin_source_name"] = registry[
+                                skill_name
+                            ][language].source_name
+                if has_config:
+                    new_entry["config"] = config
+                if existing_tags is not None:
+                    new_entry["tags"] = existing_tags
+                skills[skill_name] = new_entry
+            except Exception:
+                logger.warning(
+                    "Skipping pool skill '%s' during reconcile",
+                    skill_name,
+                    exc_info=True,
+                )
 
         for skill_name in list(skills):
             if skill_name not in discovered:
@@ -1544,44 +1552,51 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
-            existing = skills.get(skill_name) or {}
-            enabled = bool(existing.get("enabled", False))
-            channels = existing.get("channels") or ["all"]
+            try:
+                existing = skills.get(skill_name) or {}
+                enabled = bool(existing.get("enabled", False))
+                channels = existing.get("channels") or ["all"]
 
-            # Inherit source from manifest when the entry already exists.
-            # For new skills, default to "builtin" if name matches a
-            # packaged builtin, otherwise "customized".
-            if existing:
-                source = existing.get("source", "customized")
-            else:
-                source = (
-                    "builtin"
-                    if skill_name in builtin_versions
-                    else "customized"
+                # Inherit source from manifest when the entry already exists.
+                # For new skills, default to "builtin" if name matches a
+                # packaged builtin, otherwise "customized".
+                if existing:
+                    source = existing.get("source", "customized")
+                else:
+                    source = (
+                        "builtin"
+                        if skill_name in builtin_versions
+                        else "customized"
+                    )
+
+                metadata = _build_skill_metadata(
+                    skill_name,
+                    skill_dir,
+                    source=source,
+                    protected=False,
                 )
-
-            metadata = _build_skill_metadata(
-                skill_name,
-                skill_dir,
-                source=source,
-                protected=False,
-            )
-            next_entry = {
-                "enabled": enabled,
-                "channels": channels,
-                "source": source,
-                "metadata": metadata,
-                "requirements": metadata["requirements"],
-                "updated_at": metadata["updated_at"],
-            }
-            if "config" in existing:
-                next_entry["config"] = existing.get("config")
-            existing_tags = existing.get("tags")
-            if existing_tags is not None:
-                next_entry["tags"] = existing_tags
-            skills[skill_name] = next_entry
-            skills[skill_name].pop("sync_to_hub", None)
-            skills[skill_name].pop("sync_to_pool", None)
+                next_entry = {
+                    "enabled": enabled,
+                    "channels": channels,
+                    "source": source,
+                    "metadata": metadata,
+                    "requirements": metadata["requirements"],
+                    "updated_at": metadata["updated_at"],
+                }
+                if "config" in existing:
+                    next_entry["config"] = existing.get("config")
+                existing_tags = existing.get("tags")
+                if existing_tags is not None:
+                    next_entry["tags"] = existing_tags
+                skills[skill_name] = next_entry
+                skills[skill_name].pop("sync_to_hub", None)
+                skills[skill_name].pop("sync_to_pool", None)
+            except Exception:
+                logger.warning(
+                    "Skipping workspace skill '%s' during reconcile",
+                    skill_name,
+                    exc_info=True,
+                )
 
         for skill_name in list(skills):
             if skill_name not in discovered:

--- a/src/qwenpaw/agents/skills_manager.py
+++ b/src/qwenpaw/agents/skills_manager.py
@@ -505,8 +505,8 @@ def _read_json_unlocked(path: Path, default: dict[str, Any]) -> dict[str, Any]:
         return json.loads(json.dumps(default))
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-        logger.warning("Cannot read JSON from %s, resetting to default", path)
+    except json.JSONDecodeError:
+        logger.warning("Malformed JSON in %s, resetting to default", path)
         return json.loads(json.dumps(default))
 
 
@@ -570,6 +570,11 @@ def _default_pool_manifest() -> dict[str, Any]:
     }
 
 
+def _normalize_skill_manifest_entry(entry: Any) -> dict[str, Any]:
+    """Return a manifest entry as a dict, or an empty dict for legacy junk."""
+    return entry if isinstance(entry, dict) else {}
+
+
 def _is_builtin_skill(skill_name: str, builtin_names: list[str]) -> bool:
     """Check if skill name is in builtin list."""
     return skill_name in builtin_names
@@ -577,7 +582,11 @@ def _is_builtin_skill(skill_name: str, builtin_names: list[str]) -> bool:
 
 def _is_pool_builtin_entry(entry: dict[str, Any] | None) -> bool:
     """Return whether one pool manifest entry represents a builtin slot."""
-    return bool(entry) and str(entry.get("source", "") or "") == "builtin"
+    normalized = _normalize_skill_manifest_entry(entry)
+    return (
+        bool(normalized)
+        and str(normalized.get("source", "") or "") == "builtin"
+    )
 
 
 def _classify_pool_skill_source(
@@ -1076,7 +1085,9 @@ def _build_builtin_import_candidate(
     pref = preferred_language or get_builtin_skill_language_preference()
     canonical_name = _canonical_builtin_skill_name(skill_name, registry)
     variants = registry.get(canonical_name) or {}
-    current = pool_skills.get(canonical_name) or {}
+    current = _normalize_skill_manifest_entry(
+        pool_skills.get(canonical_name),
+    )
     current_version_text = str(current.get("version_text", "") or "")
     current_source = str(current.get("source", "") or "")
     current_language = ""
@@ -1460,8 +1471,17 @@ def reconcile_pool_manifest() -> dict[str, Any]:
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
+            raw_existing = skills.get(skill_name)
+            existing = _normalize_skill_manifest_entry(raw_existing)
+            if raw_existing not in (None, existing):
+                logger.warning(
+                    (
+                        "Malformed pool manifest entry for '%s'; "
+                        "rebuilding from disk"
+                    ),
+                    skill_name,
+                )
             try:
-                existing = skills.get(skill_name, {})
                 source, protected = _classify_pool_skill_source(
                     skill_name,
                     skill_dir,
@@ -1552,8 +1572,17 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
+            raw_existing = skills.get(skill_name)
+            existing = _normalize_skill_manifest_entry(raw_existing)
+            if raw_existing not in (None, existing):
+                logger.warning(
+                    (
+                        "Malformed workspace manifest entry for '%s'; "
+                        "rebuilding from disk"
+                    ),
+                    skill_name,
+                )
             try:
-                existing = skills.get(skill_name) or {}
                 enabled = bool(existing.get("enabled", False))
                 channels = existing.get("channels") or ["all"]
 

--- a/src/qwenpaw/app/routers/skills.py
+++ b/src/qwenpaw/app/routers/skills.py
@@ -39,6 +39,7 @@ from ...agents.skills_manager import (
     _default_workspace_manifest,
     _get_skill_mtime,
     _mutate_json,
+    _normalize_skill_manifest_entry,
     _read_skill_from_dir,
     get_pool_builtin_update_notice,
     get_pool_builtin_sync_status,
@@ -510,7 +511,13 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
     entries = manifest.get("skills", {})
     skill_root = get_workspace_skills_dir(workspace_dir)
     specs: list[SkillSpec] = []
-    for skill_name, entry in sorted(entries.items()):
+    for skill_name, raw_entry in sorted(entries.items()):
+        entry = _normalize_skill_manifest_entry(raw_entry)
+        if raw_entry not in (None, entry):
+            logger.warning(
+                "Skipping malformed workspace skill entry '%s' in manifest",
+                skill_name,
+            )
         try:
             source = entry.get("source", "customized")
             skill_dir = skill_root / skill_name
@@ -543,7 +550,13 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
     pool_dir = get_skill_pool_dir()
     sync_info = get_pool_builtin_sync_status(pool_skills=entries)
     specs: list[PoolSkillSpec] = []
-    for skill_name, entry in sorted(entries.items()):
+    for skill_name, raw_entry in sorted(entries.items()):
+        entry = _normalize_skill_manifest_entry(raw_entry)
+        if raw_entry not in (None, entry):
+            logger.warning(
+                "Skipping malformed pool skill entry '%s' in manifest",
+                skill_name,
+            )
         try:
             source = entry.get("source", "customized")
             skill_dir = pool_dir / skill_name
@@ -699,28 +712,14 @@ async def cancel_hub_install(task_id: str) -> dict[str, Any]:
 
 @router.get("/pool")
 async def list_pool_skills() -> list[PoolSkillSpec]:
-    try:
-        return _build_pool_skill_specs()
-    except Exception as exc:
-        logger.exception("Failed to list pool skills")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to load skill pool: {exc}",
-        ) from exc
+    return _build_pool_skill_specs()
 
 
 @router.post("/pool/refresh")
 async def refresh_pool_skills() -> list[PoolSkillSpec]:
     """Force reconcile and return updated pool skill list."""
-    try:
-        reconcile_pool_manifest()
-        return _build_pool_skill_specs()
-    except Exception as exc:
-        logger.exception("Failed to refresh pool skills")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to refresh skill pool: {exc}",
-        ) from exc
+    reconcile_pool_manifest()
+    return _build_pool_skill_specs()
 
 
 @router.get("/pool/builtin-sources")

--- a/src/qwenpaw/app/routers/skills.py
+++ b/src/qwenpaw/app/routers/skills.py
@@ -511,22 +511,29 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
     skill_root = get_workspace_skills_dir(workspace_dir)
     specs: list[SkillSpec] = []
     for skill_name, entry in sorted(entries.items()):
-        source = entry.get("source", "customized")
-        skill_dir = skill_root / skill_name
-        skill = _read_skill_from_dir(skill_dir, source)
-        if skill is None:
-            continue
-        dump = skill.model_dump()
-        dump["tags"] = entry.get("tags") or []
-        specs.append(
-            SkillSpec(
-                **dump,
-                enabled=entry.get("enabled", False),
-                channels=entry.get("channels") or ["all"],
-                config=entry.get("config") or {},
-                last_updated=_get_skill_mtime(skill_dir),
-            ),
-        )
+        try:
+            source = entry.get("source", "customized")
+            skill_dir = skill_root / skill_name
+            skill = _read_skill_from_dir(skill_dir, source)
+            if skill is None:
+                continue
+            dump = skill.model_dump()
+            dump["tags"] = entry.get("tags") or []
+            specs.append(
+                SkillSpec(
+                    **dump,
+                    enabled=entry.get("enabled", False),
+                    channels=entry.get("channels") or ["all"],
+                    config=entry.get("config") or {},
+                    last_updated=_get_skill_mtime(skill_dir),
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Skipping workspace skill '%s': failed to build spec",
+                skill_name,
+                exc_info=True,
+            )
     return specs
 
 
@@ -537,40 +544,47 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
     sync_info = get_pool_builtin_sync_status(pool_skills=entries)
     specs: list[PoolSkillSpec] = []
     for skill_name, entry in sorted(entries.items()):
-        source = entry.get("source", "customized")
-        skill_dir = pool_dir / skill_name
-        skill = _read_skill_from_dir(skill_dir, source)
-        if skill is None:
-            continue
-        info = sync_info.get(skill_name, {})
-        dump = skill.model_dump(exclude={"version_text"})
-        dump["tags"] = entry.get("tags") or []
-        specs.append(
-            PoolSkillSpec(
-                **dump,
-                protected=bool(entry.get("protected", False)),
-                version_text=str(entry.get("version_text", "") or ""),
-                commit_text=str(entry.get("commit_text", "") or ""),
-                sync_status=str(info.get("sync_status", "") or ""),
-                latest_version_text=str(
-                    info.get("latest_version_text", "") or "",
+        try:
+            source = entry.get("source", "customized")
+            skill_dir = pool_dir / skill_name
+            skill = _read_skill_from_dir(skill_dir, source)
+            if skill is None:
+                continue
+            info = sync_info.get(skill_name, {})
+            dump = skill.model_dump(exclude={"version_text"})
+            dump["tags"] = entry.get("tags") or []
+            specs.append(
+                PoolSkillSpec(
+                    **dump,
+                    protected=bool(entry.get("protected", False)),
+                    version_text=str(entry.get("version_text", "") or ""),
+                    commit_text=str(entry.get("commit_text", "") or ""),
+                    sync_status=str(info.get("sync_status", "") or ""),
+                    latest_version_text=str(
+                        info.get("latest_version_text", "") or "",
+                    ),
+                    builtin_language=str(
+                        entry.get("builtin_language", "") or "",
+                    ),
+                    available_builtin_languages=[
+                        str(language)
+                        for language in (
+                            info.get("available_languages")
+                            or entry.get("available_builtin_languages")
+                            or []
+                        )
+                        if str(language)
+                    ],
+                    config=entry.get("config") or {},
+                    last_updated=_get_skill_mtime(skill_dir),
                 ),
-                builtin_language=str(
-                    entry.get("builtin_language", "") or "",
-                ),
-                available_builtin_languages=[
-                    str(language)
-                    for language in (
-                        info.get("available_languages")
-                        or entry.get("available_builtin_languages")
-                        or []
-                    )
-                    if str(language)
-                ],
-                config=entry.get("config") or {},
-                last_updated=_get_skill_mtime(skill_dir),
-            ),
-        )
+            )
+        except Exception:
+            logger.warning(
+                "Skipping pool skill '%s': failed to build spec",
+                skill_name,
+                exc_info=True,
+            )
     return specs
 
 
@@ -685,14 +699,28 @@ async def cancel_hub_install(task_id: str) -> dict[str, Any]:
 
 @router.get("/pool")
 async def list_pool_skills() -> list[PoolSkillSpec]:
-    return _build_pool_skill_specs()
+    try:
+        return _build_pool_skill_specs()
+    except Exception as exc:
+        logger.exception("Failed to list pool skills")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to load skill pool: {exc}",
+        ) from exc
 
 
 @router.post("/pool/refresh")
 async def refresh_pool_skills() -> list[PoolSkillSpec]:
     """Force reconcile and return updated pool skill list."""
-    reconcile_pool_manifest()
-    return _build_pool_skill_specs()
+    try:
+        reconcile_pool_manifest()
+        return _build_pool_skill_specs()
+    except Exception as exc:
+        logger.exception("Failed to refresh pool skills")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to refresh skill pool: {exc}",
+        ) from exc
 
 
 @router.get("/pool/builtin-sources")


### PR DESCRIPTION
## Description

- Normalize manifest entries to dict before use (`_normalize_skill_manifest_entry`), so legacy junk is safely handled without
broad exception swallowing                                                                                                   
- Per-entry try/except in `reconcile_pool_manifest`, `reconcile_workspace_manifest`, `_build_pool_skill_specs`, and
`_build_workspace_skill_specs` . One bad skill no longer blocks the rest                                                       
- Malformed entries are rebuilt from disk on next reconcile rather than permanently skipped                                  
- Frontend error parsing enhanced to handle structured conflict responses from zip upload  
                                        

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
