### PR TITLE
feat(plugins): add reference image support to gpt-image2 plugin

### DIFF
--- a/console/src/pages/Agent/Tools/index.tsx
+++ b/console/src/pages/Agent/Tools/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Card,
   Switch,
@@ -73,6 +73,13 @@ function ToolConfigModal({
   const [form] = Form.useForm();
   const [saving, setSaving] = useState(false);
   const { t } = useTranslation();
+
+  // Reset form when tool or visibility changes
+  useEffect(() => {
+    if (visible && tool) {
+      form.setFieldsValue(tool.config_values || {});
+    }
+  }, [visible, tool, form]);
 
   const handleSave = async () => {
     try {

--- a/plugins/tool/gpt-image2/README.md
+++ b/plugins/tool/gpt-image2/README.md
@@ -87,7 +87,8 @@ Edit or generate image using reference images with OpenAI GPT Image 2 model.
   - Note: Local files are automatically converted to base64
 - `size` (str, optional): Image size, one of "1024x1024", "1024x1536", "1536x1024", "auto" (default: "1024x1024")
 - `quality` (str, optional): Quality level, one of "low", "medium", "high", "auto" (default: "auto")
-- `input_fidelity` (str, optional): Fidelity to original images, one of "high", "low" (default: "high")
+
+**Note:** GPT Image 2 always processes images at high fidelity and does not support the `input_fidelity` parameter.
 
 **Returns:**
 

--- a/plugins/tool/gpt-image2/README.md
+++ b/plugins/tool/gpt-image2/README.md
@@ -8,7 +8,7 @@ A QwenPaw tool plugin that enables image generation and editing using OpenAI's G
 - **Edit/generate images** using reference images (1-16 images)
 - Support for multiple image sizes (1024x1024, 1024x1536, 1536x1024, auto)
 - Quality options: low, medium, high, auto
-- Input fidelity control for image editing (high, low)
+- High fidelity image processing (automatic for gpt-image-2)
 - Pure backend implementation - no frontend code required
 
 ## Installation

--- a/plugins/tool/gpt-image2/README.md
+++ b/plugins/tool/gpt-image2/README.md
@@ -1,12 +1,14 @@
 # GPT Image 2 Tool Plugin
 
-A QwenPaw tool plugin that enables image generation using OpenAI's GPT Image 2 model.
+A QwenPaw tool plugin that enables image generation and editing using OpenAI's GPT Image 2 model.
 
 ## Features
 
-- Generate high-quality images from text prompts
-- Support for multiple image sizes (1024x1024, 1024x1792, 1792x1024)
+- **Generate images** from text prompts
+- **Edit/generate images** using reference images (1-16 images)
+- Support for multiple image sizes (1024x1024, 1024x1536, 1536x1024, auto)
 - Quality options: low, medium, high, auto
+- Input fidelity control for image editing (high, low)
 - Pure backend implementation - no frontend code required
 
 ## Installation
@@ -25,25 +27,41 @@ qwenpaw plugin install gpt-image2-tool.zip
 
 1. Start QwenPaw application
 2. Navigate to Agent Settings → Tools
-3. Find the `generate_image_gpt` tool (🎨 icon)
-4. Click "Configure" button
+3. Find the GPT Image 2 tools:
+   - `generate_image_gpt` (🎨 icon) - Generate images from text
+   - `edit_image_gpt` (🖼️ icon) - Edit images with reference images
+4. Click "Configure" button for each tool
 5. Enter your OpenAI API Key (get it from https://platform.openai.com/api-keys)
 6. Save configuration
-7. Enable the tool
+7. Enable the tools you want to use
 
 ## Usage
 
-Once configured and enabled, the Agent can automatically call this tool when asked to generate images:
+Once configured and enabled, the Agent can automatically call these tools when asked to generate or edit images.
+
+### Example 1: Generate Image from Text
 
 **User**: Please generate an image of a serene mountain landscape at sunset
 
 **Agent**: [Calls generate_image_gpt tool with appropriate parameters]
 
+### Example 2: Edit Image with Reference
+
+**User**: I have a photo at /path/to/my/photo.jpg, please make it look like a watercolor painting
+
+**Agent**: [Calls edit_image_gpt tool with reference image and prompt]
+
+### Example 3: Generate from Multiple References
+
+**User**: Use these product images to create a gift basket: image1.png, image2.jpg, https://example.com/image3.png
+
+**Agent**: [Calls edit_image_gpt tool with multiple reference images]
+
 ## Tool Parameters
 
 ### generate_image_gpt
 
-Generate an image using OpenAI GPT Image 2 model.
+Generate an image using OpenAI GPT Image 2 model from text prompt only.
 
 **Parameters:**
 
@@ -53,8 +71,34 @@ Generate an image using OpenAI GPT Image 2 model.
 
 **Returns:**
 
-- ImageBlock with the generated image (base64-encoded as data URI)
+- ImageBlock with the generated image
 - TextBlock with generation metadata
+
+### edit_image_gpt
+
+Edit or generate image using reference images with OpenAI GPT Image 2 model.
+
+**Parameters:**
+
+- `prompt` (str, required): Text description of the desired image edit or generation
+- `reference_images` (List[str], required): List of 1-16 reference images. Each can be:
+  - Local file path (e.g., `/path/to/image.png`, `./photo.jpg`)
+  - Web URL (e.g., `https://example.com/image.png`)
+  - Note: Local files are automatically converted to base64
+- `size` (str, optional): Image size, one of "1024x1024", "1024x1536", "1536x1024", "auto" (default: "1024x1024")
+- `quality` (str, optional): Quality level, one of "low", "medium", "high", "auto" (default: "auto")
+- `input_fidelity` (str, optional): Fidelity to original images, one of "high", "low" (default: "high")
+
+**Returns:**
+
+- ImageBlock with the edited/generated image
+- TextBlock with editing metadata
+
+**Supported Image Formats:**
+
+- PNG (.png)
+- JPEG (.jpg, .jpeg)
+- WebP (.webp)
 
 ## Requirements
 

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -43,8 +43,8 @@
         "label": "API Endpoint",
         "type": "text",
         "required": false,
-        "placeholder": "https://api.openai.com/v1/images/generations",
-        "help": "Custom API endpoint (leave empty to use default)"
+        "placeholder": "Leave empty to use default (/generations or /edits)",
+        "help": "Custom API endpoint (leave empty for auto-detection based on tool)"
       },
       {
         "name": "timeout",

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -10,9 +10,6 @@
   "dependencies": ["httpx>=0.24.0"],
   "min_version": "1.1.6",
   "meta": {
-    "tool_name": "generate_image_gpt",
-    "tool_description": "Generate high-quality images from text prompts using GPT Image 2",
-    "tool_icon": "🎨",
     "tools": [
       {
         "name": "generate_image_gpt",
@@ -85,35 +82,6 @@
     ],
     "api_key_url": "https://platform.openai.com/api-keys",
     "api_key_hint": "Get your OpenAI API key from platform.openai.com",
-    "model_url": "https://developers.openai.com/api/docs/models/gpt-image-2",
-    "requires_config": true,
-    "config_fields": [
-      {
-        "name": "api_key",
-        "label": "OpenAI API Key",
-        "type": "password",
-        "required": true,
-        "placeholder": "sk-...",
-        "help": "Get your API key from platform.openai.com"
-      },
-      {
-        "name": "endpoint",
-        "label": "API Endpoint",
-        "type": "text",
-        "required": false,
-        "placeholder": "Leave empty to use default",
-        "help": "Custom API endpoint (leave empty for auto-detection based on tool)"
-      },
-      {
-        "name": "timeout",
-        "label": "Request Timeout (seconds)",
-        "type": "number",
-        "required": false,
-        "placeholder": "60",
-        "min": 10,
-        "max": 300,
-        "help": "HTTP request timeout in seconds (default: 60)"
-      }
-    ]
+    "model_url": "https://developers.openai.com/api/docs/models/gpt-image-2"
   }
 }

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -17,12 +17,70 @@
       {
         "name": "generate_image_gpt",
         "description": "Generate high-quality images from text prompts using GPT Image 2",
-        "icon": "🎨"
+        "icon": "🎨",
+        "requires_config": true,
+        "config_fields": [
+          {
+            "name": "api_key",
+            "label": "OpenAI API Key",
+            "type": "password",
+            "required": true,
+            "placeholder": "sk-...",
+            "help": "Get your API key from platform.openai.com"
+          },
+          {
+            "name": "endpoint",
+            "label": "API Endpoint",
+            "type": "text",
+            "required": false,
+            "placeholder": "https://api.openai.com/v1/images/generations",
+            "help": "Custom API endpoint (leave empty to use default /images/generations)"
+          },
+          {
+            "name": "timeout",
+            "label": "Request Timeout (seconds)",
+            "type": "number",
+            "required": false,
+            "placeholder": "60",
+            "min": 10,
+            "max": 300,
+            "help": "HTTP request timeout in seconds (default: 60)"
+          }
+        ]
       },
       {
         "name": "edit_image_gpt",
         "description": "Edit or generate images using reference images with GPT Image 2",
-        "icon": "🖼️"
+        "icon": "🖼️",
+        "requires_config": true,
+        "config_fields": [
+          {
+            "name": "api_key",
+            "label": "OpenAI API Key",
+            "type": "password",
+            "required": true,
+            "placeholder": "sk-...",
+            "help": "Get your API key from platform.openai.com"
+          },
+          {
+            "name": "endpoint",
+            "label": "API Endpoint",
+            "type": "text",
+            "required": false,
+            "placeholder": "https://api.openai.com/v1/images/edits",
+            "help": "Custom API endpoint (leave empty to use default /images/edits)"
+          },
+          {
+            "name": "timeout",
+            "label": "Request Timeout (seconds)",
+            "type": "number",
+            "required": false,
+            "placeholder": "60",
+            "min": 10,
+            "max": 300,
+            "help": "HTTP request timeout in seconds (default: 60)"
+          }
+        ]
       }
     ],
     "api_key_url": "https://platform.openai.com/api-keys",
@@ -43,7 +101,7 @@
         "label": "API Endpoint",
         "type": "text",
         "required": false,
-        "placeholder": "Leave empty to use default (/generations or /edits)",
+        "placeholder": "Leave empty to use default",
         "help": "Custom API endpoint (leave empty for auto-detection based on tool)"
       },
       {

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "gpt-image2-tool",
   "name": "GPT Image 2 Tool",
-  "version": "1.0.0",
-  "description": "Generate images using OpenAI GPT Image 2 model",
+  "version": "1.1.0",
+  "description": "Generate and edit images using OpenAI GPT Image 2 model",
   "author": "QwenPaw Team",
   "entry": {
     "backend": "plugin.py"
@@ -13,6 +13,18 @@
     "tool_name": "generate_image_gpt",
     "tool_description": "Generate high-quality images from text prompts using GPT Image 2",
     "tool_icon": "🎨",
+    "tools": [
+      {
+        "name": "generate_image_gpt",
+        "description": "Generate high-quality images from text prompts using GPT Image 2",
+        "icon": "🎨"
+      },
+      {
+        "name": "edit_image_gpt",
+        "description": "Edit or generate images using reference images with GPT Image 2",
+        "icon": "🖼️"
+      }
+    ],
     "api_key_url": "https://platform.openai.com/api-keys",
     "api_key_hint": "Get your OpenAI API key from platform.openai.com",
     "model_url": "https://developers.openai.com/api/docs/models/gpt-image-2",

--- a/plugins/tool/gpt-image2/plugin.py
+++ b/plugins/tool/gpt-image2/plugin.py
@@ -35,9 +35,10 @@ class GPTImage2ToolPlugin:
         logger.info("✓ GPT Image 2 tool plugin registered")
 
     def _register_tool(self):
-        """Register the generate_image_gpt tool to Agent toolkit.
+        """Register GPT Image 2 tools to Agent toolkit.
 
         This is called during application startup.
+        Registers both generate_image_gpt and edit_image_gpt tools.
         """
         try:
             # Load tool module
@@ -52,18 +53,25 @@ class GPTImage2ToolPlugin:
             spec.loader.exec_module(tool_module)
 
             generate_image_gpt = tool_module.generate_image_gpt
+            edit_image_gpt = tool_module.edit_image_gpt
 
-            # Register tool function globally
+            # Register tool functions globally
             import qwenpaw.agents.tools as tools_module
 
             setattr(tools_module, "generate_image_gpt", generate_image_gpt)
             if "generate_image_gpt" not in tools_module.__all__:
                 tools_module.__all__.append("generate_image_gpt")
 
-            logger.info("✓ Registered tool function: generate_image_gpt")
+            setattr(tools_module, "edit_image_gpt", edit_image_gpt)
+            if "edit_image_gpt" not in tools_module.__all__:
+                tools_module.__all__.append("edit_image_gpt")
 
-            # Add tool to current agent's config
-            # Note: This will be executed when the agent starts up
+            logger.info(
+                "✓ Registered tool functions: "
+                "generate_image_gpt, edit_image_gpt",
+            )
+
+            # Add tools to current agent's config
             from qwenpaw.config.config import (
                 BuiltinToolConfig,
                 load_agent_config,
@@ -71,7 +79,23 @@ class GPTImage2ToolPlugin:
             )
             from qwenpaw.app.agent_context import get_current_agent_id
 
-            tool_name = "generate_image_gpt"
+            tools_to_register = [
+                {
+                    "name": "generate_image_gpt",
+                    "description": (
+                        "Generate images using OpenAI GPT Image 2"
+                    ),
+                    "icon": "🎨",
+                },
+                {
+                    "name": "edit_image_gpt",
+                    "description": (
+                        "Edit or generate images using reference images "
+                        "with OpenAI GPT Image 2"
+                    ),
+                    "icon": "🖼️",
+                },
+            ]
 
             try:
                 # Get current agent ID
@@ -79,7 +103,7 @@ class GPTImage2ToolPlugin:
                 if not agent_id:
                     logger.warning(
                         "No current agent ID found, "
-                        "tool will be registered later",
+                        "tools will be registered later",
                     )
                     return
 
@@ -92,39 +116,41 @@ class GPTImage2ToolPlugin:
 
                     agent_config.tools = ToolsConfig()
 
-                # Add tool if not exists
-                if tool_name not in agent_config.tools.builtin_tools:
-                    agent_config.tools.builtin_tools[
-                        tool_name
-                    ] = BuiltinToolConfig(
-                        name=tool_name,
-                        enabled=False,  # Default disabled
-                        description=(
-                            "Generate images using OpenAI GPT Image 2"
-                        ),
-                        display_to_user=True,
-                        async_execution=False,
-                        icon="🎨",
-                    )
-                    save_agent_config(agent_id, agent_config)
-                    logger.info(
-                        f"✓ Added {tool_name} to agent {agent_id} "
-                        f"(disabled)",
-                    )
-                else:
-                    logger.info(
-                        f"Tool {tool_name} already exists in agent "
-                        f"{agent_id}",
-                    )
+                # Add each tool if not exists
+                for tool_info in tools_to_register:
+                    tool_name = tool_info["name"]
+                    if tool_name not in agent_config.tools.builtin_tools:
+                        agent_config.tools.builtin_tools[
+                            tool_name
+                        ] = BuiltinToolConfig(
+                            name=tool_name,
+                            enabled=False,  # Default disabled
+                            description=tool_info["description"],
+                            display_to_user=True,
+                            async_execution=False,
+                            icon=tool_info["icon"],
+                        )
+                        logger.info(
+                            f"✓ Added {tool_name} to agent {agent_id} "
+                            f"(disabled)",
+                        )
+                    else:
+                        logger.info(
+                            f"Tool {tool_name} already exists in agent "
+                            f"{agent_id}",
+                        )
+
+                save_agent_config(agent_id, agent_config)
+
             except Exception as ex:
                 logger.warning(
-                    f"Failed to add tool to current agent: {ex}. "
-                    f"Tool will be available after restart.",
+                    f"Failed to add tools to current agent: {ex}. "
+                    f"Tools will be available after restart.",
                 )
 
         except Exception as e:
             logger.error(
-                f"Failed to register GPT Image 2 tool: {e}",
+                f"Failed to register GPT Image 2 tools: {e}",
                 exc_info=True,
             )
 

--- a/plugins/tool/gpt-image2/tool.py
+++ b/plugins/tool/gpt-image2/tool.py
@@ -247,12 +247,14 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
     reference_images: List[str],
     size: str = "1024x1024",
     quality: str = "auto",
-    input_fidelity: str = "high",
 ) -> ToolResponse:
     """Edit or generate image using reference images with GPT Image 2.
 
     This tool uses OpenAI's GPT Image 2 model to generate or edit images
     based on one or more reference images and a text prompt.
+
+    Note: gpt-image-2 always processes images at high fidelity and does
+    not support the input_fidelity parameter.
 
     Args:
         prompt (str):
@@ -268,9 +270,6 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
         quality (str, optional):
             Image quality level. Options: "low", "medium", "high", "auto".
             Defaults to "auto".
-        input_fidelity (str, optional):
-            Controls fidelity to original input images. Options: "high",
-            "low". Defaults to "high".
 
     Returns:
         ToolResponse:
@@ -382,22 +381,6 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
                 ],
             )
 
-        valid_fidelity = {"high", "low"}
-        if input_fidelity not in valid_fidelity:
-            return ToolResponse(
-                content=[
-                    TextBlock(
-                        type="text",
-                        text=(
-                            f"Error: Invalid input_fidelity "
-                            f"'{input_fidelity}'. "
-                            f"Must be one of: "
-                            f"{', '.join(sorted(valid_fidelity))}"
-                        ),
-                    ),
-                ],
-            )
-
         # Process reference images
         try:
             images_payload = []
@@ -429,10 +412,11 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
         # Call OpenAI API
         logger.info(
             f"Editing image with GPT Image 2: {len(reference_images)} "
-            f"reference images, size={size}, quality={quality}, "
-            f"input_fidelity={input_fidelity}",
+            f"reference images, size={size}, quality={quality}",
         )
 
+        # Note: gpt-image-2 does not support input_fidelity parameter
+        # It always processes images at high fidelity
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(
                 endpoint,
@@ -446,7 +430,6 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
                     "prompt": prompt,
                     "size": size,
                     "quality": quality,
-                    "input_fidelity": input_fidelity,
                     "n": 1,
                 },
             )
@@ -512,8 +495,7 @@ async def edit_image_gpt(  # pylint: disable=too-many-statements
                         f"Edited image using GPT Image 2\n"
                         f"Prompt: {prompt}\n"
                         f"Reference images: {len(reference_images)}\n"
-                        f"Size: {size}, Quality: {quality}, "
-                        f"Input Fidelity: {input_fidelity}\n"
+                        f"Size: {size}, Quality: {quality}\n"
                         f"Saved to: {image_path}"
                     ),
                 ),

--- a/plugins/tool/gpt-image2/tool.py
+++ b/plugins/tool/gpt-image2/tool.py
@@ -5,7 +5,8 @@
 import base64
 import logging
 import time
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional
 
 import httpx
 from agentscope.message import ImageBlock, TextBlock
@@ -241,8 +242,361 @@ async def generate_image_gpt(
         )
 
 
-def _get_tool_config() -> Optional[dict]:
+async def edit_image_gpt(  # pylint: disable=too-many-statements
+    prompt: str,
+    reference_images: List[str],
+    size: str = "1024x1024",
+    quality: str = "auto",
+    input_fidelity: str = "high",
+) -> ToolResponse:
+    """Edit or generate image using reference images with GPT Image 2.
+
+    This tool uses OpenAI's GPT Image 2 model to generate or edit images
+    based on one or more reference images and a text prompt.
+
+    Args:
+        prompt (str):
+            Text description of the desired image edit or generation.
+        reference_images (List[str]):
+            List of reference images (1-16 images). Each item can be:
+            - Web URL (https://example.com/image.png)
+            - Local file path (/path/to/image.png)
+            Note: Local files will be converted to base64 automatically.
+        size (str, optional):
+            Output image size. Options: "1024x1024", "1024x1536",
+            "1536x1024", "auto". Defaults to "1024x1024".
+        quality (str, optional):
+            Image quality level. Options: "low", "medium", "high", "auto".
+            Defaults to "auto".
+        input_fidelity (str, optional):
+            Controls fidelity to original input images. Options: "high",
+            "low". Defaults to "high".
+
+    Returns:
+        ToolResponse:
+            Contains the generated/edited image and metadata.
+
+    Example:
+        >>> result = await edit_image_gpt(
+        ...     prompt="Make this photo look like a watercolor painting",
+        ...     reference_images=["/path/to/photo.jpg"],
+        ...     quality="high"
+        ... )
+    """
+    try:
+        # Validate reference_images
+        if not reference_images:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            "Error: reference_images is required. "
+                            "Please provide at least one reference image."
+                        ),
+                    ),
+                ],
+            )
+
+        if len(reference_images) > 16:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error: Too many reference images. "
+                            f"Maximum is 16, got {len(reference_images)}."
+                        ),
+                    ),
+                ],
+            )
+
+        # Get tool config
+        tool_config = _get_tool_config("edit_image_gpt")
+        if not tool_config:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            "Error: Tool not configured. "
+                            "Please set your API key in the tool settings."
+                        ),
+                    ),
+                ],
+            )
+
+        api_key = tool_config.get("api_key")
+        if not api_key:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            "Error: OpenAI API key not configured. "
+                            "Please set your API key in the tool settings."
+                        ),
+                    ),
+                ],
+            )
+
+        # Get endpoint from config, use default if not set
+        endpoint = tool_config.get("endpoint")
+        if not endpoint or not endpoint.strip():
+            endpoint = "https://api.openai.com/v1/images/edits"
+
+        # Get timeout from config
+        timeout = tool_config.get("timeout")
+        if timeout is None or timeout <= 0:
+            timeout = 60.0
+        else:
+            timeout = float(timeout)
+
+        # Validate parameters
+        valid_sizes = {"auto", "1024x1024", "1024x1536", "1536x1024"}
+        if size not in valid_sizes:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error: Invalid size '{size}'. "
+                            f"Must be one of: {', '.join(valid_sizes)}"
+                        ),
+                    ),
+                ],
+            )
+
+        valid_quality = {"low", "medium", "high", "auto"}
+        if quality not in valid_quality:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error: Invalid quality '{quality}'. "
+                            f"Must be one of: "
+                            f"{', '.join(sorted(valid_quality))}"
+                        ),
+                    ),
+                ],
+            )
+
+        valid_fidelity = {"high", "low"}
+        if input_fidelity not in valid_fidelity:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error: Invalid input_fidelity "
+                            f"'{input_fidelity}'. "
+                            f"Must be one of: "
+                            f"{', '.join(sorted(valid_fidelity))}"
+                        ),
+                    ),
+                ],
+            )
+
+        # Process reference images
+        try:
+            images_payload = []
+            for img_path in reference_images:
+                img_dict = _process_image_url(img_path)
+                images_payload.append(img_dict)
+        except FileNotFoundError as e:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Error: Reference image not found - {str(e)}",
+                    ),
+                ],
+            )
+        except Exception as e:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Error: Failed to process reference images - "
+                            f"{str(e)}"
+                        ),
+                    ),
+                ],
+            )
+
+        # Call OpenAI API
+        logger.info(
+            f"Editing image with GPT Image 2: {len(reference_images)} "
+            f"reference images, size={size}, quality={quality}, "
+            f"input_fidelity={input_fidelity}",
+        )
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": "gpt-image-2",
+                    "images": images_payload,
+                    "prompt": prompt,
+                    "size": size,
+                    "quality": quality,
+                    "input_fidelity": input_fidelity,
+                    "n": 1,
+                },
+            )
+
+        if response.status_code != 200:
+            error_msg = f"OpenAI API error: {response.status_code}"
+            try:
+                error_data = response.json()
+                if "error" in error_data:
+                    error_msg += f" - {error_data['error'].get('message')}"
+            except Exception:
+                pass
+            logger.error(error_msg)
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Error: {error_msg}",
+                    ),
+                ],
+            )
+
+        # Parse response
+        data = response.json()
+        b64_json = data["data"][0]["b64_json"]
+
+        logger.info("Image edited successfully (base64)")
+
+        # Save image to local file
+        media_dir = DEFAULT_MEDIA_DIR / "gpt_image2"
+        media_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = int(time.time() * 1000)
+        filename = f"gpt_image2_edit_{timestamp}.png"
+        image_path = media_dir / filename
+
+        # Decode base64 and save to file
+        try:
+            image_data = base64.b64decode(b64_json)
+            image_path.write_bytes(image_data)
+            logger.info(f"Image saved to {image_path}")
+        except Exception as e:
+            logger.error(f"Failed to save image: {e}")
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=f"Error: Failed to save image - {str(e)}",
+                    ),
+                ],
+            )
+
+        # Return image with local file path
+        return ToolResponse(
+            content=[
+                ImageBlock(
+                    type="image",
+                    source={"type": "url", "url": str(image_path)},
+                ),
+                TextBlock(
+                    type="text",
+                    text=(
+                        f"Edited image using GPT Image 2\n"
+                        f"Prompt: {prompt}\n"
+                        f"Reference images: {len(reference_images)}\n"
+                        f"Size: {size}, Quality: {quality}, "
+                        f"Input Fidelity: {input_fidelity}\n"
+                        f"Saved to: {image_path}"
+                    ),
+                ),
+            ],
+        )
+
+    except httpx.TimeoutException:
+        logger.error("Image editing timed out")
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=("Error: Image editing timed out. Please try again."),
+                ),
+            ],
+        )
+    except Exception as e:
+        logger.error(f"Image editing failed: {e}", exc_info=True)
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=f"Error: Image editing failed - {str(e)}",
+                ),
+            ],
+        )
+
+
+def _process_image_url(image_path: str) -> dict:
+    """Convert image path/URL to API format.
+
+    Args:
+        image_path: Web URL or local file path
+
+    Returns:
+        dict: {"image_url": "..."} for API payload
+
+    Raises:
+        FileNotFoundError: If local file doesn't exist
+        ValueError: If file format is not supported
+    """
+    if image_path.startswith(("http://", "https://")):
+        # Web URL - use directly
+        return {"image_url": image_path}
+
+    # Local file - convert to base64 data URL
+    path_obj = Path(image_path)
+
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Image file not found: {image_path}")
+
+    if not path_obj.is_file():
+        raise ValueError(f"Not a file: {image_path}")
+
+    # Detect MIME type from extension
+    ext = path_obj.suffix.lower()
+    mime_type_map = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+    }
+
+    if ext not in mime_type_map:
+        raise ValueError(
+            f"Unsupported image format: {ext}. "
+            f"Supported formats: {', '.join(mime_type_map.keys())}",
+        )
+
+    mime_type = mime_type_map[ext]
+
+    # Read and encode image
+    with open(path_obj, "rb") as f:
+        image_data = base64.b64encode(f.read()).decode("utf-8")
+
+    return {"image_url": f"data:{mime_type};base64,{image_data}"}
+
+
+def _get_tool_config(tool_name: str = "generate_image_gpt") -> Optional[dict]:
     """Get tool configuration including API key and endpoint.
+
+    Args:
+        tool_name: Name of the tool to get config for
 
     Returns:
         dict or None: Tool config if configured, None otherwise
@@ -263,7 +617,7 @@ def _get_tool_config() -> Optional[dict]:
 
         # Get tool config for current agent
         tool_config = registry.get_tool_config(
-            "generate_image_gpt",
+            tool_name,
             agent_id,
         )
         if not tool_config:

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -151,12 +151,31 @@ async def list_tools(
         manifest = tool_to_manifest.get(tool_config.name)
         if manifest and "meta" in manifest:
             meta = manifest["meta"]
-            tool_info.requires_config = meta.get(
-                "requires_config",
-                False,
-            )
+
+            # Try to get tool-specific config first (from meta.tools array)
+            config_fields_data = None
+            requires_config = False
+
+            tools = meta.get("tools", [])
+            if isinstance(tools, list):
+                for tool in tools:
+                    if (
+                        isinstance(tool, dict)
+                        and tool.get("name") == tool_config.name
+                    ):
+                        # Found tool-specific config
+                        requires_config = tool.get("requires_config", False)
+                        config_fields_data = tool.get("config_fields", [])
+                        break
+
+            # Fallback to global config if tool-specific not found
+            if config_fields_data is None:
+                requires_config = meta.get("requires_config", False)
+                config_fields_data = meta.get("config_fields", [])
+
+            tool_info.requires_config = requires_config
+
             # Convert config_fields to Pydantic models
-            config_fields_data = meta.get("config_fields", [])
             if config_fields_data:
                 tool_info.config_fields = [
                     ToolConfigField(**field) for field in config_fields_data
@@ -315,7 +334,24 @@ async def get_tool_config(
     if plugin_id:
         manifest = registry.get_plugin_manifest(plugin_id)
         if manifest and "meta" in manifest:
-            config_fields = manifest["meta"].get("config_fields", [])
+            meta = manifest["meta"]
+
+            # Try to get tool-specific config fields first
+            config_fields = None
+            tools = meta.get("tools", [])
+            if isinstance(tools, list):
+                for tool in tools:
+                    if (
+                        isinstance(tool, dict)
+                        and tool.get("name") == tool_name
+                    ):
+                        config_fields = tool.get("config_fields", [])
+                        break
+
+            # Fallback to global config fields
+            if config_fields is None:
+                config_fields = meta.get("config_fields", [])
+
             masked_config = dict(config)
             for field in config_fields:
                 if (
@@ -361,7 +397,23 @@ async def update_tool_config(
     if plugin_id:
         manifest = registry.get_plugin_manifest(plugin_id)
         if manifest and "meta" in manifest:
-            config_fields = manifest["meta"].get("config_fields", [])
+            meta = manifest["meta"]
+
+            # Try to get tool-specific config fields first
+            config_fields = None
+            tools = meta.get("tools", [])
+            if isinstance(tools, list):
+                for tool in tools:
+                    if (
+                        isinstance(tool, dict)
+                        and tool.get("name") == tool_name
+                    ):
+                        config_fields = tool.get("config_fields", [])
+                        break
+
+            # Fallback to global config fields
+            if config_fields is None:
+                config_fields = meta.get("config_fields", [])
 
             # Get existing config
             existing_config = (

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-many-nested-blocks
+# pylint: disable=too-many-nested-blocks,too-many-branches
 """API routes for built-in tools management."""
 
 from __future__ import annotations
@@ -122,9 +122,16 @@ async def list_tools(
     tool_to_manifest = {}
     for manifest in all_manifests.values():
         meta = manifest.get("meta", {})
+        # Support old format: meta.tool_name
         tool_name = meta.get("tool_name")
         if tool_name:
             tool_to_manifest[tool_name] = manifest
+        # Support new format: meta.tools array
+        tools = meta.get("tools", [])
+        if isinstance(tools, list):
+            for tool in tools:
+                if isinstance(tool, dict) and "name" in tool:
+                    tool_to_manifest[tool["name"]] = manifest
 
     # Optimize: Load agent_config once instead of per-tool
     # (reuse the already-loaded agent_config from above)

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1285,9 +1285,8 @@ class BuiltinToolConfig(BaseModel):
     )
 
 
-def _default_builtin_tools() -> (
-    Dict[str, BuiltinToolConfig]
-):  # pylint: disable=too-many-nested-blocks
+# pylint: disable=too-many-nested-blocks
+def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
     """Return a fresh copy of the canonical built-in tool definitions.
 
     This includes both hardcoded tools and dynamically registered tools

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1285,7 +1285,9 @@ class BuiltinToolConfig(BaseModel):
     )
 
 
