### PR TITLE
fix(providers): preserve provider metadata in provider info response

### DIFF
--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -369,4 +369,5 @@ class Provider(ProviderInfo, ABC):
             freeze_url=self.freeze_url,
             require_api_key=self.require_api_key,
             generate_kwargs=self.generate_kwargs,
+            meta=self.meta,
         )


### PR DESCRIPTION
## Description

This PR fixes an issue where DashScope regional Base URL options were configured on the backend but were not exposed to the Console provider configuration UI.

The DashScope provider already defines `meta.base_url_options`, and the Console already renders a Base URL dropdown when `provider.meta.base_url_options` is present. However, `Provider.get_info()` did not pass `self.meta` when constructing `ProviderInfo`, so the `/providers` response omitted the metadata. As a result, the Console fell back to rendering the regular Base URL text input instead of the expected regional dropdown.

This change preserves provider metadata in `Provider.get_info()`, allowing the existing Console logic to receive DashScope `base_url_options` and render the region dropdown correctly.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** None. This change only exposes existing provider metadata through the provider info response. API-key handling, URL validation, and provider request behavior are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
  ********************************Passed******************************** 

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
