### PR TITLE
fix(mcp): fix lifecycle-task leak in stateful clients and refactor shared logic…

### DIFF
--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -95,8 +95,9 @@ class MCPClientManager:
     ) -> None:
         """Replace or add a client with new configuration.
 
-        Flow: connect new (outside lock) → swap + close old (inside lock).
-        This ensures minimal lock holding time.
+        Flow: connect new (outside lock) → atomic swap (inside lock) →
+        close old (outside lock).
+        The lock is held only for the dict swap, not during the slow close().
 
         Args:
             key: Client identifier (from config)
@@ -114,21 +115,24 @@ class MCPClientManager:
             await self._force_cleanup_client(new_client)
             raise
 
-        # 2. Swap and close old client inside lock
+        # 2. Atomically swap inside lock (dict ops only — no async I/O here)
         async with self._lock:
             old_client = self._clients.get(key)
             self._clients[key] = new_client
-
-            if old_client is not None:
-                logger.debug(f"Closing old MCP client: {key}")
-                try:
-                    await old_client.close()
-                except Exception as e:
-                    logger.warning(
-                        f"Error closing old MCP client '{key}': {e}",
-                    )
-            else:
+            if old_client is None:
                 logger.debug(f"Added new MCP client: {key}")
+
+        # 3. Close old client outside lock — close() may await for up to
+        #    a full reconnect sleep (≥1 s) and should not block get_clients()
+        #    / get_client() / close_all().  Matches remove_client() pattern.
+        if old_client is not None:
+            logger.debug(f"Closing old MCP client: {key}")
+            try:
+                await old_client.close()
+            except Exception as e:
+                logger.warning(
+                    f"Error closing old MCP client '{key}': {e}",
+                )
 
     async def remove_client(self, key: str) -> None:
         """Remove and close a client.
@@ -191,41 +195,25 @@ class MCPClientManager:
     async def _force_cleanup_client(client: Any) -> None:
         """Force-close a client whose ``connect()`` was interrupted.
 
-        ``StatefulClientBase.close()`` refuses to run when
-        ``is_connected`` is still ``False`` (which is the case when
-        ``connect()`` times out or raises).  We bypass that guard by
-        closing the ``AsyncExitStack`` directly — this triggers the
-        ``stdio_client`` finally-block that sends SIGTERM/SIGKILL to
-        the child process.
+        Called when ``connect()`` raises (timeout or other error) so that
+        any background lifecycle task and subprocess are torn down.
 
-        The ``ClientSession`` is registered on the same stack via
-        ``enter_async_context``, so ``stack.aclose()`` exits it in
-        LIFO order — no separate session teardown is needed.
+        For ``StdIOStatefulClient`` / ``HttpStatefulClient`` the
+        ``connect()`` timeout path already calls ``_stop_event.set()``
+        and ``await _lifecycle_task`` before re-raising, so by the time
+        this helper runs the task is already done and ``close()`` returns
+        early as a no-op.  The call is kept for correctness in edge-cases
+        and for compatibility with other client implementations.
         """
         if client is None:
             return
-
-        stack = getattr(client, "stack", None)
-        if stack is None:
-            return
-
         try:
-            await stack.aclose()
+            await client.close(ignore_errors=True)
         except Exception:
             logger.debug(
                 "Error during force-cleanup of MCP client",
                 exc_info=True,
             )
-        finally:
-            for attr, default in (
-                ("stack", None),
-                ("session", None),
-                ("is_connected", False),
-            ):
-                try:
-                    setattr(client, attr, default)
-                except Exception:
-                    pass
 
     @staticmethod
     def _build_client(client_config: "MCPClientConfig") -> Any:

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -32,8 +32,401 @@ from agentscope.mcp import StatefulClientBase
 
 logger = logging.getLogger(__name__)
 
+# anyio is a required transitive dependency of the mcp package, so it is
+# always available in practice.  The try/except guards against edge cases
+# (e.g. partial installs during testing) without making the whole module
+# fail to import.
+try:
+    import anyio as _anyio
 
