### PR TITLE
🔒 Replace weak MD5 hash with SHA-256 for data hashing

### DIFF
--- a/src/copaw/agents/utils/file_handling.py
+++ b/src/copaw/agents/utils/file_handling.py
@@ -166,7 +166,7 @@ async def download_file_from_base64(
         download_path.mkdir(parents=True, exist_ok=True)
 
         if not filename:
-            file_hash = hashlib.md5(file_content).hexdigest()
+            file_hash = hashlib.sha256(file_content).hexdigest()
             filename = f"file_{file_hash}"
 
         local_file_path = download_path / filename
@@ -215,7 +215,7 @@ async def download_file_from_url(
             filename = (
                 url_filename
                 if url_filename
-                else f"file_{hashlib.md5(url.encode()).hexdigest()}"
+                else f"file_{hashlib.sha256(url.encode()).hexdigest()}"
             )
         local_file_path = download_path / filename
         _download_remote_to_path(url, local_file_path)

--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -2424,7 +2424,7 @@ class DingTalkChannel(BaseChannel):
         )
         if not url:
             return None
-        key = hashlib.md5(
+        key = hashlib.sha256(
             (download_code + robot_code).encode(),
         ).hexdigest()[:24]
         return await self._download_media_to_local(

--- a/src/copaw/app/channels/imessage/channel.py
+++ b/src/copaw/app/channels/imessage/channel.py
@@ -488,7 +488,7 @@ ORDER BY m.ROWID ASC
     ) -> Optional[str]:
         """Handle remote HTTP/HTTPS URLs."""
         try:
-            url_hash = hashlib.md5(url.encode()).hexdigest()[:16]
+            url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
             ext = self._get_file_extension(content_type, filename_hint)
             safe_basename = self._sanitize_filename(filename_hint)
             safe_filename = f"{safe_basename}_{url_hash}{ext}"
@@ -573,7 +573,7 @@ ORDER BY m.ROWID ASC
                     )
                     return None
 
-                url_hash = hashlib.md5(b64_data.encode()).hexdigest()[:16]
+                url_hash = hashlib.sha256(b64_data.encode()).hexdigest()[:16]
                 safe_basename = self._sanitize_filename(filename_hint)
                 safe_filename = f"{safe_basename}_{url_hash}{ext}"
                 local_path = str(self._media_dir / safe_filename)

--- a/src/copaw/app/channels/wecom/channel.py
+++ b/src/copaw/app/channels/wecom/channel.py
@@ -522,7 +522,7 @@ class WecomChannel(BaseChannel):
             safe_name = (
                 "".join(c for c in fn if c.isalnum() or c in "-_.") or "media"
             )
-            url_hash = hashlib.md5(url.encode()).hexdigest()[:8]
+            url_hash = hashlib.sha256(url.encode()).hexdigest()[:8]
             path = self._media_dir / f"wecom_{url_hash}_{safe_name}"
             path.write_bytes(data)
             return str(path)


### PR DESCRIPTION
Replaces MD5 hashing with SHA-256 in iMessage, WeCom, and DingTalk channels, as well as file handling utilities. This addresses a potential security vulnerability where MD5 was used for data hashing. String truncation has been maintained where necessary to preserve filename and key lengths.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
