### PR TITLE
fix: use RotatingFileHandler for log rotation on all platforms

### DIFF
--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -188,20 +188,12 @@ def add_project_file_handler(log_path: Path) -> None:
         if base is not None and Path(base).resolve() == log_path:
             return
 
-    is_windows_or_linux = platform.system() in ("Windows", "Linux")
-    if is_windows_or_linux:
-        file_handler = logging.FileHandler(
-            log_path,
-            encoding="utf-8",
-            mode="a",
-        )
-    else:
-        file_handler = logging.handlers.RotatingFileHandler(
-            log_path,
-            encoding="utf-8",
-            maxBytes=_LOG_MAX_BYTES,
-            backupCount=_LOG_BACKUP_COUNT,
-        )
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_path,
+        encoding="utf-8",
+        maxBytes=_LOG_MAX_BYTES,
+        backupCount=_LOG_BACKUP_COUNT,
+    )
 
     file_handler.setLevel(logger.level or logging.INFO)
 
@@ -209,3 +201,4 @@ def add_project_file_handler(log_path: Path) -> None:
         PlainFormatter("%(asctime)s | %(message)s", "%Y-%m-%d %H:%M:%S"),
     )
     logger.addHandler(file_handler)
+

--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -85,6 +85,26 @@ class ColorFormatter(logging.Formatter):
         return f"{prefix} | {original_msg}"
 
 
+class _SafeRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """RotatingFileHandler that tolerates Windows file-locking errors.
+
+    On Windows, ``os.rename()`` inside ``doRollover()`` raises
+    ``PermissionError`` when the log file is held open by another
+    process (e.g. a log viewer or the debug-log console reader).
+    This subclass catches the error, reopens the stream so logging
+    continues without data loss, and defers rotation to the next
+    size-exceeding emit.
+    """
+
+    def doRollover(self):
+        try:
+            super().doRollover()
+        except PermissionError:
+            if self.stream:
+                self.stream.close()
+            self.stream = self._open()
+
+
 class PlainFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         full_path = record.pathname
@@ -169,10 +189,11 @@ def setup_logger(level: int | str = logging.INFO):
 
 
 def add_project_file_handler(log_path: Path) -> None:
-    """Add a file handler to the project logger for daemon logs.
+    """Add a rotating file handler to the project logger for daemon logs.
 
-    Windows/Linux: Uses simple FileHandler to avoid file locking issues.
-    macOS: Uses RotatingFileHandler with automatic log rotation.
+    Uses _SafeRotatingFileHandler on all platforms with automatic log
+    rotation (max 5 MiB per file, 3 backups).  On Windows, rotation
+    errors caused by file locking are tolerated gracefully.
 
     Idempotent: if the logger already has a file handler for the same path,
     no new handler is added (avoids duplicate lines and leaked descriptors
@@ -189,7 +210,7 @@ def add_project_file_handler(log_path: Path) -> None:
         if base is not None and Path(base).resolve() == log_path:
             return
 
-    file_handler = logging.handlers.RotatingFileHandler(
+    file_handler = _SafeRotatingFileHandler(
         log_path,
         encoding="utf-8",
         maxBytes=_LOG_MAX_BYTES,

--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Logging setup for application logging and optional file output."""
+
 import logging
 import logging.handlers
 import os
@@ -201,4 +202,3 @@ def add_project_file_handler(log_path: Path) -> None:
         PlainFormatter("%(asctime)s | %(message)s", "%Y-%m-%d %H:%M:%S"),
     )
     logger.addHandler(file_handler)
-


### PR DESCRIPTION
## Problem

On Windows and Linux, qwenpaw.log uses FileHandler(mode=append) which grows indefinitely. The constants _LOG_MAX_BYTES (5 MiB) and _LOG_BACKUP_COUNT (3) are defined but only used on macOS.

Observed on a Windows machine after 18 days: qwenpaw.log reached 5.5 MiB with no rotation.

## Fix

Remove platform check (is_windows_or_linux) - apply RotatingFileHandler uniformly on all platforms. This is a minimal change; the constants and logging.handlers import already exist in the file.

## Testing

RotatingFileHandler is a standard logging.handlers class stable for decades. macOS has been using it in QwenPaw without issues.