-class StdIOStatefulClient(StatefulClientBase):
+    _ANYIO_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+        _anyio.ClosedResourceError,
+        _anyio.BrokenResourceError,
+    )
+except ImportError:
+    _anyio = None
+    _ANYIO_TRANSPORT_ERRORS = ()
+
+# All exception types that indicate a dead transport — anyio stream errors,
+# httpx transport failures, and low-level socket/pipe errors (including stdio
+# pipe breaks when an MCP subprocess exits unexpectedly).
+_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    *_ANYIO_TRANSPORT_ERRORS,
+    httpx.TransportError,
+    EOFError,
+    ConnectionResetError,
+    BrokenPipeError,
+)
+
+
+def _is_transport_error(exc: BaseException) -> bool:
+    """Return ``True`` if *exc* indicates a broken or closed transport.
+
+    Transport errors mean the underlying stream is dead; the client should
+    reconnect rather than treat the failure as permanent.  See
+    ``_TRANSPORT_ERRORS`` for the full list of recognised exception types.
+    """
+    return isinstance(exc, _TRANSPORT_ERRORS)
+
+
+class _MCPClientMixin:
+    """Mixin providing shared tool-call and lifecycle logic for both clients.
+
+    ``StdIOStatefulClient`` and ``HttpStatefulClient`` share identical
+    ``list_tools``, ``call_tool``, ``close``, ``connect``, ``reload``,
+    ``_run_lifecycle``, ``_validate_connection``, and
+    ``_handle_transport_error`` implementations.  This mixin is the single
+    authoritative source for all of them.
+
+    Subclasses must implement ``_setup_transport`` to establish the
+    transport-specific connection and enter it into the provided
+    ``AsyncExitStack``.
+
+    Attributes declared below are set by the concrete subclass's
+    ``__init__``.  They are listed here (as bare annotations, no assignment)
+    so that static type checkers (mypy, pyright) can verify usages inside
+    mixin methods without requiring a full Protocol.
+    """
+
+    # Attributes provided by the concrete subclass's __init__.
+    # Bare annotations (no assignment) have no runtime effect; they exist
+    # only so static type checkers can verify usages in mixin methods.
+    name: str
+    session: ClientSession | None
+    is_connected: bool
+    _cached_tools: Any
+    _stop_event: asyncio.Event
+    _reload_event: asyncio.Event
+    _ready_event: asyncio.Event
+    _lifecycle_task: asyncio.Task | None
+
+    # ------------------------------------------------------------------
+    # Transport hook (implemented by each concrete subclass)
+    # ------------------------------------------------------------------
+
+    async def _setup_transport(
+        self,
+        stack: AsyncExitStack,
+    ) -> tuple[Any, Any]:
+        """Enter the transport context manager and
+         return ``(read, write)`` streams.
+
+        Subclasses enter their transport-specific context manager (e.g.
+        ``stdio_client``, ``streamable_http_client``, or ``sse_client``)
+        into *stack* and return the two stream objects that
+        ``ClientSession`` expects.
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _run_lifecycle(self) -> None:
+        """Run MCP client lifecycle in a dedicated task.
+
+        This ensures ``__aenter__`` and ``__aexit__`` are called in the
+        same asyncio task, avoiding the cross-task cancel-scope error.
+        Transport setup is delegated to ``_setup_transport``.
+        """
+        while not self._stop_event.is_set():
+            try:
+                logger.debug(f"Connecting MCP client: {self.name}")
+
+                async with AsyncExitStack() as stack:
+                    read_stream, write_stream = await self._setup_transport(
+                        stack,
+                    )
+
+                    self.session = ClientSession(read_stream, write_stream)
+                    await stack.enter_async_context(self.session)
+                    await self.session.initialize()
+
+                    self.is_connected = True
+                    self._ready_event.set()
+                    logger.info(f"MCP client connected: {self.name}")
+
+                    # Wait for a reload or stop signal (0.1 s poll).
+                    while (
+                        not self._reload_event.is_set()
+                        and not self._stop_event.is_set()
+                    ):
+                        await asyncio.sleep(0.1)
+
+                    # Clear state before the context manager exits and
+                    # tears down the transport / subprocess.
+                    self.session = None
+                    self.is_connected = False
+                    self._cached_tools = None
+
+                    if self._reload_event.is_set():
+                        logger.info(f"Reloading MCP client: {self.name}")
+                        self._reload_event.clear()
+                        self._ready_event.clear()
+                    else:
+                        logger.info(f"Stopping MCP client: {self.name}")
+
+                # AsyncExitStack exits here in THIS task — no cross-task issue.
+
+            except Exception as e:
+                logger.error(
+                    f"Error in MCP client lifecycle for {self.name}: {e}",
+                    exc_info=True,
+                )
+                self.session = None
+                self.is_connected = False
+                self._cached_tools = None
+                self._ready_event.clear()
+                await asyncio.sleep(1)
+
+        logger.info(f"MCP client lifecycle task exited: {self.name}")
+
+    async def connect(self, timeout: float = 30.0) -> None:
+        """Connect to the MCP server.
+
+        Starts the background lifecycle task and waits until the first
+        connection is established.
+
+        Args:
+            timeout: Connection timeout in seconds (default 30 s).
+
+        Raises:
+            RuntimeError: If already connected.
+            asyncio.TimeoutError: If the connection is not established
+                within *timeout* seconds.
+        """
+        has_task = (
+            self._lifecycle_task is not None
+            and not self._lifecycle_task.done()
+        )
+        if self.is_connected or has_task:
+            raise RuntimeError(
+                f"MCP client '{self.name}' is already connected or a "
+                f"lifecycle task is still running. "
+                f"Call close() before connecting again.",
+            )
+
+        # Clear both events: _stop_event so the task does not exit
+        # immediately, and _ready_event so the wait below blocks until
+        # the *new* connection is established (the event may still be
+        # set from a previous connect/close cycle because the stop path
+        # in _run_lifecycle does not clear it).
+        self._stop_event.clear()
+        self._ready_event.clear()
+        self._lifecycle_task = asyncio.create_task(self._run_lifecycle())
+
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Timeout waiting for MCP client '{self.name}' to connect",
+            )
+            self._stop_event.set()
+            if self._lifecycle_task:
+                await self._lifecycle_task
+            raise
+
+    async def reload(self, timeout: float = 30.0) -> None:
+        """Reload the MCP client (tear down and reconnect).
+
+        Args:
+            timeout: Reconnection timeout in seconds (default 30 s).
+
+        Raises:
+            RuntimeError: If not connected.
+            asyncio.TimeoutError: If the new connection is not
+                established within *timeout* seconds.
+        """
+        if not self.is_connected:
+            raise RuntimeError(
+                f"MCP client '{self.name}' is not connected. "
+                f"Call connect() first.",
+            )
+
+        logger.info(f"Triggering reload for MCP client: {self.name}")
+        self._reload_event.set()
+        # Clear _ready_event *before* waiting.  When connected,
+        # _ready_event is already set; without this clear, the wait
+        # below would return immediately before the reload has started.
+        self._ready_event.clear()
+
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
+            logger.info(f"Reload completed for MCP client: {self.name}")
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Timeout waiting for MCP client '{self.name}' to reload",
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def list_tools(self):
+        """Return all tools available from the MCP server.
+
+        Returns:
+            List of available MCP tools
+
+        Raises:
+            RuntimeError: If not connected
+        """
+        self._validate_connection()
+
+        try:
+            res = await self.session.list_tools()
+        except Exception as exc:
+            self._handle_transport_error(exc)
+            raise
+
+        self._cached_tools = res.tools
+        return res.tools
+
+    async def call_tool(self, name: str, arguments: dict | None = None):
+        """Call a tool on the MCP server.
+
+        Args:
+            name: Tool name
+            arguments: Tool arguments (optional)
+
+        Returns:
+            Tool call result
+
+        Raises:
+            RuntimeError: If not connected
+        """
+        self._validate_connection()
+
+        try:
+            return await self.session.call_tool(name, arguments or {})
+        except Exception as exc:
+            self._handle_transport_error(exc)
+            raise
+
+    async def close(self, ignore_errors: bool = True) -> None:
+        """Close the MCP client and stop its background lifecycle task.
+
+        Unlike the old guard (``if not self.is_connected: return``), this
+        method always attempts to stop the lifecycle task when one is still
+        running.  The old guard was a bug: when the client is in a reconnect
+        loop (``is_connected=False`` but the task is alive and will spawn a
+        new subprocess the moment it wakes from ``asyncio.sleep``), skipping
+        the stop leaked the eventual subprocess permanently.
+
+        Args:
+            ignore_errors: When ``True`` (default), exceptions during cleanup
+                are logged but not re-raised.
+
+        Raises:
+            RuntimeError: If not connected and no task is running, and
+                ``ignore_errors`` is ``False``.
+        """
+        has_task = self._lifecycle_task is not None and not (
+            self._lifecycle_task.done()
+        )
+
+        if not self.is_connected and not has_task:
+            if not ignore_errors:
+                raise RuntimeError(
+                    f"MCP client '{self.name}' is not connected. "
+                    f"Call connect() before closing.",
+                )
+            return
+
+        try:
+            # Signal stop and wait for the lifecycle task to finish.  This
+            # must happen even when is_connected is False (reconnect loop).
+            self._stop_event.set()
+            if self._lifecycle_task:
+                await self._lifecycle_task
+        except Exception as e:
+            if not ignore_errors:
+                raise
+            logger.warning(
+                f"Error closing MCP client '{self.name}': {e}",
+            )
+        finally:
+            # Clear the reference unconditionally — including when the current
+            # coroutine is cancelled (CancelledError is BaseException, not
+            # Exception, so it bypasses the except block above).  _stop_event
+            # is already set at this point, so the task will exit on its next
+            # iteration even if we don't hold the reference.
+            self._lifecycle_task = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _handle_transport_error(self, exc: BaseException) -> None:
+        """Mark the client as disconnected and schedule a reconnect when *exc*
+        indicates a transport/stream failure rather than an MCP-level error.
+
+        **HTTP / streamable_http scenario**
+        ``streamable_http_client``'s ``post_writer`` background task silently
+        closes ``write_stream`` in its ``finally`` block when an internal
+        error occurs (e.g. HTTP read timeout after 300 s).  The lifecycle
+        loop keeps seeing ``is_connected=True`` because the failure never
+        propagates to it.  Without this handler every subsequent
+        ``call_tool`` call would raise ``anyio.ClosedResourceError``
+        indefinitely — the client would never recover without a process
+        restart.
+
+        **StdIO scenario**
+        If the MCP subprocess exits unexpectedly, the stdio pipe breaks and
+        subsequent ``call_tool`` calls raise ``BrokenPipeError``,
+        ``EOFError``, or ``anyio.ClosedResourceError``.  The same handler
+        detects these and triggers a reconnect.  For StdIO, reconnecting
+        means spawning a *new* subprocess.  The lifecycle task exits the
+        current ``AsyncExitStack`` (which terminates the dead/old subprocess)
+        and then opens a fresh one, so there is no subprocess accumulation.
+
+        By proactively setting ``is_connected=False`` and firing
+        ``_reload_event``, we ensure the lifecycle loop's inner 0.1 s poll
+        detects the dead stream and tears down the old context before opening
+        a fresh connection.
+
+        Note: ``self.session`` is intentionally *not* cleared here.
+        ``_validate_connection`` checks ``is_connected`` first, so the stale
+        ``session`` reference is never reached before the lifecycle task
+        replaces it.  Clearing it here would require a lock (the lifecycle
+        task also writes ``session``), adding unnecessary complexity.
+        """
+        if not _is_transport_error(exc):
+            return
+        logger.warning(
+            "Transport error on MCP client '%s' (%s: %s); "
+            "marking as disconnected and scheduling reconnect.",
+            self.name,
+            type(exc).__name__,
+            exc,
+        )
+        self.is_connected = False
+        self._cached_tools = None
+        # session is left as-is; see docstring above.
+        if not self._stop_event.is_set():
+            self._reload_event.set()
+
+    def _validate_connection(self) -> None:
+        """Raise ``RuntimeError`` if the session is not ready.
+
+        Raises:
+            RuntimeError: If not connected or session not initialized
+        """
+        if not self.is_connected:
+            raise RuntimeError(
+                f"MCP client '{self.name}' is not connected. "
+                f"Call connect() first.",
+            )
+
+        if not self.session:
+            raise RuntimeError(
+                f"MCP client '{self.name}' session is not initialized. "
+                f"Call connect() first.",
+            )
+
+
+class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
     """StdIO MCP client with proper cross-task lifecycle management.
 
     Drop-in replacement for agentscope.mcp.StdIOStatefulClient that solves
