### PR TITLE
fix(agent-config): preserve complete config on save to prevent nested…

### DIFF
--- a/console/src/pages/Agent/Config/useAgentConfig.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.tsx
@@ -25,7 +25,7 @@ export function useAgentConfig() {
   const [savingTimezone, setSavingTimezone] = useState(false);
   const [approvalLevel, setApprovalLevel] =
     useState<ToolExecutionLevel>("AUTO");
-  const initialApprovalLevelRef = useRef<ToolExecutionLevel>("AUTO");
+  const originalConfigRef = useRef<AgentsRunningConfig | null>(null);
 
   const fetchConfig = useCallback(async () => {
     setLoading(true);
@@ -40,7 +40,6 @@ export function useAgentConfig() {
         config.approval_level || "AUTO"
       ).toUpperCase() as ToolExecutionLevel;
       setApprovalLevel(loadedLevel);
-      initialApprovalLevelRef.current = loadedLevel;
       const contextBackend =
         config.context_manager_backend in CONTEXT_MANAGER_BACKEND_MAPPINGS
           ? config.context_manager_backend
@@ -73,6 +72,10 @@ export function useAgentConfig() {
           timeout_seconds: 30.0,
         },
       });
+
+      // Store original config for complete save
+      originalConfigRef.current = config;
+
       setLanguage(langResp.language);
       setTimezone(tzResp.timezone || "UTC");
     } catch (err) {
@@ -92,12 +95,18 @@ export function useAgentConfig() {
     try {
       const values = await form.validateFields();
       setSaving(true);
+
+      // Merge form values with original config to ensure complete config
       const configToSave: AgentsRunningConfig = {
+        ...originalConfigRef.current!,
         ...(values as AgentsRunningConfig),
         approval_level: approvalLevel,
       };
+
       await api.updateAgentRunningConfig(configToSave);
-      initialApprovalLevelRef.current = approvalLevel;
+
+      // Update original config after successful save
+      originalConfigRef.current = configToSave;
       message.success(t("agentConfig.saveSuccess"));
     } catch (err) {
       if (err instanceof Error && "errorFields" in err) return;


### PR DESCRIPTION
… config loss

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
