### PR TITLE
fix(channels): keep markdown tables renderable across split_text chunks

### DIFF
--- a/src/qwenpaw/app/channels/utils.py
+++ b/src/qwenpaw/app/channels/utils.py
@@ -8,11 +8,16 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+# Matches a GFM table separator row, e.g. ``| --- | :---: |``.
+_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-{3,}:?(\s*\|\s*:?-{3,}:?)*\s*\|?\s*$",
+)
 
 
 def _is_windows_drive(netloc: str) -> bool:
@@ -31,64 +36,179 @@ def _is_windows_drive(netloc: str) -> bool:
     return False
 
 
+def _is_table_separator(line: str) -> bool:
+    """Return True if ``line`` looks like a GFM table separator row."""
+    return bool(_TABLE_SEPARATOR_RE.match(line)) and "-" in line
+
+
+def _split_table_block(
+    table_lines: List[str],
+    max_len: int,
+) -> List[str]:
+    """Split a markdown table into chunks, each a complete table.
+
+    Header and separator rows are duplicated into every chunk so the
+    output stays renderable on the receiver even when the original
+    table exceeds ``max_len``.
+    """
+    if len(table_lines) < 2:
+        return ["\n".join(table_lines)]
+
+    header, separator = table_lines[0], table_lines[1]
+    data_rows = table_lines[2:]
+    if not data_rows:
+        return ["\n".join(table_lines)]
+
+    preamble = header + "\n" + separator
+    preamble_len = len(preamble) + 1  # +1 for the \n before first row
+
+    chunks: List[str] = []
+    current_rows: List[str] = []
+    current_len = preamble_len
+    for row in data_rows:
+        row_len = len(row) + 1
+        if current_rows and current_len + row_len > max_len:
+            chunks.append(preamble + "\n" + "\n".join(current_rows))
+            current_rows = []
+            current_len = preamble_len
+        current_rows.append(row)
+        current_len += row_len
+
+    if current_rows:
+        chunks.append(preamble + "\n" + "\n".join(current_rows))
+    return chunks
+
+
+def _collect_table_lines(
+    lines: List[str],
+    start: int,
+) -> Tuple[List[str], int]:
+    """Collect a GFM table starting at ``lines[start]``.
+
+    Returns the table lines and the index of the first line after it.
+    """
+    table_lines: List[str] = [lines[start], lines[start + 1]]
+    cursor = start + 2
+    while cursor < len(lines) and "|" in lines[cursor]:
+        if _FENCE_RE.match(lines[cursor].strip()):
+            break
+        table_lines.append(lines[cursor])
+        cursor += 1
+    return table_lines, cursor
+
+
+class _SplitBuffer:
+    """Accumulator used by :func:`split_text`."""
+
+    def __init__(self, max_len: int) -> None:
+        self.max_len = max_len
+        self.chunks: List[str] = []
+        self._current: List[str] = []
+        self._length = 0
+        self.fence_open: str = ""
+
+    def _flush(self) -> None:
+        """Emit the buffered content, closing an open code fence."""
+        body = "".join(self._current).rstrip("\n")
+        if self.fence_open:
+            body += "\n```"
+        self.chunks.append(body)
+        self._current.clear()
+        self._length = 0
+
+    def _flush_for(self, incoming_len: int) -> None:
+        """Flush if appending ``incoming_len`` would overflow ``max_len``."""
+        if not self._current or self._length + incoming_len <= self.max_len:
+            return
+        saved_fence = self.fence_open
+        self._flush()
+        if saved_fence:
+            reopener = saved_fence + "\n"
+            self._current.append(reopener)
+            self._length = len(reopener)
+
+    def _hard_split_long_line(self, line: str) -> None:
+        """Split an oversize single line at ``max_len`` boundaries."""
+        for k in range(0, len(line), self.max_len):
+            self.chunks.append(line[k : k + self.max_len])
+
+    def emit_line(self, line: str) -> None:
+        """Append a source line, hard-splitting if it exceeds ``max_len``."""
+        line_with_nl = line + "\n"
+        self._flush_for(len(line_with_nl))
+        if len(line_with_nl) > self.max_len:
+            self._hard_split_long_line(line)
+            return
+        self._current.append(line_with_nl)
+        self._length += len(line_with_nl)
+
+    def emit_table_chunk(self, table_text: str) -> None:
+        """Append a self-contained table chunk; emit alone if oversized."""
+        block = table_text.rstrip("\n") + "\n"
+        if self._current and self._length + len(block) > self.max_len:
+            self._flush()
+        if len(block) > self.max_len and not self._current:
+            self.chunks.append(block.rstrip("\n"))
+            return
+        self._current.append(block)
+        self._length += len(block)
+
+    def finalize(self) -> List[str]:
+        """Flush remaining buffered content and return all chunks."""
+        if self._current:
+            self.chunks.append("".join(self._current).rstrip("\n"))
+        return [c for c in self.chunks if c.strip()]
+
+
 def split_text(text: str, max_len: int = 3000) -> List[str]:
