### PR TITLE
fix(model): filter out malformed tool_use blocks from OpenAI-compatible model response

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -289,7 +289,7 @@ class OpenAIChatModelCompat(OpenAIChatModel):
             _sanitize_tool_schemas(schemas),
         )
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches, too-many-statements
     async def _parse_openai_stream_response(
         self,
         start_datetime: datetime,
@@ -309,6 +309,18 @@ class OpenAIChatModelCompat(OpenAIChatModel):
             response=sanitized_response,
             structured_model=structured_model,
         ):
+            # Filter out malformed tool_use blocks (null id or empty name)
+            # emitted by some OpenAI-compatible models, to prevent bad entries
+            # from being persisted into session history (issue #4185).
+            parsed.content = [
+                b
+                for b in parsed.content
+                if not (
+                    b.get("type") == "tool_use"
+                    and (not isinstance(b.get("id"), str) or not b.get("name"))
+                )
+            ]
+
             # Attach extra_content (Gemini thought_signature) to tool_use
             # blocks.
             if sanitized_response.extra_contents:


### PR DESCRIPTION
## Problem

Some OpenAI-compatible models occasionally return `tool_use` blocks with `id: null` and/or an empty `name`. These malformed entries were passed through unchanged and persisted into session history, causing affected chats to become unopenable from the UI even though both the chat index and session file existed.

Example of a problematic persisted entry:
`{"type": "tool_use", "id": null, "name": "", "input": {}, "raw_input": "{}"}`

## Fix

In `_parse_openai_stream_response`, unconditionally filter out any `tool_use` block where:
- `id` is not a valid string (e.g. `null`), **or**
- `name` is empty

The filter runs before the `extra_contents` (Gemini thought_signature) attachment step so that malformed blocks are eliminated regardless of which model path is taken.

## Impact

- No valid tool calls are affected (they always carry a non-null string `id` and a non-empty `name`).
- Prevents malformed entries from reaching session persistence, resolving the broken-chat symptom described in the linked issue.