### PR TITLE
chore(console): Optimize language switching logic and replace with the latest language icon

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@agentscope-ai/chat": "^1.1.62",
         "@agentscope-ai/design": "^1.0.14",
-        "@agentscope-ai/icons": "^1.0.63",
+        "@agentscope-ai/icons": "^1.0.67",
         "@ant-design/icons": "^5.0.1",
         "@ant-design/plots": "^2.6.8",
         "@ant-design/x-markdown": "^2.2.2",
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/@agentscope-ai/icons": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@agentscope-ai/icons/-/icons-1.0.63.tgz",
-      "integrity": "sha512-3eUcjGQV7HYF4DdKQxAjouXrbSvD3ZhayGHhdf+c4G5jUNXs9zKcR7lbnnPrf2ctgDErGrcNRAzyBG9FyyXS1Q==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@agentscope-ai/icons/-/icons-1.0.67.tgz",
+      "integrity": "sha512-tbly1taaZTHcu9IdmBOWK9ZLLNZ/j2suVKqUgwR0hcr+BAN0kNT08r5sFRvpRDALcdxJdwLNzMlIv0670XfA3g==",
       "license": "ISC"
     },
     "node_modules/@agentscope-ai/icons-override-antd": {

--- a/console/package.json
+++ b/console/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@agentscope-ai/chat": "^1.1.62",
     "@agentscope-ai/design": "^1.0.14",
-    "@agentscope-ai/icons": "^1.0.63",
+    "@agentscope-ai/icons": "^1.0.67",
     "@ant-design/icons": "^5.0.1",
     "@ant-design/plots": "^2.6.8",
     "@ant-design/x-markdown": "^2.2.2",

--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -8,7 +8,7 @@ import {
   SparkEnglish02Line,
   SparkJapanLine,
   SparkRusLine,
-  SparkSort02Line,
+  SparkPtLine,
 } from "@agentscope-ai/icons";
 
 interface LanguageConfig {
@@ -22,7 +22,7 @@ const LANGUAGE_LIST: LanguageConfig[] = [
   { key: "zh", label: "简体中文", icon: <SparkChinese02Line /> },
   { key: "ja", label: "日本語", icon: <SparkJapanLine /> },
   { key: "ru", label: "Русский", icon: <SparkRusLine /> },
-  { key: "pt-BR", label: "Português (Brasil)", icon: <SparkSort02Line /> },
+  { key: "pt-BR", label: "Português (Brasil)", icon: <SparkPtLine /> },
 ];
 
 const KNOWN_LANG_KEYS = new Set(LANGUAGE_LIST.map((lang) => lang.key));

--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -8,15 +8,30 @@ import {
   SparkEnglish02Line,
   SparkJapanLine,
   SparkRusLine,
+  SparkSort02Line,
 } from "@agentscope-ai/icons";
+
+interface LanguageConfig {
+  key: string;
+  label: string;
+  icon: React.ReactElement;
+}
+
+const LANGUAGE_LIST: LanguageConfig[] = [
+  { key: "en", label: "English", icon: <SparkEnglish02Line /> },
+  { key: "zh", label: "简体中文", icon: <SparkChinese02Line /> },
+  { key: "ja", label: "日本語", icon: <SparkJapanLine /> },
+  { key: "ru", label: "Русский", icon: <SparkRusLine /> },
+  { key: "pt-BR", label: "Português (Brasil)", icon: <SparkSort02Line /> },
+];
+
+const KNOWN_LANG_KEYS = new Set(LANGUAGE_LIST.map((lang) => lang.key));
 
 export default function LanguageSwitcher() {
   const { i18n } = useTranslation();
 
   const currentLanguage = i18n.resolvedLanguage || i18n.language;
-  // Use full language code (e.g. "pt-BR") when available, fallback to base code (e.g. "en" from "en-US")
-  const knownLanguages = ["en", "zh", "ja", "ru", "pt-BR"];
-  const currentLangKey = knownLanguages.includes(currentLanguage)
+  const currentLangKey = KNOWN_LANG_KEYS.has(currentLanguage)
     ? currentLanguage
     : currentLanguage.split("-")[0];
 
@@ -30,41 +45,15 @@ export default function LanguageSwitcher() {
       );
   };
 
-  const items: MenuProps["items"] = [
-    {
-      key: "en",
-      label: "English",
-      onClick: () => changeLanguage("en"),
-    },
-    {
-      key: "zh",
-      label: "简体中文",
-      onClick: () => changeLanguage("zh"),
-    },
-    {
-      key: "ja",
-      label: "日本語",
-      onClick: () => changeLanguage("ja"),
-    },
-    {
-      key: "ru",
-      label: "Русский",
-      onClick: () => changeLanguage("ru"),
-    },
-    {
-      key: "pt-BR",
-      label: "Português (Brasil)",
-      onClick: () => changeLanguage("pt-BR"),
-    },
-  ];
+  const items: MenuProps["items"] = LANGUAGE_LIST.map(({ key, label }) => ({
+    key,
+    label,
+    onClick: () => changeLanguage(key),
+  }));
 
-  const LIGHT_ICON: Record<string, React.ReactElement> = {
-    en: <SparkEnglish02Line />,
-    zh: <SparkChinese02Line />,
-    ja: <SparkJapanLine />,
-    ru: <SparkRusLine />,
-    "pt-BR": <SparkEnglish02Line />,
-  };
+  const iconMap: Record<string, React.ReactElement> = Object.fromEntries(
+    LANGUAGE_LIST.map(({ key, icon }) => [key, icon]),
+  );
 
   return (
     <Dropdown
@@ -72,7 +61,7 @@ export default function LanguageSwitcher() {
       placement="bottomRight"
       overlayClassName={styles.languageDropdown}
     >
-      <Button icon={LIGHT_ICON[currentLangKey]} type="text" />
+      <Button icon={iconMap[currentLangKey]} type="text" />
     </Dropdown>
   );
 }

--- a/console/src/pages/Settings/Agents/components/AgentModal.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentModal.tsx
@@ -231,7 +231,7 @@ export function AgentModal({
               allowClear
               onClear={handleClearModel}
               loading={loadingProviders}
-              style={{ width: "45%" }}
+              style={{ width: "45%", gap: "8px" }}
               showSearch
               optionFilterProp="label"
               options={eligibleProviders.map((p) => ({
@@ -308,13 +308,13 @@ export function AgentModal({
               : t("agent.initialSkills")}
           </Text>
           <Space size={4}>
-            <Button size="small" type="text" onClick={handleSelectAll}>
+            <Button size="small" type="primary" onClick={handleSelectAll}>
               {t("agent.selectAll")}
             </Button>
-            <Button size="small" type="text" onClick={handleSelectBuiltin}>
+            <Button size="small" type="default" onClick={handleSelectBuiltin}>
               {t("agent.selectBuiltin")}
             </Button>
-            <Button size="small" type="text" onClick={handleSelectNone}>
+            <Button size="small" type="default" onClick={handleSelectNone}>
               {t("agent.selectNone")}
             </Button>
           </Space>


### PR DESCRIPTION
## Description

Optimize language switching logic and replace with the latest language icon.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
