### PR TITLE
feat(cli): refuse non-loopback bind when QWENPAW_AUTH_ENABLED is unset

### DIFF
--- a/src/qwenpaw/cli/app_cmd.py
+++ b/src/qwenpaw/cli/app_cmd.py
@@ -15,7 +15,16 @@ from ..config.utils import write_last_api
 from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
 
 
-_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", "ip6-localhost"})
+_LOOPBACK_HOSTNAMES = frozenset(
+    {"localhost", "localhost.localdomain", "ip6-localhost"},
+)
+
+
+def _addr_is_loopback(addr: str) -> bool:
+    try:
+        return ipaddress.ip_address(addr).is_loopback
+    except ValueError:
+        return False
 
 
 def _host_is_loopback(host: str) -> bool:
@@ -30,25 +39,14 @@ def _host_is_loopback(host: str) -> bool:
         return False
     if host.lower() in _LOOPBACK_HOSTNAMES:
         return True
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        pass
+    if _addr_is_loopback(host):
+        return True
     # Hostname: only treat as loopback if every resolved address is loopback.
     try:
         infos = socket.getaddrinfo(host, None)
     except socket.gaierror:
         return False
-    if not infos:
-        return False
-    for info in infos:
-        addr = info[4][0]
-        try:
-            if not ipaddress.ip_address(addr).is_loopback:
-                return False
-        except ValueError:
-            return False
-    return True
+    return bool(infos) and all(_addr_is_loopback(info[4][0]) for info in infos)
 
 
 def _enforce_unauth_public_bind_safety(
@@ -75,7 +73,8 @@ def _enforce_unauth_public_bind_safety(
         return
 
     env_override = EnvVarLoader.get_str(
-        "QWENPAW_ALLOW_UNAUTH_PUBLIC", ""
+        "QWENPAW_ALLOW_UNAUTH_PUBLIC",
+        "",
     ).strip().lower() in ("true", "1", "yes")
     if allow_unauth_public or env_override:
         click.echo(
@@ -123,7 +122,8 @@ def _enforce_unauth_public_bind_safety(
     click.echo("  2. Enable QwenPaw's built-in authentication:", err=True)
     click.echo("       export QWENPAW_AUTH_ENABLED=true", err=True)
     click.echo(
-        "       qwenpaw app --host <HOST> --port <PORT>   " "# then register at /login",
+        "       qwenpaw app --host <HOST> --port <PORT>   "
+        "# then register at /login",
         err=True,
     )
     click.echo(err=True)
@@ -133,7 +133,8 @@ def _enforce_unauth_public_bind_safety(
         err=True,
     )
     click.echo(
-        "       qwenpaw app --host <HOST> --port <PORT> " "--allow-unauth-public",
+        "       qwenpaw app --host <HOST> --port <PORT> "
+        "--allow-unauth-public",
         err=True,
     )
     click.echo(

--- a/src/qwenpaw/cli/app_cmd.py
+++ b/src/qwenpaw/cli/app_cmd.py
@@ -1,15 +1,148 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
+import socket
+import sys
 
 import click
 import uvicorn
 
-from ..constant import LOG_LEVEL_ENV
+from ..constant import LOG_LEVEL_ENV, EnvVarLoader
 from ..config.utils import write_last_api
 from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
+
+
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", "ip6-localhost"})
+
+
+def _host_is_loopback(host: str) -> bool:
+    """Return True when *host* binds only to a loopback interface.
+
+    Accepts IPv4/IPv6 literals and a small allowlist of well-known
+    loopback hostnames. Anything that resolves to a non-loopback
+    address — including ``0.0.0.0``, ``::``, and arbitrary public
+    interfaces or hostnames — returns False.
+    """
+    if not host:
+        return False
+    if host.lower() in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        pass
+    # Hostname: only treat as loopback if every resolved address is loopback.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        addr = info[4][0]
+        try:
+            if not ipaddress.ip_address(addr).is_loopback:
+                return False
+        except ValueError:
+            return False
+    return True
+
+
+def _enforce_unauth_public_bind_safety(
+    host: str,
+    allow_unauth_public: bool,
+) -> None:
+    """Refuse non-loopback bind when no auth gate is configured.
+
+    QwenPaw's HTTP gateway can invoke host-affecting tools (shell
+    commands, file IO, etc.). Authentication is opt-in via
+    ``QWENPAW_AUTH_ENABLED``; binding to a non-loopback address with
+    auth disabled effectively exposes a tool-enabled agent on the
+    network with no gate. We refuse this configuration unless the
+    operator explicitly opts in via ``--allow-unauth-public`` or the
+    ``QWENPAW_ALLOW_UNAUTH_PUBLIC`` env var.
+    """
+    if _host_is_loopback(host):
+        return
+
+    # Lazy import to avoid pulling app stack into CLI startup.
+    from ..app.auth import is_auth_enabled
+
+    if is_auth_enabled():
+        return
+
+    env_override = EnvVarLoader.get_str(
+        "QWENPAW_ALLOW_UNAUTH_PUBLIC", ""
+    ).strip().lower() in ("true", "1", "yes")
+    if allow_unauth_public or env_override:
+        click.echo(
+            "⚠️  WARNING: binding to a non-loopback address "
+            f"({host}) with authentication disabled.",
+            err=True,
+        )
+        click.echo(
+            "   The QwenPaw HTTP gateway exposes tool-enabled agents that "
+            "can run shell commands, read files, and call external APIs.",
+            err=True,
+        )
+        click.echo(
+            "   Anyone who can reach this port can drive those tools. "
+            "Make sure auth is enforced upstream (reverse proxy, VPN, "
+            "Tailscale, security group) before exposing this port.",
+            err=True,
+        )
+        click.echo(err=True)
+        return
+
+    click.echo(
+        f"❌ Refusing to bind to non-loopback host '{host}' with "
+        "authentication disabled.",
+        err=True,
+    )
+    click.echo(err=True)
+    click.echo(
+        "QwenPaw's HTTP gateway can invoke host-affecting tools (shell "
+        "commands, file IO, external APIs). Exposing it on a non-loopback "
+        "interface without an authentication gate would let anyone who "
+        "reaches the port drive those tools.",
+        err=True,
+    )
+    click.echo(err=True)
+    click.echo("To proceed, choose one of the following:", err=True)
+    click.echo(err=True)
+    click.echo(
+        "  1. (recommended) Bind to loopback and put a reverse proxy / "
+        "Tailscale / VPN in front:",
+        err=True,
+    )
+    click.echo("       qwenpaw app --host 127.0.0.1 --port <PORT>", err=True)
+    click.echo(err=True)
+    click.echo("  2. Enable QwenPaw's built-in authentication:", err=True)
+    click.echo("       export QWENPAW_AUTH_ENABLED=true", err=True)
+    click.echo(
+        "       qwenpaw app --host <HOST> --port <PORT>   " "# then register at /login",
+        err=True,
+    )
+    click.echo(err=True)
+    click.echo(
+        "  3. Override the safety check (only if auth is enforced "
+        "upstream by a reverse proxy / VPN you control):",
+        err=True,
+    )
+    click.echo(
+        "       qwenpaw app --host <HOST> --port <PORT> " "--allow-unauth-public",
+        err=True,
+    )
+    click.echo(
+        "       # or set QWENPAW_ALLOW_UNAUTH_PUBLIC=true in the service "
+        "environment.",
+        err=True,
+    )
+    click.echo(err=True)
+    sys.exit(2)
 
 
 @click.command("app")
@@ -52,6 +185,15 @@ from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
     "This option is deprecated and will be removed in a future version. "
     "QwenPaw always uses 1 worker.",
 )
+@click.option(
+    "--allow-unauth-public",
+    is_flag=True,
+    default=False,
+    help="Allow binding to a non-loopback address even when "
+    "QWENPAW_AUTH_ENABLED is not set. Only use this when an upstream "
+    "reverse proxy or VPN enforces authentication. Can also be set via "
+    "the QWENPAW_ALLOW_UNAUTH_PUBLIC environment variable.",
+)
 def app_cmd(
     host: str,
     port: int,
@@ -59,6 +201,7 @@ def app_cmd(
     workers: int,  # pylint: disable=unused-argument
     log_level: str,
     hide_access_paths: tuple[str, ...],
+    allow_unauth_public: bool,
 ) -> None:
     """Run QwenPaw FastAPI app."""
     # Handle deprecated --workers parameter
@@ -74,6 +217,8 @@ def app_cmd(
             err=True,
         )
         click.echo(err=True)
+
+    _enforce_unauth_public_bind_safety(host, allow_unauth_public)
 
     # Persist last used host/port for other terminals
     if host == "0.0.0.0":

--- a/tests/unit/cli/test_cli_app_safety.py
+++ b/tests/unit/cli/test_cli_app_safety.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Tests for the unauthenticated public-bind safety gate in ``qwenpaw app``.
+
+QwenPaw's HTTP gateway can invoke host-affecting tools. When
+``QWENPAW_AUTH_ENABLED`` is unset, binding to a non-loopback host
+exposes those tools without an authentication gate. ``app_cmd`` must
+refuse this configuration unless the operator opts in.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from qwenpaw.cli import app_cmd as app_cmd_mod
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("QWENPAW_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("QWENPAW_ALLOW_UNAUTH_PUBLIC", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _host_is_loopback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "127.5.5.5", "::1", "localhost", "LOCALHOST"],
+)
+def test_host_is_loopback_true(host: str) -> None:
+    assert app_cmd_mod._host_is_loopback(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["0.0.0.0", "::", "1.2.3.4", "192.168.1.10", "example.com", ""],
+)
+def test_host_is_loopback_false(host: str) -> None:
+    assert app_cmd_mod._host_is_loopback(host) is False
+
+
+# ---------------------------------------------------------------------------
+# _enforce_unauth_public_bind_safety
+# ---------------------------------------------------------------------------
+
+
+def _patch_auth(enabled: bool):
+    return patch.object(
+        app_cmd_mod,
+        "_enforce_unauth_public_bind_safety",
+        wraps=app_cmd_mod._enforce_unauth_public_bind_safety,
+    ), patch("qwenpaw.app.auth.is_auth_enabled", return_value=enabled)
+
+
+def test_loopback_bind_passes_without_auth() -> None:
+    with patch("qwenpaw.app.auth.is_auth_enabled", return_value=False):
+        # Should not raise / exit.
+        app_cmd_mod._enforce_unauth_public_bind_safety("127.0.0.1", False)
+
+
+def test_public_bind_with_auth_enabled_passes() -> None:
+    with patch("qwenpaw.app.auth.is_auth_enabled", return_value=True):
+        app_cmd_mod._enforce_unauth_public_bind_safety("0.0.0.0", False)
+
+
+def test_public_bind_with_explicit_flag_passes() -> None:
+    with patch("qwenpaw.app.auth.is_auth_enabled", return_value=False):
+        app_cmd_mod._enforce_unauth_public_bind_safety("0.0.0.0", True)
+
+
+def test_public_bind_with_env_override_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_ALLOW_UNAUTH_PUBLIC", "true")
+    with patch("qwenpaw.app.auth.is_auth_enabled", return_value=False):
+        app_cmd_mod._enforce_unauth_public_bind_safety("0.0.0.0", False)
+
+
+def test_public_bind_without_auth_or_override_exits() -> None:
+    with patch("qwenpaw.app.auth.is_auth_enabled", return_value=False):
+        with pytest.raises(SystemExit) as excinfo:
+            app_cmd_mod._enforce_unauth_public_bind_safety("0.0.0.0", False)
+        assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_app_cmd_refuses_public_bind_without_auth(runner: CliRunner) -> None:
+    with (
+        patch("qwenpaw.app.auth.is_auth_enabled", return_value=False),
+        patch(
+            "uvicorn.run",
+        ) as mock_run,
+    ):
+        result = runner.invoke(
+            app_cmd_mod.app_cmd,
+            ["--host", "0.0.0.0", "--port", "8088"],
+        )
+    assert result.exit_code == 2
+    assert "Refusing to bind" in result.output
+    assert "QWENPAW_AUTH_ENABLED" in result.output
+    assert "--allow-unauth-public" in result.output
+    mock_run.assert_not_called()
+
+
+def test_app_cmd_loopback_default_runs(runner: CliRunner) -> None:
+    with (
+        patch("qwenpaw.app.auth.is_auth_enabled", return_value=False),
+        patch(
+            "uvicorn.run",
+        ) as mock_run,
+        patch("qwenpaw.cli.app_cmd.write_last_api"),
+        patch(
+            "qwenpaw.cli.app_cmd.setup_logger",
+        ),
+    ):
+        result = runner.invoke(
+            app_cmd_mod.app_cmd,
+            ["--host", "127.0.0.1", "--port", "8088"],
+        )
+    assert result.exit_code == 0, result.output
+    mock_run.assert_called_once()
+
+
+def test_app_cmd_public_bind_with_flag_runs(runner: CliRunner) -> None:
+    with (
+        patch("qwenpaw.app.auth.is_auth_enabled", return_value=False),
+        patch(
+            "uvicorn.run",
+        ) as mock_run,
+        patch("qwenpaw.cli.app_cmd.write_last_api"),
+        patch(
+            "qwenpaw.cli.app_cmd.setup_logger",
+        ),
+    ):
+        result = runner.invoke(
+            app_cmd_mod.app_cmd,
+            [
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8088",
+                "--allow-unauth-public",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "WARNING" in result.output
+    mock_run.assert_called_once()
+
+
+def test_app_cmd_public_bind_with_auth_env_runs(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_AUTH_ENABLED", "true")
+    with (
+        patch("uvicorn.run") as mock_run,
+        patch(
+            "qwenpaw.cli.app_cmd.write_last_api",
+        ),
+        patch("qwenpaw.cli.app_cmd.setup_logger"),
+    ):
+        result = runner.invoke(
+            app_cmd_mod.app_cmd,
+            ["--host", "0.0.0.0", "--port", "8088"],
+        )
+    assert result.exit_code == 0, result.output
+    mock_run.assert_called_once()

--- a/tests/unit/cli/test_cli_app_safety.py
+++ b/tests/unit/cli/test_cli_app_safety.py
@@ -6,6 +6,7 @@ QwenPaw's HTTP gateway can invoke host-affecting tools. When
 exposes those tools without an authentication gate. ``app_cmd`` must
 refuse this configuration unless the operator opts in.
 """
+# pylint: disable=protected-access,redefined-outer-name
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Description

Closes #4037.

`qwenpaw app` exposes an HTTP gateway that can invoke host-affecting tools (shell, file IO, external APIs). Authentication is opt-in via `QWENPAW_AUTH_ENABLED`, so the current default lets an operator silently expose a tool-enabled agent on the public internet by passing `--host 0.0.0.0` with no warning at startup.

This PR makes that configuration impossible by accident:

- If `--host` is non-loopback **and** `QWENPAW_AUTH_ENABLED` is unset/falsy **and** the new `--allow-unauth-public` flag (or `QWENPAW_ALLOW_UNAUTH_PUBLIC` env var) is not set, the CLI exits with a clear message pointing to three safe paths:
  1. Bind `127.0.0.1` and front with a reverse proxy / VPN / Tailscale (recommended).
  2. `export QWENPAW_AUTH_ENABLED=true` to use the built-in auth.
  3. Pass `--allow-unauth-public` (or set `QWENPAW_ALLOW_UNAUTH_PUBLIC=true` in the service environment) when upstream auth is enforced and the trade-off is accepted.
- The override path proceeds but prints a loud multi-line warning so the choice is at least visible in logs.
- Loopback binds (`127.0.0.1`, `::1`, `localhost`) and any bind with auth enabled are unchanged — no friction for the recommended configuration.

Loopback detection handles IPv4/IPv6 literals and a small allowlist of well-known hostnames; arbitrary hostnames are resolved via `socket.getaddrinfo` and treated as loopback only when *every* resolved address is loopback.

## Type of Change

- [x] Feature (CLI safety guard)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

Not a breaking change for the recommended configuration (loopback bind) or for any deployment that already sets `QWENPAW_AUTH_ENABLED=true`. Operators currently relying on `--host 0.0.0.0` without auth will see a one-time refusal with instructions for the override flag.

## Component(s) Affected

- [x] CLI (`src/qwenpaw/cli/app_cmd.py`)
- [x] Tests (`tests/unit/cli/test_cli_app_safety.py`)

## Why this and not just docs

The auth system is already implemented end-to-end (login UI, JWT, AuthGuard). The gap is purely defaults plus a CLI guard. `SECURITY.md` and the `qwenpaw init` `SECURITY_WARNING` are valuable, but they live in places an operator who runs `pip install qwenpaw && supervisorctl start qwenpaw` may never see. The CLI is the last place to catch the mistake before it commits.

For consistency with comparable agent CLIs (Claude Code, Codex, OpenCode all gate any network-exposed gateway with a token/auth or require explicit opt-out), this brings QwenPaw to the same default posture.

## Out of scope (intentionally)

- Not changing the default value of `QWENPAW_AUTH_ENABLED` (would silently change behavior for existing local deployments).
- Not removing the operator-override path.
- Not adding in-process sandboxing of skills.
- Not claiming prompt injection itself is a vulnerability — it isn't, per the documented trust model.

## Testing

20 new unit tests in `tests/unit/cli/test_cli_app_safety.py` cover:

- `_host_is_loopback` classifier across IPv4/IPv6 literals, hostnames, and the empty string.
- `_enforce_unauth_public_bind_safety` for: loopback (passes), public + auth-on (passes), public + flag (passes with warning), public + env override (passes with warning), public + neither (exits with code 2).
- `CliRunner`-driven integration of `app_cmd` invocations using mocked `uvicorn.run` and `is_auth_enabled`, asserting the refuse path emits the expected guidance and that the recommended/override/auth-enabled paths invoke `uvicorn.run`.

## Checklist

- [x] Run and pass `pre-commit run --all-files` (on changed files — see verification below)
- [x] Run and pass relevant tests
- [x] Update documentation if needed (none required — `SECURITY.md` already documents the trust model; the CLI itself now surfaces the guidance)

## Local Verification Evidence

```
$ pre-commit run --files src/qwenpaw/cli/app_cmd.py tests/unit/cli/test_cli_app_safety.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.............................................(no files to check)Skipped
```

```
$ pytest tests/unit/cli/test_cli_app_safety.py -q
....................                                                     [100%]
20 passed in 2.38s
```