### PR TITLE
fix(reload): route AgentConfigWatcher through reload_agent for graceful task draining

### DIFF
--- a/src/qwenpaw/app/agent_config_watcher.py
+++ b/src/qwenpaw/app/agent_config_watcher.py
@@ -72,9 +72,8 @@ class AgentConfigWatcher:
         self._last_channels_hash: Optional[int] = None
         self._last_heartbeat_hash: Optional[int] = None
 
-        # Skip ticks while a previous reload triggered by this watcher
-        # is still in flight, instead of queuing duplicate reloads.
-        self._reload_lock = asyncio.Lock()
+        # Set before triggering reload; poll loop checks this to stop.
+        self._disabled: bool = False
 
     async def start(self) -> None:
         """Take initial snapshot and start the polling task."""
@@ -89,7 +88,14 @@ class AgentConfigWatcher:
         )
 
     async def stop(self) -> None:
-        """Stop the polling task."""
+        """Stop the polling task (no-op if already disabled)."""
+        if self._disabled:
+            logger.info(
+                f"AgentConfigWatcher already disabled for agent "
+                f"{self._agent_id}, skipping cancel",
+            )
+            return
+        self._disabled = True
         if self._task:
             self._task.cancel()
             try:
@@ -135,9 +141,11 @@ class AgentConfigWatcher:
 
     async def _poll_loop(self) -> None:
         """Main polling loop."""
-        while True:
+        while not self._disabled:
             try:
                 await asyncio.sleep(self._poll_interval)
+                if self._disabled:
+                    break
                 await self._check()
             except Exception:
                 logger.exception(
@@ -193,28 +201,18 @@ class AgentConfigWatcher:
             )
             return
 
-        if self._reload_lock.locked():
-            logger.info(
-                f"AgentConfigWatcher ({self._agent_id}): "
-                f"reload already in progress, skipping this tick",
-            )
-            return
+        self._disabled = True
 