-    """Split text into chunks that fit within max_len characters.
+    """Split text into chunks no longer than ``max_len`` characters.
 
-    Splits at newline boundaries to preserve formatting. If a single
-    line exceeds max_len it is hard-split at max_len.
+    Splits at newline boundaries to preserve formatting; a single line
+    that exceeds ``max_len`` is hard-split.
 
-    Markdown code fences are tracked so that a chunk ending inside an
-    open fence gets a closing fence appended and the next chunk gets
-    a matching opening fence prepended, keeping code blocks rendered
-    correctly across split messages.
+    Two markdown structures are kept renderable across chunks:
+
+    - **Code fences** (```` ``` ```` / ``~~~``): a chunk ending inside
+      an open fence gets a closing fence appended and the next chunk
+      gets a matching opening fence prepended.
+    - **GFM pipe tables**: a table is treated as an atomic unit and
+      only split between data rows; every resulting chunk repeats the
+      header and separator so it stays a valid, renderable table
+      (otherwise channels like WeChat fall back to plain text).
     """
     if len(text) <= max_len:
         return [text]
 
-    chunks: List[str] = []
-    current: List[str] = []
-    current_len = 0
-    fence_open: str = ""
-
-    def _flush() -> None:
-        nonlocal fence_open
-        body = "".join(current).rstrip("\n")
-        if fence_open:
-            body += "\n```"
-        chunks.append(body)
-        current.clear()
-
-    for line in text.split("\n"):
-        line_with_nl = line + "\n"
+    buf = _SplitBuffer(max_len)
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         stripped = line.strip()
 
         if _FENCE_RE.match(stripped):
-            if fence_open:
-                fence_open = ""
-            else:
-                fence_open = stripped
+            buf.fence_open = "" if buf.fence_open else stripped
+            buf.emit_line(line)
+            i += 1
+            continue
 
-        if current and current_len + len(line_with_nl) > max_len:
-            saved_fence = fence_open
-            _flush()
-            current_len = 0
-            if saved_fence:
-                fence_open = saved_fence
-                reopener = saved_fence + "\n"
-                current.append(reopener)
-                current_len += len(reopener)
+        is_table_start = (
+            not buf.fence_open
+            and "|" in line
+            and i + 1 < len(lines)
+            and _is_table_separator(lines[i + 1])
+        )
+        if is_table_start:
+            table_lines, next_i = _collect_table_lines(lines, i)
+            for table_chunk in _split_table_block(table_lines, max_len):
+                buf.emit_table_chunk(table_chunk)
+            i = next_i
+            continue
 
-        if len(line_with_nl) > max_len:
-            for i in range(0, len(line), max_len):
-                chunks.append(line[i : i + max_len])
-        else:
-            current.append(line_with_nl)
-            current_len += len(line_with_nl)
+        buf.emit_line(line)
+        i += 1
 
-    if current:
-        chunks.append("".join(current).rstrip("\n"))
-
-    return [c for c in chunks if c.strip()]
+    return buf.finalize()
 
 
 def file_url_to_local_path(url: str) -> Optional[str]:


### PR DESCRIPTION
## Description

### What
Make `channels.utils.split_text` aware of GFM markdown tables so that
long agent replies stay renderable on the receiver side.

## Why
WeChat users reported that when an agent reply contains a large
markdown table, `split_text` cuts the table mid-way at the per-message
length limit. The trailing chunk loses the header + separator rows
and the WeChat client falls back to plain text, breaking the table
layout. The same risk applies to every channel that uses
`split_text` (`wechat`, `wecom`, `qq`, `onebot`).

### How
- Detect GFM pipe tables (a line containing `|` followed by a valid
  separator row like `| --- | :---: |`) and treat the whole table as
  an atomic unit during splitting.
- When a table exceeds `max_len`, split between data rows; each
  resulting chunk re-emits the header and separator so it stays a
  complete, renderable table.
- Existing code-fence (` ``` ` / `~~~`) reopen-on-next-chunk behavior
  is preserved; pipe lines inside a fenced block are not treated as
  a table.
- Pure non-table input keeps the exact previous behavior — fully
  backward compatible for all current callers.
- Refactored the splitter into a small `_SplitBuffer` helper to keep
  the main loop shallow.

### Compatibility
No public API change. All five existing call sites
(`wechat`, `wecom`, `qq`, `onebot`) keep their previous behavior on
non-table input and benefit transparently when a table is present.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
