### PR TITLE
perf(console): Chat performance optimization

### DIFF
--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { IconButton } from "@agentscope-ai/design";
 import {
   SparkHistoryLine,
@@ -11,8 +11,6 @@ import { Flex, Tooltip } from "antd";
 import ChatSessionDrawer from "../ChatSessionDrawer";
 import ChatSearchPanel from "../ChatSearchPanel";
 import PlanPanel from "../../../../components/PlanPanel";
-import { planApi } from "../../../../api/modules/plan";
-import { useAgentStore } from "../../../../stores/agentStore";
 
 const PlanIcon = () => (
   <svg
@@ -30,27 +28,18 @@ const PlanIcon = () => (
   </svg>
 );
 
-const ChatActionGroup: React.FC = () => {
+interface ChatActionGroupProps {
+  planEnabled?: boolean;
+}
+
+const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
+  planEnabled = false,
+}) => {
   const { t } = useTranslation();
   const [historyOpen, setHistoryOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [planOpen, setPlanOpen] = useState(false);
-  const [planEnabled, setPlanEnabled] = useState(false);
   const { createSession } = useChatAnywhereSessions();
-  const { selectedAgent } = useAgentStore();
-
-  useEffect(() => {
-    let cancelled = false;
-    planApi
-      .getPlanConfig()
-      .then((cfg) => {
-        if (!cancelled) setPlanEnabled(cfg.enabled);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedAgent]);
 
   return (
     <Flex gap={8} align="center">

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -220,7 +220,29 @@ function useMultimodalCapabilities(
     supportsVideo: boolean;
   }>({ supportsMultimodal: false, supportsImage: false, supportsVideo: false });
 
+  const updateCapsIfChanged = useCallback(
+    (next: {
+      supportsMultimodal: boolean;
+      supportsImage: boolean;
+      supportsVideo: boolean;
+    }) => {
+      setMultimodalCaps((prev) =>
+        prev.supportsMultimodal === next.supportsMultimodal &&
+        prev.supportsImage === next.supportsImage &&
+        prev.supportsVideo === next.supportsVideo
+          ? prev
+          : next,
+      );
+    },
+    [],
+  );
+
   const fetchMultimodalCaps = useCallback(async () => {
+    const noCaps = {
+      supportsMultimodal: false,
+      supportsImage: false,
+      supportsVideo: false,
+    };
     try {
       const [providers, activeModels] = await Promise.all([
         providerApi.listProviders(),
@@ -232,22 +254,14 @@ function useMultimodalCapabilities(
       const activeProviderId = activeModels?.active_llm?.provider_id;
       const activeModelId = activeModels?.active_llm?.model;
       if (!activeProviderId || !activeModelId) {
-        setMultimodalCaps({
-          supportsMultimodal: false,
-          supportsImage: false,
-          supportsVideo: false,
-        });
+        updateCapsIfChanged(noCaps);
         return;
       }
       const provider = (providers as ProviderInfo[]).find(
         (p) => p.id === activeProviderId,
       );
       if (!provider) {
-        setMultimodalCaps({
-          supportsMultimodal: false,
-          supportsImage: false,
-          supportsVideo: false,
-        });
+        updateCapsIfChanged(noCaps);
         return;
       }
       const allModels: ModelInfo[] = [
@@ -255,19 +269,15 @@ function useMultimodalCapabilities(
         ...(provider.extra_models ?? []),
       ];
       const model = allModels.find((m) => m.id === activeModelId);
-      setMultimodalCaps({
+      updateCapsIfChanged({
         supportsMultimodal: model?.supports_multimodal ?? false,
         supportsImage: model?.supports_image ?? false,
         supportsVideo: model?.supports_video ?? false,
       });
     } catch {
-      setMultimodalCaps({
-        supportsMultimodal: false,
-        supportsImage: false,
-        supportsVideo: false,
-      });
+      updateCapsIfChanged(noCaps);
     }
-  }, [selectedAgent]);
+  }, [selectedAgent, updateCapsIfChanged]);
 
   // Fetch caps on mount and whenever refreshKey changes
   useEffect(() => {
@@ -526,55 +536,38 @@ export default function ChatPage() {
 
   const isChatActive = useCallback(() => isChatActiveRef.current, []);
 
-  // Consume approvals from Context and filter by current session
+  // Consume approvals from Context and filter by current session.
+  // Uses a serialized key to avoid creating a new Map (and triggering
+  // re-renders of the entire Chat tree) when the filtered result is identical.
+  const prevApprovalKeyRef = useRef("");
+
   useEffect(() => {
-    // Get current session ID from multiple sources
-    // During new session creation, chatId may be empty but window.currentSessionId gets set
     const currentSessionId = window.currentSessionId || chatId || "";
 
-    // Filter approvals by root_session_id (includes children sessions)
-    console.debug(
-      "[Approval] Filtering approvals:",
-      "currentSessionId=",
-      currentSessionId,
-      "chatId=",
-      chatId,
-      "window.currentSessionId=",
-      window.currentSessionId,
-      "approvals=",
-      approvals.map((a) => ({
-        tool: a.tool_name,
-        session: a.session_id.slice(0, 8),
-        root: a.root_session_id.slice(0, 8),
-      })),
-    );
-
-    // If no session ID yet, check if we have approvals that could tell us the session
-    // (e.g., first message sent, approval arrives before session ID is set in window)
+    // When no session ID is available yet, use the first approval's
+    // root_session_id as a hint (handles the race where approval arrives
+    // before the session ID is propagated).
     let effectiveSessionId = currentSessionId;
     if (!effectiveSessionId && approvals.length > 0) {
-      // Use the root_session_id from the first approval as a hint
-      // This handles the race condition where approval arrives before session ID is propagated
       effectiveSessionId = approvals[0].root_session_id;
-      console.log(
-        "[Approval] No session ID yet, using first approval's root_session_id:",
-        effectiveSessionId,
-      );
     }
 
     const sessionApprovals = effectiveSessionId
       ? approvals.filter(
           (approval) => approval.root_session_id === effectiveSessionId,
         )
-      : approvals; // Show all if no session ID (fallback)
+      : approvals;
 
-    console.debug(
-      "[Approval] After filtering:",
-      sessionApprovals.length,
-      "approval(s)",
-    );
+    // Build a stable key from the filtered request IDs so we can skip
+    // the Map rebuild when nothing changed (avoids re-render every 2.5s poll).
+    const approvalKey = sessionApprovals
+      .map((a) => a.request_id)
+      .sort()
+      .join(",");
 
-    // Convert to map for display
+    if (approvalKey === prevApprovalKeyRef.current) return;
+    prevApprovalKeyRef.current = approvalKey;
+
     const newMap = new Map<string, ApprovalMessageData>();
     for (const approval of sessionApprovals) {
       newMap.set(approval.request_id, {
@@ -597,27 +590,12 @@ export default function ChatPage() {
 
   const handleApprove = useCallback(
     async (requestId: string) => {
-      console.log("[Approval] handleApprove called:", requestId);
-      console.log(
-        "[Approval] Current requests map size:",
-        approvalRequests.size,
-      );
       const request = approvalRequests.get(requestId);
-      if (!request) {
-        console.error("[Approval] Request not found:", requestId);
-        return;
-      }
+      if (!request) return;
 
-      // Use currentSessionId (root session) instead of request.sessionId (sub-agent session)
       const rootSessionId = window.currentSessionId || chatId || "";
-      console.log("[Approval] Sending approve command:", {
-        requestId,
-        rootSessionId,
-        subAgentSessionId: request.sessionId,
-      });
 
       try {
-        // Add exit animation class
         const cardElement = document.querySelector(
           `[data-approval-id="${requestId}"]`,
         );
@@ -630,21 +608,19 @@ export default function ChatPage() {
           requestId,
           rootSessionId,
         );
-        console.log("[Approval] Approve command sent successfully");
         message.success(t("approval.approved"));
 
-        // Delay removal to let animation complete
-        // Backend will remove from pending list, next poll will update UI
+        // Delay removal to let exit animation complete
         setTimeout(() => {
           setApprovalRequests((prev) => {
             const next = new Map(prev);
             next.delete(requestId);
             return next;
           });
-        }, 300); // Match animation duration
+        }, 300);
       } catch (error) {
         message.error(t("approval.approveFailed"));
-        console.error("[Approval] Failed to approve:", error);
+        console.error("Failed to approve:", error);
       }
     },
     [approvalRequests, chatId, t, message],
@@ -1060,7 +1036,7 @@ export default function ChatPage() {
             <ChatHeaderTitle />
             <span style={{ flex: 1 }} />
             <ModelSelector />
-            <ChatActionGroup />
+            <ChatActionGroup planEnabled={planEnabled} />
           </>
         ),
       },
@@ -1127,25 +1103,12 @@ export default function ChatPage() {
           return toDisplayUrl(url);
         },
         cancel(data: { session_id: string }) {
-          console.log(
-            "[Cancel] Cancel button clicked, session_id:",
-            data.session_id,
-          );
-          const chatId =
+          const resolvedChatId =
             sessionApi.getRealIdForSession(data.session_id) ?? data.session_id;
-          console.log("[Cancel] Resolved chat_id:", chatId);
-          if (chatId) {
-            console.log("[Cancel] Calling stopChat API...");
-            chatApi
-              .stopChat(chatId)
-              .then(() => {
-                console.log("[Cancel] stopChat API succeeded");
-              })
-              .catch((err) => {
-                console.error("[Cancel] Failed to stop chat:", err);
-              });
-          } else {
-            console.warn("[Cancel] No chat_id found, cannot stop");
+          if (resolvedChatId) {
+            chatApi.stopChat(resolvedChatId).catch((err) => {
+              console.error("Failed to stop chat:", err);
+            });
           }
         },
         async reconnect(data: { session_id: string; signal?: AbortSignal }) {
@@ -1242,39 +1205,16 @@ export default function ChatPage() {
             onApprove={handleApprove}
             onDeny={handleDeny}
             onCancel={() => {
-              console.log("[Chat] onCancel called for approval card");
               const sessionId = window.currentSessionId || "";
-
-              // Use the same fallback chain as customFetch:
-              // 1. sessionApi.getRealIdForSession (UUID from backend)
-              // 2. chatIdRef.current (URL param)
-              // 3. sessionId (timestamp fallback)
               const resolvedChatId =
                 sessionApi.getRealIdForSession(sessionId) ??
                 chatIdRef.current ??
                 sessionId;
 
-              console.log(
-                "[Chat] Resolved chat_id for stop:",
-                resolvedChatId,
-                "from session_id:",
-                sessionId,
-                "chatIdRef:",
-                chatIdRef.current,
-              );
-
               if (resolvedChatId) {
-                console.log("[Chat] Calling stopChat with:", resolvedChatId);
-                chatApi
-                  .stopChat(resolvedChatId)
-                  .then(() => {
-                    console.log("[Chat] stopChat succeeded");
-                  })
-                  .catch((err) => {
-                    console.error("[Chat] stopChat failed:", err);
-                  });
-              } else {
-                console.warn("[Chat] No chat_id resolved, cannot cancel task");
+                chatApi.stopChat(resolvedChatId).catch((err) => {
+                  console.error("Failed to stop chat:", err);
+                });
               }
             }}
           />

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -340,6 +340,35 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   private sessionList: IAgentScopeRuntimeWebUISession[] = [];
 
   /**
+   * Pending resolvers waiting for a specific session's realId.
+   * Used to replace setTimeout-based busy-wait with event-driven notification.
+   */
+  private realIdResolvers: Map<string, Array<() => void>> = new Map();
+
+  /** Notify any pending waiters that a session's realId has been resolved. */
+  private notifyRealIdResolved(sessionId: string): void {
+    const resolvers = this.realIdResolvers.get(sessionId);
+    if (resolvers) {
+      this.realIdResolvers.delete(sessionId);
+      for (const resolve of resolvers) resolve();
+    }
+  }
+
+  /** Wait until a session's realId is available (set by updateSession). */
+  private waitForRealId(sessionId: string): Promise<void> {
+    const session = this.sessionList.find((x) => x.id === sessionId) as
+      | ExtendedSession
+      | undefined;
+    if (session?.realId) return Promise.resolve();
+
+    return new Promise<void>((resolve) => {
+      const existing = this.realIdResolvers.get(sessionId) || [];
+      existing.push(resolve);
+      this.realIdResolvers.set(sessionId, existing);
+    });
+  }
+
+  /**
    * When set, getSessionList will move the matching session to the front on the first call,
    * so the library's useMount auto-selects it instead of always defaulting to sessions[0].
    * Cleared after first use.
@@ -591,19 +620,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
       // Pure local session (not yet sent to backend): wait until updateSession
       // resolves the realId, then fetch history with the real UUID.
-      await new Promise<void>((resolve) => {
-        const check = () => {
-          const s = this.sessionList.find((x) => x.id === sessionId) as
-            | ExtendedSession
-            | undefined;
-          if (s?.realId) {
-            resolve();
-          } else {
-            setTimeout(check, 100);
-          }
-        };
-        setTimeout(check, 100);
-      });
+      await this.waitForRealId(sessionId);
 
       const refreshed = this.sessionList.find((s) => s.id === sessionId) as
         | ExtendedSession
@@ -674,6 +691,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
           const { list, realId } = resolveRealId(this.sessionList, tempId);
           this.sessionList = list;
           if (realId) {
+            this.notifyRealIdResolved(tempId);
             this.onSessionIdResolved?.(tempId, realId);
           }
         });
@@ -684,6 +702,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         const { list, realId } = resolveRealId(this.sessionList, tempId);
         this.sessionList = list;
         if (realId) {
+          this.notifyRealIdResolved(tempId);
           this.onSessionIdResolved?.(tempId, realId);
         }
       });


### PR DESCRIPTION
## Description

1.Approval state reference stabilization — ConsolePollService polls every 2.5 seconds to trigger Context changes, rebuilding the Map each time and causing the Chat component to re-render. This has been changed to use serialization key comparison, skipping updates if the content hasn't changed.

2.Remove production debug logs.

3.Eliminate duplicate requests from planApi.getPlanConfig().

4.The polling of `setTimeout(100)` while waiting for `realId` to be resolved in `_doGetSession` has been changed to a Promise + callback notification mechanism.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