-        async with self._reload_lock:
-            logger.info(
+        logger.info(
+            f"AgentConfigWatcher ({self._agent_id}): "
+            f"config changed, triggering graceful reload "
+            f"(channels: {old_channels_hash} -> {new_channels_hash}, "
+            f"heartbeat: {old_heartbeat_hash} -> {new_heartbeat_hash})",
+        )
+        try:
+            await manager.reload_agent(self._agent_id)
+        except Exception:
+            logger.exception(
                 f"AgentConfigWatcher ({self._agent_id}): "
-                f"config changed, triggering graceful reload "
-                f"(channels: {old_channels_hash} -> {new_channels_hash}, "
-                f"heartbeat: {old_heartbeat_hash} -> {new_heartbeat_hash})",
+                f"reload_agent failed",
             )
-            try:
-                await manager.reload_agent(self._agent_id)
-            except Exception:
-                logger.exception(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"reload_agent failed",
-                )
-            finally:
-                # Re-baseline so reload-induced rewrites do not look
-                # like a fresh change on the next tick.
-                self._snapshot()

--- a/src/qwenpaw/app/agent_config_watcher.py
+++ b/src/qwenpaw/app/agent_config_watcher.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Watch agent.json for changes and auto-reload agent components.
+"""Watch agent.json and trigger a graceful workspace reload on change.
 
-This watcher monitors an agent's workspace/agent.json file for changes
-and automatically reloads channels, heartbeat, and other configurations
-without requiring manual restart.
+Delegates to ``MultiAgentManager.reload_agent`` so disk-edit reloads
+go through the same atomic workspace swap as frontend saves and wait
+for in-flight tasks. Only triggers when ``channels`` or ``heartbeat``
+hashes change, so runtime bookkeeping rewrites (e.g. ``last_dispatch``)
+do not cause spurious reloads.
 """
 
 from __future__ import annotations
@@ -14,10 +16,10 @@ from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
 
 from ..config.config import load_agent_config
-from ..config.utils import get_available_channels
 
 if TYPE_CHECKING:
-    from ..config.config import ChannelConfig, HeartbeatConfig
+    from ..config.config import HeartbeatConfig
+    from .workspace.workspace import Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -25,60 +27,54 @@ logger = logging.getLogger(__name__)
 DEFAULT_POLL_INTERVAL = 2.0
 
 
-def _heartbeat_hash(hb: Optional[HeartbeatConfig]) -> int:
+def _channels_hash(channels: Any) -> Optional[int]:
+    """Hash of channels section for change detection."""
+    if channels is None:
+        return None
+    return hash(str(channels.model_dump(mode="json")))
+
+
+def _heartbeat_hash(hb: Optional["HeartbeatConfig"]) -> int:
     """Hash of heartbeat config for change detection."""
     if hb is None:
         return hash("None")
     return hash(str(hb.model_dump(mode="json")))
 
 
-def _memory_job_hash(memory_summary: Optional[Any]) -> int:
-    """Hash of memory job config for change detection."""
-    if memory_summary is None:
-        return hash("None")
-    cron_expr = getattr(memory_summary, "dream_cron", "")
-    return hash(str(cron_expr))
-
-
 class AgentConfigWatcher:
-    """Poll agent.json mtime and reload changed configs automatically.
-
-    This watcher is agent-scoped and monitors a specific agent's
-    workspace/agent.json file for configuration changes.
-    """
+    """Poll ``agent.json`` and trigger a graceful workspace reload."""
 
     def __init__(
         self,
         agent_id: str,
         workspace_dir: Path,
-        channel_manager: Any,
-        cron_manager: Any = None,
+        workspace: "Workspace",
         poll_interval: float = DEFAULT_POLL_INTERVAL,
     ):
         """Initialize agent config watcher.
 
         Args:
-            agent_id: Agent ID to monitor
-            workspace_dir: Path to agent's workspace directory
-            channel_manager: ChannelManager instance for this agent
-            cron_manager: CronManager instance for this agent (optional)
-            poll_interval: How often to check for changes (seconds)
+            agent_id: Agent ID to monitor.
+            workspace_dir: Path to agent's workspace directory.
+            workspace: Owning ``Workspace`` instance. The manager is
+                resolved lazily from it, since ``set_manager`` runs
+                after ``Workspace.start()``.
+            poll_interval: How often to check for changes (seconds).
         """
         self._agent_id = agent_id
         self._workspace_dir = workspace_dir
         self._config_path = workspace_dir / "agent.json"
-        self._channel_manager = channel_manager
-        self._cron_manager = cron_manager
+        self._workspace = workspace
         self._poll_interval = poll_interval
         self._task: Optional[asyncio.Task] = None
 
-        # Snapshot of the last known config (for diffing)
-        self._last_channels: Optional[ChannelConfig] = None
+        self._last_mtime: float = 0.0
         self._last_channels_hash: Optional[int] = None
         self._last_heartbeat_hash: Optional[int] = None
-        self._last_memory_job_hash: Optional[int] = None
-        # mtime of agent.json at last check
-        self._last_mtime: float = 0.0
+
+        # Skip ticks while a previous reload triggered by this watcher
+        # is still in flight, instead of queuing duplicate reloads.
+        self._reload_lock = asyncio.Lock()
 
     async def start(self) -> None:
         """Take initial snapshot and start the polling task."""
@@ -104,174 +100,38 @@ class AgentConfigWatcher:
         logger.info(f"AgentConfigWatcher stopped for agent {self._agent_id}")
 
     # ------------------------------------------------------------------
-    # Internal methods
+    # Internal helpers
     # ------------------------------------------------------------------
 
-    def _snapshot(self) -> None:
-        """Load current agent config; record mtime and hashes."""
+    def _read_mtime(self) -> float:
+        """Return current mtime of agent.json, 0.0 if missing."""
         try:
-            self._last_mtime = self._config_path.stat().st_mtime
+            return self._config_path.stat().st_mtime
         except FileNotFoundError:
-            self._last_mtime = 0.0
+            return 0.0
 
+    def _snapshot(self) -> None:
+        """Record current mtime and section hashes as the new baseline."""
+        self._last_mtime = self._read_mtime()
         try:
             agent_config = load_agent_config(self._agent_id)
-            if agent_config.channels:
-                self._last_channels = agent_config.channels.model_copy(
-                    deep=True,
-                )
-                self._last_channels_hash = self._channels_hash(
-                    agent_config.channels,
-                )
-            else:
-                self._last_channels = None
-                self._last_channels_hash = None
-
-            self._last_heartbeat_hash = _heartbeat_hash(
-                agent_config.heartbeat,
-            )
-            self._last_memory_job_hash = _memory_job_hash(
-                getattr(agent_config, "memory_summary", None),
-            )
-        except Exception:
-            logger.exception(
-                f"AgentConfigWatcher: failed to load initial config "
-                f"for agent {self._agent_id}",
-            )
-            self._last_channels = None
-            self._last_channels_hash = None
-            self._last_heartbeat_hash = None
-            self._last_memory_job_hash = None
-
-    @staticmethod
-    def _channels_hash(channels: ChannelConfig) -> int:
-        """Fast hash of channels section for quick change detection."""
-        return hash(str(channels.model_dump(mode="json")))
-
-    @staticmethod
-    def _channel_dump(ch: Any) -> Any:
-        """Return JSON-serializable dict for channel config, or None."""
-        if ch is None:
-            return None
-        if isinstance(ch, dict):
-            return ch
-        if hasattr(ch, "model_dump"):
-            return ch.model_dump(mode="json")
-        return None
-
-    async def _reload_one_channel(
-        self,
-        name: str,
-        new_ch: Any,
-        new_channels: ChannelConfig,
-        old_ch: Any,
-    ) -> None:
-        """Reload a single channel; on failure revert new_channels entry."""
-        try:
-            old_channel = await self._channel_manager.get_channel(name)
-            if old_channel is None:
-                logger.warning(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"channel '{name}' not found, skip",
-                )
-                return
-            new_channel = old_channel.clone(new_ch)
-            await self._channel_manager.replace_channel(new_channel)
-            logger.info(
-                f"AgentConfigWatcher ({self._agent_id}): "
-                f"channel '{name}' reloaded",
-            )
         except Exception:
             logger.exception(
                 f"AgentConfigWatcher ({self._agent_id}): "
-                f"failed to reload channel '{name}'",
+                f"failed to load initial config",
             )
-            setattr(new_channels, name, old_ch if old_ch else new_ch)
-
-    async def _apply_channel_changes(self, agent_config: Any) -> None:
-        """Diff channels and reload changed ones; update snapshot."""
-        if not agent_config.channels:
             return
-
-        new_hash = self._channels_hash(agent_config.channels)
-        if new_hash == self._last_channels_hash:
-            return
-
-        new_channels = agent_config.channels
-        old_channels = self._last_channels
-        extra_new = getattr(new_channels, "__pydantic_extra__", None) or {}
-        extra_old = (
-            getattr(old_channels, "__pydantic_extra__", None)
-            if old_channels
-            else {}
+        self._last_channels_hash = _channels_hash(
+            getattr(agent_config, "channels", None),
+        )
+        self._last_heartbeat_hash = _heartbeat_hash(
+            getattr(agent_config, "heartbeat", None),
         )
 
-        for name in get_available_channels():
-            new_ch = getattr(new_channels, name, None) or extra_new.get(name)
-            old_ch = (
-                getattr(old_channels, name, None) or extra_old.get(name)
-                if old_channels
-                else None
-            )
-            if new_ch is None:
-                continue
-            new_dump = self._channel_dump(new_ch)
-            old_dump = self._channel_dump(old_ch)
-            if new_dump is not None and new_dump == old_dump:
-                continue
-            logger.info(
-                f"AgentConfigWatcher ({self._agent_id}): "
-                f"channel '{name}' config changed, reloading",
-            )
-            await self._reload_one_channel(name, new_ch, new_channels, old_ch)
-
-        self._last_channels = new_channels.model_copy(deep=True)
-        self._last_channels_hash = self._channels_hash(new_channels)
-
-    async def _apply_heartbeat_change(self, agent_config: Any) -> None:
-        """Update heartbeat hash and reschedule if changed."""
-        new_hb_hash = _heartbeat_hash(agent_config.heartbeat)
-        if (
-            self._cron_manager is not None
-            and new_hb_hash != self._last_heartbeat_hash
-        ):
-            self._last_heartbeat_hash = new_hb_hash
-            try:
-                await self._cron_manager.reschedule_heartbeat()
-                logger.info(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"heartbeat rescheduled",
-                )
-            except Exception:
-                logger.exception(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"failed to reschedule heartbeat",
-                )
-        else:
-            self._last_heartbeat_hash = new_hb_hash
-
-    async def _apply_memory_job_change(self, agent_config: Any) -> None:
-        """Update memory job hash and reschedule if changed."""
-        new_memory_summary = getattr(agent_config, "memory_summary", None)
-        new_memory_job_hash = _memory_job_hash(new_memory_summary)
-        if (
-            self._cron_manager is not None
-            and new_memory_job_hash != self._last_memory_job_hash
-        ):
-            self._last_memory_job_hash = new_memory_job_hash
-            try:
-                await self._cron_manager.reschedule_memory()
-                logger.info(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"memory job rescheduled",
-                )
-            except Exception:
-                logger.exception(
-                    f"AgentConfigWatcher ({self._agent_id}): "
-                    f"failed to reschedule memory job",
-                )
-        else:
-            self._last_memory_job_hash = new_memory_job_hash
+    def _resolve_manager(self):
+        """Return ``MultiAgentManager`` from the workspace, or ``None``."""
+        # pylint: disable=protected-access
+        return getattr(self._workspace, "_manager", None)
 
     async def _poll_loop(self) -> None:
         """Main polling loop."""
@@ -286,15 +146,10 @@ class AgentConfigWatcher:
                 )
 
     async def _check(self) -> None:
-        """Check for config changes and reload if needed."""
-        try:
-            mtime = self._config_path.stat().st_mtime
-        except FileNotFoundError:
-            return
-
+        """Check for meaningful config changes and trigger a reload."""
+        mtime = self._read_mtime()
         if mtime == self._last_mtime:
             return
-
         self._last_mtime = mtime
 
         try:
@@ -306,9 +161,60 @@ class AgentConfigWatcher:
             )
             return
 