-def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
+def _default_builtin_tools() -> (
+    Dict[str, BuiltinToolConfig]
+):  # pylint: disable=too-many-nested-blocks
     """Return a fresh copy of the canonical built-in tool definitions.
 
     This includes both hardcoded tools and dynamically registered tools
@@ -1422,6 +1424,7 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
         all_manifests = registry.get_all_plugin_manifests()
         for plugin_id, manifest in all_manifests.items():
             meta = manifest.get("meta", {})
+            # Support old format: meta.tool_name
             if meta.get("tool_name"):
                 tool_name = meta["tool_name"]
                 if tool_name not in tools:
@@ -1436,6 +1439,24 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
                         async_execution=False,
                         icon=meta.get("tool_icon", "🔧"),
                     )
+            # Support new format: meta.tools array
+            tools_list = meta.get("tools", [])
+            if isinstance(tools_list, list):
+                for tool_info in tools_list:
+                    if isinstance(tool_info, dict) and "name" in tool_info:
+                        tool_name = tool_info["name"]
+                        if tool_name not in tools:
+                            tools[tool_name] = BuiltinToolConfig(
+                                name=tool_name,
+                                enabled=False,
+                                description=tool_info.get(
+                                    "description",
+                                    f"Tool from plugin {plugin_id}",
+                                ),
+                                display_to_user=True,
+                                async_execution=False,
+                                icon=tool_info.get("icon", "🔧"),
+                            )
     except Exception:
         # Plugins not loaded yet, return hardcoded tools only
         pass

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -301,8 +301,18 @@ class PluginRegistry:
         """
         for plugin_id, manifest in self._plugin_manifests.items():
             meta = manifest.get("meta", {})
