### PR TITLE
perf(console): Solve duplicate rendering

### DIFF
--- a/console/src/components/ConsolePollService/index.tsx
+++ b/console/src/components/ConsolePollService/index.tsx
@@ -32,13 +32,20 @@ export default function ConsolePollService() {
   }, []);
 
   useEffect(() => {
+    const prevApprovalsRef = { current: '' };
     const tick = () => {
       consoleApi
         .getPushMessages()
         .then((res) => {
-          // Update pending approvals (global, will be filtered by Chat component)
+          // Update pending approvals only when they actually change,
+          // to avoid triggering unnecessary re-renders in Chat component
+          // every 2.5s polling cycle.
           if (res?.pending_approvals) {
-            setApprovals(res.pending_approvals);
+            const serialized = JSON.stringify(res.pending_approvals);
+            if (serialized !== prevApprovalsRef.current) {
+              prevApprovalsRef.current = serialized;
+              setApprovals(res.pending_approvals);
+            }
           }
 
           // Update message bubbles

--- a/console/src/components/ConsolePollService/index.tsx
+++ b/console/src/components/ConsolePollService/index.tsx
@@ -32,7 +32,7 @@ export default function ConsolePollService() {
   }, []);
 
   useEffect(() => {
-    const prevApprovalsRef = { current: '' };
+    const prevApprovalsRef = { current: "" };
     const tick = () => {
       consoleApi
         .getPushMessages()


### PR DESCRIPTION
## Description

1. By comparing pending_approvals using JSON.stringify, setApprovals is only called when the data actually changes. — This avoids unnecessary re-rendering triggered by polling.

Fixes #4023 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