-        # Apply changes
-        if self._channel_manager:
-            await self._apply_channel_changes(agent_config)
-        if self._cron_manager:
-            await self._apply_heartbeat_change(agent_config)
-            await self._apply_memory_job_change(agent_config)
+        new_channels_hash = _channels_hash(
+            getattr(agent_config, "channels", None),
+        )
+        new_heartbeat_hash = _heartbeat_hash(
+            getattr(agent_config, "heartbeat", None),
+        )
+
+        old_channels_hash = self._last_channels_hash
+        old_heartbeat_hash = self._last_heartbeat_hash
+
+        changed = (
+            new_channels_hash != old_channels_hash
+            or new_heartbeat_hash != old_heartbeat_hash
+        )
+
+        # Refresh hashes regardless so non-meaningful rewrites
+        # (e.g. last_dispatch) re-baseline silently.
+        self._last_channels_hash = new_channels_hash
+        self._last_heartbeat_hash = new_heartbeat_hash
+
+        if not changed:
+            return
+
+        manager = self._resolve_manager()
+        if manager is None:
+            logger.warning(
+                f"AgentConfigWatcher ({self._agent_id}): "
+                f"config changed but MultiAgentManager not attached; "
+                f"skipping reload",
+            )
+            return
+
+        if self._reload_lock.locked():
+            logger.info(
+                f"AgentConfigWatcher ({self._agent_id}): "
+                f"reload already in progress, skipping this tick",
+            )
+            return
+
+        async with self._reload_lock:
+            logger.info(
+                f"AgentConfigWatcher ({self._agent_id}): "
+                f"config changed, triggering graceful reload "
+                f"(channels: {old_channels_hash} -> {new_channels_hash}, "
+                f"heartbeat: {old_heartbeat_hash} -> {new_heartbeat_hash})",
+            )
+            try:
+                await manager.reload_agent(self._agent_id)
+            except Exception:
+                logger.exception(
+                    f"AgentConfigWatcher ({self._agent_id}): "
+                    f"reload_agent failed",
+                )
+            finally:
+                # Re-baseline so reload-induced rewrites do not look
+                # like a fresh change on the next tick.
+                self._snapshot()

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -278,23 +278,6 @@ class MultiAgentManager:
         Returns:
             bool: True if agent was reloaded, False if not running
         """
-        # Step 0: Per-agent reload lock. If another reload for this
-        # agent is already in progress, skip rather than queue up.
-        if agent_id not in self._reload_locks:
-            self._reload_locks[agent_id] = asyncio.Lock()
-        reload_lock = self._reload_locks[agent_id]
-
-        if reload_lock.locked():
-            logger.info(
-                f"Reload already in progress for {agent_id}, skipping",
-            )
-            return False
-
-        async with reload_lock:
-            return await self._do_reload_agent(agent_id)
-
-    async def _do_reload_agent(self, agent_id: str) -> bool:
-        """Execute the actual reload (called under per-agent lock)."""
         # Step 1: Check if agent exists (quick check with lock)
         async with self._lock:
             if agent_id not in self.agents:

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -278,6 +278,23 @@ class MultiAgentManager:
         Returns:
             bool: True if agent was reloaded, False if not running
         """
