### PR TITLE
feat(channel): propagate user display name to agent env context

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -611,6 +611,7 @@ class BaseChannel(ABC):
         session_id: str,
         content_parts: List[Any],
         channel_meta: Optional[Dict[str, Any]] = None,
+        display_name: Optional[str] = None,
     ) -> "AgentRequest":
         """
         Build AgentRequest from runtime content parts (Message content list).
@@ -632,12 +633,14 @@ class BaseChannel(ABC):
             role=Role.USER,
             content=content_parts,
         )
-        return AgentRequest(
+        request = AgentRequest(
             session_id=session_id,
             user_id=sender_id,
             input=[msg],
             channel=channel_id,
         )
+        request.display_name = display_name or ""
+        return request
 
     def build_agent_request_from_native(
         self,

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -360,6 +360,7 @@ class DingTalkChannel(BaseChannel):
             session_id=session_id,
             content_parts=content_parts,
             channel_meta=meta,
+            display_name=sender_id,
         )
         # Set serializable channel_meta (exclude non-JSON-serializable objects)
         serializable_meta = {

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -378,6 +378,7 @@ class FeishuChannel(BaseChannel):
             session_id=session_id,
             content_parts=content_parts,
             channel_meta=meta,
+            display_name=payload.get("sender_id") or "",
         )
         # Ensure channel_meta is on request for _before_consume_process
         # (AgentRequest may not have the field; base also sets from payload).

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -332,6 +332,8 @@ class AgentRunner(Runner):
             user_id = request.user_id
             channel = getattr(request, "channel", DEFAULT_CHANNEL)
 
+            display_name = getattr(request, "display_name", "") or ""
+
             logger.info(
                 "Handle agent query:\n%s",
                 json.dumps(
@@ -356,6 +358,7 @@ class AgentRunner(Runner):
                     if self.workspace_dir
                     else str(WORKING_DIR)
                 ),
+                user_name=display_name,
             )
 
             # Get MCP clients from manager (hot-reloadable)

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -64,7 +64,7 @@ def build_env_context(
     if user_id is not None:
         parts.append(f"- User ID: {user_id}")
     if user_name:
-        parts.append(f"-User Nme: {user_name}")
+        parts.append(f"- User Name: {user_name}")
     if channel is not None:
         parts.append(f"- Channel: {channel}")
 

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -35,6 +35,7 @@ def build_env_context(
     channel: Optional[str] = None,
     working_dir: Optional[str] = None,
     add_hint: bool = True,
+    user_name: Optional[str] = None,
 ) -> str:
     """
     Build environment context with current request context prepended.
@@ -45,6 +46,7 @@ def build_env_context(
         channel: Current channel name
         working_dir: Working directory path
         add_hint: Whether to add hint context
+        user_name: Display name of the current user
     Returns:
         Formatted environment context string
     """
@@ -61,6 +63,8 @@ def build_env_context(
         parts.append(f"- Session ID: {session_id}")
     if user_id is not None:
         parts.append(f"- User ID: {user_id}")
+    if user_name:
+        parts.append(f"-User Nme: {user_name}")
     if channel is not None:
         parts.append(f"- Channel: {channel}")
 


### PR DESCRIPTION
## Description

Feishu channel already resolves the sender's display name (nickname) from the event payload or Contact API, but this information was lost before reaching the agent's environment context. The agent only saw the raw `open_id` (e.g. `ou_xxxx`) as `User ID`, making it impossible to address the user by name.

This PR introduces a unified `display_name` field on `AgentRequest` via the base channel layer, allowing any channel to propagate a human-readable sender name to the runner. The runner then surfaces it as `- User Name: xxx` in the environment context passed to the agent.

Both Feishu and DingTalk channels are updated to pass their already-available display names through this new mechanism.

**Related Issue:** Fixes #

**Security Considerations:** No security impact. `display_name` is derived from the same sender information already logged and stored in `user_id`/`sender_id`. No new external API calls or permission changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
  ********************************Passed******************************** 

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
