### PR TITLE
feat(DingTalk): process quoted messages for user-sent replies

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/handler.py
+++ b/src/qwenpaw/app/channels/dingtalk/handler.py
@@ -210,6 +210,177 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
             logger.exception("failed to fetch richText download url(s)")
         return content
 
+    def _handle_quoted_media(
+        self,
+        replied_content: Any,
+        replied_msg_type: str,
+        robot_code: str,
+        text_parts: List[str],
+        content_parts: List[Any],
+    ) -> None:
+        """Handle quoted media message (picture/voice/audio/video/file)."""
+        quoted_type_mapping = {
+            "picture": "image",
+            "voice": "audio",
+            "audio": "audio",
+            "video": "video",
+            "file": "file",
+        }
+        mapped = quoted_type_mapping.get(replied_msg_type, "file")
+        dl_code = ""
+        if isinstance(replied_content, dict):
+            dl_code = (
+                replied_content.get("downloadCode")
+                or replied_content.get("download_code")
+                or ""
+            ).strip()
+        if not dl_code or not robot_code:
+            text_parts.insert(0, f"[quoted {mapped} message]")
+            return
+        # Prefer recognition text for voice messages.
+        if mapped == "audio" and isinstance(replied_content, dict):
+            recognition = (replied_content.get("recognition") or "").strip()
+            if recognition:
+                text_parts.insert(
+                    0,
+                    f"[quoted voice message: {recognition}]",
+                )
+                return
+        filename_hint = (
+            self._extract_filename_hint(replied_content)
+            if isinstance(replied_content, dict)
+            else None
+        )
+        part = self._fetch_download_url_and_content(
+            dl_code,
+            robot_code,
+            mapped,
+            filename_hint=filename_hint,
+        )
+        if part is not None:
+            content_parts.append(part)
+        else:
+            text_parts.insert(0, f"[quoted {mapped}: download failed]")
+
+    def _handle_quoted_rich_text(
+        self,
+        replied_content: Any,
+        robot_code: str,
+        text_parts: List[str],
+        content_parts: List[Any],
+    ) -> None:
+        """Handle quoted richText message (text + picture items)."""
+        rich_list = []
+        if isinstance(replied_content, dict):
+            rich_list = replied_content.get("richText") or []
+        has_content = False
+        for item in rich_list:
+            if not isinstance(item, dict):
+                continue
+            item_type = (item.get("msgType") or "").strip()
+            if item_type == "text":
+                item_text = (item.get("content") or "").strip()
+                if item_text:
+                    text_parts.insert(0, f"[quoted message: {item_text}]")
+                    has_content = True
+            elif item_type == "picture":
+                dl_code = (
+                    item.get("downloadCode")
+                    or item.get("download_code")
+                    or item.get("pictureDownloadCode")
+                    or item.get("picture_download_code")
+                    or ""
+                ).strip()
+                if dl_code and robot_code:
+                    part = self._fetch_download_url_and_content(
+                        dl_code,
+                        robot_code,
+                        "image",
+                    )
+                    if part is not None:
+                        content_parts.append(part)
+                        has_content = True
+                    else:
+                        text_parts.insert(
+                            0,
+                            "[quoted image: download failed]",
+                        )
+                        has_content = True
+        if not has_content:
+            text_parts.insert(0, "[quoted richText message]")
+
+    def _process_quoted_message(
+        self,
+        raw_data: Dict[str, Any],
+        text_parts: List[str],
+        content_parts: List[Any],
+    ) -> None:
+        """Process quoted (replied-to) message from DingTalk callback.
+
+        Only user messages carry retrievable content; bot messages
+        (interactiveCard) have no content in the callback payload.
+        """
+        text_data = raw_data.get("text")
+        if not isinstance(text_data, dict):
+            return
+        if not text_data.get("isReplyMsg"):
+            return
+
+        replied_msg = text_data.get("repliedMsg")
+        if not isinstance(replied_msg, dict):
+            return
+
+        replied_msg_type = (replied_msg.get("msgType") or "").strip()
+        replied_content = replied_msg.get("content")
+
+        # Bot message (e.g. interactiveCard): no content in payload.
+        if not replied_content:
+            text_parts.insert(
+                0,
+                "[quoted bot message: content unavailable]",
+            )
+            return
+
+        robot_code = (raw_data.get("robotCode") or "").strip()
+
+        if replied_msg_type == "text":
+            quoted_text = ""
+            if isinstance(replied_content, dict):
+                quoted_text = (replied_content.get("text") or "").strip()
+            elif isinstance(replied_content, str):
+                quoted_text = replied_content.strip()
+            if quoted_text:
+                text_parts.insert(0, f"[quoted message: {quoted_text}]")
+
+        elif replied_msg_type in (
+            "picture",
+            "voice",
+            "audio",
+            "video",
+            "file",
+        ):
+            self._handle_quoted_media(
+                replied_content,
+                replied_msg_type,
+                robot_code,
+                text_parts,
+                content_parts,
+            )
+
+        elif replied_msg_type == "richText":
+            self._handle_quoted_rich_text(
+                replied_content,
+                robot_code,
+                text_parts,
+                content_parts,
+            )
+
+        else:
+            text_parts.insert(
+                0,
+                f"[quoted {replied_msg_type or 'unknown'} message]",
+            )
+
     async def process(self, callback: CallbackMessage) -> tuple[int, str]:
         # pylint: disable=too-many-branches,too-many-statements
         try:
@@ -262,6 +433,28 @@ class DingTalkChannelHandler(dingtalk_stream.ChatbotHandler):
                     0,
                     TextContent(type=ContentType.TEXT, text=text),
                 )
+            # Handle quoted (replied-to) message if present.
+            quoted_text_parts: List[str] = []
+            quoted_content_parts: List[Any] = []
+            self._process_quoted_message(
+                raw_data,
+                quoted_text_parts,
+                quoted_content_parts,
+            )
+            # Merge quoted parts into the main content list.
+            target_parts = content if content else content_parts
+            if quoted_text_parts:
+                quoted_combined = "\n".join(quoted_text_parts)
+                target_parts.insert(
+                    0,
+                    TextContent(type=ContentType.TEXT, text=quoted_combined),
+                )
+            if quoted_content_parts:
+                # Insert quoted media after quoted text but before user text.
+                insert_pos = 1 if quoted_text_parts else 0
+                for part in reversed(quoted_content_parts):
+                    target_parts.insert(insert_pos, part)
+
             # Use rich content (text + media with local paths) when present.
             parts_to_send = content if content else content_parts
 


### PR DESCRIPTION
## Description

Add quoted (replied-to) message handling for the DingTalk channel, aligned with Feishu and WeCom implementations.

Only user messages carry retrievable content in DingTalk's callback payload. Bot messages (e.g. interactiveCard) have no content available via API — in this case we insert a hint [quoted bot message: content unavailable] to inform the agent that the user referenced a bot response.

### Changes:

- Add _process_quoted_message, _handle_quoted_media, _handle_quoted_rich_text methods to parse repliedMsg from callback data
- Support quoted types: text, picture, audio/voice, video, file, richText (text + picture)
- Prefer DingTalk's built-in recognition text for voice quotes over downloading audio
- Integrate into process method before content assembly

**Related Issue:** Fixes #3747 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
