### PR TITLE
docs(release-notes): add New Contributors section to v1.1.6

### DIFF
--- a/website/public/release-notes/v1.1.6.md
+++ b/website/public/release-notes/v1.1.6.md
@@ -92,3 +92,17 @@
 
 - **Console Unit Tests**: Added Vitest setup with unit and component tests covering Chat, API layer, and shared components ([#3559](https://github.com/agentscope-ai/QwenPaw/pull/3559), [#4121](https://github.com/agentscope-ai/QwenPaw/pull/4121))
 - **Integration Smoke Tests**: Added app startup and settings/environment variable smoke tests ([#4081](https://github.com/agentscope-ai/QwenPaw/pull/4081))
+
+## New Contributors
+* @karls0r made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4021
+* @Jailtonfonseca made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4009
+* @hllqkb made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4005
+* @yutai78786 made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4081
+* @tqjason made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/3574
+* @JingHou1215 made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/3999
+* @wjt0321 made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4076
+* @1105623876 made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4032
+* @Keillion made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/4142
+* @q1023884985 made their first contribution in https://github.com/agentscope-ai/QwenPaw/pull/3928
+
+**Full Changelog**: https://github.com/agentscope-ai/QwenPaw/compare/v1.1.5...v1.1.6

--- a/website/public/release-notes/v1.1.6.zh.md
+++ b/website/public/release-notes/v1.1.6.zh.md
@@ -92,3 +92,17 @@
 
 - **控制台单元测试**：引入 Vitest 测试框架，覆盖聊天、API 层和共享组件的单元测试与组件测试 ([#3559](https://github.com/agentscope-ai/QwenPaw/pull/3559), [#4121](https://github.com/agentscope-ai/QwenPaw/pull/4121))
 - **集成冒烟测试**：新增应用启动和设置/环境变量冒烟测试 ([#4081](https://github.com/agentscope-ai/QwenPaw/pull/4081))
+
+## 新贡献者
+* @karls0r 在 https://github.com/agentscope-ai/QwenPaw/pull/4021 提交了首个贡献
+* @Jailtonfonseca 在 https://github.com/agentscope-ai/QwenPaw/pull/4009 提交了首个贡献
+* @hllqkb 在 https://github.com/agentscope-ai/QwenPaw/pull/4005 提交了首个贡献
+* @yutai78786 在 https://github.com/agentscope-ai/QwenPaw/pull/4081 提交了首个贡献
+* @tqjason 在 https://github.com/agentscope-ai/QwenPaw/pull/3574 提交了首个贡献
+* @JingHou1215 在 https://github.com/agentscope-ai/QwenPaw/pull/3999 提交了首个贡献
+* @wjt0321 在 https://github.com/agentscope-ai/QwenPaw/pull/4076 提交了首个贡献
+* @1105623876 在 https://github.com/agentscope-ai/QwenPaw/pull/4032 提交了首个贡献
+* @Keillion 在 https://github.com/agentscope-ai/QwenPaw/pull/4142 提交了首个贡献
+* @q1023884985 在 https://github.com/agentscope-ai/QwenPaw/pull/3928 提交了首个贡献
+
+**完整的变更日志**: https://github.com/agentscope-ai/QwenPaw/compare/v1.1.5...v1.1.6


### PR DESCRIPTION
## Summary

The GitHub release for v1.1.6 includes a "New Contributors" section and "Full Changelog" link that were missing from the website's release notes markdown files.

## Changes

- **`website/public/release-notes/v1.1.6.md`**: Added "New Contributors" section with 10 new contributors and "Full Changelog" link
- **`website/public/release-notes/v1.1.6.zh.md`**: Added Chinese "新贡献者" section with 10 new contributors and "完整的变更日志" link

This ensures the release notes on the website ([qwenpaw.agentscope.io/release-notes/](https://qwenpaw.agentscope.io/release-notes/)) are consistent with the GitHub Release.