+            # Check old format: meta.tool_name
             if meta.get("tool_name") == tool_name:
                 return plugin_id
+            # Check new format: meta.tools array
+            tools = meta.get("tools", [])
+            if isinstance(tools, list):
+                for tool in tools:
+                    if (
+                        isinstance(tool, dict)
+                        and tool.get("name") == tool_name
+                    ):
+                        return plugin_id
         return None
 
     def get_tool_config(


### PR DESCRIPTION
## Description

This PR adds support for reference image-based image generation/editing to the gpt-image2 plugin, enabling users to provide 1-16 reference images when generating new images.

**Related Issue:** Fixes #4167

## Type of Change

- [x] New feature
- [x] Bug fix (configuration UI support)

## Component(s) Affected

- [x] Core / Backend (plugins, config)

## Changes

### 1. New Tool: `edit_image_gpt`
- Added new tool function that supports 1-16 reference images
- Uses OpenAI `/images/edits` API endpoint
- Supports local file paths and web URLs as image inputs
- Auto-converts local files to base64 data URLs for API
- Supports PNG, JPEG, WebP formats

### 2. Plugin System Enhancements
- Updated `plugin.json` to support multiple tools in a single plugin
- Maintains backward compatibility with old `meta.tool_name` format
- Both tools (`generate_image_gpt` and `edit_image_gpt`) can be configured separately

### 3. Backend Configuration Support
- Enhanced `registry.py` to support both single tool and tools array formats
- Enhanced `config.py` to register tools from `meta.tools` array
- Enhanced `tools.py` API route to map tools from array format

### 4. Bug Fixes
- Removed `input_fidelity` parameter as gpt-image-2 doesn't support it
- Fixed configuration UI not showing for `edit_image_gpt`

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] Documentation updated (README.md)
- [x] Ready for review

