### PR TITLE
feat(feishu): surface sender nickname to agent env context

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -861,6 +861,8 @@ class FeishuChannel(BaseChannel):
                 "feishu_sender_id": sender_id,
                 "is_group": is_group,
             }
+            # Surface human-readable sender name to env_context.
+            meta["user_name"] = nickname
             receive_id = chat_id if is_group else sender_id
             receive_id_type = "chat_id" if is_group else "open_id"
             meta["feishu_receive_id"] = receive_id

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -347,9 +347,15 @@ class AgentRunner(Runner):
                 ),
             )
 
+            # Optional sender display name from channel_meta.user_name.
+            channel_meta = getattr(request, "channel_meta", None)
+            if not isinstance(channel_meta, dict):
+                channel_meta = {}
+            user_name = channel_meta.get("user_name")
             env_context = build_env_context(
                 session_id=session_id,
                 user_id=user_id,
+                user_name=user_name,
                 channel=channel,
                 working_dir=(
                     str(self.workspace_dir)

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 def build_env_context(
     session_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    user_name: Optional[str] = None,
     channel: Optional[str] = None,
     working_dir: Optional[str] = None,
     add_hint: bool = True,
@@ -42,6 +43,8 @@ def build_env_context(
     Args:
         session_id: Current session ID
         user_id: Current user ID
+        user_name: Optional human-readable sender name (e.g. IM nickname).
+            Only rendered when provided by the channel via channel_meta.
         channel: Current channel name
         working_dir: Working directory path
         add_hint: Whether to add hint context
@@ -61,6 +64,8 @@ def build_env_context(
         parts.append(f"- Session ID: {session_id}")
     if user_id is not None:
         parts.append(f"- User ID: {user_id}")
+    if user_name:
+        parts.append(f"- User Name: {user_name}")
     if channel is not None:
         parts.append(f"- Channel: {channel}")
 


### PR DESCRIPTION
## Description

The Feishu channel already resolves the sender's nickname via the Contact API, but the value never reaches the agent: `AgentRequest.user_id` is intentionally kept as the raw `open_id` for session file naming, `to_handle` routing and allowlist matching, so the nickname was only surfaced in display-layer fields.

This PR pipes the nickname through the existing `channel_meta` transport — no schema changes, no impact on session/routing.

- **Feishu channel**: write resolved nickname into `native.meta["user_name"]`. `base._consume` already forwards `payload.meta` to `request.channel_meta`, so no extra plumbing.
- **Runner**: read `channel_meta.user_name` and pass it to `build_env_context`.
- **`build_env_context`**: add optional `user_name` param; render `- User Name: {user_name}` only when truthy.

Other channels can opt in by writing a single key into their native `meta`. Behavior is automatic and fully backward-compatible (no new config flag).

**Related Issue:** Fixes #4050 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
