### PR TITLE
 fix(WeChat): flush WeChat merge buffer immediately for cron sends

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1128,6 +1128,10 @@ class WeChatChannel(BaseChannel):
                     self._flush_merge_buffer(to_handle),
                 ),
             )
+        elif not self._merge_meta.get("wechat_context_token"):
+            # Full-merge mode: cron/proactive calls won't trigger
+            # _on_process_completed, so flush immediately.
+            await self._flush_merge_buffer(to_handle)
 
     async def _flush_merge_buffer(
         self,
@@ -1196,6 +1200,7 @@ class WeChatChannel(BaseChannel):
                     media_parts,
                     meta,
                 )
+
             return
 
         # Merging disabled: send everything immediately


### PR DESCRIPTION
## Description

When message_merge_delay_ms=0 (full-merge mode), outgoing messages are buffered in _merge_buffer and only flushed by _on_process_completed at the end of a user-initiated request. Cron sends never trigger that callback, so messages get stuck in the buffer until a user manually sends a message.

Fix: in _buffer_parts_for_merge, when delay_ms==0, check self._merge_meta for the absence of wechat_context_token (only populated by the incoming-message pipeline) and flush immediately for cron/proactive calls.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
