### PR TITLE
fix(agent): replace hardcoded agent name with config-driven value

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -171,7 +171,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         )
         # Initialize parent ReActAgent
         init_kwargs: dict[str, Any] = {
-            "name": "Friday",
+            "name": agent_config.name or "QwenPaw",
             "model": model,
             "sys_prompt": sys_prompt,
             "toolkit": toolkit,

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -207,7 +207,7 @@ class DynamicMultiAgentRunner:
 runner = DynamicMultiAgentRunner()
 
 agent_app = AgentApp(
-    app_name="Friday",
+    app_name="QwenPaw",
     app_description="A helpful assistant with background task support",
     runner=runner,
     enable_stream_task=True,

--- a/src/qwenpaw/app/runner/command_dispatch.py
+++ b/src/qwenpaw/app/runner/command_dispatch.py
@@ -119,7 +119,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
             )
             # Yield hint first so user sees it before restart runs.
             hint = Msg(
-                name="Friday",
+                name=runner.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(
@@ -142,8 +142,11 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
             manager=manager,
             agent_id=agent_id,
             session_id=session_id,
+            agent_name=runner.agent_name,
         )
         msg = await handler.handle_daemon_command(query, daemon_ctx)
+        if parsed[0] in ("reload-config", "restart"):
+            runner.invalidate_agent_name_cache()
         yield msg, True
         logger.info("handle_daemon_command %s completed", query)
         return
@@ -156,7 +159,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
                 "run_command_path: control command but workspace not set",
             )
             error_msg = Msg(
-                name="Friday",
+                name=runner.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(
@@ -186,7 +189,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
                 f"run_command_path: channel not found: {channel_id}",
             )
             error_msg = Msg(
-                name="Friday",
+                name=runner.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(
@@ -219,7 +222,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
                 control_ctx,
             )
             response_msg = Msg(
-                name="Friday",
+                name=runner.agent_name,
                 role="assistant",
                 content=[TextBlock(type="text", text=response_text)],
             )
@@ -231,7 +234,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
             else:
                 logger.exception("Control command unexpected error: %s", query)
             error_msg = Msg(
-                name="Friday",
+                name=runner.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(
@@ -256,7 +259,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
         memory.load_state_dict(memory_state, strict=False)
 
     conv_handler = CommandHandler(
-        agent_name="Friday",
+        agent_name=runner.agent_name,
         memory=memory,
         memory_manager=runner.memory_manager,
         context_manager=context_manager,
@@ -265,7 +268,7 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
         response_msg = await conv_handler.handle_conversation_command(query)
     except (RuntimeError, AppBaseException) as e:
         response_msg = Msg(
-            name="Friday",
+            name=runner.agent_name,
             role="assistant",
             content=[TextBlock(type="text", text=str(e))],
         )

--- a/src/qwenpaw/app/runner/daemon_commands.py
+++ b/src/qwenpaw/app/runner/daemon_commands.py
@@ -60,6 +60,7 @@ class DaemonContext:
     agent_id: Optional[str] = None
     # Session ID for approval commands.
     session_id: str = ""
+    agent_name: str = "QwenPaw"
 
 
 def _get_last_lines(
@@ -235,7 +236,7 @@ class DaemonCommandHandlerMixin:
         parsed = parse_daemon_query(query)
         if not parsed:
             return Msg(
-                name="Friday",
+                name=context.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(type="text", text="Unknown daemon command."),
@@ -261,7 +262,7 @@ class DaemonCommandHandlerMixin:
             text = "Unknown daemon subcommand."
         logger.info("handle_daemon_command %s completed", query)
         return Msg(
-            name="Friday",
+            name=context.agent_name,
             role="assistant",
             content=[TextBlock(type="text", text=text)],
         )

--- a/src/qwenpaw/app/runner/mission_dispatch.py
+++ b/src/qwenpaw/app/runner/mission_dispatch.py
@@ -37,6 +37,7 @@ async def maybe_handle_mission_command(
     agent_id: str,
     rewrite_fn: Callable[[list, str], None],
     session_id: str = "",
+    agent_name: str = "QwenPaw",
 ) -> Msg | dict[str, Any] | None:
     """Handle ``/mission`` if the query matches.
 
@@ -60,7 +61,7 @@ async def maybe_handle_mission_command(
 
     if isinstance(result, str):
         return Msg(
-            name="Friday",
+            name=agent_name,
             role="assistant",
             content=[TextBlock(type="text", text=result)],
         )

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -123,6 +123,22 @@ class AgentRunner(Runner):
         self.memory_manager: BaseMemoryManager | None = None
         self.context_manager: BaseContextManager | None = None
         self._task_tracker = task_tracker  # Task tracker for background tasks
+        self._agent_name: str | None = None
+
+    @property
+    def agent_name(self) -> str:
+        """Agent display name from config, cached after first access."""
+        if self._agent_name is None:
+            try:
+                cfg = load_agent_config(self.agent_id)
+                self._agent_name = cfg.name if cfg and cfg.name else "QwenPaw"
+            except Exception:
+                self._agent_name = "QwenPaw"
+        return self._agent_name
+
+    def invalidate_agent_name_cache(self) -> None:
+        """Clear cached agent_name so next access re-reads config."""
+        self._agent_name = None
 
     def set_chat_manager(self, chat_manager):
         """Set chat manager for auto-registration.
@@ -182,8 +198,8 @@ class AgentRunner(Runner):
         user_input = parts[1] if len(parts) > 1 else ""
         return (name, user_input) if name else None
 
-    @staticmethod
     def _maybe_inject_skill(
+        self,
         query: str | None,
         msgs: list,
         skills: dict,
@@ -231,7 +247,7 @@ class AgentRunner(Runner):
             desc = post.get("description") or "No description."
             logger.info("Skill info: %s", name)
             return Msg(
-                name="Friday",
+                name=self.agent_name,
                 role="assistant",
                 content=[
                     TextBlock(
@@ -419,6 +435,7 @@ class AgentRunner(Runner):
                 agent_id=self.agent_id,
                 rewrite_fn=self._rewrite_last_message_text,
                 session_id=session_id,
+                agent_name=self.agent_name,
             )
             if isinstance(mission_result, Msg):
                 yield mission_result, True


### PR DESCRIPTION
## Description

- Add `AgentRunner.agent_name` property 
- Replace hardcoded "Friday" references across runner, command_dispatch, daemon_commands, mission_dispatch, and react_agent
- Fallback to "QwenPaw" when the config name is empty or unreadable

Fixes #4099 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
