### PR TITLE
feat: support local audio file in console channel

### DIFF
--- a/src/copaw/app/channels/console/channel.py
+++ b/src/copaw/app/channels/console/channel.py
@@ -25,6 +25,7 @@ from ....config.config import ConsoleConfig as ConsoleChannelConfig
 from ...console_push_store import append as push_store_append
 from ....constant import DEFAULT_MEDIA_DIR
 from ..base import (
+    AudioContent,
     BaseChannel,
     ContentType,
     FileContent,
@@ -215,11 +216,10 @@ class ConsoleChannel(BaseChannel):
                     None,
                 )
                 if url:
-                    # Todo: support local audio file
-                    return FileContent(
-                        type=ContentType.FILE,
-                        filename=getattr(part, "filename", None) or url,
-                        file_url=str(self._media_dir / url),
+                    return AudioContent(
+                        type=ContentType.AUDIO,
+                        data=str(self._media_dir / url),
+                        format=getattr(part, "format", None),
                     )
             elif content_type == ContentType.FILE:
                 url = getattr(part, "file_url", None)
@@ -381,7 +381,7 @@ class ConsoleChannel(BaseChannel):
             elif t == ContentType.VIDEO and getattr(p, "video_url", None):
                 print(f"{_YELLOW}🎬 [Video: {p.video_url}]{_RESET}")
             elif t == ContentType.AUDIO and getattr(p, "data", None):
-                print(f"{_YELLOW}🔊 [Audio]{_RESET}")
+                print(f"{_YELLOW}🔊 [Audio: {p.data}]{_RESET}")
             elif t == ContentType.FILE:
                 url = (
                     getattr(p, "file_url", None)


### PR DESCRIPTION
Updated ConsoleChannel to correctly handle ContentType.AUDIO by returning AudioContent with resolved local paths instead of generic FileContent. Also updated terminal output to display audio file paths.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
