### PR TITLE
feat(memory): add auto-memory management features

### DIFF
--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -682,19 +682,15 @@ class LightContextManager(BaseContextManager):
         if command_handler is not None and command_handler.is_command(query):
             return None
 
-        agent_config = load_agent_config(self.agent_id)
-        rlmc = agent_config.running.reme_light_memory_config
-        ms = rlmc.auto_memory_search_config
-
-        if not ms.enabled:
-            return None
-
         memory_manager = agent.memory_manager
         if memory_manager is None:
             return None
 
         try:
-            result = await memory_manager.retrieve(msg, agent_name=agent.name)
+            result = await memory_manager.auto_memory_search(
+                msg,
+                agent_name=agent.name,
+            )
         except BaseException as e:
             logger.warning(
                 "memory_manager.retrieve failed, skipping e=%s",
@@ -924,9 +920,8 @@ class LightContextManager(BaseContextManager):
             )
             logger.info(f"Marked {updated_count} messages as compacted")
 
-            rlmc = running_config.reme_light_memory_config
-            if messages_to_compact and rlmc.summarize_when_compact:
-                memory_manager.add_summarize_task(
+            if messages_to_compact:
+                await memory_manager.summarize_when_compact(
                     messages=messages_to_compact,
                 )
 
@@ -989,33 +984,13 @@ class LightContextManager(BaseContextManager):
             if memory_manager is None:
                 return None
 
-            agent_config = load_agent_config(self.agent_id)
-            rlmc = agent_config.running.reme_light_memory_config
-            auto_memory_interval = rlmc.auto_memory_interval
-
-            if auto_memory_interval is None or auto_memory_interval <= 0:
-                return None
-
             memory = agent.memory
-            # memory.content is list[tuple[Msg, marks]]
-            # Find indices of user messages to locate recent interval
-            user_msg_indices = [
-                i
-                for i, (msg, _) in enumerate(memory.content)
-                if msg.role == "user"
-            ]
+            all_messages = [msg for msg, _ in memory.content]
 
-            if (
-                len(user_msg_indices) >= auto_memory_interval
-                and len(user_msg_indices) % auto_memory_interval == 0
-            ):
-                # Get messages from the start of recent interval
-                start_index = user_msg_indices[-auto_memory_interval]
-                recent_messages = [
-                    msg for msg, _ in memory.content[start_index:]
-                ]
-                if recent_messages:
-                    memory_manager.add_summarize_task(messages=recent_messages)
+            if all_messages:
+                await memory_manager.auto_memory(
+                    all_messages=all_messages,
+                )
         except Exception as e:
             logger.warning("post_reply hook failed: %s", e)
 

--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -127,6 +127,58 @@ class BaseMemoryManager(ABC):
         """
         return None
 
+    async def auto_memory_search(
+        self,
+        messages: list[Msg] | Msg,
+        agent_name: str = "",
+        **kwargs,
+    ) -> dict | None:
+        """Auto-search memory before replying (pre_reply phase).
+
+        Implementations should check internal config to decide whether
+        auto search is enabled, and if so, retrieve relevant memory context.
+
+        Args:
+            messages: The incoming user message(s).
+            agent_name: Name of the owning agent.
+
+        Returns:
+            None if auto-search is disabled or no relevant memory found.
+            dict with updated kwargs if memory context should be merged.
+        """
+        return None
+
+    async def summarize_when_compact(
+        self,
+        messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Trigger memory summarization when context compaction occurs.
+
+        Called during pre_reasoning after compaction. Implementations should
+        check internal config and schedule a summarize task if appropriate.
+
+        Args:
+            messages: The messages that were compacted.
+        """
+        return None
+
+    async def auto_memory(
+        self,
+        all_messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Periodically auto-extract memory from conversation.
+
+        Called during post_reply. Implementations should check internal
+        config (e.g. auto_memory_interval) and trigger memory extraction
+        at the configured cadence.
+
+        Args:
+            all_messages: All conversation messages.
+        """
+        return None
+
     async def _summarize_worker(self) -> None:
         """Background worker that processes summarize tasks serially."""
         while True:

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -523,6 +523,74 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             logger.exception(f"memory_search failed: {e}")
             return None
 
+    async def auto_memory_search(
+        self,
+        messages: list[Msg] | Msg,
+        agent_name: str = "",
+        **kwargs,
+    ) -> dict | None:
+        """Auto-search memory if auto_memory_search_config.enabled is True."""
+        agent_config = load_agent_config(self.agent_id)
+        rlmc = agent_config.running.reme_light_memory_config
+        ms = rlmc.auto_memory_search_config
+
+        if not ms.enabled:
+            return None
+
+        return await self.retrieve(messages, agent_name=agent_name)
+
+    async def summarize_when_compact(
+        self,
+        messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Schedule summarize task if summarize_when_compact is enabled."""
+        if not messages:
+            return
+
+        agent_config = load_agent_config(self.agent_id)
+        rlmc = agent_config.running.reme_light_memory_config
+
+        if rlmc.summarize_when_compact:
+            self.add_summarize_task(messages=messages)
+
+    async def auto_memory(
+        self,
+        all_messages: list[Msg],
+        **kwargs,
+    ) -> None:
+        """Auto-extract memory every N user queries."""
+        agent_config = load_agent_config(self.agent_id)
+        rlmc = agent_config.running.reme_light_memory_config
+        auto_memory_interval = rlmc.auto_memory_interval
+
+        if auto_memory_interval is None or auto_memory_interval <= 0:
+            return
+
+        user_message_count = sum(
+            1 for msg in all_messages if msg.role == "user"
+        )
+
+        if (
+            user_message_count >= auto_memory_interval
+            and user_message_count % auto_memory_interval == 0
+        ):
+            # Find the start of the recent interval window
+            user_count = 0
+            start_idx = 0
+            for i, msg in enumerate(all_messages):
+                if msg.role == "user":
+                    user_count += 1
+                    if (
+                        user_count
+                        == user_message_count - auto_memory_interval + 1
+                    ):
+                        start_idx = i
+                        break
+            recent_messages = all_messages[start_idx:]
+            if recent_messages:
+                self.add_summarize_task(messages=recent_messages)
+
     async def dream(self, **kwargs) -> None:
         """Run one dream-based memory optimization pass."""
         logger.info("running dream-based memory optimization")


### PR DESCRIPTION
- Implement auto_memory_search method for automatic memory retrieval
- Add summarize_when_compact method for triggering summaries during compaction
- Create auto_memory method for periodic memory extraction from conversations
- Update light context manager to use new auto-memory methods
- Replace manual config checks with dedicated auto-memory manager methods
- Integrate auto-memory functionality into pre_reply and post_reply hooks

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
