### PR TITLE
fix(chat): remove redundant URL prefix stripping in file preview paths

### DIFF
--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -43,16 +43,7 @@ export const chatApi = {
     if (!filename) return "";
     if (filename.startsWith("http://") || filename.startsWith("https://"))
       return filename;
-    // Strip any existing /files/preview/ or /api/files/preview/ prefix to
-    // avoid double-prefixing when the URL is resolved a second time (e.g.
-    // when reloading chat history). See GitHub issue #3600.
     let cleaned = filename.replace(/^\/+/, "");
-    const previewPrefix = FILES_PREVIEW.replace(/^\/+/, "");
-    if (cleaned.startsWith(`api/${previewPrefix}/`)) {
-      cleaned = cleaned.slice(`api/${previewPrefix}/`.length);
-    } else if (cleaned.startsWith(`${previewPrefix}/`)) {
-      cleaned = cleaned.slice(`${previewPrefix}/`.length);
-    }
     const path = `${FILES_PREVIEW}/${cleaned}`;
     const url = getApiUrl(path);
 

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -142,7 +142,7 @@ function contentToRequestParts(
 function normalizeOutputMessageContent(content: unknown): unknown {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return content;
-  return (content as ContentItem[]).map(resolveContentItemUrl);
+  return content as ContentItem[];
 }
 
 /**

--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -18,16 +18,6 @@ async def preview_file(
     """Preview file."""
     normalized = unquote(filepath)
 
-    # Tolerate duplicated preview prefix from some clients, e.g.
-    # /api/files/preview/api/files/preview/C%3A/Users/...
-    while True:
-        trimmed = normalized.lstrip("/")
-        prefix = "api/files/preview/"
-        if trimmed.startswith(prefix):
-            normalized = trimmed[len(prefix) :]
-            continue
-        break
-
     # Normalize /C:/... to C:/... on Windows.
     if (
         len(normalized) >= 4


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

Relates to #4047

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