## Testing

### Manual Testing
1. Install the updated plugin
2. Configure both tools with OpenAI API keys
3. Test `generate_image_gpt` with text prompt
4. Test `edit_image_gpt` with reference images (local paths and URLs)

### Example Usage
```python
# Generate from text only
await generate_image_gpt(
    prompt="A serene mountain landscape at sunset",
    size="1024x1024",
    quality="high"
)

# Edit with reference images
await edit_image_gpt(
    prompt="Make this photo look like a watercolor painting",
    reference_images=["/path/to/photo.jpg"],
    size="1024x1024",
    quality="high"
)
```

## Local Verification Evidence

```bash
pre-commit run --all-files
# All checks passed (black, flake8, pylint, mypy)

# Files modified:
#  - plugins/tool/gpt-image2/README.md
#  - plugins/tool/gpt-image2/plugin.json
#  - plugins/tool/gpt-image2/plugin.py
#  - plugins/tool/gpt-image2/tool.py
#  - src/qwenpaw/plugins/registry.py
#  - src/qwenpaw/app/routers/tools.py
#  - src/qwenpaw/config/config.py
```

## Technical Details

### API Compatibility
- Correctly uses `gpt-image-2` model without `input_fidelity` parameter
- gpt-image-2 always processes images at high fidelity automatically

### Performance Considerations
- Local files are converted to base64 on-the-fly (not passed through model context)
- Supports up to 16 reference images as per OpenAI API limits

### Backward Compatibility
- Old plugins with `meta.tool_name` format continue to work
- New plugins can use `meta.tools` array for multiple tools
- Configuration system supports both formats seamlessly

## Commits

- `b332d998` feat(plugins): add reference image support to gpt-image2 plugin
- `70d82bf7` fix(plugins): support tools array format in plugin config
- `54e397b6` fix(plugins): remove input_fidelity parameter for gpt-image-2