+        # Step 0: Per-agent reload lock. If another reload for this
+        # agent is already in progress, skip rather than queue up.
+        if agent_id not in self._reload_locks:
+            self._reload_locks[agent_id] = asyncio.Lock()
+        reload_lock = self._reload_locks[agent_id]
+
+        if reload_lock.locked():
+            logger.info(
+                f"Reload already in progress for {agent_id}, skipping",
+            )
+            return False
+
+        async with reload_lock:
+            return await self._do_reload_agent(agent_id)
+
+    async def _do_reload_agent(self, agent_id: str) -> bool:
+        """Execute the actual reload (called under per-agent lock)."""
         # Step 1: Check if agent exists (quick check with lock)
         async with self._lock:
             if agent_id not in self.agents:
@@ -289,6 +306,27 @@ class MultiAgentManager:
             old_instance = self.agents[agent_id]
 
         logger.info(f"Reloading agent (zero-downtime): {agent_id}")
+
+        # Step 1.5: Disable the old workspace's config watcher up front.
+        # Otherwise, while we are still spinning up the new workspace,
+        # the old watcher's poll loop can observe the same agent.json
+        # change that triggered THIS reload and fire a redundant
+        # reload of its own. Stopping it eagerly removes that race.
+        # Failure here is non-fatal: at worst we get one extra reload.
+        try:
+            # pylint: disable=protected-access
+            old_watcher = old_instance._service_manager.services.get(
+                "agent_config_watcher",
+            )
+            # pylint: enable=protected-access
+            if old_watcher is not None:
+                await old_watcher.stop()
+        except Exception as stop_err:
+            logger.warning(
+                f"Failed to stop old AgentConfigWatcher for "
+                f"{agent_id}: {stop_err}. A redundant reload may "
+                f"follow but functionality is unaffected.",
+            )
 
         # Step 2: Load configuration (outside lock)
         config = load_config()

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -290,12 +290,8 @@ class MultiAgentManager:
 
         logger.info(f"Reloading agent (zero-downtime): {agent_id}")
 
