### PR TITLE
feat(skill): Add skill install/uninstall cli

### DIFF
--- a/src/qwenpaw/agents/skills_manager.py
+++ b/src/qwenpaw/agents/skills_manager.py
@@ -2277,11 +2277,46 @@ class SkillService:
                 "updated_at": metadata["updated_at"],
             }
 
-        _mutate_json(
-            get_workspace_skill_manifest_path(self.workspace_dir),
-            _default_workspace_manifest(),
-            _update,
-        )
+        try:
+            _mutate_json(
+                get_workspace_skill_manifest_path(self.workspace_dir),
+                _default_workspace_manifest(),
+                _update,
+            )
+        except Exception as exc:
+            try:
+                if skill_dir.exists():
+                    shutil.rmtree(skill_dir, ignore_errors=True)
+            except Exception as cleanup_exc:
+                raise SkillsError(
+                    message=(
+                        "Workspace skill files were created, but manifest "
+                        "update failed and rollback cleanup also failed."
+                    ),
+                    details={
+                        "skill_name": skill_name,
+                        "workspace_dir": str(self.workspace_dir),
+                        "manifest_path": str(
+                            get_workspace_skill_manifest_path(
+                                self.workspace_dir,
+                            ),
+                        ),
+                        "cleanup_error": str(cleanup_exc),
+                    },
+                ) from exc
+            raise SkillsError(
+                message=(
+                    "Workspace skill files were created, but manifest "
+                    "update failed. File changes were rolled back."
+                ),
+                details={
+                    "skill_name": skill_name,
+                    "workspace_dir": str(self.workspace_dir),
+                    "manifest_path": str(
+                        get_workspace_skill_manifest_path(self.workspace_dir),
+                    ),
+                },
+            ) from exc
         return skill_name
 
     def save_skill(
@@ -2722,11 +2757,26 @@ class SkillService:
         def _update(payload: dict[str, Any]) -> None:
             payload.get("skills", {}).pop(skill_name, None)
 
-        _mutate_json(
-            get_workspace_skill_manifest_path(self.workspace_dir),
-            _default_workspace_manifest(),
-            _update,
-        )
+        try:
+            _mutate_json(
+                get_workspace_skill_manifest_path(self.workspace_dir),
+                _default_workspace_manifest(),
+                _update,
+            )
+        except Exception as exc:
+            raise SkillsError(
+                message=(
+                    "Workspace skill files were deleted, but manifest "
+                    "update failed."
+                ),
+                details={
+                    "skill_name": skill_name,
+                    "workspace_dir": str(self.workspace_dir),
+                    "manifest_path": str(
+                        get_workspace_skill_manifest_path(self.workspace_dir),
+                    ),
+                },
+            ) from exc
         return True
 
     def load_skill_file(
@@ -2835,11 +2885,38 @@ class SkillPoolService:
             if config is not None:
                 payload["skills"][skill_name]["config"] = dict(config)
 
-        _mutate_json(
-            get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
-            _update,
-        )
+        try:
+            _mutate_json(
+                get_pool_skill_manifest_path(),
+                _default_pool_manifest(),
+                _update,
+            )
+        except Exception as exc:
+            try:
+                if skill_dir.exists():
+                    shutil.rmtree(skill_dir, ignore_errors=True)
+            except Exception as cleanup_exc:
+                raise SkillsError(
+                    message=(
+                        "Skill pool files were created, but manifest update "
+                        "failed and rollback cleanup also failed."
+                    ),
+                    details={
+                        "skill_name": skill_name,
+                        "manifest_path": str(get_pool_skill_manifest_path()),
+                        "cleanup_error": str(cleanup_exc),
+                    },
+                ) from exc
+            raise SkillsError(
+                message=(
+                    "Skill pool manifest update failed after file creation. "
+                    "File changes were rolled back."
+                ),
+                details={
+                    "skill_name": skill_name,
+                    "manifest_path": str(get_pool_skill_manifest_path()),
+                },
+            ) from exc
         return skill_name
 
     def import_from_zip(
@@ -2964,11 +3041,23 @@ class SkillPoolService:
         def _update(payload: dict[str, Any]) -> None:
             payload.get("skills", {}).pop(skill_name, None)
 
-        _mutate_json(
-            get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
-            _update,
-        )
+        try:
+            _mutate_json(
+                get_pool_skill_manifest_path(),
+                _default_pool_manifest(),
+                _update,
+            )
+        except Exception as exc:
+            raise SkillsError(
+                message=(
+                    "Skill pool files were deleted, but manifest update "
+                    "failed."
+                ),
+                details={
+                    "skill_name": skill_name,
+                    "manifest_path": str(get_pool_skill_manifest_path()),
+                },
+            ) from exc
         return True
 
     def set_pool_skill_tags(

--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -7,15 +7,23 @@ from pathlib import Path
 import click
 
 from ..agents.skills_manager import (
+    SkillConflictError,
     SkillPoolService,
     SkillService,
     get_workspace_skills_dir,
+    list_workspaces,
+    read_skill_pool_manifest,
     read_skill_manifest,
     reconcile_pool_manifest,
     reconcile_workspace_manifest,
 )
-from ..constant import WORKING_DIR
+from ..agents.skills_hub import (
+    import_pool_skill_from_hub,
+    install_skill_from_hub,
+)
 from ..config import load_config
+from ..constant import WORKING_DIR
+from ..security.skill_scanner import SkillScanError
 from .utils import prompt_checkbox, prompt_confirm
 
 
@@ -30,6 +38,40 @@ def _get_agent_workspace(agent_id: str) -> Path:
     except Exception:
         pass
     return WORKING_DIR
+
+
+def _require_agent_workspace(agent_id: str) -> Path:
+    normalized_agent_id = str(agent_id or "").strip()
+    if not normalized_agent_id:
+        raise click.ClickException("Agent ID cannot be empty.")
+    workspaces = list_workspaces()
+    for workspace in workspaces:
+        if workspace.get("agent_id") == normalized_agent_id:
+            return Path(str(workspace["workspace_dir"])).expanduser()
+
+    available_agents = sorted(
+        str(workspace.get("agent_id") or "")
+        for workspace in workspaces
+        if str(workspace.get("agent_id") or "")
+    )
+    if available_agents:
+        raise click.ClickException(
+            "Agent "
+            f"'{normalized_agent_id}' not found. Available agents: "
+            f"{', '.join(available_agents)}",
+        )
+    raise click.ClickException(
+        f"Agent '{normalized_agent_id}' not found.",
+    )
+
+
+def _raise_conflict(exc: SkillConflictError) -> None:
+    detail = exc.detail or {}
+    message = str(detail.get("message") or str(exc))
+    suggested_name = str(detail.get("suggested_name") or "").strip()
+    if suggested_name:
+        message = f"{message} Suggested name: {suggested_name}"
+    raise click.ClickException(message)
 
 
 def _print_skill_changes(
@@ -314,3 +356,136 @@ def info_cmd(
     click.echo(
         "Description: " f"{skill.description or 'No description.'}",
     )
+
+
+@skills_group.command("install")
+@click.argument("bundle_url", required=True)
+@click.option(
+    "--agent-id",
+    "agent_id",
+    default="",
+    help="Install directly into the given agent workspace.",
+)
+@click.option(
+    "--enable/--no-enable",
+    default=True,
+    help="Enable after import when installing into an agent workspace.",
+)
+def install_cmd(
+    bundle_url: str,
+    agent_id: str,
+    enable: bool,
+) -> None:
+    """Install a skill from a URL.
+
+    Without ``--agent-id``, the skill is imported into the local skill pool.
+    With ``--agent-id``, the skill is imported directly into that workspace.
+    """
+    normalized_agent_id = str(agent_id or "").strip()
+
+    try:
+        if normalized_agent_id:
+            workspace_dir = _require_agent_workspace(normalized_agent_id)
+            result = install_skill_from_hub(
+                workspace_dir=workspace_dir,
+                bundle_url=bundle_url,
+                enable=enable,
+            )
+            click.echo(
+                f"✓ Installed skill '{result.name}' to agent "
+                f"'{normalized_agent_id}'.",
+            )
+            if result.enabled:
+                click.echo("✓ Skill enabled.")
+            click.echo(f"Source: {result.source_url}")
+            click.echo(f"Workspace: {workspace_dir}")
+            return
+
+        result = import_pool_skill_from_hub(
+            bundle_url=bundle_url,
+        )
+        click.echo(f"✓ Installed skill '{result.name}' to the skill pool.")
+        click.echo(f"Source: {result.source_url}")
+    except SkillConflictError as exc:
+        _raise_conflict(exc)
+    except SkillScanError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@skills_group.command("uninstall")
+@click.argument("skill_name", required=True)
+@click.option(
+    "--agent-id",
+    "agent_id",
+    default="",
+    help="Remove the skill from the given agent workspace.",
+)
+def uninstall_cmd(
+    skill_name: str,
+    agent_id: str,
+) -> None:
+    """Uninstall a skill from the skill pool or one agent workspace."""
+    normalized_skill_name = str(skill_name or "").strip()
+    if not normalized_skill_name:
+        raise click.ClickException("Skill name cannot be empty.")
+
+    normalized_agent_id = str(agent_id or "").strip()
+
+    try:
+        if normalized_agent_id:
+            workspace_dir = _require_agent_workspace(normalized_agent_id)
+            manifest = read_skill_manifest(workspace_dir).get("skills", {})
+            if normalized_skill_name not in manifest:
+                raise click.ClickException(
+                    f"Skill '{normalized_skill_name}' was not found for "
+                    f"agent '{normalized_agent_id}'.",
+                )
+
+            skill_service = SkillService(workspace_dir)
+            if bool(manifest[normalized_skill_name].get("enabled", False)):
+                disable_result = skill_service.disable_skill(
+                    normalized_skill_name,
+                )
+                if not disable_result.get("success"):
+                    raise click.ClickException(
+                        f"Failed to disable skill '{normalized_skill_name}' "
+                        f"for agent '{normalized_agent_id}'.",
+                    )
+
+            deleted = skill_service.delete_skill(normalized_skill_name)
+            if not deleted:
+                raise click.ClickException(
+                    f"Failed to uninstall skill '{normalized_skill_name}' "
+                    f"from agent '{normalized_agent_id}'.",
+                )
+
+            click.echo(
+                f"✓ Uninstalled skill '{normalized_skill_name}' from agent "
+                f"'{normalized_agent_id}'.",
+            )
+            return
+
+        manifest = read_skill_pool_manifest().get("skills", {})
+        if normalized_skill_name not in manifest:
+            raise click.ClickException(
+                f"Skill '{normalized_skill_name}' was not found "
+                "in the skill pool.",
+            )
+
+        deleted = SkillPoolService().delete_skill(normalized_skill_name)
+        if not deleted:
+            raise click.ClickException(
+                f"Failed to uninstall skill '{normalized_skill_name}' "
+                "from the skill pool.",
+            )
+
+        click.echo(
+            f"✓ Uninstalled skill '{normalized_skill_name}' "
+            "from the skill pool.",
+        )
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -79,7 +79,7 @@ the app is not running).
 | `qwenpaw daemon version`       | Version and paths                                                                         |
 | `qwenpaw daemon logs [-n N]`   | Last N lines of log (default 100; from `qwenpaw.log` in working dir)                      |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Workspace targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
 
 ```bash
 qwenpaw daemon status                     # Default agent status
@@ -509,7 +509,7 @@ ask QwenPaw and send the reply". **Requires `qwenpaw app` to be running.**
 | `qwenpaw cron resume <job_id>` | Resume a paused job                           |
 | `qwenpaw cron run <job_id>`    | Run once immediately                          |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Agent targeting:** use `--agent-id` when targeting one agent.
 
 ### Creating jobs
 
@@ -593,7 +593,7 @@ Manage chat sessions via the API. **Requires `qwenpaw app` to be running.**
 | `qwenpaw chats update <id> --name "..."` | Rename a session                                              |
 | `qwenpaw chats delete <id>`              | Delete a session                                              |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Agent targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
 
 ```bash
 qwenpaw chats list                        # Default agent's chats
@@ -614,15 +614,21 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 
 ### qwenpaw skills
 
-| Command                 | What it does                                      |
-| ----------------------- | ------------------------------------------------- |
-| `qwenpaw skills list`   | Show all skills and their enabled/disabled status |
-| `qwenpaw skills config` | Interactively enable/disable skills (checkbox UI) |
-| `qwenpaw skills info`   | Show local details for one workspace skill        |
+| Command                    | What it does                                              |
+| -------------------------- | --------------------------------------------------------- |
+| `qwenpaw skills install`   | Install a skill from a supported URL source               |
+| `qwenpaw skills uninstall` | Remove a skill from the skill pool or one agent workspace |
+| `qwenpaw skills list`      | Show all skills and their enabled/disabled status         |
+| `qwenpaw skills config`    | Interactively enable/disable skills (checkbox UI)         |
+| `qwenpaw skills info`      | Show local details for one workspace skill                |
 
-**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
+**Agent targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
 
 ```bash
+qwenpaw skills install https://skills.sh/owner/repo/skill  # Import into the local skill pool
+qwenpaw skills install https://skills.sh/owner/repo/skill --agent-id abc123  # Import directly into a specific agent workspace
+qwenpaw skills uninstall skill-creator  # Remove from the local skill pool
+qwenpaw skills uninstall skill-creator --agent-id abc123  # Remove from a specific agent workspace
 qwenpaw skills list                   # See default agent's skills
 qwenpaw skills list --agent-id abc123 # See specific agent's skills
 qwenpaw skills config                 # Configure default agent
@@ -713,7 +719,7 @@ See [Config & Working Directory](./config) and [Multi-Agent](./multi-agent) for 
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    Partial ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |     **Yes**      |
 | `qwenpaw chats`     | `list` · `get` · `create` · `update` · `delete`                                      |     **Yes**      |
-| `qwenpaw skills`    | `list` · `config` · `info`                                                           |        No        |
+| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `info`                                 |        No        |
 | `qwenpaw task`      | —                                                                                    |        No        |
 | `qwenpaw auth`      | `reset-password`                                                                     |        No        |
 | `qwenpaw plugin`    | `install` · `list` · `info` · `uninstall` · `validate`                               |        No        |

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -509,7 +509,7 @@ ask QwenPaw and send the reply". **Requires `qwenpaw app` to be running.**
 | `qwenpaw cron resume <job_id>` | Resume a paused job                           |
 | `qwenpaw cron run <job_id>`    | Run once immediately                          |
 
-**Agent targeting:** use `--agent-id` when targeting one agent.
+**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
 
 ### Creating jobs
 

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -79,7 +79,7 @@ the app is not running).
 | `qwenpaw daemon version`       | Version and paths                                                                         |
 | `qwenpaw daemon logs [-n N]`   | Last N lines of log (default 100; from `qwenpaw.log` in working dir)                      |
 
-**Workspace targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
+**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
 
 ```bash
 qwenpaw daemon status                     # Default agent status
@@ -593,7 +593,7 @@ Manage chat sessions via the API. **Requires `qwenpaw app` to be running.**
 | `qwenpaw chats update <id> --name "..."` | Rename a session                                              |
 | `qwenpaw chats delete <id>`              | Delete a session                                              |
 
-**Agent targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
+**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
 
 ```bash
 qwenpaw chats list                        # Default agent's chats
@@ -622,7 +622,7 @@ Extend QwenPaw's capabilities with skills (PDF reading, web search, etc.).
 | `qwenpaw skills config`    | Interactively enable/disable skills (checkbox UI)         |
 | `qwenpaw skills info`      | Show local details for one workspace skill                |
 
-**Agent targeting:** use `--agent-id` for one agent. Without it, `install` / `uninstall` act on the skill pool.
+**Multi-Agent Support:** All commands support the `--agent-id` parameter (defaults to `default`).
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # Import into the local skill pool

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -72,7 +72,7 @@ Docker 镜像或 pip 安装包已内置控制台，无需单独构建。
 | `qwenpaw daemon version`       | 版本与路径                                                                     |
 | `qwenpaw daemon logs [-n N]`   | 最近 N 行日志（默认 100，来自工作目录 `qwenpaw.log`）                          |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**指定工作区：** 指定单个智能体工作区时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
 
 ```bash
 qwenpaw daemon status                     # 默认智能体状态
@@ -496,7 +496,7 @@ qwenpaw agents chat \
 | `qwenpaw cron resume <job_id>` | 恢复暂停的任务                 |
 | `qwenpaw cron run <job_id>`    | 立刻执行一次                   |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**指定智能体：** 需要指定智能体时使用 `--agent-id`。
 
 ### 创建任务
 
@@ -578,7 +578,7 @@ JSON 结构见 `qwenpaw cron get <job_id>` 的返回。
 | `qwenpaw chats update <id> --name "..."` | 重命名会话                                         |
 | `qwenpaw chats delete <id>`              | 删除会话                                           |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**指定智能体：** 指定单个智能体时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
 
 ```bash
 qwenpaw chats list                        # 默认智能体的会话
@@ -599,15 +599,21 @@ qwenpaw chats delete <chat_id>
 
 ### qwenpaw skills
 
-| 命令                    | 说明                              |
-| ----------------------- | --------------------------------- |
-| `qwenpaw skills list`   | 列出所有技能及启用/禁用状态       |
-| `qwenpaw skills config` | 交互式启用/禁用技能（复选框界面） |
-| `qwenpaw skills info`   | 查看某个 workspace 技能的本地详情 |
+| 命令                       | 说明                               |
+| -------------------------- | ---------------------------------- |
+| `qwenpaw skills install`   | 从受支持的 URL 来源安装技能        |
+| `qwenpaw skills uninstall` | 从技能池或单个智能体工作区移除技能 |
+| `qwenpaw skills list`      | 列出所有技能及启用/禁用状态        |
+| `qwenpaw skills config`    | 交互式启用/禁用技能（复选框界面）  |
+| `qwenpaw skills info`      | 查看某个 workspace 技能的本地详情  |
 
-**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
+**指定智能体：** 指定单个智能体时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
 
 ```bash
+qwenpaw skills install https://skills.sh/owner/repo/skill  # 导入到本地技能池
+qwenpaw skills install https://skills.sh/owner/repo/skill --agent-id abc123  # 直接导入到特定智能体工作区
+qwenpaw skills uninstall skill-creator  # 从本地技能池移除
+qwenpaw skills uninstall skill-creator --agent-id abc123  # 从特定智能体工作区移除
 qwenpaw skills list                   # 看默认智能体的技能
 qwenpaw skills list --agent-id abc123 # 看特定智能体的技能
 qwenpaw skills config                 # 交互式配置默认智能体
@@ -697,7 +703,7 @@ qwenpaw --host 0.0.0.0 --port 9090 cron list
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    部分需要 ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |      **是**       |
 | `qwenpaw chats`     | `list` · `get` · `create` · `update` · `delete`                                      |      **是**       |
-| `qwenpaw skills`    | `list` · `config` · `info`                                                           |        否         |
+| `qwenpaw skills`    | `install` · `uninstall` · `list` · `config` · `info`                                 |        否         |
 | `qwenpaw task`      | —                                                                                    |        否         |
 | `qwenpaw auth`      | `reset-password`                                                                     |        否         |
 | `qwenpaw plugin`    | `install` · `list` · `info` · `uninstall` · `validate`                               |        否         |

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -496,7 +496,7 @@ qwenpaw agents chat \
 | `qwenpaw cron resume <job_id>` | 恢复暂停的任务                 |
 | `qwenpaw cron run <job_id>`    | 立刻执行一次                   |
 
-**指定智能体：** 需要指定智能体时使用 `--agent-id`。
+**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
 
 ### 创建任务
 

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -72,7 +72,7 @@ Docker 镜像或 pip 安装包已内置控制台，无需单独构建。
 | `qwenpaw daemon version`       | 版本与路径                                                                     |
 | `qwenpaw daemon logs [-n N]`   | 最近 N 行日志（默认 100，来自工作目录 `qwenpaw.log`）                          |
 
-**指定工作区：** 指定单个智能体工作区时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
+**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
 
 ```bash
 qwenpaw daemon status                     # 默认智能体状态
@@ -578,7 +578,7 @@ JSON 结构见 `qwenpaw cron get <job_id>` 的返回。
 | `qwenpaw chats update <id> --name "..."` | 重命名会话                                         |
 | `qwenpaw chats delete <id>`              | 删除会话                                           |
 
-**指定智能体：** 指定单个智能体时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
+**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
 
 ```bash
 qwenpaw chats list                        # 默认智能体的会话
@@ -607,7 +607,7 @@ qwenpaw chats delete <chat_id>
 | `qwenpaw skills config`    | 交互式启用/禁用技能（复选框界面）  |
 | `qwenpaw skills info`      | 查看某个 workspace 技能的本地详情  |
 
-**指定智能体：** 指定单个智能体时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
+**多智能体支持：** 所有命令都支持 `--agent-id` 参数（默认为 `default`）。
 
 ```bash
 qwenpaw skills install https://skills.sh/owner/repo/skill  # 导入到本地技能池

--- a/website/public/docs/skills.en.md
+++ b/website/public/docs/skills.en.md
@@ -178,6 +178,8 @@ The workspace skill page supports importing from the following URL sources:
 
 CLI supports the same URL-based import flow:
 
+**Workspace targeting:** use `--agent-id` when targeting a single agent workspace; without it, `install` / `uninstall` act on the skill pool.
+
 ```bash
 qwenpaw skills install <skill_url>
 qwenpaw skills install <skill_url> --agent-id <agent_id>

--- a/website/public/docs/skills.en.md
+++ b/website/public/docs/skills.en.md
@@ -176,6 +176,20 @@ The workspace skill page supports importing from the following URL sources:
 - `https://github.com/...`
 - `https://modelscope.cn/skills/...`
 
+CLI supports the same URL-based import flow:
+
+```bash
+qwenpaw skills install <skill_url>
+qwenpaw skills install <skill_url> --agent-id <agent_id>
+```
+
+CLI also supports uninstalling from the shared pool or one workspace:
+
+```bash
+qwenpaw skills uninstall <skill_name>
+qwenpaw skills uninstall <skill_name> --agent-id <agent_id>
+```
+
 #### Steps
 
 1. In [Console](./console) → **Workspace → Skills**, click **Import from Skills Hub**.

--- a/website/public/docs/skills.zh.md
+++ b/website/public/docs/skills.zh.md
@@ -165,6 +165,8 @@ $QWENPAW_WORKING_DIR/                      # 默认 ~/.qwenpaw
 
 CLI 支持相同的基于 URL 的导入方式：
 
+**指定工作区：** 指定单个智能体工作区时使用 `--agent-id`；不指定时，`install` / `uninstall` 作用于技能池。
+
 ```bash
 qwenpaw skills install <skill_url>
 qwenpaw skills install <skill_url> --agent-id <agent_id>

--- a/website/public/docs/skills.zh.md
+++ b/website/public/docs/skills.zh.md
@@ -163,6 +163,20 @@ $QWENPAW_WORKING_DIR/                      # 默认 ~/.qwenpaw
 - `https://github.com/...`
 - `https://modelscope.cn/skills/...`
 
+CLI 支持相同的基于 URL 的导入方式：
+
+```bash
+qwenpaw skills install <skill_url>
+qwenpaw skills install <skill_url> --agent-id <agent_id>
+```
+
+CLI 也支持从共享技能池或单个工作区卸载技能：
+
+```bash
+qwenpaw skills uninstall <skill_name>
+qwenpaw skills uninstall <skill_name> --agent-id <agent_id>
+```
+
 #### 步骤
 
 1. 打开 [控制台](./console) → **工作区 → 技能**，点击 **从 Skills Hub 导入技能**。


### PR DESCRIPTION
## Description

Add skill cli for install from url and uninstall skills.
Better for agent to manage skill installation/uninstallation.

**Related Issue:** Fixes #2384 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [x] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic