### PR TITLE
fix(WeCom): show operator in resolved approval card

### DIFF
--- a/src/qwenpaw/app/channels/wecom/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/wecom/cards/tool_guard.py
@@ -154,13 +154,13 @@ def build_resolved_card(
     ``type`` in {1, 2} (0 is rejected by the bot endpoint).  We provide
     a project URL so it stays meaningful when clicked.
     """
-    by_text = f" by {operator_display}" if operator_display else ""
+    by_text = f"by {operator_display}" if operator_display else ""
     if action == APPROVE_KEY:
         title = "✅ Approved"
-        desc = f"Tool {tool_name} approved{by_text}."
+        desc = f"{by_text}\n{tool_name}"
     elif action == DENY_KEY:
         title = "🚫 Denied"
-        desc = f"Tool {tool_name} denied{by_text}."
+        desc = f"{by_text}\n{tool_name}"
     else:
         title = "⌛ Expired"
         desc = f"Approval for {tool_name} has expired."
@@ -169,8 +169,8 @@ def build_resolved_card(
         "card_type": "text_notice",
         "task_id": task_id,
         "main_title": {
-            "title": title,
-            "desc": _truncate(desc, 30),
+            "title": _truncate(title, 36),
+            "desc": _truncate(desc, 44),
         },
         "card_action": {"type": 1, "url": _RESOLVED_CARD_URL},
     }


### PR DESCRIPTION
## Description

Display the operator's userid in the resolved approval card. Previously the operator info was truncated due to a 30-char limit on desc. Now desc shows by {userid} followed by the tool name, and truncation limits are aligned with WeCom guidelines (title ≤36, desc ≤44).
<img width="282" height="98" alt="image" src="https://github.com/user-attachments/assets/e9bafe96-189f-4a0a-9c7c-41ba82f1cf92" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
