### PR TITLE
fix(exception): fix ConfigurationException key passing

### DIFF
--- a/src/qwenpaw/agents/skills_hub.py
+++ b/src/qwenpaw/agents/skills_hub.py
@@ -252,6 +252,7 @@ def _read_response_bytes(
     _ensure_not_cancelled()
     if max_bytes is not None and max_bytes <= 0:
         raise ConfigurationException(
+            config_key="skills_hub.max_bytes",
             message="max_bytes must be greater than 0",
         )
 
@@ -1162,7 +1163,10 @@ def _fetch_bundle_from_skills_sh_url(
 ) -> tuple[Any, str]:
     spec = _extract_skills_sh_spec(bundle_url)
     if spec is None:
-        raise ConfigurationException(message="Invalid skills.sh URL format")
+        raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
+            message="Invalid skills.sh URL format",
+        )
     owner, repo, skill = spec
     default_branch = _github_get_default_branch(owner, repo) or "main"
     bundle, source_url = _fetch_bundle_from_repo_and_skill_hint(
@@ -1289,6 +1293,7 @@ def _fetch_bundle_from_github_url(
     spec = _extract_github_spec(bundle_url)
     if spec is None:
         raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
             message="Invalid GitHub URL format. Use a repo or path URL, e.g. "
             "https://github.com/owner/repo or "
             "https://github.com/owner/repo/tree/branch/path/to/skill",
@@ -1321,7 +1326,10 @@ def _fetch_bundle_from_skillsmp_url(
 ) -> tuple[Any, str]:
     spec = _extract_skillsmp_spec(bundle_url)
     if spec is None:
-        raise ConfigurationException(message="Invalid skillsmp URL format")
+        raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
+            message="Invalid skillsmp URL format",
+        )
     owner, repo, skill_hint = spec
     return _fetch_bundle_from_repo_and_skill_hint(
         owner=owner,
@@ -1397,6 +1405,7 @@ def _fetch_bundle_from_modelscope_url(
     spec = _extract_modelscope_skill_spec(bundle_url)
     if spec is None:
         raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
             message="Invalid ModelScope URL format. Use URL like "
             "https://modelscope.cn/skills/@owner/skill-name",
         )
@@ -1480,6 +1489,7 @@ def _fetch_bundle_from_lobehub_url(
     identifier = _extract_lobehub_identifier(bundle_url)
     if not identifier:
         raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
             message="Invalid LobeHub skill URL format",
         )
     params = (
@@ -1510,6 +1520,7 @@ def _fetch_bundle_from_clawhub_slug(
 ) -> tuple[Any, str]:
     if not slug:
         raise ConfigurationException(
+            config_key="skills_hub.slug",
             message="slug is required for clawhub install",
         )
     base = _hub_base_url()
@@ -1605,6 +1616,7 @@ def install_skill_from_hub(
 ) -> HubInstallResult:
     if not bundle_url or not _is_http_url(bundle_url):
         raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
             message="bundle_url must be a valid http(s) URL",
         )
     with _with_cancel_checker(cancel_checker):
@@ -1664,6 +1676,7 @@ def import_pool_skill_from_hub(
 ) -> HubInstallResult:
     if not bundle_url or not _is_http_url(bundle_url):
         raise ConfigurationException(
+            config_key="skills_hub.bundle_url",
             message="bundle_url must be a valid http(s) URL",
         )
 

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -357,6 +357,7 @@ class CronManager:
         parts = [p for p in spec.schedule.cron.split() if p]
         if len(parts) != 5:
             raise ConfigurationException(
+                config_key="cron.schedule.cron",
                 message=(
                     f"cron must have 5 fields, "
                     f"got {len(parts)}: {spec.schedule.cron}"

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -81,6 +81,7 @@ class ScheduleSpec(BaseModel):
 
         # 6 fields (seconds) or too short: reject
         raise ConfigurationException(
+            config_key="cron.schedule.cron",
             message=(
                 "cron must have 5 fields (or 4/3 fields that can be "
                 "normalized); seconds not supported"
@@ -149,12 +150,14 @@ class CronJobSpec(BaseModel):
         if self.task_type == "text":
             if not (self.text and self.text.strip()):
                 raise ConfigurationException(
+                    config_key="cron.text",
                     message="task_type is text but text is empty",
                 )
             self.request = None
         elif self.task_type == "agent":
             if self.request is None:
                 raise ConfigurationException(
+                    config_key="cron.request",
                     message="task_type is agent but request is missing",
                 )
             # Keep request.user_id and request.session_id in sync with target

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -380,6 +380,7 @@ class SafeJSONSession(SessionBase):
         path = key.split(".") if isinstance(key, str) else list(key)
         if not path:
             raise ConfigurationException(
+                config_key="session.key",
                 message="key path is empty",
             )
 


### PR DESCRIPTION
## Description

Pass `config_key` to `ConfigurationException` to ensure correct argument passing to `agentscope-runtime`.

In [agentscope-runtime](https://github.com/agentscope-ai/agentscope-runtime/blob/main/src/agentscope_runtime/engine/schemas/exception.py), the `config_key` parameter is required.  

```
# Configuration-related exceptions
class ConfigurationException(InternalServerErrorException):
    """Configuration error"""

    def __init__(
        self,
        config_key: str,
        message: str = None,
        details: Optional[Dict[str, Any]] = None,
    ):
        if message is None:
            message = f"Configuration error: {config_key}"
        super().__init__("CONFIGURATION_ERROR", message, details)
```

As a result, when I run `qwenpaw skill install abc.com` (a non-existent URL), it currently throws:

```
Error: ConfigurationException.__init__() missing 1 required positional argument: 'config_key'
```

Instead of the expected:

```
Error: [500] CONFIGURATION_ERROR: bundle_url must be a valid http(s) URL
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Local Verification Evidence

Before

## Additional Notes

[Optional: any other context]