@@ -112,217 +505,22 @@ class StdIOStatefulClient(StatefulClientBase):
         # Tool cache
         self._cached_tools = None
 
-    async def _run_lifecycle(self) -> None:
-        """Run MCP client lifecycle in a dedicated task.
-
-        This ensures __aenter__ and __aexit__ are called in the same task,
-        avoiding the cross-task cancel scope error.
-        """
+    async def _setup_transport(
+        self,
+        stack: AsyncExitStack,
+    ) -> tuple[Any, Any]:
+        # Local import: stdio_client pulls in anyio's subprocess machinery;
+        # deferring it here keeps module import time fast and avoids pulling
+        # platform-specific code at import time for users who only use HTTP.
         from mcp.client.stdio import stdio_client
 
-        while not self._stop_event.is_set():
-            try:
-                logger.debug(f"Connecting MCP client: {self.name}")
-
-                # Enter context manager in THIS task
-                async with AsyncExitStack() as stack:
-                    context = await stack.enter_async_context(
-                        stdio_client(self.server_params),
-                    )
-                    read_stream, write_stream = context[0], context[1]
-
-                    # Initialize session
-                    self.session = ClientSession(read_stream, write_stream)
-                    await stack.enter_async_context(self.session)
-                    await self.session.initialize()
-
-                    # Mark as connected and signal ready
-                    self.is_connected = True
-                    self._ready_event.set()
-                    logger.info(f"MCP client connected: {self.name}")
-
-                    # Wait for reload or stop signal
-                    while (
-                        not self._reload_event.is_set()
-                        and not self._stop_event.is_set()
-                    ):
-                        await asyncio.sleep(0.1)
-
-                    # Clear state before exiting context
-                    self.session = None
-                    self.is_connected = False
-                    self._cached_tools = None
-
-                    if self._reload_event.is_set():
-                        logger.info(f"Reloading MCP client: {self.name}")
-                        self._reload_event.clear()
-                        self._ready_event.clear()
-                        # Context manager will exit here, then loop restarts
-                    else:
-                        logger.info(f"Stopping MCP client: {self.name}")
-                        # Context manager will exit here, then loop exits
-
-                # Context manager exits cleanly in THIS task
-
-            except Exception as e:
-                logger.error(
-                    f"Error in MCP client lifecycle for {self.name}: {e}",
-                    exc_info=True,
-                )
-                self.session = None
-                self.is_connected = False
-                self._cached_tools = None
-                self._ready_event.clear()
-                await asyncio.sleep(1)
-
-        logger.info(f"MCP client lifecycle task exited: {self.name}")
-
-    async def connect(self, timeout: float = 30.0) -> None:
-        """Connect to MCP server.
-
-        Args:
-            timeout: Connection timeout in seconds (default 30s)
-
-        Raises:
-            RuntimeError: If already connected
-            asyncio.TimeoutError: If connection times out
-        """
-        if self.is_connected:
-            raise RuntimeError(
-                f"MCP client '{self.name}' is already connected. "
-                f"Call close() before connecting again.",
-            )
-
-        # Start lifecycle task
-        self._stop_event.clear()
-        self._lifecycle_task = asyncio.create_task(self._run_lifecycle())
-
-        # Wait for initial connection
-        try:
-            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.error(
-                f"Timeout waiting for MCP client '{self.name}' to connect",
-            )
-            # Clean up failed task
-            self._stop_event.set()
-            if self._lifecycle_task:
-                await self._lifecycle_task
-            raise
-
-    async def close(self, ignore_errors: bool = True) -> None:
-        """Close MCP client and clean up resources.
-
-        Args:
-            ignore_errors: Whether to ignore errors during cleanup
-
-        Raises:
-            RuntimeError: If not connected (unless ignore_errors=True)
-        """
-        if not self.is_connected:
-            if not ignore_errors:
-                raise RuntimeError(
-                    f"MCP client '{self.name}' is not connected. "
-                    f"Call connect() before closing.",
-                )
-            return
-
-        try:
-            # Signal stop and wait for lifecycle task to finish
-            self._stop_event.set()
-            if self._lifecycle_task:
-                await self._lifecycle_task
-                self._lifecycle_task = None
-        except Exception as e:
-            if not ignore_errors:
-                raise
-            logger.warning(
-                f"Error closing MCP client '{self.name}': {e}",
-            )
-
-    async def reload(self, timeout: float = 30.0) -> None:
-        """Reload the MCP client (reconnect).
-
-        Args:
-            timeout: Connection timeout in seconds (default 30s)
-
-        Raises:
-            RuntimeError: If not connected
-            asyncio.TimeoutError: If reload times out
-        """
-        if not self.is_connected:
-            raise RuntimeError(
-                f"MCP client '{self.name}' is not connected. "
-                f"Call connect() first.",
-            )
-
-        logger.info(f"Triggering reload for MCP client: {self.name}")
-        self._reload_event.set()
-
-        # Wait for new connection
-        try:
-            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
-            logger.info(f"Reload completed for MCP client: {self.name}")
-        except asyncio.TimeoutError:
-            logger.error(
-                f"Timeout waiting for MCP client '{self.name}' to reload",
-            )
-            raise
-
-    async def list_tools(self):
-        """Get all available tools from the server.
-
-        Returns:
-            List of available MCP tools
-
-        Raises:
-            RuntimeError: If not connected
-        """
-        self._validate_connection()
-
-        res = await self.session.list_tools()
-
-        # Cache the tools for later use
-        self._cached_tools = res.tools
-        return res.tools
-
-    async def call_tool(self, name: str, arguments: dict | None = None):
-        """Call a tool on the MCP server.
-
-        Args:
-            name: Tool name
-            arguments: Tool arguments (optional)
-
-        Returns:
-            Tool call result
-
-        Raises:
-            RuntimeError: If not connected
-        """
-        self._validate_connection()
-
-        return await self.session.call_tool(name, arguments or {})
-
-    def _validate_connection(self) -> None:
-        """Validate the connection to the MCP server.
-
-        Raises:
-            RuntimeError: If not connected or session not initialized
-        """
-        if not self.is_connected:
-            raise RuntimeError(
-                f"MCP client '{self.name}' is not connected. "
-                f"Call connect() first.",
-            )
-
-        if not self.session:
-            raise RuntimeError(
-                f"MCP client '{self.name}' session is not initialized. "
-                f"Call connect() first.",
-            )
+        context = await stack.enter_async_context(
+            stdio_client(self.server_params),
+        )
+        return context[0], context[1]
 
 
-class HttpStatefulClient(StatefulClientBase):
+class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
     """HTTP/SSE MCP client with proper cross-task lifecycle management.
 
     Drop-in replacement for agentscope.mcp.HttpStatefulClient that solves
@@ -393,211 +591,43 @@ class HttpStatefulClient(StatefulClientBase):
         # Tool cache
         self._cached_tools = None
 
-    async def _run_lifecycle(self) -> None:
-        """Run MCP client lifecycle in a dedicated task."""
-        while not self._stop_event.is_set():
-            try:
-                logger.debug(f"Connecting MCP client: {self.name}")
-
-                # Enter context manager in THIS task
-                async with AsyncExitStack() as stack:
-                    # Select client based on transport
-                    if self.transport == "streamable_http":
-                        # Create httpx.AsyncClient with headers and timeout
-                        timeout_seconds = (
-                            self.timeout.total_seconds()
-                            if isinstance(self.timeout, timedelta)
-                            else self.timeout
-                        )
-                        sse_read_timeout_seconds = (
-                            self.sse_read_timeout.total_seconds()
-                            if isinstance(self.sse_read_timeout, timedelta)
-                            else self.sse_read_timeout
-                        )
-
-                        # Configure httpx client with MCP-recommended timeouts
-                        http_client = httpx.AsyncClient(
-                            headers=self.headers or {},
-                            timeout=httpx.Timeout(
-                                connect=timeout_seconds,
-                                read=sse_read_timeout_seconds,
-                                write=timeout_seconds,
-                                pool=timeout_seconds,
-                            ),
-                            **self.client_kwargs,
-                        )
-
-                        # Add http_client to exit stack for proper cleanup
-                        await stack.enter_async_context(http_client)
-
-                        context = await stack.enter_async_context(
-                            streamable_http_client(
-                                url=self.url,
-                                http_client=http_client,
-                            ),
-                        )
-                    else:
-                        context = await stack.enter_async_context(
-                            sse_client(
-                                url=self.url,
-                                headers=self.headers,
-                                timeout=self.timeout,
-                                sse_read_timeout=self.sse_read_timeout,
-                                **self.client_kwargs,
-                            ),
-                        )
-
-                    read_stream, write_stream = context[0], context[1]
-
-                    # Initialize session
-                    self.session = ClientSession(read_stream, write_stream)
-                    await stack.enter_async_context(self.session)
-                    await self.session.initialize()
-
-                    # Mark as connected and signal ready
-                    self.is_connected = True
-                    self._ready_event.set()
-                    logger.info(f"MCP client connected: {self.name}")
-
-                    # Wait for reload or stop signal
-                    while (
-                        not self._reload_event.is_set()
-                        and not self._stop_event.is_set()
-                    ):
-                        await asyncio.sleep(0.1)
-
-                    # Clear state before exiting context
-                    self.session = None
-                    self.is_connected = False
-                    self._cached_tools = None
-
-                    if self._reload_event.is_set():
-                        logger.info(f"Reloading MCP client: {self.name}")
-                        self._reload_event.clear()
-                        self._ready_event.clear()
-                    else:
-                        logger.info(f"Stopping MCP client: {self.name}")
-
-                # Context manager exits cleanly in THIS task
-
-            except Exception as e:
-                logger.error(
-                    f"Error in MCP client lifecycle for {self.name}: {e}",
-                    exc_info=True,
-                )
-                self.session = None
-                self.is_connected = False
-                self._cached_tools = None
-                self._ready_event.clear()
-                await asyncio.sleep(1)
-
-        logger.info(f"MCP client lifecycle task exited: {self.name}")
-
-    async def connect(self, timeout: float = 30.0) -> None:
-        """Connect to MCP server.
-
-        Args:
-            timeout: Connection timeout in seconds
-
-        Raises:
-            RuntimeError: If already connected
-            asyncio.TimeoutError: If connection times out
-        """
-        if self.is_connected:
-            raise RuntimeError(
-                f"MCP client '{self.name}' is already connected. "
-                f"Call close() before connecting again.",
+    async def _setup_transport(
+        self,
+        stack: AsyncExitStack,
+    ) -> tuple[Any, Any]:
+        if self.transport == "streamable_http":
+            timeout_seconds = (
+                self.timeout.total_seconds()
+                if isinstance(self.timeout, timedelta)
+                else self.timeout
             )
-
-        self._stop_event.clear()
-        self._lifecycle_task = asyncio.create_task(self._run_lifecycle())
-
-        try:
-            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.error(
-                f"Timeout waiting for MCP client '{self.name}' to connect",
+            sse_read_timeout_seconds = (
+                self.sse_read_timeout.total_seconds()
+                if isinstance(self.sse_read_timeout, timedelta)
+                else self.sse_read_timeout
             )
-            self._stop_event.set()
-            if self._lifecycle_task:
-                await self._lifecycle_task
-            raise
-
-    async def close(self, ignore_errors: bool = True) -> None:
-        """Close MCP client and clean up resources.
-
-        Args:
-            ignore_errors: Whether to ignore errors during cleanup
-
-        Raises:
-            RuntimeError: If not connected (unless ignore_errors=True)
-        """
-        if not self.is_connected:
-            if not ignore_errors:
-                raise RuntimeError(
-                    f"MCP client '{self.name}' is not connected. "
-                    f"Call connect() before closing.",
-                )
-            return
-
-        try:
-            self._stop_event.set()
-            if self._lifecycle_task:
-                await self._lifecycle_task
-                self._lifecycle_task = None
-        except Exception as e:
-            if not ignore_errors:
-                raise
-            logger.warning(
-                f"Error closing MCP client '{self.name}': {e}",
+            http_client = httpx.AsyncClient(
+                headers=self.headers or {},
+                timeout=httpx.Timeout(
+                    connect=timeout_seconds,
+                    read=sse_read_timeout_seconds,
+                    write=timeout_seconds,
+                    pool=timeout_seconds,
+                ),
+                **self.client_kwargs,
             )
-
-    async def list_tools(self):
-        """Get all available tools from the server.
-
-        Returns:
-            List of available MCP tools
-
-        Raises:
-            RuntimeError: If not connected
-        """
-        self._validate_connection()
-
-        res = await self.session.list_tools()
-        self._cached_tools = res.tools
-        return res.tools
-
-    async def call_tool(self, name: str, arguments: dict | None = None):
-        """Call a tool on the MCP server.
-
-        Args:
-            name: Tool name
-            arguments: Tool arguments (optional)
-
-        Returns:
-            Tool call result
-
-        Raises:
-            RuntimeError: If not connected
-        """
-        self._validate_connection()
-
-        return await self.session.call_tool(name, arguments or {})
-
-    def _validate_connection(self) -> None:
-        """Validate the connection to the MCP server.
-
-        Raises:
-            RuntimeError: If not connected or session not initialized
-        """
-        if not self.is_connected:
-            raise RuntimeError(
-                f"MCP client '{self.name}' is not connected. "
-                f"Call connect() first.",
+            await stack.enter_async_context(http_client)
+            context = await stack.enter_async_context(
+                streamable_http_client(url=self.url, http_client=http_client),
             )
-
-        if not self.session:
-            raise RuntimeError(
-                f"MCP client '{self.name}' session is not initialized. "
-                f"Call connect() first.",
+        else:
+            context = await stack.enter_async_context(
+                sse_client(
+                    url=self.url,
+                    headers=self.headers,
+                    timeout=self.timeout,
+                    sse_read_timeout=self.sse_read_timeout,
+                    **self.client_kwargs,
+                ),
             )
+        return context[0], context[1]


### PR DESCRIPTION
## Problem

MCP subprocesses were accumulating as children of the `qwenpaw app` daemon across agent hot-reloads (#4105).  Root cause: `StdIOStatefulClient.close()` and `HttpStatefulClient.close()` returned early when `is_connected=False`, even if the background lifecycle task was still running in a reconnect loop. Every hot-reload called `mcp_manager.close_all()`, but the reconnecting clients were silently skipped — their tasks eventually spawned fresh subprocesses that were never cleaned up.

A secondary issue (#4100): `HttpStatefulClient` did not recover from transport-layer failures (`anyio.ClosedResourceError`, HTTP timeouts, etc.) because the error never propagated back to the lifecycle loop.

## Changes

### Bug fixes
- **`close()` lifecycle-task leak** — always stop the lifecycle task when it is running, regardless of `is_connected` state (`is_connected=False` + running task = reconnect loop, not a clean idle state).
- **`close()` stale `_lifecycle_task` reference on cancellation** — moved `self._lifecycle_task = None` to a `finally` block so it is cleared even when the calling coroutine is cancelled (`CancelledError` is `BaseException`, not `Exception`).
- **`connect()` spurious ready on reconnect** — cleared `_ready_event` before creating the lifecycle task so a second `connect()` after `close()` waits for the *new* connection rather than returning immediately.
- **`reload()` returning before reconnect completes** — cleared `_ready_event` before waiting so the caller blocks until the new session is actually established.
- **`connect()` double lifecycle-task on transport error** — added `has_task` guard to prevent creating a second task when one is already running in a reconnect loop.
- **Transport-error auto-recovery (`#4100`)** — introduced `_handle_transport_error()` and `_TRANSPORT_ERRORS` to detect broken-pipe, EOF, and `anyio` / `httpx` transport errors in `call_tool` / `list_tools` and trigger a reconnect via `_reload_event`, fixing the case where `streamable_http_client`'s internal `post_writer` task silently closes the
  write stream.
- **`_force_cleanup_client` silent no-op** (`manager.py`) — replaced the dead `client.stack` attribute access (which was always `None` for the new clients) with a direct `client.close(ignore_errors=True)` call.
- **`replace_client()` holding lock during `close()`** (`manager.py`) — moved `old_client.close()` outside the lock to match `remove_client()`'s pattern and avoid blocking `get_clients()` / `close_all()` for the duration of the lifecycle-task shutdown.

### Refactoring
- Extracted `_MCPClientMixin` containing all shared logic (`_run_lifecycle`, `connect`, `reload`, `close`, `list_tools`, `call_tool`, `_handle_transport_error`, `_validate_connection`).  Each concrete class now only implements `__init__` and `_setup_transport`.
- `reload()` was previously only on `StdIOStatefulClient`; it is now available on `HttpStatefulClient` as well via the mixin.
- Consolidated all transport-error exception types into a single `_TRANSPORT_ERRORS` tuple for clarity.