### PR TITLE
feat(tool): Add async execution support for delegate_external_agent

### DIFF
--- a/console/src/pages/Agent/Tools/index.tsx
+++ b/console/src/pages/Agent/Tools/index.tsx
@@ -283,7 +283,10 @@ export default function ToolsPage() {
                 )}
 
                 <div className={styles.cardFooter}>
-                  {tool.name === "execute_shell_command" && (
+                  {[
+                    "execute_shell_command",
+                    "delegate_external_agent",
+                  ].includes(tool.name) && (
                     <Button
                       className={styles.toggleButton}
                       onClick={() => toggleAsyncExecution(tool)}

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -242,13 +242,16 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 enabled_tools = {
                     name: tool.enabled for name, tool in builtin_tools.items()
                 }
-                # Only execute_shell_command supports async_execution
+                # Only selected long-running tools support async_execution.
+                async_capable_tool_names = {
+                    "execute_shell_command",
+                    "delegate_external_agent",
+                }
                 async_execution_tools = {
-                    "execute_shell_command": builtin_tools.get(
-                        "execute_shell_command",
-                    ).async_execution
-                    if "execute_shell_command" in builtin_tools
-                    else False,
+                    name: builtin_tools.get(name).async_execution
+                    if name in builtin_tools
+                    else False
+                    for name in async_capable_tool_names
                 }
         except Exception as e:
             logger.warning(

--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -6,9 +6,12 @@ Uses the ACP protocol.
 
 import asyncio
 import logging
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncGenerator, Optional
 
+from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
 
 from ...config.context import get_current_workspace_dir
@@ -25,8 +28,32 @@ from ..acp.tool_adapter import (
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _RunnerState:
+    agent_id: str
+    chat_id: str
+    runner: str
+    action: str
+    status: str
+    created_at: float
+    updated_at: float
+    content: list[TextBlock] = field(default_factory=list)
+    error: Optional[str] = None
+    pending_permission: Any = None
+
+
+_runner_state_lock = asyncio.Lock()
+_runner_states: dict[tuple[str, str, str], _RunnerState] = {}
+
+
 def _current_workspace_dir() -> Path:
     return (get_current_workspace_dir() or Path(WORKING_DIR)).expanduser()
+
+
+def _current_agent_id() -> str:
+    from ...app.agent_context import get_current_agent_id
+
+    return get_current_agent_id()
 
 
 def _resolve_execution_cwd(cwd: str, workspace_dir: Path) -> Path:
@@ -93,10 +120,21 @@ def _validate_action_inputs(
     runner_name: str,
     message_text: str,
 ) -> Optional[str]:
-    if not runner_name:
+    allowed_actions = {
+        "list",
+        "status",
+        "start",
+        "message",
+        "respond",
+        "close",
+    }
+    if action_name not in allowed_actions:
+        return (
+            "Error: action must be one of: list, status, start, message, "
+            "respond, close."
+        )
+    if action_name not in {"list", "status"} and not runner_name:
         return "Error: runner is empty."
-    if action_name not in {"start", "message", "respond", "close"}:
-        return "Error: action must be one of: start, message, respond, close."
     if action_name in {"message", "respond"} and not message_text:
         if action_name == "message":
             return (
@@ -108,6 +146,221 @@ def _validate_action_inputs(
             "exact selected permission option id in message."
         )
     return None
+
+
+def _task_key(
+    agent_id: str,
+    chat_id: str,
+    runner_name: str,
+) -> tuple[str, str, str]:
+    return agent_id, chat_id, runner_name
+
+
+def _format_timestamp(value: float) -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(value))
+
+
+async def _get_runner_state(
+    *,
+    agent_id: str,
+    chat_id: str,
+    runner_name: str,
+) -> Optional[_RunnerState]:
+    async with _runner_state_lock:
+        return _runner_states.get(_task_key(agent_id, chat_id, runner_name))
+
+
+async def _set_runner_state(state: _RunnerState) -> None:
+    async with _runner_state_lock:
+        _runner_states[
+            _task_key(state.agent_id, state.chat_id, state.runner)
+        ] = state
+
+
+async def _append_runner_state_content(
+    state: _RunnerState,
+    blocks: list[TextBlock],
+) -> None:
+    if not blocks:
+        return
+    async with _runner_state_lock:
+        state.content.extend(blocks)
+        state.updated_at = time.time()
+
+
+async def _set_runner_state_status(
+    state: _RunnerState,
+    status: str,
+    *,
+    error: Optional[str] = None,
+    pending_permission: Any = None,
+) -> None:
+    async with _runner_state_lock:
+        state.status = status
+        state.error = error
+        state.pending_permission = pending_permission
+        state.updated_at = time.time()
+
+
+def _copy_content_text(blocks: list[TextBlock], limit: int = 12000) -> str:
+    parts = [
+        str(
+            block.get("text")
+            if isinstance(block, dict)
+            else getattr(block, "text", ""),
+        )
+        for block in blocks
+    ]
+    text = "\n\n".join(part.strip() for part in parts if part and part.strip())
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def _format_task_state_text(
+    *,
+    runner_name: str,
+    session_state: str,
+    state: Optional[_RunnerState],
+    pending_permission: Any = None,
+) -> str:
+    lines = [
+        f"runner: {runner_name}",
+        f"session: {session_state}",
+    ]
+    if state is None:
+        lines.append("task: none")
+    else:
+        effective_status = (
+            "permission_required"
+            if pending_permission is not None
+            else state.status
+        )
+        lines.extend(
+            [
+                f"task: {effective_status}",
+                f"last action: {state.action}",
+                f"started at: {_format_timestamp(state.created_at)}",
+                f"updated at: {_format_timestamp(state.updated_at)}",
+            ],
+        )
+        if state.error:
+            lines.append(f"error: {state.error}")
+        response_text_value = _copy_content_text(state.content)
+        if response_text_value:
+            lines.extend(["", "Last response:", response_text_value])
+    return "\n".join(lines)
+
+
+async def _get_runner_session_state(
+    service: Any,
+    *,
+    chat_id: str,
+    runner_name: str,
+) -> str:
+    existing = await service.get_session(chat_id=chat_id, agent=runner_name)
+    if existing is None:
+        return "closed"
+    if getattr(existing.process, "returncode", None) is not None:
+        return "exited"
+    pending_permission = await service.get_pending_permission(
+        chat_id=chat_id,
+        agent=runner_name,
+    )
+    if pending_permission is not None:
+        return "waiting_for_permission"
+    return "open"
+
+
+async def _format_acp_runner_states_response() -> ToolResponse:
+    runners = _get_available_acp_runners()
+    if not runners:
+        return response_text(
+            "No enabled ACP runners are currently configured.",
+        )
+
+    try:
+        chat_id = _request_context_chat_id()
+    except ValueError:
+        chat_id = ""
+    service = _get_acp_service() if chat_id else None
+
+    agent_id = _current_agent_id()
+    lines = ["Available external ACP runners and states:"]
+    for runner_name in runners:
+        session_state = ""
+        task_state = ""
+        if chat_id and service is not None:
+            session_state = await _get_runner_session_state(
+                service,
+                chat_id=chat_id,
+                runner_name=runner_name,
+            )
+            state = await _get_runner_state(
+                agent_id=agent_id,
+                chat_id=chat_id,
+                runner_name=runner_name,
+            )
+            if state is not None:
+                task_state = state.status
+        details = []
+        if session_state:
+            details.append(f"session: {session_state}")
+        if task_state:
+            details.append(f"task: {task_state}")
+        if details:
+            lines.append(f"- {runner_name} ({', '.join(details)})")
+        else:
+            lines.append(f"- {runner_name}")
+    return response_text("\n".join(lines))
+
+
+async def _format_runner_status_response(runner_name: str) -> ToolResponse:
+    available_runners = _get_available_acp_runners()
+    if runner_name not in available_runners:
+        return response_text(
+            f"Error: runner '{runner_name}' is not available. "
+            + _format_available_runners_text(),
+        )
+    try:
+        chat_id = _request_context_chat_id()
+    except ValueError as e:
+        return response_text(f"Error: {e}")
+
+    agent_id = _current_agent_id()
+    service = _get_acp_service()
+    session_state = await _get_runner_session_state(
+        service,
+        chat_id=chat_id,
+        runner_name=runner_name,
+    )
+    pending_permission = await service.get_pending_permission(
+        chat_id=chat_id,
+        agent=runner_name,
+    )
+    state = await _get_runner_state(
+        agent_id=agent_id,
+        chat_id=chat_id,
+        runner_name=runner_name,
+    )
+    status_text = _format_task_state_text(
+        runner_name=runner_name,
+        session_state=session_state,
+        state=state,
+        pending_permission=pending_permission,
+    )
+    if pending_permission is None:
+        return response_text(status_text)
+
+    permission_response = format_permission_suspended_response(
+        suspended_permission=pending_permission,
+    )
+    permission_text = _copy_content_text(permission_response.content)
+    return response_text(f"{status_text}\n\n{permission_text}")
+
+
+async def _format_all_runner_status_response() -> ToolResponse:
+    return await _format_acp_runner_states_response()
 
 
 async def _get_bound_session(
@@ -428,31 +681,256 @@ async def _stream_action_responses(
     )
 
 
+async def _create_runner_state(
+    *,
+    action_name: str,
+    runner_name: str,
+    chat_id: str,
+) -> _RunnerState:
+    state = _RunnerState(
+        agent_id=_current_agent_id(),
+        chat_id=chat_id,
+        runner=runner_name,
+        action=action_name,
+        status="running",
+        created_at=time.time(),
+        updated_at=time.time(),
+    )
+    await _set_runner_state(state)
+    return state
+
+
+async def _handle_immediate_action(
+    *,
+    action_name: str,
+    runner_name: str,
+) -> Optional[ToolResponse]:
+    if action_name == "list":
+        return await _format_acp_runner_states_response()
+    if action_name == "status":
+        if runner_name:
+            return await _format_runner_status_response(runner_name)
+        return await _format_all_runner_status_response()
+    if action_name == "close":
+        chat_id = _request_context_chat_id()
+        service = _get_acp_service()
+        existing = await service.get_session(
+            chat_id=chat_id,
+            agent=runner_name,
+        )
+        await service.close_chat_session(
+            chat_id=chat_id,
+            agent=runner_name,
+        )
+        return format_close_response(
+            runner_name=runner_name,
+            closed=existing is not None,
+        )
+    return None
+
+
+async def _finalize_runner_state(
+    *,
+    service: Any,
+    state: _RunnerState,
+    chat_id: str,
+    runner_name: str,
+) -> None:
+    pending_permission = await service.get_pending_permission(
+        chat_id=chat_id,
+        agent=runner_name,
+    )
+    if pending_permission is not None:
+        await _set_runner_state_status(
+            state,
+            "permission_required",
+            pending_permission=pending_permission,
+        )
+        return
+    await _set_runner_state_status(state, "completed")
+
+
+async def _set_failed_runner_state(
+    state: Optional[_RunnerState],
+    error: Exception,
+) -> None:
+    if state is not None:
+        await _set_runner_state_status(state, "failed", error=str(error))
+
+
+def _parse_timeout(
+    max_runtime: Optional[float],
+) -> tuple[Optional[float], Optional[str]]:
+    try:
+        timeout_seconds = None if max_runtime is None else float(max_runtime)
+    except (TypeError, ValueError):
+        return None, "Error: max_runtime must be a number in seconds."
+    if timeout_seconds is not None and timeout_seconds <= 0:
+        return None, "Error: max_runtime must be greater than 0."
+    return timeout_seconds, None
+
+
+async def _validate_runner_start(
+    *,
+    service: Any,
+    state: _RunnerState,
+    action_name: str,
+    chat_id: str,
+    runner_name: str,
+) -> Optional[ToolResponse]:
+    if action_name != "start":
+        return None
+    start_error = await _validate_start_request(
+        service=service,
+        chat_id=chat_id,
+        runner_name=runner_name,
+    )
+    if start_error is None:
+        return None
+    await _set_runner_state_status(
+        state,
+        "failed",
+        error=start_error,
+    )
+    return response_text(start_error, stream=True)
+
+
+async def _cancel_runner_turn(
+    *,
+    service: Any,
+    chat_id: str,
+    action_name: str,
+    runner_name: str,
+) -> None:
+    if (
+        service is not None
+        and chat_id
+        and action_name in {"start", "message", "respond"}
+    ):
+        await _cancel_running_acp_turn(
+            service=service,
+            chat_id=chat_id,
+            runner_name=runner_name,
+        )
+
+
+def _interrupted_response(runner_name: str) -> ToolResponse:
+    return response_text(
+        (
+            f"ACP conversation with runner '{runner_name}' was "
+            "interrupted by the user. The ACP session is still open; "
+            "continue with "
+            f'delegate_external_agent(action="message", '
+            f'runner="{runner_name}", message="continue").'
+        ),
+        stream=True,
+        is_last=True,
+    )
+
+
+async def _run_streaming_agent_action(
+    *,
+    action_name: str,
+    runner_name: str,
+    message_text: str,
+    execution_cwd: Path,
+    timeout_seconds: Optional[float],
+) -> AsyncGenerator[ToolResponse, None]:
+    service = None
+    chat_id = ""
+    state = None
+    try:
+        service = _get_acp_service()
+        chat_id = _request_context_chat_id()
+        state = await _create_runner_state(
+            action_name=action_name,
+            runner_name=runner_name,
+            chat_id=chat_id,
+        )
+        start_error_response = await _validate_runner_start(
+            service=service,
+            state=state,
+            action_name=action_name,
+            chat_id=chat_id,
+            runner_name=runner_name,
+        )
+        if start_error_response is not None:
+            yield start_error_response
+            return
+        async for item in _stream_action_responses(
+            service=service,
+            chat_id=chat_id,
+            action_name=action_name,
+            runner_name=runner_name,
+            message_text=message_text,
+            execution_cwd=execution_cwd,
+            max_runtime=timeout_seconds,
+        ):
+            await _append_runner_state_content(
+                state,
+                list(item.content or []),
+            )
+            yield item
+        await _finalize_runner_state(
+            service=service,
+            state=state,
+            chat_id=chat_id,
+            runner_name=runner_name,
+        )
+    except asyncio.CancelledError:
+        await _cancel_runner_turn(
+            service=service,
+            chat_id=chat_id,
+            action_name=action_name,
+            runner_name=runner_name,
+        )
+        if state is not None:
+            await _set_runner_state_status(state, "cancelled")
+        yield _interrupted_response(runner_name)
+        raise
+    except ImportError as e:
+        await _set_failed_runner_state(state, e)
+        yield response_text(f"ACP mode not available: {e}.", stream=True)
+    except ValueError as e:
+        await _set_failed_runner_state(state, e)
+        yield response_text(f"Error: {e}", stream=True)
+    except Exception as e:
+        await _set_failed_runner_state(state, e)
+        yield response_text(f"ACP execution error: {e}", stream=True)
+
+
 async def delegate_external_agent(
     action: str,
-    runner: str,
+    runner: str = "",
     message: str = "",
     cwd: str = "",
-    max_runtime: float = 60.0,  # Default timeout to prevent infinite hangs
+    max_runtime: Optional[float] = 300,
 ) -> ToolResponse | AsyncGenerator[ToolResponse, None]:
     # pylint: disable=too-many-return-statements
     """
     Open, talk to, respond to permissions for, or close an ACP agent session.
 
     1. Call delegate_external_agent(
+        action="list", runner=""
+        ) to list available external ACP runners and states.
+    2. Call delegate_external_agent(
+        action="status", runner=...
+        ) to inspect the current runner session, task state, last response, or
+        pending permission request.
+    3. Call delegate_external_agent(
         action="start", runner=..., message=...
         ) to open a new conversation.
-    2. Call delegate_external_agent(
+    4. Call delegate_external_agent(
         action="message", runner=..., message=...
         ) to keep talking.
-    3. When a permission request appears, first ask the user which option to
+    5. When a permission request appears, first ask the user which option to
        choose. Then call
        delegate_external_agent(
            action="respond", runner=..., message=...
         ) to respond to the pending permission request. You must strictly
         choose one option from the provided permission request, and the chosen
         option must come from the exact options shown in that request.
-    4. Call delegate_external_agent(
+    6. Call delegate_external_agent(
         action="close", runner=...
         ) to end the conversation.
 
@@ -460,13 +938,17 @@ async def delegate_external_agent(
 
     Args:
         action (`str`):
-            One of `start`, `message`, `respond`, or `close`. Use `respond`
-            only for a pending permission request. First ask the user which
-            option to choose, then pass the exact selected option id in
-            `message`.
+            One of `list`, `status`, `start`, `message`, `respond`, or
+            `close`. Use `list` to show enabled external ACP runners and
+            states. Use `status` to inspect one runner or all runners,
+            especially when `view_task` or `wait_task` can no longer find an
+            async delegate task. Use `respond` only for a pending permission
+            request. First ask the user which option to choose, then pass the
+            exact selected option id in `message`.
         runner (`str`):
             ACP runner name, for example `qwen_code`, `opencode`,
-            `claude_code` or `codex`.
+            `claude_code` or `codex`. Not required for `action="list"` or
+            `action="status"` without a specific runner.
         message (`str`):
             The message to send to the external agent. Used for `start` and
             `message`. For `respond`, pass the exact selected permission option
@@ -474,18 +956,13 @@ async def delegate_external_agent(
             is empty, a default `hi` is sent.
         cwd (`str`):
             Working directory for the agent. Defaults to the current workspace.
-        max_runtime (`float`, default=60.0):
-            **Maximum runtime in seconds for a single ACP turn.**
-            Prevents infinite hangs if the external agent fails
-            to respond. Default is 60.0 seconds. Increase for
-            complex tasks that require more time.
-            When the limit is reached, the tool sends an ACP
-            cancel signal but keeps the session open, allowing
-            continuation with ``delegate_external_agent(
-            action="message", runner=...,
-            message="continue")``.
-            **Note: Always set a reasonable timeout to avoid
-            indefinite waiting.**
+        max_runtime (`float | None`):
+            Optional max runtime in seconds for a single ACP turn. Defaults to
+            300 seconds. `None` means no timeout is applied. When the limit is
+            reached, the tool sends ACP cancel for the current turn but keeps
+            the ACP session open, so you can continue later with
+            `delegate_external_agent(action="message", runner=..., `
+            `message="continue")`.
 
     Returns:
         `AsyncGenerator[ToolResponse, None]`:
@@ -498,13 +975,9 @@ async def delegate_external_agent(
     action_name = str(action or "").strip().lower()
     runner_name = str(runner or "").strip()
     message_text = str(message or "")
-    try:
-        timeout_seconds = float(max_runtime)
-    except (TypeError, ValueError):
-        return response_text("Error: max_runtime must be a number in seconds.")
-
-    if timeout_seconds <= 0:
-        return response_text("Error: max_runtime must be greater than 0.")
+    timeout_seconds, timeout_error = _parse_timeout(max_runtime)
+    if timeout_error:
+        return response_text(timeout_error)
 
     validation_error = _validate_action_inputs(
         action_name=action_name,
@@ -514,22 +987,15 @@ async def delegate_external_agent(
     if validation_error:
         return response_text(validation_error)
 
-    if action_name == "close":
+    immediate_actions = {"list", "status", "close"}
+    if action_name in immediate_actions:
         try:
-            chat_id = _request_context_chat_id()
-            service = _get_acp_service()
-            existing = await service.get_session(
-                chat_id=chat_id,
-                agent=runner_name,
-            )
-            await service.close_chat_session(
-                chat_id=chat_id,
-                agent=runner_name,
-            )
-            return format_close_response(
+            immediate_response = await _handle_immediate_action(
+                action_name=action_name,
                 runner_name=runner_name,
-                closed=existing is not None,
             )
+            if immediate_response is not None:
+                return immediate_response
         except ImportError as e:
             return response_text(f"ACP mode not available: {e}.")
         except ValueError as e:
@@ -537,59 +1003,10 @@ async def delegate_external_agent(
         except Exception as e:
             return response_text(f"ACP execution error: {e}")
 
-    async def _runner() -> AsyncGenerator[ToolResponse, None]:
-        service = None
-        chat_id = ""
-        try:
-            service = _get_acp_service()
-            chat_id = _request_context_chat_id()
-            if action_name == "start":
-                start_error = await _validate_start_request(
-                    service=service,
-                    chat_id=chat_id,
-                    runner_name=runner_name,
-                )
-                if start_error:
-                    yield response_text(start_error, stream=True)
-                    return
-            async for item in _stream_action_responses(
-                service=service,
-                chat_id=chat_id,
-                action_name=action_name,
-                runner_name=runner_name,
-                message_text=message_text,
-                execution_cwd=execution_cwd,
-                max_runtime=timeout_seconds,
-            ):
-                yield item
-        except asyncio.CancelledError:
-            if (
-                service is not None
-                and chat_id
-                and action_name in {"start", "message", "respond"}
-            ):
-                await _cancel_running_acp_turn(
-                    service=service,
-                    chat_id=chat_id,
-                    runner_name=runner_name,
-                )
-            yield response_text(
-                (
-                    f"ACP conversation with runner '{runner_name}' was "
-                    "interrupted by the user. The ACP session is still open; "
-                    "continue with "
-                    f'delegate_external_agent(action="message", '
-                    f'runner="{runner_name}", message="continue").'
-                ),
-                stream=True,
-                is_last=True,
-            )
-            raise
-        except ImportError as e:
-            yield response_text(f"ACP mode not available: {e}.", stream=True)
-        except ValueError as e:
-            yield response_text(f"Error: {e}", stream=True)
-        except Exception as e:
-            yield response_text(f"ACP execution error: {e}", stream=True)
-
-    return _runner()
+    return _run_streaming_agent_action(
+        action_name=action_name,
+        runner_name=runner_name,
+        message_text=message_text,
+        execution_cwd=execution_cwd,
+        timeout_seconds=timeout_seconds,
+    )


### PR DESCRIPTION
## Description

This PR improves `delegate_external_agent` for long-running external ACP runner workflows.

Main changes:

- Add async execution support for `delegate_external_agent` in both the backend tool configuration path and Console tool settings UI.
- Add `delegate_external_agent(action="list")` to show available external ACP runners and their current session/task state.
- Add `delegate_external_agent(action="status")` to inspect runner state, including the current session state, latest task status, last response, and pending permission request details when applicable.

The agent now also appends a status hint after delegate tool calls so follow-up turns can recover runner state through `list` or `status` when normal async task helpers can no longer find the task.

**Related Issue:** N/A

**Security Considerations:** No new credential handling or channel authentication changes. The new status output is scoped to the current agent/session runner state.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Ran `pre-commit run --all-files`.
- Verified lint/type/format hooks pass after the async/list/status changes and pre-commit auto-fixes were committed.
- `pytest` was not run; this change is currently verified through pre-commit checks.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed
```

```bash
pytest
# Not run
```

## Additional Notes

Channel contract checks are not applicable because this PR does not change a channel adapter contract.
