### PR TITLE
fix(shell): Unix 平台下用临时文件重定向避免 execute_shell_command 超时挂起

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -501,8 +501,12 @@ async def execute_shell_command(
                             os.killpg(pgid, signal.SIGKILL)
                             await asyncio.wait_for(proc.wait(), timeout=2)
 
-                        stdout_str = smart_decode(_read_file_bytes(stdout_path))
-                        stderr_str = smart_decode(_read_file_bytes(stderr_path))
+                        stdout_str = smart_decode(
+                            _read_file_bytes(stdout_path),
+                        )
+                        stderr_str = smart_decode(
+                            _read_file_bytes(stderr_path),
+                        )
                         if stderr_str:
                             stderr_str += f"\n{stderr_suffix}"
                         else:

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -25,6 +25,19 @@ from ...config.context import (
 )
 
 
+def _read_file_bytes(path: str) -> bytes:
+    """Read all bytes from a file, returning empty bytes on error.
+
+    Used by the Unix execution path to read stdout/stderr from temp files
+    after the shell process has exited.
+    """
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except OSError:
+        return b""
+
+
 def _kill_process_tree_win32(pid: int) -> None:
     """Kill a process and all its descendants on Windows via taskkill.
 
@@ -430,71 +443,99 @@ async def execute_shell_command(
                 shell_executable,
             )
         else:
-            proc = await asyncio.create_subprocess_shell(
-                cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                bufsize=0,
-                cwd=str(working_dir),
-                env=env,
-                start_new_session=True,
-                executable=shell_executable,
-            )
+            # Unix: redirect stdout/stderr to temp files via shell redirection
+            # instead of using asyncio.subprocess.PIPE.
+            #
+            # Why? When a shell command spawns background/daemon processes
+            # (e.g. dev servers, browsers, Docker containers), those children
+            # inherit the pipe file descriptors.  asyncio's communicate()
+            # waits until ALL processes holding the pipe fd close it, so it
+            # hangs indefinitely even after the direct shell child has exited.
+            #
+            # By redirecting output to temp files at the shell level, the
+            # output is written directly to disk — fd inheritance by child
+            # processes is irrelevant, and wait() only needs to wait for the
+            # direct shell process to exit.  This mirrors the Windows
+            # _execute_subprocess_sync strategy.
+            stdout_str = ""
+            stderr_str = ""
+            returncode = 0
+            stdout_path = None
+            stderr_path = None
 
             try:
-                # Apply timeout to communicate directly; wait()+communicate()
-                # can hang if descendants keep stdout/stderr pipes open.
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(),
-                    timeout=timeout,
-                )
-                stdout_str = smart_decode(stdout)
-                stderr_str = smart_decode(stderr)
-                returncode = proc.returncode
+                _, stdout_path = tempfile.mkstemp(prefix="qwenpaw_stdout_")
+                _, stderr_path = tempfile.mkstemp(prefix="qwenpaw_stderr_")
 
-            except asyncio.TimeoutError:
-                stderr_suffix = (
-                    f"⚠️ TimeoutError: The command execution exceeded "
-                    f"the timeout of {timeout} seconds. "
-                    f"Please consider increasing the timeout value if this command "
-                    f"requires more time to complete."
+                # Wrap the command so the shell writes stdout/stderr to files
+                # instead of Python's pipe buffers.
+                wrapped_cmd = f"{cmd} >'{stdout_path}' 2>'{stderr_path}'"
+
+                proc = await asyncio.create_subprocess_shell(
+                    wrapped_cmd,
+                    cwd=str(working_dir),
+                    env=env,
+                    start_new_session=True,
+                    executable=shell_executable,
                 )
-                returncode = -1
+
                 try:
-                    # Kill the entire process group so that child processes
-                    # spawned by the shell are also terminated.
-                    pgid = os.getpgid(proc.pid)
-                    os.killpg(pgid, signal.SIGTERM)
+                    await asyncio.wait_for(proc.wait(), timeout=timeout)
+                    returncode = proc.returncode
+                except asyncio.TimeoutError:
+                    stderr_suffix = (
+                        f"TimeoutError: The command execution exceeded "
+                        f"the timeout of {timeout} seconds. "
+                        f"Please consider increasing the timeout value if this command "
+                        f"requires more time to complete."
+                    )
+                    returncode = -1
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=2)
-                    except asyncio.TimeoutError:
-                        os.killpg(pgid, signal.SIGKILL)
-                        await asyncio.wait_for(proc.wait(), timeout=2)
+                        # Kill the entire process group so that child processes
+                        # spawned by the shell are also terminated.
+                        pgid = os.getpgid(proc.pid)
+                        os.killpg(pgid, signal.SIGTERM)
+                        try:
+                            await asyncio.wait_for(proc.wait(), timeout=2)
+                        except asyncio.TimeoutError:
+                            os.killpg(pgid, signal.SIGKILL)
+                            await asyncio.wait_for(proc.wait(), timeout=2)
 
-                    # Drain remaining output.
-                    try:
-                        stdout, stderr = await asyncio.wait_for(
-                            proc.communicate(),
-                            timeout=1,
-                        )
-                    except asyncio.TimeoutError:
-                        stdout, stderr = b"", b""
-                    stdout_str = smart_decode(stdout)
-                    stderr_str = smart_decode(stderr)
-                    if stderr_str:
-                        stderr_str += f"\n{stderr_suffix}"
-                    else:
-                        stderr_str = stderr_suffix
-                except (ProcessLookupError, OSError):
-                    # Process already gone or pgid lookup failed — fall back
-                    # to direct kill on the process itself.
-                    try:
-                        proc.kill()
-                        await proc.wait()
+                        stdout_str = smart_decode(_read_file_bytes(stdout_path))
+                        stderr_str = smart_decode(_read_file_bytes(stderr_path))
+                        if stderr_str:
+                            stderr_str += f"\n{stderr_suffix}"
+                        else:
+                            stderr_str = stderr_suffix
                     except (ProcessLookupError, OSError):
-                        pass
-                    stdout_str = ""
-                    stderr_str = stderr_suffix
+                        # Process already gone or pgid lookup failed — fall back
+                        # to direct kill on the process itself.
+                        try:
+                            proc.kill()
+                            await proc.wait()
+                        except (ProcessLookupError, OSError):
+                            pass
+                        stdout_str = ""
+                        stderr_str = stderr_suffix
+
+                # Read captured output from temp files.
+                # In the timeout path above these are already populated;
+                # in the normal (no-timeout) path this is where we first read
+                # them, since the output went directly to disk.
+                stdout_str = smart_decode(_read_file_bytes(stdout_path))
+                stderr_str = smart_decode(_read_file_bytes(stderr_path))
+
+            except Exception as e:
+                returncode = -1
+                stdout_str = ""
+                stderr_str = str(e)
+            finally:
+                for path in (stdout_path, stderr_path):
+                    if path is not None:
+                        try:
+                            os.unlink(path)
+                        except OSError:
+                            pass
 
         if returncode == 0:
             if stdout_str:


### PR DESCRIPTION
## Summary

修复 `execute_shell_command` 在 Unix 平台下遇到启动后台进程的 shell 命令时会一直等待直至超时的问题。

## Description

原始版本使用 `asyncio.subprocess.PIPE` + `communicate()` 捕获命令输出。当命令启动了后台/守护进程（如浏览器进程），子进程会继承 pipe 的文件描述符，导致 `communicate()` 一直等待所有持有该 fd 的进程关闭才返回——主命令早已执行完毕，但工具却挂起超时。

**修复方案：** 修改src/qwenpaw/agents/tools/shell.py，将 stdout/stderr 重定向到临时文件（通过 shell 级别的 `>` 和 `2>` 重定向），用 `wait()` 替代 `communicate()`。输出直接写磁盘，子进程继承 fd 不再影响结果，`wait()` 只需等待直接子进程退出即可返回。

**复现场景：** 执行 `playwright open` 等 playwright cli 命令时，主命令早已完成，但其启动的后台子进程（如浏览器进程）仍持有 pipe fd，导致工具一直等待直至超时。

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Type of Change

- Bug fix

## Testing

测试方式： 在安装playwright cli后让agent执行 playwright-cli open https://www.baidu.com
该命令会启动浏览器后台进程。

修改前： 同样的命令和 30s timeout，返回 exit code -1 超时
🔧 execute_shell_command: {"command": "playwright-cli open https://www.baidu.com", "timeout": 30}
✅ execute_shell_command: Command failed with exit code -1.
[stderr] ⚠️ TimeoutError: The command execution exceeded the timeout of 30seconds.

修改后： 同样的命令和 30s timeout，正常返回
🔧 execute_shell_command: {"command": "playwright-cli open https://www.baidu.com", "timeout": 30}
✅ execute_shell_command:
### Browser `default` opened with pid 1006339.
### Ran Playwright code: await page.goto('https://www.baidu.com/');
### Page
- Page URL: https://www.baidu.com/
- Page Title: 百度一下，你就知道
- Console: 0 errors, 4 warnings

## Local Verification Evidence


<img width="1282" height="642" alt="image" src="https://github.com/user-attachments/assets/8b3386c8-a3d8-4be2-bba4-86c458102b7b" />
