### PR TITLE
perf(console): skip chat history lookup for non-arrow keys

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -376,6 +376,7 @@ function useMessageHistoryNavigation(
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!isChatActive()) return;
+      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
 
       const target = e.target as HTMLElement;
       const isChatSender =


### PR DESCRIPTION
## Description

This PR avoids running chat history navigation logic for every keydown event in the Console chat input.

Previously, the global `keydown` handler first checked chat state, sender DOM ancestry, IME composition state, modifier keys, textarea selection, and message history before determining whether the key was `ArrowUp` or `ArrowDown`. With long conversations containing many tool calls, normal typing can trigger unnecessary work on every character input.

This change adds an early return for non-arrow keys immediately after confirming the chat view is active, so regular text input bypasses the history navigation path.

In a local headed Playwright benchmark with 120 mocked tool-call messages and a 1,034-character input sequence:

- Median browser input time improved from `10939.9ms` to `9590.3ms` (`~12.3%` faster)
- Average browser input time improved from `11417.1ms` to `10103.2ms` (`~11.5%` faster)
- Synthetic 10,000-keydown handler time improved from `282.1ms` to `198.6ms` (`~29.6%` faster)

**Related Issue:** N/A

**Security Considerations:** N/A. This change only affects frontend keyboard event handling and does not touch authentication, environment variables, or data handling.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Performance improvement

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Manually verified the Console frontend build and formatting for the changed file.

The attempted targeted Vitest command did not run any test because `ChatPage.test.tsx` is currently excluded by the Vitest configuration.

## Local Verification Evidence

```bash
cd console
npx prettier --check src/pages/Chat/index.tsx
# Checking formatting...
# All matched files use Prettier code style!

NODE_OPTIONS=--max-old-space-size=4096 npm run build
# ✓ built in 1m 2s

npm run test:run -- ChatPage.test.tsx
# No test files found, exiting with code 1
# exclude: **/pages/Chat/ChatPage.test.tsx
```
## Additional Notes

Benchmark setup: headed Playwright, mocked Console API responses, 120 synthetic tool-call messages, and repeated typing of a 1,034-character prompt. The benchmark artifacts are local only and are not included in this PR.