### PR TITLE
fix(message_processing): return resolved path for file:// URL audio blocks

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -59,6 +59,12 @@ async def _process_single_file_block(
                     local_path = urllib.request.url2pathname(parsed.path)
                 except Exception:
                     return None
+                logger.debug(
+                    "Resolved file:// URL to local path: %s -> %s",
+                    url,
+                    local_path,
+                )
+                return local_path
             local_path = await download_file_from_url(
                 url,
                 filename,


### PR DESCRIPTION
## Summary

Fixes audio (and any media) blocks delivered with `{"type": "url", "url": "file://..."}` source: the local path was extracted correctly via `url2pathname()` but then unconditionally overwritten by `download_file_from_url()`, which is HTTP-only and returns `None` for `file://` URLs. As a result `_process_single_file_block` returned `None` for `file://` audio blocks, `_process_audio_block` was never invoked, and the agent saw the raw audio block instead of a transcribed text.

## Setup that reproduces it

- QwenPaw v1.1.5 / current `main`
- Telegram channel
- `audio_mode = "auto"`
- A working OpenAI-compat Whisper provider (any `/v1/audio/transcriptions` endpoint)

Send a voice message; the workspace media file lands in `~/.qwenpaw/workspaces/<agent>/media/<id>.oga`. The constructed audio block has `source = {"type": "url", "url": "file:///.../<id>.oga"}`. Without this fix, the LLM receives that audio block raw instead of the transcribed `[Voice message]: ...`.

## Relation to #1896

Orthogonal. PR #1896 normalises `data` → `{"type": "url", "url": "file://..."}` for blocks that arrive without a `source` dict. After that normalisation lands, `_process_single_file_block` still drops the resulting `file://` URL on the floor — that's what this PR fixes. Both can land independently; the audio pipeline only works end-to-end with both.

## Change

`src/qwenpaw/agents/utils/message_processing.py` — for the `parsed.scheme == "file"` branch, return the resolved local path immediately instead of falling through to `download_file_from_url()`. Six added lines, no removals, no behaviour change for HTTP URLs.

## Tests

Happy to add unit coverage for `_process_single_file_block` (currently uncovered) if that helps the review — let me know if you'd prefer the PR to grow.

## Issue

Confirmed in #1516 (comment).

🤖 Authored with [Claude Code](https://claude.com/claude-code) (Ren, Anthropic Claude Opus 4.7) — final review and submission by @karls0r.