### PR TITLE
fix(mcp): use sse_read_timeout as MCP tool execution_timeout instead of HTTP connect timeout

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -492,7 +492,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 await self.toolkit.register_mcp_client(
                     client,
                     namesake_strategy=namesake_strategy,
-                    execution_timeout=client.sse_read_timeout,
+                    execution_timeout=client.read_timeout_seconds,
                 )
             except (ClosedResourceError, asyncio.CancelledError) as error:
                 if self._should_propagate_cancelled_error(error):
@@ -509,7 +509,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                         await self.toolkit.register_mcp_client(
                             recovered_client,
                             namesake_strategy=namesake_strategy,
-                            execution_timeout=client.sse_read_timeout,
+                            execution_timeout=client.read_timeout_seconds,
                         )
                         continue
                     except asyncio.CancelledError as recover_error:

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -492,7 +492,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 await self.toolkit.register_mcp_client(
                     client,
                     namesake_strategy=namesake_strategy,
-                    execution_timeout=client.timeout,
+                    execution_timeout=client.sse_read_timeout,
                 )
             except (ClosedResourceError, asyncio.CancelledError) as error:
                 if self._should_propagate_cancelled_error(error):
@@ -509,7 +509,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                         await self.toolkit.register_mcp_client(
                             recovered_client,
                             namesake_strategy=namesake_strategy,
-                            execution_timeout=client.timeout,
+                            execution_timeout=client.sse_read_timeout,
                         )
                         continue
                     except asyncio.CancelledError as recover_error:

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -64,7 +64,7 @@ class StdIOStatefulClient(StatefulClientBase):
             "ignore",
             "replace",
         ] = "strict",
-        **kwargs,
+        read_timeout_seconds: float = 60 * 5,
     ) -> None:
         """Initialize the StdIO MCP client.
 
@@ -76,6 +76,7 @@ class StdIOStatefulClient(StatefulClientBase):
             cwd: The working directory to use when spawning the process
             encoding: The text encoding used when sending/receiving messages
             encoding_error_handler: The text encoding error handler
+            read_timeout_seconds: The read timeout seconds
 
         Raises:
             TypeError: If name or command is not a string
@@ -96,6 +97,7 @@ class StdIOStatefulClient(StatefulClientBase):
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
         )
+        self.read_timeout_seconds = read_timeout_seconds
 
         # Lifecycle management
         self._lifecycle_task: asyncio.Task | None = None
@@ -109,8 +111,6 @@ class StdIOStatefulClient(StatefulClientBase):
 
         # Tool cache
         self._cached_tools = None
-
-        self.sse_read_timeout = kwargs.get("sse_read_timeout")
 
     async def _run_lifecycle(self) -> None:
         """Run MCP client lifecycle in a dedicated task.
@@ -377,6 +377,7 @@ class HttpStatefulClient(StatefulClientBase):
         self.headers = headers
         self.timeout = timeout
         self.sse_read_timeout = sse_read_timeout
+        self.read_timeout_seconds = sse_read_timeout
         self.client_kwargs = client_kwargs
 
         # Lifecycle management

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -110,7 +110,7 @@ class StdIOStatefulClient(StatefulClientBase):
         # Tool cache
         self._cached_tools = None
 
-        self.timeout = kwargs.get("timeout")
+        self.sse_read_timeout = kwargs.get("sse_read_timeout")
 
     async def _run_lifecycle(self) -> None:
         """Run MCP client lifecycle in a dedicated task.


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
