### PR TITLE
feat(console): streamline add model flow

### DIFF
--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -24,6 +24,8 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
   const { message } = useAppMessage();
   const [modalOpen, setModalOpen] = useState(false);
   const [modelManageOpen, setModelManageOpen] = useState(false);
+  const [modelManageStartsAdding, setModelManageStartsAdding] = useState(false);
+  const [openModelsAfterConfig, setOpenModelsAfterConfig] = useState(false);
 
   const handleDeleteProvider = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -65,6 +67,45 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
 
   const hasModels = totalCount > 0;
   const isAvailable = isConfigured && hasModels;
+  const modelActionLabel = hasModels
+    ? t("models.models")
+    : t("models.addModel");
+
+  const openModelManager = (startAdding: boolean) => {
+    setModelManageStartsAdding(startAdding);
+    setModelManageOpen(true);
+  };
+
+  const handleModelAction = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (!isConfigured) {
+      setOpenModelsAfterConfig(true);
+      setModalOpen(true);
+      return;
+    }
+
+    openModelManager(!hasModels);
+  };
+
+  const handleProviderConfigSaved = async () => {
+    await onSaved();
+
+    if (openModelsAfterConfig) {
+      setOpenModelsAfterConfig(false);
+      openModelManager(!hasModels);
+    }
+  };
+
+  const handleProviderConfigClose = () => {
+    setOpenModelsAfterConfig(false);
+    setModalOpen(false);
+  };
+
+  const handleModelManageClose = () => {
+    setModelManageOpen(false);
+    setModelManageStartsAdding(false);
+  };
 
   const providerTag = provider.is_custom ? (
     <span className={styles.customTag}>{t("models.custom")}</span>
@@ -158,15 +199,12 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
 
       <div className={styles.cardActions}>
         <Button
-          type="default"
+          type={hasModels ? "default" : "primary"}
           size="small"
-          onClick={(e) => {
-            e.stopPropagation();
-            setModelManageOpen(true);
-          }}
+          onClick={handleModelAction}
           className={styles.actionBtn}
         >
-          {t("models.models")}
+          {modelActionLabel}
         </Button>
         <Button
           type="default"
@@ -196,14 +234,15 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
         provider={provider}
         activeModels={activeModels}
         open={modalOpen}
-        onClose={() => setModalOpen(false)}
-        onSaved={onSaved}
+        onClose={handleProviderConfigClose}
+        onSaved={handleProviderConfigSaved}
       />
       <ModelManageModal
         provider={provider}
         open={modelManageOpen}
-        onClose={() => setModelManageOpen(false)}
+        onClose={handleModelManageClose}
         onSaved={onSaved}
+        initialAdding={modelManageStartsAdding}
       />
     </Card>
   );

--- a/console/src/pages/Settings/Models/components/modals/ModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ModelManageModal.tsx
@@ -7,6 +7,7 @@ interface ModelManageModalProps {
   open: boolean;
   onClose: () => void;
   onSaved: () => void;
+  initialAdding?: boolean;
 }
 
 export function ModelManageModal({
@@ -14,6 +15,7 @@ export function ModelManageModal({
   open,
   onClose,
   onSaved,
+  initialAdding = false,
 }: ModelManageModalProps) {
   // Route to the appropriate specialized modal based on provider type
   if (provider.id === "qwenpaw-local") {
@@ -33,6 +35,7 @@ export function ModelManageModal({
       open={open}
       onClose={onClose}
       onSaved={onSaved}
+      initialAdding={initialAdding}
     />
   );
 }

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -208,6 +208,7 @@ interface RemoteModelManageModalProps {
   open: boolean;
   onClose: () => void;
   onSaved: () => void | Promise<void>;
+  initialAdding?: boolean;
 }
 
 function CapabilityTags({
@@ -264,6 +265,7 @@ export function RemoteModelManageModal({
   open,
   onClose,
   onSaved,
+  initialAdding = false,
 }: RemoteModelManageModalProps) {
   const { t } = useTranslation();
   const { isDark } = useTheme();
@@ -573,6 +575,12 @@ export function RemoteModelManageModal({
       setDiscoveringModels(false);
     }
   };
+
+  useEffect(() => {
+    if (open && initialAdding && !isOpenRouter) {
+      setAdding(true);
+    }
+  }, [initialAdding, isOpenRouter, open]);
 
   useEffect(() => {
     if (!adding) {


### PR DESCRIPTION
## Summary
- make the provider card show `Add Model` as the primary action when a provider has no models
- open the add-model form immediately from that action instead of requiring another click inside the modal
- when a provider is not configured yet, continue from the provider config save directly into model management

Fixes #4036

## Testing
- `cd console && npx tsc -b --noEmit`
- `cd console && npx prettier --check src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx src/pages/Settings/Models/components/modals/ModelManageModal.tsx src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx`
- `git diff --check`