### PR TITLE
I have optimized my internal processes by replacing blocking file ope…

### DIFF
--- a/src/copaw/agents/tools/file_io.py
+++ b/src/copaw/agents/tools/file_io.py
@@ -5,12 +5,13 @@ import os
 from pathlib import Path
 from typing import Optional
 
+import aiofiles
 from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
 
 from ...constant import WORKING_DIR
 from ...config.context import get_current_workspace_dir
-from .utils import truncate_file_output, read_file_safe
+from .utils import truncate_file_output, read_file_safe_async
 
 
 def _resolve_file_path(file_path: str) -> str:
@@ -101,7 +102,7 @@ async def read_file(  # pylint: disable=too-many-return-statements
         )
 
     try:
-        content = read_file_safe(file_path)
+        content = await read_file_safe_async(file_path)
         all_lines = content.split("\n")
         total = len(all_lines)
 
@@ -188,8 +189,8 @@ async def write_file(
     file_path = _resolve_file_path(file_path)
 
     try:
-        with open(file_path, "w", encoding="utf-8") as file:
-            file.write(content)
+        async with aiofiles.open(file_path, "w", encoding="utf-8") as file:
+            await file.write(content)
         return ToolResponse(
             content=[
                 TextBlock(
@@ -260,7 +261,7 @@ async def edit_file(
         )
 
     try:
-        content = read_file_safe(resolved_path)
+        content = await read_file_safe_async(resolved_path)
     except Exception as e:
         return ToolResponse(
             content=[
@@ -329,8 +330,8 @@ async def append_file(
     file_path = _resolve_file_path(file_path)
 
     try:
-        with open(file_path, "a", encoding="utf-8") as file:
-            file.write(content)
+        async with aiofiles.open(file_path, "a", encoding="utf-8") as file:
+            await file.write(content)
         return ToolResponse(
             content=[
                 TextBlock(

--- a/src/copaw/agents/tools/utils.py
+++ b/src/copaw/agents/tools/utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Shared utilities for file and shell tools."""
 
+import aiofiles
+
 # Default truncation limits
 DEFAULT_MAX_LINES = 1000
 DEFAULT_MAX_BYTES = 30 * 1024  # 30KB
@@ -238,3 +240,25 @@ def read_file_safe(file_path: str) -> str:
     except UnicodeDecodeError:
         with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
             return f.read()
+
+
+async def read_file_safe_async(file_path: str) -> str:
+    """Read file with Unicode error handling asynchronously.
+
+    Args:
+        file_path: Path to the file.
+
+    Returns:
+        File content as string.
+    """
+    try:
+        async with aiofiles.open(file_path, "r", encoding="utf-8") as f:
+            return await f.read()
+    except UnicodeDecodeError:
+        async with aiofiles.open(
+            file_path,
+            "r",
+            encoding="utf-8",
+            errors="ignore",
+        ) as f:
+            return await f.read()


### PR DESCRIPTION
…rations with asynchronous I/O. This update ensures that my interactions with the codebase are more efficient and responsive.

- Integrated a safe asynchronous utility for handling file operations.
- Updated my core file manipulation methods to use non-blocking functions.
- Improved my overall responsiveness and event loop performance during task execution.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
