### PR TITLE
feat(provider): allow Dashscope base URL selection in Console UI

### DIFF
--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -31,6 +31,14 @@ export interface ProviderInfo {
   api_key: string;
   base_url: string;
   generate_kwargs: Record<string, unknown>;
+  /** Provider-specific metadata (e.g. base_url_options for region selection). */
+  meta?: Record<string, unknown>;
+}
+
+/** Predefined base URL option exposed via `ProviderInfo.meta.base_url_options`. */
+export interface BaseUrlOption {
+  label: string;
+  value: string;
 }
 
 export interface ProviderConfigRequest {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -998,6 +998,8 @@
     "lmstudioEndpointHint": "LM Studio endpoint, e.g. http://localhost:1234/v1",
     "apiEndpointHint": "API endpoint, e.g. https://api.example.com",
     "pleaseEnterBaseURL": "Please enter the API base URL",
+    "selectBaseURL": "Select a base URL",
+    "selectBaseURLHint": "Select the regional endpoint for this provider",
     "pleaseEnterValidURL": "Please enter a valid URL",
     "apiKeyShouldStart": "API Key should start with \"{{prefix}}\"",
     "configurationSaved": "{{name}} configuration saved",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -806,6 +806,8 @@
     "lmstudioEndpointHint": "LM Studioエンドポイント、例: http://localhost:1234/v1",
     "apiEndpointHint": "APIエンドポイント、例: https://api.example.com",
     "pleaseEnterBaseURL": "APIベースURLを入力してください",
+    "selectBaseURL": "ベースURLを選択してください",
+    "selectBaseURLHint": "このプロバイダーのリージョンエンドポイントを選択",
     "pleaseEnterValidURL": "有効なURLを入力してください",
     "apiKeyShouldStart": "APIキーは \"{{prefix}}\" で始まる必要があります",
     "configurationSaved": "{{name}} の設定を保存しました",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -998,6 +998,8 @@
     "lmstudioEndpointHint": "LM Studio endpoint, e.g. http://localhost:1234/v1",
     "apiEndpointHint": "API endpoint, e.g. https://api.example.com",
     "pleaseEnterBaseURL": "Digite the API base URL",
+    "selectBaseURL": "Selecione uma URL base",
+    "selectBaseURLHint": "Selecione o endpoint regional deste provedor",
     "pleaseEnterValidURL": "Digite a valid URL",
     "apiKeyShouldStart": "API Key should start with \"{{prefix}}\"",
     "configurationSaved": "{{name}} Configuracao saved",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -806,6 +806,8 @@
     "lmstudioEndpointHint": "LM Studio endpoint, например http://localhost:1234/v1",
     "apiEndpointHint": "API endpoint, например https://api.example.com",
     "pleaseEnterBaseURL": "Пожалуйста, введите базовый URL API",
+    "selectBaseURL": "Выберите базовый URL",
+    "selectBaseURLHint": "Выберите региональную конечную точку этого провайдера",
     "pleaseEnterValidURL": "Пожалуйста, введите корректный URL",
     "apiKeyShouldStart": "API-ключ должен начинаться с «{{prefix}}»",
     "configurationSaved": "Конфигурация {{name}} сохранена",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -861,6 +861,8 @@
     "lmstudioEndpointHint": "LM Studio 端点，例如 http://localhost:1234/v1",
     "apiEndpointHint": "API 端点，例如 https://api.example.com",
     "pleaseEnterBaseURL": "请输入 API 基础 URL",
+    "selectBaseURL": "请选择基础 URL",
+    "selectBaseURLHint": "选择该服务商的区域接入点",
     "pleaseEnterValidURL": "请输入有效的 URL",
     "apiKeyShouldStart": "API 密钥应以 \"{{prefix}}\" 开头",
     "configurationSaved": "{{name}} 配置已保存",

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -3,7 +3,10 @@ import type { KeyboardEvent, ReactNode, UIEvent } from "react";
 import { Form, Input, Modal, Button, Select } from "@agentscope-ai/design";
 import { useAppMessage } from "../../../../../hooks/useAppMessage";
 import { ApiOutlined, DownOutlined, RightOutlined } from "@ant-design/icons";
-import type { ProviderConfigRequest } from "../../../../../api/types";
+import type {
+  BaseUrlOption,
+  ProviderConfigRequest,
+} from "../../../../../api/types";
 import api from "../../../../../api";
 import { useTranslation } from "react-i18next";
 import { getLocalizedTestConnectionMessage } from "./testConnectionMessage";
@@ -248,6 +251,7 @@ interface ProviderConfigModalProps {
     chat_model: string;
     support_connection_check: boolean;
     generate_kwargs: Record<string, unknown>;
+    meta?: Record<string, unknown>;
   };
   activeModels: any;
   open: boolean;
@@ -271,6 +275,24 @@ export function ProviderConfigModal({
   const { message } = useAppMessage();
   const selectedChatModel = Form.useWatch("chat_model", form);
   const canEditBaseUrl = !provider.freeze_url;
+
+  const baseUrlOptions = useMemo<BaseUrlOption[]>(() => {
+    const raw = provider.meta?.base_url_options;
+    if (!Array.isArray(raw)) return [];
+    return raw.flatMap((item) => {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as BaseUrlOption).label === "string" &&
+        typeof (item as BaseUrlOption).value === "string"
+      ) {
+        return [item as BaseUrlOption];
+      }
+      return [];
+    });
+  }, [provider.meta]);
+
+  const useBaseUrlSelect = canEditBaseUrl && baseUrlOptions.length > 0;
 
   const parseGenerateConfig = (value?: string) => {
     const trimmed = value?.trim();
@@ -313,6 +335,9 @@ export function ProviderConfigModal({
     if (!canEditBaseUrl) {
       return undefined;
     }
+    if (useBaseUrlSelect) {
+      return t("models.selectBaseURLHint");
+    }
     if (provider.id === "azure-openai") {
       return t("models.azureEndpointHint");
     }
@@ -337,7 +362,14 @@ export function ProviderConfigModal({
         : t("models.openAICompatibleEndpoint");
     }
     return t("models.apiEndpointHint");
-  }, [canEditBaseUrl, provider.id, provider.is_custom, effectiveChatModel, t]);
+  }, [
+    canEditBaseUrl,
+    useBaseUrlSelect,
+    provider.id,
+    provider.is_custom,
+    effectiveChatModel,
+    t,
+  ]);
 
   const baseUrlPlaceholder = useMemo(() => {
     if (!canEditBaseUrl) {
@@ -618,7 +650,20 @@ export function ProviderConfigModal({
           }
           extra={baseUrlExtra}
         >
-          <Input placeholder={baseUrlPlaceholder} disabled={!canEditBaseUrl} />
+          {useBaseUrlSelect ? (
+            <Select
+              options={baseUrlOptions.map((option) => ({
+                label: `${option.label} — ${option.value}`,
+                value: option.value,
+              }))}
+              placeholder={t("models.selectBaseURL")}
+            />
+          ) : (
+            <Input
+              placeholder={baseUrlPlaceholder}
+              disabled={!canEditBaseUrl}
+            />
+          )}
         </Form.Item>
 
         {/* API Key */}

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -237,11 +237,6 @@ MEMORY_COMPACT_RATIO = EnvVarLoader.get_float(
     allow_inf=False,
 )
 
-DASHSCOPE_BASE_URL = EnvVarLoader.get_str(
-    "DASHSCOPE_BASE_URL",
-    "https://dashscope.aliyuncs.com/compatible-mode/v1",
-)
-
 # CORS configuration — comma-separated list of allowed origins for dev mode.
 # Example: QWENPAW_CORS_ORIGINS="http://localhost:5173,http://127.0.0.1:5173"
 # When unset, CORS middleware is not applied.

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -22,7 +22,12 @@ from qwenpaw.providers.provider import ModelInfo, Provider
 
 logger = logging.getLogger(__name__)
 
-DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+DASHSCOPE_BASE_URLS = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+)
+DASHSCOPE_BASE_URL = DASHSCOPE_BASE_URLS[0]
 CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 
@@ -131,7 +136,7 @@ class AnthropicProvider(Provider):
         from agentscope.model import AnthropicChatModel
 
         client_kwargs = {"base_url": self.base_url}
-        if self.base_url == DASHSCOPE_BASE_URL:
+        if self.base_url in DASHSCOPE_BASE_URLS:
             client_kwargs["default_headers"] = {
                 "x-dashscope-agentapp": json.dumps(
                     {

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -27,7 +27,6 @@ DASHSCOPE_BASE_URLS = (
     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
 )
-DASHSCOPE_BASE_URL = DASHSCOPE_BASE_URLS[0]
 CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+DASHSCOPE_BASE_URLS = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+)
+DASHSCOPE_BASE_URL = DASHSCOPE_BASE_URLS[0]
 CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec(
@@ -140,7 +145,7 @@ class OpenAIProvider(Provider):
 
         client_kwargs = {"base_url": self.base_url}
 
-        if self.base_url == DASHSCOPE_BASE_URL:
+        if self.base_url in DASHSCOPE_BASE_URLS:
             client_kwargs["default_headers"] = {
                 "x-dashscope-agentapp": json.dumps(
                     {

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -25,7 +25,6 @@ DASHSCOPE_BASE_URLS = (
     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
 )
-DASHSCOPE_BASE_URL = DASHSCOPE_BASE_URLS[0]
 CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec(

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -516,7 +516,25 @@ PROVIDER_DASHSCOPE = OpenAIProvider(
     base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
     api_key_prefix="sk",
     models=DASHSCOPE_MODELS,
-    freeze_url=True,
+    meta={
+        "base_url_options": [
+            {
+                "label": "China (Beijing)",
+                "value": "https://dashscope.aliyuncs.com/"
+                "compatible-mode/v1",
+            },
+            {
+                "label": "International (Singapore)",
+                "value": "https://dashscope-intl.aliyuncs.com/"
+                "compatible-mode/v1",
+            },
+            {
+                "label": "US (Virginia)",
+                "value": "https://dashscope-us.aliyuncs.com/"
+                "compatible-mode/v1",
+            },
+        ],
+    },
 )
 
 PROVIDER_ALIYUN_CODINGPLAN = OpenAIProvider(


### PR DESCRIPTION
## Description                           
                                                                                                                        
  Currently the DashScope provider's base URL is hardcoded and frozen, so users cannot reach DashScope's regional       
  endpoints from the Console UI. This PR exposes the three published regional endpoints — China (Beijing), International
   (Singapore), and US (Virginia) — as a region dropdown in the provider configuration modal, and persists the selected 
  URL like any other provider config.                                                                                   

  Backend:
  - Drop `freeze_url=True` from `PROVIDER_DASHSCOPE` and add `meta.base_url_options` describing the three regional URLs.
  - Replace the single-URL `==` check in `OpenAIProvider`/`AnthropicProvider` with a tuple membership test so the       
  `x-dashscope-agentapp` header is sent for any of the three URLs.                                                      
                                                                                                                        
  Frontend:                                                                                                             
  - Extend `ProviderInfo` with an optional `meta` field and a `BaseUrlOption` shape.
  - In `ProviderConfigModal`, render a `<Select>` populated from `meta.base_url_options` when present (and the URL is   
  editable); otherwise keep the existing `<Input>` behavior unchanged.                                                  
  - Add `selectBaseURL` / `selectBaseURLHint` strings to all five locales.                                              
                                                                                                                        
  **Related Issue:** Relates to user request for DashScope region selection (no tracking issue filed).                  
                                                                                                                        
  **Security Considerations:** None. The selectable URLs are all official DashScope endpoints; the provider's existing  
  API-key handling and URL validator are unchanged.               
                                                                                                                        
  ## Type of Change                                               

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change                                                                                                 
  - [ ] Documentation
  - [ ] Refactoring                                                                                                     
                                                                  
  ## Component(s) Affected

  - [x] Core / Backend (app, agents, config, providers, utils, local_models)                                            
  - [x] Console (frontend web UI)
  - [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)                                                        
  - [ ] Skills                                                                                                          
  - [ ] CLI
  - [ ] Documentation (website)                                                                                         
  - [ ] Tests                                                     
  - [ ] CI/CD
  - [ ] Scripts / Deploy
                                                                                                                        
  ## Checklist
                                                                                                                        
  - [ ] I ran `pre-commit run --all-files` locally and it passes  
  - [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
  - [x] I ran tests locally (`pytest` or as relevant) and they pass                                                     
  - [ ] Documentation updated (if needed)
  - [x] Ready for review                                                                                                
                                                                  
  ## Testing                                                                                                            
                                                                  
  1. Open Settings → Models, click the DashScope provider.
  2. Confirm the **Base URL** field is now a dropdown with three options:                                               
     - China (Beijing) — `https://dashscope.aliyuncs.com/compatible-mode/v1`                                            
     - International (Singapore) — `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`                             
     - US (Virginia) — `https://dashscope-us.aliyuncs.com/compatible-mode/v1`                                           
  3. With a valid API key for the chosen region, click **Test Connection** — it should succeed.                         
  4. Save the config, reload the page, and confirm the selection persists.                                              
  5. Switch to a different region and re-test; the request should hit the new endpoint and still send the               
  `x-dashscope-agentapp` header (verifiable via packet inspection or by confirming the request succeeds against         
  DashScope, which requires that header for compatible-mode endpoints).                                                 
  6. Other providers (Azure OpenAI, Anthropic, OpenAI, Ollama, LM Studio, custom) should still render the regular text  
  input.                                                                                                                
   
  ## Local Verification Evidence                                                                                        
                                                                  
  ```bash
  pytest tests/unit/providers/
  # 95 passed in 13.57s                                                                                                 
   
  pre-commit run --all-files was not executed in this sandbox; will run before merge.                                   
                                                                  
  Additional Notes                                                                                                      
                                                                  
  - The meta.base_url_options mechanism is generic — any other provider with a finite set of regional endpoints can now 
  opt into the same dropdown UI by setting meta.base_url_options and leaving freeze_url=False.
  - Existing users with a previously-saved DashScope config retain their base URL (the stored value is the China        
  endpoint, which is still the first option in the dropdown), so this change is non-breaking for current installs. 