### PR TITLE
fix(cli): bypass proxies for loopback API checks (#3664)

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -13,6 +13,7 @@ from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
 
 from ...config.utils import read_last_api
+from ...utils.http import trust_env_for_url
 
 
 DEFAULT_AGENT_API_BASE_URL = "http://127.0.0.1:8088"
@@ -65,9 +66,11 @@ def create_agent_api_client(
     default_timeout: float = DEFAULT_AGENT_API_TIMEOUT,
 ) -> httpx.Client:
     """Create an HTTP client targeting the local agent API."""
+    normalized = _normalize_api_base_url(base_url)
     return httpx.Client(
-        base_url=_normalize_api_base_url(base_url),
+        base_url=normalized,
         timeout=default_timeout,
+        trust_env=trust_env_for_url(normalized),
     )
 
 

--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -26,6 +26,7 @@ from ..utils.console_static import (
     CONSOLE_STATIC_ENV,
     resolve_console_static_dir,
 )
+from ..utils.http import trust_env_for_url
 from ..utils.system_info import summarize_python_environment
 from .doctor_checks import (
     active_llm_local_failure_hint,
@@ -82,6 +83,11 @@ def _same_python_executable(a: str, b: str) -> bool:
             return a == b
 
 
+def _http_get(url: str, **kwargs) -> httpx.Response:
+    kwargs.setdefault("trust_env", trust_env_for_url(url))
+    return httpx.get(url, **kwargs)
+
+
 def _fetch_running_server_python(
     base: str,
     timeout: float,
@@ -113,7 +119,7 @@ def _fetch_running_server_python(
         )
 
     try:
-        runtime_resp = httpx.get(runtime_url, timeout=timeout)
+        runtime_resp = _http_get(runtime_url, timeout=timeout)
     except httpx.RequestError as exc:
         return None, None, f"(not available: {exc})"
     if runtime_resp.status_code == 200:
@@ -833,7 +839,7 @@ def run_doctor_checks(
     health_url = f"{base}/api/agent/health"
     version_url = f"{base}/api/version"
     try:
-        health_resp = httpx.get(health_url, timeout=timeout)
+        health_resp = _http_get(health_url, timeout=timeout)
     except httpx.RequestError as exc:
         failed = True
         click.echo(
@@ -860,7 +866,7 @@ def run_doctor_checks(
             )
 
         try:
-            version_resp = httpx.get(version_url, timeout=timeout)
+            version_resp = _http_get(version_url, timeout=timeout)
         except httpx.RequestError as exc:
             failed = True
             click.echo(
@@ -904,7 +910,7 @@ def run_doctor_checks(
 
         if health_resp.status_code == 200:
             try:
-                root_resp = httpx.get(
+                root_resp = _http_get(
                     f"{base}/",
                     timeout=timeout,
                     follow_redirects=True,

--- a/src/qwenpaw/cli/http.py
+++ b/src/qwenpaw/cli/http.py
@@ -7,6 +7,8 @@ from typing import Any, Optional
 import click
 import httpx
 
+from ..utils.http import trust_env_for_url
+
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8088"
 
@@ -17,7 +19,11 @@ def client(base_url: str) -> httpx.Client:
     base = base_url.rstrip("/")
     if not base.endswith("/api"):
         base = f"{base}/api"
-    return httpx.Client(base_url=base, timeout=30.0)
+    return httpx.Client(
+        base_url=base,
+        timeout=30.0,
+        trust_env=trust_env_for_url(base),
+    )
 
 
 def print_json(data: Any) -> None:

--- a/src/qwenpaw/utils/http.py
+++ b/src/qwenpaw/utils/http.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+_LOOPBACK_HOSTNAMES = {"localhost"}
+
+
+def is_loopback_url(url: str) -> bool:
+    """Return True when *url* targets a localhost or loopback address."""
+    host = (urlparse(url).hostname or "").lower().rstrip(".")
+    if host in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def trust_env_for_url(url: str) -> bool:
+    """Return whether httpx should trust proxy/cert env vars for *url*."""
+    return not is_loopback_url(url)

--- a/tests/unit/cli/test_cli_doctor_proxy.py
+++ b/tests/unit/cli/test_cli_doctor_proxy.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from typing import Any
+
+from qwenpaw.cli import doctor_cmd
+
+
+class _Response:
+    def __init__(
+        self,
+        status_code: int = 200,
+        json_data: dict[str, Any] | None = None,
+        text: str = "",
+        content_type: str = "application/json",
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.text = text
+        self.headers = {"content-type": content_type}
+
+    def json(self) -> dict[str, Any]:
+        return self._json_data
+
+
+# Doctor uses direct GET probes, so verify they apply the same proxy policy.
+def test_doctor_http_get_bypasses_env_for_loopback(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get(_url: str, **kwargs):
+        captured.update(kwargs)
+        return _Response()
+
+    monkeypatch.setattr(doctor_cmd.httpx, "get", _fake_get)
+
+    doctor_cmd._http_get("http://127.1.2.3:8088/api/version", timeout=2.0)
+
+    assert captured["trust_env"] is False
+
+
+def test_doctor_http_get_keeps_env_for_remote_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get(_url: str, **kwargs):
+        captured.update(kwargs)
+        return _Response()
+
+    monkeypatch.setattr(doctor_cmd.httpx, "get", _fake_get)
+
+    doctor_cmd._http_get("http://192.168.1.10:8088/api/version", timeout=2.0)
+
+    assert captured["trust_env"] is True

--- a/tests/unit/cli/test_cli_http_proxy.py
+++ b/tests/unit/cli/test_cli_http_proxy.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw.agents.tools import agent_management
+from qwenpaw.cli import http as cli_http
+
+
+# CLI API clients hit the local QwenPaw service, so loopback URLs skip proxies.
+def test_cli_http_client_bypasses_env_for_loopback(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_client(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(cli_http.httpx, "Client", _fake_client)
+
+    cli_http.client("http://127.1.2.3:8088")
+
+    assert captured["trust_env"] is False
+
+
+# Explicit remote API targets should still honor the user's proxy env.
+def test_cli_http_client_keeps_env_for_remote_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_client(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(cli_http.httpx, "Client", _fake_client)
+
+    cli_http.client("http://192.168.1.10:8088")
+
+    assert captured["trust_env"] is True
+
+
+# Agent-management API helpers share the same local API proxy policy.
+def test_agent_api_client_bypasses_env_for_loopback(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_client(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(agent_management.httpx, "Client", _fake_client)
+
+    agent_management.create_agent_api_client("http://localhost:8088")
+
+    assert captured["trust_env"] is False

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.utils.http import is_loopback_url, trust_env_for_url
+
+
+# Local API calls should bypass env proxies for localhost/loopback targets.
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8088/api",
+        "http://localhost.:8088/api",
+        "http://127.0.0.1:8088/api",
+        "http://127.1.2.3:8088/api",
+        "http://[::1]:8088/api",
+    ],
+)
+def test_is_loopback_url_recognizes_loopback_targets(url: str) -> None:
+    assert is_loopback_url(url) is True
+    assert trust_env_for_url(url) is False
+
+
+# Non-loopback URLs keep httpx's normal env proxy behavior.
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://192.168.1.10:8088/api",
+        "https://example.com/api",
+        "http://10.0.0.1:8088/api",
+    ],
+)
+def test_is_loopback_url_keeps_non_loopback_targets(url: str) -> None:
+    assert is_loopback_url(url) is False
+    assert trust_env_for_url(url) is True


### PR DESCRIPTION
## Description

This PR prevents Windows system proxy settings from intercepting QwenPaw loopback API calls. It adds a shared helper for detecting localhost/loopback URLs, keeps environment proxy handling enabled for non-loopback URLs, and disables `trust_env` only for local QwenPaw API requests.

The change covers both shared CLI local API clients and direct `qwenpaw doctor` local API probes (`/api/doctor/runtime`, health, version, and console checks).

**Related Issue:** Fixes #3664

**Security Considerations:** No new credential handling or external access is introduced. Only localhost/loopback HTTP requests bypass environment proxy settings; remote URLs keep the previous `trust_env=True` behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Ran targeted unit tests for loopback URL detection, shared CLI clients, and doctor local API probes.
- Manually reproduced the original failure shape with a local target server returning 200 and a fake proxy returning 502. After the fix, `qwenpaw doctor` no longer sends loopback API probes to the proxy.

## Local Verification Evidence

```bash
$env:PYTHONPATH = (Resolve-Path 'src').Path
D:\projects\CoPaw\.venv\Scripts\python.exe -m pytest -o cache_dir=.tmp_pytest_cache_codex tests/unit/utils/test_http.py tests/unit/cli/test_cli_http_proxy.py tests/unit/cli/test_cli_doctor_proxy.py
# 15 passed, 1 warning in 4.47s

# Manual proxy reproduction:
# local target 200 + fake proxy 502
# qwenpaw doctor: proxy_seen=[]
# API checks returned HTTP 200
```

## Additional Notes

This PR intentionally does not change external connectivity checks or provider/channel HTTP clients, so users who need proxies for non-local services keep the existing behavior.