### PR TITLE
feat: add openwond draw tool plugin (GPT Image 2 + Nano Banana)

### DIFF
--- a/plugins/tool/openwond-draw/README.md
+++ b/plugins/tool/openwond-draw/README.md
@@ -1,0 +1,45 @@
+# OpenWond Draw Tool Plugin 🎨
+
+Image generation for QwenPaw agents via OpenWond relay.
+
+## Supported Models
+
+| Model | Credits | Quality | Use Case |
+|:---|:---:|:---:|:---|
+| `gpt-image-2` | 4 | 🥇 Highest | Epic posters, art, cinematic |
+| `nano-banana-v2` | 4 | 🥈 Good | Fast generation, fallback |
+| `nano-banana-pro` | 6 | 🥇 Premium | Better Nano Banana quality |
+
+## ⏱️ Timeout
+
+**Default: 900 seconds.** GPT Image 2 is slow but worth the wait.
+
+If it times out, retry with `model="nano-banana-v2"` for a faster result.
+
+## Configuration
+
+1. Install the plugin
+2. Go to Agent Settings → Tools → `generate_image_openwond`
+3. Click Configure
+4. Enter your OpenWond API Key
+5. Save and enable
+
+## Usage
+
+Once configured, the agent can generate images automatically:
+
+```python
+# GPT Image 2 (default, best quality)
+result = await generate_image_openwond(
+    prompt="Epic cinematic poster of a divine dragon",
+)
+
+# Nano Banana (faster fallback)
+result = await generate_image_openwond(
+    prompt="A cute cat in a wizard hat",
+    model="nano-banana-v2",
+    resolution="1K",
+)
+```
+
+Or just tell the agent: "Generate an image of..." and it will call the tool.

--- a/plugins/tool/openwond-draw/plugin.json
+++ b/plugins/tool/openwond-draw/plugin.json
@@ -1,0 +1,46 @@
+{
+  "id": "openwond-draw-tool",
+  "name": "OpenWond Draw Tool",
+  "version": "1.0.0",
+  "description": "Generate images via OpenWond relay. Supports GPT Image 2 (primary) and Nano Banana series (fallback). Default timeout 900s — GPT Image 2 generation is slow but worth the wait.",
+  "author": "QwenPaw Community",
+  "entry": {
+    "backend": "plugin.py"
+  },
+  "dependencies": ["httpx>=0.24.0"],
+  "min_version": "1.1.6",
+  "meta": {
+    "tool_name": "generate_image_openwond",
+    "tool_description": "Generate images using OpenWond relay. Supports GPT Image 2 (4 credits) and Nano Banana series (4-6 credits). Default timeout 900s.",
+    "tool_icon": "🎨",
+    "requires_config": true,
+    "config_fields": [
+      {
+        "name": "api_key",
+        "label": "OpenWond API Key",
+        "type": "password",
+        "required": true,
+        "placeholder": "f_...",
+        "help": "Your OpenWond relay API key"
+      },
+      {
+        "name": "endpoint",
+        "label": "API Endpoint",
+        "type": "text",
+        "required": false,
+        "placeholder": "https://image.openwond.com/v1/draw",
+        "help": "Custom API endpoint (leave empty for default)"
+      },
+      {
+        "name": "timeout",
+        "label": "Request Timeout (seconds)",
+        "type": "number",
+        "required": false,
+        "placeholder": "900",
+        "min": 60,
+        "max": 900,
+        "help": "Generation timeout. GPT Image 2 is slow — 900s recommended (default)"
+      }
+    ]
+  }
+}

