### PR TITLE
Fix(Provider): Increase `max_token` for anthropic compatible models

### DIFF
--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -156,8 +156,16 @@ class AnthropicProvider(Provider):
                 ),
             }
 
+        self.generate_kwargs = self.get_effective_generate_kwargs(model_id)
+
+        if "max_tokens" in self.generate_kwargs:
+            max_tokens = self.generate_kwargs.pop("max_tokens")
+        else:
+            max_tokens = 16384
+
         return AnthropicChatModel(
             model_name=model_id,
+            max_tokens=max_tokens,
             stream=True,
             api_key=self.api_key,
             stream_tool_parsing=False,
@@ -168,7 +176,7 @@ class AnthropicProvider(Provider):
     async def probe_model_multimodal(
         self,
         model_id: str,
-        timeout: float = 10,
+        timeout: float = 60,
         image_only: bool = False,  # pylint: disable=unused-argument
     ) -> ProbeResult:
         """Probe multimodal support using Anthropic messages API format.

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -144,7 +144,7 @@ class GeminiProvider(Provider):
     async def probe_model_multimodal(
         self,
         model_id: str,
-        timeout: float = 10,
+        timeout: float = 60,
         image_only: bool = False,
     ) -> ProbeResult:
         """Probe multimodal support using Gemini generateContent API.

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -177,7 +177,7 @@ class OpenAIProvider(Provider):
     async def probe_model_multimodal(
         self,
         model_id: str,
-        timeout: float = 10,
+        timeout: float = 60,
         image_only: bool = False,
     ) -> ProbeResult:
         """Probe multimodal support via OpenAI-compatible API."""

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -18,6 +18,54 @@ def _make_provider(is_custom: bool = False) -> AnthropicProvider:
     )
 
 
+def test_get_chat_model_instance_uses_configured_max_tokens(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeAnthropicChatModel:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "agentscope.model.AnthropicChatModel",
+        FakeAnthropicChatModel,
+    )
+
+    provider = _make_provider()
+    provider.generate_kwargs = {
+        "max_tokens": 4096,
+        "temperature": 0.2,
+    }
+
+    provider.get_chat_model_instance("claude-3-5-sonnet")
+
+    assert captured["model_name"] == "claude-3-5-sonnet"
+    assert captured["max_tokens"] == 4096
+
+
+def test_get_chat_model_instance_uses_default_max_tokens_when_unset(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeAnthropicChatModel:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "agentscope.model.AnthropicChatModel",
+        FakeAnthropicChatModel,
+    )
+
+    provider = _make_provider()
+
+    provider.get_chat_model_instance("claude-3-5-sonnet")
+
+    assert captured["model_name"] == "claude-3-5-sonnet"
+    assert captured["max_tokens"] == 16384
+
+
 async def test_check_connection_success(monkeypatch) -> None:
     provider = _make_provider()
     called = {"count": 0}


### PR DESCRIPTION
## Description

Increase the `max_token` value from `2048` to `16384`.

**Related Issue:** Fixes #4040 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
