### PR TITLE
fix(console): collapse sidebar on mobile

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -50,6 +50,15 @@ import { KEY_TO_PATH, DEFAULT_OPEN_KEYS } from "./constants";
 // ── Layout ────────────────────────────────────────────────────────────────
 
 const { Sider } = Layout;
+const MOBILE_SIDEBAR_QUERY = "(max-width: 768px)";
+
+function isMobileSidebarViewport() {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(MOBILE_SIDEBAR_QUERY).matches
+  );
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -70,6 +79,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const [accountLoading, setAccountLoading] = useState(false);
   const [accountForm] = Form.useForm();
   const [collapsed, setCollapsed] = useState(false);
+  const [isMobile, setIsMobile] = useState(isMobileSidebarViewport);
 
   // ── Effects ──────────────────────────────────────────────────────────────
 
@@ -78,6 +88,30 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       .getStatus()
       .then((res) => setAuthEnabled(res.enabled))
       .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(MOBILE_SIDEBAR_QUERY);
+    const syncMobileSidebar = () => {
+      setIsMobile(mediaQuery.matches);
+      if (mediaQuery.matches) {
+        setCollapsed(true);
+      }
+    };
+
+    syncMobileSidebar();
+    mediaQuery.addEventListener("change", syncMobileSidebar);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncMobileSidebar);
+    };
   }, []);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
@@ -421,9 +455,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
 
   // ── Render ────────────────────────────────────────────────────────────────
 
+  const siderWidth = collapsed ? (isMobile ? 56 : 72) : 240;
+
   return (
     <Sider
-      width={collapsed ? 72 : 240}
+      width={siderWidth}
       className={`${styles.sider}${
         collapsed ? ` ${styles.siderCollapsed}` : ""
       }${isDark ? ` ${styles.siderDark}` : ""}`}

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -389,6 +389,42 @@
   color: rgba(0, 0, 0, 0.88) !important;
 }
 
+@media (max-width: 768px) {
+  .sider {
+    height: calc(100vh - 56px);
+    padding: 0 8px;
+    flex: 0 0 auto !important;
+    max-width: 240px !important;
+
+    &.siderCollapsed {
+      padding: 0 6px;
+
+      .collapseToggleContainer {
+        width: calc(100% + 12px);
+        margin: 0 -6px;
+      }
+    }
+  }
+
+  .collapsedNav {
+    gap: 2px;
+    padding: 2px 0;
+  }
+
+  .collapsedNavItem {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+  }
+
+  .collapseToggleContainer {
+    width: calc(100% + 16px);
+    margin: 0 -8px;
+    padding: 8px 0;
+    justify-content: center;
+  }
+}
+
 // ─── Update Modal ─────────────────────────────────────────────────────────────
 .updateModal {
   :global(.qwenpaw-modal-content) {


### PR DESCRIPTION
## Summary
- automatically collapse the console sidebar on narrow viewports
- use a narrower collapsed sidebar width on mobile
- tighten collapsed icon rail spacing for small screens

Fixes #4221

## Tests
- cd console && npx prettier --check src/layouts/Sidebar.tsx src/layouts/index.module.less
- cd console && npx tsc -b --noEmit

Note: full 
pm run build timed out locally before producing useful output; targeted typecheck and formatting checks passed.