### PR TITLE
fix(pack): restore conda packaging tools before conda-pack (#3988)

### DIFF
--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -132,21 +132,6 @@ def main() -> int:
                 "-y",
             ],
         )
-        _run(
-            [
-                conda,
-                "run",
-                "-n",
-                env_name,
-                "python",
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                "pip",
-            ],
-        )
-
         # Install qwenpaw with all dependencies
         # Scope CMAKE_ARGS to this specific command to avoid affecting other
         # CMake-based packages. Only set if we need to compile from source.
@@ -201,6 +186,23 @@ def main() -> int:
                     str(wheels_cache),
                 ],
             )
+        # pip may uninstall/reinstall files owned by conda while resolving
+        # qwenpaw[full]. Restore conda-managed packaging tools before packing.
+        _run(
+            [
+                conda,
+                "run",
+                "-n",
+                env_name,
+                conda,
+                "install",
+                "-y",
+                "--force-reinstall",
+                "pip",
+                "setuptools",
+                "wheel",
+            ],
+        )
         _run(
             [
                 conda,


### PR DESCRIPTION
## Description

This PR fixes Windows desktop packaging failures where `conda-pack` reports conda-managed `setuptools` files as deleted or overwritten after installing `qwenpaw[full]` into the temporary packaging environment.

The root cause is that pip dependency resolution can uninstall/reinstall packages that were originally managed by conda. The packaging script now avoids explicitly upgrading pip with pip, then restores conda-managed `pip`, `setuptools`, and `wheel` before running `conda-pack`. The existing unpinned `conda-pack` install behavior is preserved.

**Related Issue:** Fixes #3988

**Security Considerations:** No security-sensitive runtime behavior changes. This only affects the temporary conda environment used by desktop packaging scripts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Ran Python syntax validation for the changed packaging script.
- Ran full A/B Windows packaging reproductions from clean temporary repository copies:
  - Original script reproduced the reported `CondaPackError` for overwritten `setuptools` files during `conda-pack`.
  - Patched script passed the `conda-pack` phase and produced `dist\qwenpaw-env.zip`.
- The patched full run then stopped later in the Codex sandbox because PowerShell ConstrainedLanguage blocks `[System.IO.Path]::IsPathRooted(...)`; this happens after the fixed `conda-pack` step and is unrelated to this issue.

## Local Verification Evidence

```bash
python -m py_compile scripts\pack\build_common.py
# passed

scripts/pack/build_win.ps1  # A/B full packaging runs from clean temporary copies
# original: CondaPackError: Files managed by conda were found to have been deleted/overwritten - setuptools 82.0.1
# patched: Packed to ...\dist\qwenpaw-env.zip
```

## Additional Notes

The fix intentionally does not pin or change the `conda-pack` version. The packaging script keeps installing `conda-pack` using the existing unversioned conda spec.