--- a/plugins/tool/openwond-draw/plugin.py
+++ b/plugins/tool/openwond-draw/plugin.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""OpenWond Draw Tool Plugin Entry Point."""
+
+import importlib.util
+import logging
+import os
+
+from qwenpaw.plugins.api import PluginApi
+
+logger = logging.getLogger(__name__)
+
+
+class OpenWondDrawToolPlugin:
+    """OpenWond Draw Tool Plugin.
+
+    Registers generate_image_openwond tool into the Agent's toolkit.
+    """
+
+    def register(self, api: PluginApi):
+        """Register the OpenWond draw tool.
+
+        Args:
+            api: PluginApi instance
+        """
+        logger.info("Registering OpenWond Draw tool...")
+
+        api.register_startup_hook(
+            hook_name="register_openwond_draw_tool",
+            callback=self._register_tool,
+            priority=50,
+        )
+
+        logger.info("✓ OpenWond Draw tool plugin registered")
+
+    def _register_tool(self):
+        """Register the generate_image_openwond tool to Agent toolkit."""
+        try:
+            plugin_dir = os.path.dirname(os.path.abspath(__file__))
+            tool_path = os.path.join(plugin_dir, "tool.py")
+
+            spec = importlib.util.spec_from_file_location(
+                "openwond_draw_tool",
+                tool_path,
+            )
+            tool_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(tool_module)
+
+            generate_image_openwond = tool_module.generate_image_openwond
+
+            import qwenpaw.agents.tools as tools_module
+
+            setattr(
+                tools_module,
+                "generate_image_openwond",
+                generate_image_openwond,
+            )
+            if "generate_image_openwond" not in tools_module.__all__:
+                tools_module.__all__.append("generate_image_openwond")
+
+            logger.info(
+                "✓ Registered tool function: generate_image_openwond",
+            )
+
+            from qwenpaw.config.config import (
+                BuiltinToolConfig,
+                load_agent_config,
+                save_agent_config,
+            )
+            from qwenpaw.app.agent_context import get_current_agent_id
+
+            try:
+                agent_id = get_current_agent_id()
+                if not agent_id:
+                    return
+
+                agent_config = load_agent_config(agent_id)
+
+                if not agent_config.tools:
+                    from qwenpaw.config.config import ToolsConfig
+                    agent_config.tools = ToolsConfig()
+
+                tool_name = "generate_image_openwond"
+                existing_names = [
+                    t.name for t in (
+                        agent_config.tools.builtin_tools or []
+                    )
+                ]
+                if tool_name not in existing_names:
+                    tool_cfg = BuiltinToolConfig(
+                        name=tool_name,
+                        enabled=True,
+                    )
+                    if agent_config.tools.builtin_tools is None:
+                        agent_config.tools.builtin_tools = []
+                    agent_config.tools.builtin_tools.append(tool_cfg)
+
+                save_agent_config(agent_config)
+                logger.info(
+                    f"✓ Tool added to agent {agent_id} config",
+                )
+
+            except Exception as e:
+                logger.warning(
+                    f"Could not update agent config: {e}",
+                )
+
+        except Exception as e:
+            logger.error(
+                f"Failed to register openwond draw tool: {e}",
+            )

--- a/plugins/tool/openwond-draw/tool.py
+++ b/plugins/tool/openwond-draw/tool.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+"""OpenWond image generation tool for QwenPaw agents.
+
+Generate images via OpenWond relay service. Supports GPT Image 2
+as the primary model and Nano Banana series as fallback.
+
+Timeout: 900s default — GPT Image 2 is slow but delivers high quality.
+"""
+
+import json
+import logging
+import os
+import time
+
+import httpx
+from agentscope.message import ImageBlock, TextBlock
+from agentscope.tool import ToolResponse
+from qwenpaw.constant import DEFAULT_MEDIA_DIR
+
+logger = logging.getLogger(__name__)
+
+_AVAILABLE_MODELS = {
+    "gpt-image2": {
+        "description": "GPT Image 2 (4 credits, primary)",
+        "priority": 1,
+    },
+    "nano-banana-v2": {
+        "description": "Nano Banana V2 (4 credits, fallback)",
+        "priority": 2,
+    },
+    "nano-banana-pro": {
+        "description": "Nano Banana Pro (6 credits, premium fallback)",
+        "priority": 3,
+    },
+}
+
+_DEFAULT_TIMEOUT = 900  # proven stable in practice
+_MAX_TIMEOUT = 900
+
+
+def _get_tool_config() -> dict | None:
+    """Retrieve tool configuration from plugin settings."""
+    try:
+        from qwenpaw.app.agent_context import get_current_agent_id
+        from qwenpaw.config.config import load_agent_config
+
+        agent_id = get_current_agent_id()
+        if not agent_id:
+            return None
+
+        agent_config = load_agent_config(agent_id)
+        if not agent_config or not agent_config.tools:
+            return None
+
+        tool_configs = (
+            agent_config.tools.plugin_tools or []
+        )
+        for cfg in tool_configs:
+            if getattr(cfg, "name", "") == "openwond-draw-tool":
+                return getattr(cfg, "config", {}) or {}
+    except Exception as e:
+        logger.debug(f"Failed to load tool config: {e}")
+    return None
+
+
+async def generate_image_openwond(
+    prompt: str,
+    model: str = "gpt-image2",
+    resolution: str = "2K",
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> ToolResponse:
+    """Generate an image using OpenWond relay service.
+
+    Supports GPT Image 2 (primary) and Nano Banana series as fallback.
+    The OpenWond relay handles model inference; results are saved locally.
+
+    Args:
+        prompt:
+            Text description of the image to generate. Be detailed for
+            best results. Include style, palette, composition cues.
+        model:
+            Model to use. Options:
+            - ``"gpt-image2"`` (default, 4 credits, highest quality)
+            - ``"nano-banana-v2"`` (4 credits, fast fallback)
+            - ``"nano-banana-pro"`` (6 credits, premium fallback)
+        resolution:
+            Output resolution. Options: ``"1K"``, ``"2K"`` (default),
+            ``"4K"``. Higher resolutions consume more credits.
+        timeout:
+            Maximum wait time in seconds. GPT Image 2 is slow —
+            900s recommended (default). Capped at 900s.
+
+    Returns:
+        ToolResponse:
+            Contains the generated image and generation metadata.
+
+    Example:
+        >>> result = await generate_image_openwond(
+        ...     prompt="Epic cinematic poster of a divine dragon",
+        ...     model="gpt-image2",
+        ...     resolution="2K",
+        ... )
+    """
+    # ── Validate & clamp ──
+    model = model.lower().replace(" ", "-")
+    if model not in _AVAILABLE_MODELS:
+        available = ", ".join(_AVAILABLE_MODELS)
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        f"Unknown model '{model}'. "
+                        f"Available: {available}"
+                    ),
+                ),
+            ],
+        )
+
+    timeout = min(max(timeout, 60), _MAX_TIMEOUT)
+
+    # ── Load config ──
+    config = _get_tool_config()
+    api_key = (
+        config.get("api_key")
+        if config
+        else os.environ.get("OPENWOND_API_KEY", "")
+    )
+    endpoint = (
+        config.get("endpoint")
+        if config
+        else os.environ.get(
+            "OPENWOND_ENDPOINT",
+            "https://image.openwond.com/v1/draw",
+        )
+    )
+
+    if not api_key:
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        "Error: OpenWond API key not configured.\n"
+                        "Set it in Agent Settings → Tools or via "
+                        "OPENWOND_API_KEY env var."
+                    ),
+                ),
+            ],
+        )
+
+    # ── Build request ──
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "resolution": resolution,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    logger.info(
+        f"🎨 [OpenWond] Generating with {model} @ {resolution} "
+        f"(timeout={timeout}s)...",
+    )
+
+    start = time.time()
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:
+            resp = await client.post(
+                endpoint,
+                json=payload,
+                headers=headers,
+            )
+
+        elapsed = time.time() - start
+        logger.info(
+            f"✅ [OpenWond] Response in {elapsed:.1f}s "
+            f"(status={resp.status_code})",
+        )
+
+        if resp.status_code != 200:
+            try:
+                err = resp.json()
+                detail = err.get("detail", err.get("error", resp.text))
+            except Exception:
+                detail = resp.text[:300]
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error {resp.status_code}: {detail}"
+                        ),
+                    ),
+                ],
+            )
+
+        result = resp.json()
+
+        # ── Extract image URL — try multiple response formats ──
+        image_url = (
+            result.get("data", {}).get("url")
+            or result.get("url")
+            or result.get("image_url")
+            or result.get("data", "")
+        )
+        if not image_url:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            "Error: No image URL in response. "
+                            f"Raw: {json.dumps(result, ensure_ascii=False)[:500]}"
+                        ),
+                    ),
+                ],
+            )
+
+        # ── Download and save locally ──
+        media_dir = DEFAULT_MEDIA_DIR or os.path.join(
+            os.getcwd(),
+            "media",
+        )
+        os.makedirs(media_dir, exist_ok=True)
+
+        timestamp = int(time.time())
+        safe_name = "".join(
+            c for c in prompt[:30] if c.isalnum() or c in " _-"
+        ).strip().replace(" ", "_") or "openwond"
+        filename = f"openwond_{safe_name}_{timestamp}.jpeg"
+        filepath = os.path.join(media_dir, filename)
+
+        async with httpx.AsyncClient(timeout=60) as dl_client:
+            dl_resp = await dl_client.get(image_url)
+            dl_resp.raise_for_status()
+            with open(filepath, "wb") as f:
+                f.write(dl_resp.content)
+
+        size_kb = os.path.getsize(filepath) / 1024
+        logger.info(
+            f"💾 Saved to {filepath} ({size_kb:.0f}KB)",
+        )
+
+        return ToolResponse(
+            content=[
+                ImageBlock(
+                    type="image",
+                    source={
+                        "type": "url",
+                        "url": f"file://{os.path.abspath(filepath)}",
+                    },
+                ),
+                TextBlock(
+                    type="text",
+                    text=(
+                        f"Generated image using {model}\n"
+                        f"Prompt: {prompt}\n"
+                        f"Resolution: {resolution}\n"
+                        f"Time: {elapsed:.1f}s | Size: {size_kb:.0f}KB\n"
+                        f"Saved to: {filepath}"
+                    ),
+                ),
+            ],
+        )
+
+    except httpx.TimeoutException:
+        logger.error(
+            f"[OpenWond] Timeout after {timeout}s — "
+            f"GPT Image 2 can be slow. Consider retrying with "
+            f"a shorter prompt or using nano-banana-v2 fallback.",
+        )
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        "⏱️ Image generation timed out after "
+                        f"{timeout} seconds.\n\n"
+                        "GPT Image 2 can be slow. Try:\n"
+                        f"1. Retry with `model='nano-banana-v2'` "
+                        f"(faster, 4 credits)\n"
+                        "2. Shorten the prompt\n"
+                        "3. Increase timeout if your config allows"
+                    ),
+                ),
+            ],
+        )
+
+    except Exception as e:
+        logger.error(
+            f"[OpenWond] Generation failed: {e}",
+            exc_info=True,
+        )
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        f"Error: Image generation failed - {str(e)}"
+                    ),
+                ),
+            ],
+        )


### PR DESCRIPTION
## 🎨 OpenWond Draw Tool Plugin  Image generation for QwenPaw agents via OpenWond relay. Supports GPT Image 2 as the primary model with Nano Banana series as fallback.  ### Features  - **3 models**: `gpt-image-2` (4 credits, primary), `nano-banana-v2` (4 credits), `nano-banana-pro` (6 credits) - **Resolutions**: 1K, 2K, 4K - **900s timeout**: GPT Image 2 is slow but high quality — proven stable in practice - **Auto-download + save**: Generated images saved locally and returned as ImageBlock - **Configurable**: API key, endpoint, and timeout via Agent Settings UI - **Graceful timeout**: Suggests Nano Banana fallback on timeout  ### Usage  ```python # Default: GPT Image 2 @ 2K result = await generate_image_openwond(prompt=Epic dragon poster)  # Fast fallback result = await generate_image_openwond(prompt=Cat wizard, model=nano-banana-v2, resolution=1K) ```  ### Related  Complements the existing `gpt-image2` plugin (OpenAI direct) by offering a relay-based alternative.