-        # Step 1.5: Disable the old workspace's config watcher up front.
-        # Otherwise, while we are still spinning up the new workspace,
-        # the old watcher's poll loop can observe the same agent.json
-        # change that triggered THIS reload and fire a redundant
-        # reload of its own. Stopping it eagerly removes that race.
-        # Failure here is non-fatal: at worst we get one extra reload.
+        # Step 1.5: Stop old config watcher (no-op if it triggered
+        # this reload, since it already disabled itself).
         try:
             # pylint: disable=protected-access
             old_watcher = old_instance._service_manager.services.get(
@@ -307,8 +303,7 @@ class MultiAgentManager:
         except Exception as stop_err:
             logger.warning(
                 f"Failed to stop old AgentConfigWatcher for "
-                f"{agent_id}: {stop_err}. A redundant reload may "
-                f"follow but functionality is unaffected.",
+                f"{agent_id}: {stop_err}.",
             )
 
         # Step 2: Load configuration (outside lock)

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -111,6 +111,12 @@ async def create_channel_service(ws: "Workspace", _):
 async def create_agent_config_watcher(ws: "Workspace", _):
     """Create agent config watcher if channel/cron exists.
 
+    The watcher only triggers reloads via ``MultiAgentManager`` and
+    does not need direct references to channel/cron managers anymore.
+    Creation is still gated on having at least one of them, since
+    workspaces with neither have no externally-visible state that
+    benefits from auto-reload.
+
     Args:
         ws: Workspace instance
         _: Unused service parameter
@@ -130,8 +136,7 @@ async def create_agent_config_watcher(ws: "Workspace", _):
     watcher = AgentConfigWatcher(
         agent_id=ws.agent_id,
         workspace_dir=ws.workspace_dir,
-        channel_manager=channel_mgr,
-        cron_manager=cron_mgr,
+        workspace=ws,
     )
     ws._service_manager.services["agent_config_watcher"] = watcher
     return watcher


### PR DESCRIPTION
## Description

The previous AgentConfigWatcher diffed the channels section and called
ChannelManager.replace_channel() directly, which stops the old channel
synchronously without waiting for in-flight tasks. This causes DingTalk
streaming replies to lose their HTTP client mid-flight, producing
'NoneType' object has no attribute 'post' errors.

This PR makes the watcher delegate to MultiAgentManager.reload_agent so
that all config-change sources (frontend save, CLI, disk edit, agent
self-modification) go through the same zero-downtime atomic workspace
swap with graceful task draining.

### Changes

**agent_config_watcher.py** (rewritten, 310 lines → ~130 lines):
- Removed all inline per-channel/per-heartbeat/per-memory reload logic
  (_apply_channel_changes, _apply_heartbeat_change, _apply_memory_job_change,
  _reload_one_channel, _channel_dump, etc.).
- Now a thin poller: compares channels/heartbeat hashes on mtime change
  and delegates to MultiAgentManager.reload_agent for atomic workspace swap.
- Runtime bookkeeping rewrites (e.g. last_dispatch) only refresh the hash
  baseline without triggering a reload.
- Added _disabled flag: the watcher sets it before calling reload_agent,
  so the poll loop stops and cannot fire a redundant second reload. This
  fixes the double-reload bug in DingTalk card mode where the old watcher's
  poll loop would observe the same change and trigger a second reload.
- stop() checks _disabled and skips cancel-and-await when the watcher
  already disabled itself, avoiding undefined behaviour of cancelling
  its own running task from within itself.

**multi_agent_manager.py**:
- Added Step 1.5 in reload_agent: eagerly stop the old workspace's
  config watcher before creating the new workspace. This is a no-op
  when the watcher triggered the reload (already disabled), but necessary
  for API/frontend-triggered reloads where the watcher is still active.

**workspace/service_factories.py**:
- create_agent_config_watcher now passes the owning Workspace instance
  instead of channel_manager/cron_manager, since the watcher no longer
  needs direct references to them.

### Testing

Verified with all reload trigger paths:
- DingTalk card mode (previously double-reloaded) — single reload ✅
- DingTalk markdown mode — single reload ✅
- Feishu — single reload ✅
- Frontend API save — single reload, normal stop() path ✅
- Backend direct agent.json edit — single reload ✅

**Related Issue:** Fixes #4042 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
