### PR TITLE
refactor(console): extract QrcodeAuthBlock component and fix polling …

### DIFF
--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -8,15 +8,13 @@ import {
   Select,
 } from "@agentscope-ai/design";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
-import { Alert, ConfigProvider, Spin } from "antd";
+import { Alert, ConfigProvider } from "antd";
 import { LinkOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { FormInstance } from "antd";
-import { useCallback, useEffect } from "react";
 import { getChannelLabel, type ChannelKey } from "./constants";
-import { useChannelQrcode } from "./useChannelQrcode";
+import { QrcodeAuthBlock } from "./QrcodeAuthBlock";
 import styles from "../index.module.less";
-import { useTheme } from "../../../../contexts/ThemeContext";
 import { useAgentStore } from "../../../../stores/agentStore";
 
 const CHANNELS_WITH_ACCESS_CONTROL: ChannelKey[] = [
@@ -111,7 +109,6 @@ export function ChannelDrawer({
   onSubmit,
 }: ChannelDrawerProps) {
   const { t, i18n } = useTranslation();
-  const { isDark } = useTheme();
   const { selectedAgent, agents } = useAgentStore();
   const currentAgent = agents.find((a) => a.id === selectedAgent);
   const defaultMediaDir = currentAgent?.workspace_dir
@@ -120,96 +117,6 @@ export function ChannelDrawer({
   const currentLang = i18n.language?.startsWith("zh") ? "zh" : "en";
   const label = activeKey ? getChannelLabel(activeKey, t) : activeLabel;
   const { message } = useAppMessage();
-
-  // WeChat QR code hook
-  const wechatQrcode = useChannelQrcode({
-    channel: "wechat",
-    successStatus: "confirmed",
-    successCredentialKey: "bot_token",
-    pollInterval: 2000,
-    onSuccess: useCallback(
-      (credentials: Record<string, string>) => {
-        form.setFieldsValue({ bot_token: credentials.bot_token });
-        message.success(t("channels.wechatLoginSuccess"));
-      },
-      [form, message, t],
-    ),
-    onError: useCallback(
-      (type: "fetch" | "expired") => {
-        if (type === "expired") {
-          message.warning(t("channels.wechatQrcodeExpired"));
-        } else {
-          message.error(t("channels.wechatQrcodeFailed"));
-        }
-      },
-      [message, t],
-    ),
-  });
-
-  // DingTalk QR code hook
-  const dingtalkQrcode = useChannelQrcode({
-    channel: "dingtalk",
-    successStatus: "success",
-    successCredentialKey: "client_id",
-    pollInterval: 5000,
-    onSuccess: useCallback(
-      (credentials: Record<string, string>) => {
-        form.setFieldsValue({
-          client_id: credentials.client_id,
-          client_secret: credentials.client_secret,
-        });
-        message.success(t("channels.dingtalkAuthSuccess"));
-      },
-      [form, message, t],
-    ),
-    onExpired: useCallback(() => {
-      message.warning(t("channels.dingtalkQrcodeExpired"));
-    }, [message, t]),
-    onError: useCallback(
-      (type: "fetch" | "expired") => {
-        if (type === "expired") {
-          message.warning(t("channels.dingtalkQrcodeExpired"));
-        } else {
-          message.error(t("channels.dingtalkQrcodeFailed"));
-        }
-      },
-      [message, t],
-    ),
-  });
-
-  // WeCom QR code hook
-  const wecomQrcode = useChannelQrcode({
-    channel: "wecom",
-    successStatus: "success",
-    successCredentialKey: "bot_id",
-    pollInterval: 3000,
-    onSuccess: useCallback(
-      (credentials: Record<string, string>) => {
-        form.setFieldsValue({
-          bot_id: credentials.bot_id,
-          secret: credentials.secret,
-        });
-        message.success(t("channels.wecomAuthSuccess"));
-      },
-      [form, message, t],
-    ),
-    onError: useCallback(
-      (_type: "fetch" | "expired") => {
-        message.error(t("channels.wecomQrcodeFailed"));
-      },
-      [message, t],
-    ),
-  });
-
-  // Stop all QR code polling when drawer closes
-  useEffect(() => {
-    if (!open) {
-      wechatQrcode.reset();
-      dingtalkQrcode.reset();
-      wecomQrcode.reset();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
 
   // ── Access control fields (shared across multiple channels) ──────────────
 
@@ -355,41 +262,30 @@ export function ChannelDrawer({
                 style={{ marginBottom: 16 }}
               />
             </ConfigProvider>
-            <Form.Item label={t("channels.dingtalkScanAuth")}>
-              <Button
-                type="primary"
-                block
-                loading={dingtalkQrcode.loading}
-                onClick={dingtalkQrcode.fetchQrcode}
-              >
-                {t("channels.dingtalkGetQrcode")}
-              </Button>
-              {dingtalkQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <Spin />
-                </div>
-              )}
-              {dingtalkQrcode.qrcodeImg && !dingtalkQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <img
-                    src={`data:image/png;base64,${dingtalkQrcode.qrcodeImg}`}
-                    alt="DingTalk QR Code"
-                    style={{ width: 200, height: 200 }}
-                  />
-                  <div
-                    style={{
-                      marginTop: 8,
-                      fontSize: 12,
-                      color: isDark
-                        ? "rgba(255,255,255,0.45)"
-                        : "rgba(0,0,0,0.45)",
-                    }}
-                  >
-                    {t("channels.dingtalkScanHint")}
-                  </div>
-                </div>
-              )}
-            </Form.Item>
+            <QrcodeAuthBlock
+              label={t("channels.dingtalkScanAuth")}
+              buttonText={t("channels.dingtalkGetQrcode")}
+              imageAlt="DingTalk QR Code"
+              hintText={t("channels.dingtalkScanHint")}
+              channel="dingtalk"
+              successStatus="success"
+              successCredentialKey="client_id"
+              pollInterval={5000}
+              onSuccess={(credentials) => {
+                form.setFieldsValue({
+                  client_id: credentials.client_id,
+                  client_secret: credentials.client_secret,
+                });
+                message.success(t("channels.dingtalkAuthSuccess"));
+              }}
+              onError={(type) => {
+                if (type === "expired") {
+                  message.warning(t("channels.dingtalkQrcodeExpired"));
+                } else {
+                  message.error(t("channels.dingtalkQrcodeFailed"));
+                }
+              }}
+            />
             <Form.Item
               name="client_id"
               label="Client ID"
@@ -944,41 +840,26 @@ export function ChannelDrawer({
                 style={{ marginBottom: 16 }}
               />
             </ConfigProvider>
-            <Form.Item label={t("channels.wecomScanAuth")}>
-              <Button
-                type="primary"
-                block
-                loading={wecomQrcode.loading}
-                onClick={wecomQrcode.fetchQrcode}
-              >
-                {t("channels.loginWeCom")}
-              </Button>
-              {wecomQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <Spin />
-                </div>
-              )}
-              {wecomQrcode.qrcodeImg && !wecomQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <img
-                    src={`data:image/png;base64,${wecomQrcode.qrcodeImg}`}
-                    alt="WeCom QR Code"
-                    style={{ width: 200, height: 200 }}
-                  />
-                  <div
-                    style={{
-                      marginTop: 8,
-                      fontSize: 12,
-                      color: isDark
-                        ? "rgba(255,255,255,0.45)"
-                        : "rgba(0,0,0,0.45)",
-                    }}
-                  >
-                    {t("channels.wecomAuthHint")}
-                  </div>
-                </div>
-              )}
-            </Form.Item>
+            <QrcodeAuthBlock
+              label={t("channels.wecomScanAuth")}
+              buttonText={t("channels.loginWeCom")}
+              imageAlt="WeCom QR Code"
+              hintText={t("channels.wecomAuthHint")}
+              channel="wecom"
+              successStatus="success"
+              successCredentialKey="bot_id"
+              pollInterval={3000}
+              onSuccess={(credentials) => {
+                form.setFieldsValue({
+                  bot_id: credentials.bot_id,
+                  secret: credentials.secret,
+                });
+                message.success(t("channels.wecomAuthSuccess"));
+              }}
+              onError={() => {
+                message.error(t("channels.wecomQrcodeFailed"));
+              }}
+            />
             <Form.Item
               name="bot_id"
               label="Bot ID"
@@ -1069,41 +950,27 @@ export function ChannelDrawer({
                 style={{ marginBottom: 16 }}
               />
             </ConfigProvider>
-            <Form.Item label={t("channels.wechatScanLogin")}>
-              <Button
-                type="primary"
-                block
-                loading={wechatQrcode.loading}
-                onClick={wechatQrcode.fetchQrcode}
-              >
-                {t("channels.wechatGetQrcode")}
-              </Button>
-              {wechatQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <Spin />
-                </div>
-              )}
-              {wechatQrcode.qrcodeImg && !wechatQrcode.loading && (
-                <div style={{ textAlign: "center", marginTop: 12 }}>
-                  <img
-                    src={`data:image/png;base64,${wechatQrcode.qrcodeImg}`}
-                    alt="WeChat QR Code"
-                    style={{ width: 200, height: 200 }}
-                  />
-                  <div
-                    style={{
-                      marginTop: 8,
-                      fontSize: 12,
-                      color: isDark
-                        ? "rgba(255,255,255,0.45)"
-                        : "rgba(0,0,0,0.45)",
-                    }}
-                  >
-                    {t("channels.wechatScanHint")}
-                  </div>
-                </div>
-              )}
-            </Form.Item>
+            <QrcodeAuthBlock
+              label={t("channels.wechatScanLogin")}
+              buttonText={t("channels.wechatGetQrcode")}
+              imageAlt="WeChat QR Code"
+              hintText={t("channels.wechatScanHint")}
+              channel="wechat"
+              successStatus="confirmed"
+              successCredentialKey="bot_token"
+              pollInterval={2000}
+              onSuccess={(credentials) => {
+                form.setFieldsValue({ bot_token: credentials.bot_token });
+                message.success(t("channels.wechatLoginSuccess"));
+              }}
+              onError={(type) => {
+                if (type === "expired") {
+                  message.warning(t("channels.wechatQrcodeExpired"));
+                } else {
+                  message.error(t("channels.wechatQrcodeFailed"));
+                }
+              }}
+            />
             <Form.Item
               name="bot_token"
               label={t("channels.wechatBotToken")}

--- a/console/src/pages/Control/Channels/components/QrcodeAuthBlock.tsx
+++ b/console/src/pages/Control/Channels/components/QrcodeAuthBlock.tsx
@@ -1,10 +1,7 @@
 import { Button, Form } from "@agentscope-ai/design";
 import { Spin } from "antd";
 import { useTheme } from "../../../../contexts/ThemeContext";
-import {
-  useChannelQrcode,
-  type ChannelQrcodeConfig,
-} from "./useChannelQrcode";
+import { useChannelQrcode, type ChannelQrcodeConfig } from "./useChannelQrcode";
 
 interface QrcodeAuthBlockProps extends ChannelQrcodeConfig {
   /** Form.Item label text */
@@ -53,9 +50,7 @@ export function QrcodeAuthBlock({
             style={{
               marginTop: 8,
               fontSize: 12,
-              color: isDark
-                ? "rgba(255,255,255,0.45)"
-                : "rgba(0,0,0,0.45)",
+              color: isDark ? "rgba(255,255,255,0.45)" : "rgba(0,0,0,0.45)",
             }}
           >
             {hintText}

--- a/console/src/pages/Control/Channels/components/QrcodeAuthBlock.tsx
+++ b/console/src/pages/Control/Channels/components/QrcodeAuthBlock.tsx
@@ -1,0 +1,67 @@
+import { Button, Form } from "@agentscope-ai/design";
+import { Spin } from "antd";
+import { useTheme } from "../../../../contexts/ThemeContext";
+import {
+  useChannelQrcode,
+  type ChannelQrcodeConfig,
+} from "./useChannelQrcode";
+
+interface QrcodeAuthBlockProps extends ChannelQrcodeConfig {
+  /** Form.Item label text */
+  label: string;
+  /** Button text */
+  buttonText: string;
+  /** Alt text for the QR code image */
+  imageAlt: string;
+  /** Hint text shown below the QR code */
+  hintText: string;
+}
+
+export function QrcodeAuthBlock({
+  label,
+  buttonText,
+  imageAlt,
+  hintText,
+  ...qrcodeConfig
+}: QrcodeAuthBlockProps) {
+  const { isDark } = useTheme();
+  const qrcode = useChannelQrcode(qrcodeConfig);
+
+  return (
+    <Form.Item label={label}>
+      <Button
+        type="primary"
+        block
+        loading={qrcode.loading}
+        onClick={qrcode.fetchQrcode}
+      >
+        {buttonText}
+      </Button>
+      {qrcode.loading && (
+        <div style={{ textAlign: "center", marginTop: 12 }}>
+          <Spin />
+        </div>
+      )}
+      {qrcode.qrcodeImg && !qrcode.loading && (
+        <div style={{ textAlign: "center", marginTop: 12 }}>
+          <img
+            src={`data:image/png;base64,${qrcode.qrcodeImg}`}
+            alt={imageAlt}
+            style={{ width: 200, height: 200 }}
+          />
+          <div
+            style={{
+              marginTop: 8,
+              fontSize: 12,
+              color: isDark
+                ? "rgba(255,255,255,0.45)"
+                : "rgba(0,0,0,0.45)",
+            }}
+          >
+            {hintText}
+          </div>
+        </div>
+      )}
+    </Form.Item>
+  );
+}

--- a/console/src/pages/Control/Channels/components/useChannelQrcode.ts
+++ b/console/src/pages/Control/Channels/components/useChannelQrcode.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../../../../api";
 
-interface ChannelQrcodeConfig {
+export interface ChannelQrcodeConfig {
   /** Channel name used in the API path, e.g. "wechat" or "wecom" */
   channel: string;
   /** Status value that indicates successful authorization */
@@ -12,13 +12,11 @@ interface ChannelQrcodeConfig {
   pollInterval?: number;
   /** Called when authorization succeeds with the credentials map */
   onSuccess: (credentials: Record<string, string>) => void;
-  /** Called when the QR code expires (optional) */
-  onExpired?: () => void;
-  /** Called when QR code fetch or polling fails */
+  /** Called when QR code fetch fails or polling detects expiry */
   onError: (type: "fetch" | "expired") => void;
 }
 
-interface ChannelQrcodeState {
+export interface ChannelQrcodeState {
   qrcodeImg: string;
   loading: boolean;
   fetchQrcode: () => Promise<void>;
@@ -41,7 +39,6 @@ export function useChannelQrcode(
     successCredentialKey,
     pollInterval = 2000,
     onSuccess,
-    onExpired,
     onError,
   } = config;
 
@@ -93,7 +90,6 @@ export function useChannelQrcode(
               return;
             } else if (result.status === "expired") {
               setQrcodeImg("");
-              onExpired?.();
               onError("expired");
               return;
             }
@@ -116,7 +112,6 @@ export function useChannelQrcode(
     successCredentialKey,
     pollInterval,
     onSuccess,
-    onExpired,
     onError,
     reset,
     stopPoll,


### PR DESCRIPTION
…leak on drawer close

- Extract QrcodeAuthBlock component that encapsulates useChannelQrcode hook + UI, so polling automatically stops when Drawer's destroyOnClose unmounts the component
- Remove redundant onExpired callback (was causing duplicate warnings with onError)
- Remove 3x duplicated QR code rendering code (~105 lines) in ChannelDrawer
- Export ChannelQrcodeConfig and ChannelQrcodeState types from useChannelQrcode

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
