### PR TITLE
feat(console): Chat floating in the menu

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -277,11 +277,6 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
 
   const agentMenuItems: MenuProps["items"] = [
     {
-      key: "chat",
-      label: collapsed ? null : t("nav.chat"),
-      icon: <SparkChatTabFill size={16} />,
-    },
-    {
       key: "control-group",
       label: collapsed ? null : t("nav.control"),
       children: [
@@ -460,6 +455,18 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
           <div className={styles.agentScopedSection}>
             <div className={styles.agentSelectorContainer}>
               <AgentSelector collapsed={collapsed} />
+              {/* Chat entry — sticky together with agent selector */}
+              <button
+                className={`${styles.stickyChatButton}${
+                  selectedKey === "chat"
+                    ? ` ${styles.stickyChatButtonActive}`
+                    : ""
+                }`}
+                onClick={() => navigate("/chat")}
+              >
+                <SparkChatTabFill size={16} />
+                <span>{t("nav.chat")}</span>
+              </button>
             </div>
             <Menu
               mode="inline"

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -69,12 +69,40 @@
       }
     }
   }
-  // AgentSelector container - fixed at top
+  // AgentSelector + Chat container - sticky at top
   .agentSelectorContainer {
     position: sticky;
     top: 0;
     z-index: 10;
     margin-bottom: 4px;
+    // Opaque background so scrolled content is hidden behind
+    background: #f9f7f3;
+    border-radius: 12px 12px 0 0;
+  }
+
+  // Sticky Chat button — matches menu item appearance
+  .stickyChatButton {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    height: 40px;
+    padding: 0 8px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: rgba(0, 0, 0, 0.88);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.2s;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  .stickyChatButtonActive {
+    background: rgba(43, 18, 0, 0.08);
   }
 
   // Menu takes remaining space
@@ -212,6 +240,26 @@
   .agentScopedSection {
     background: rgba(255, 255, 255, 0.04);
     border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  // Sticky container background (dark mode)
+  .agentSelectorContainer {
+    background: #1e1e1e;
+  }
+
+  // Chat button (dark mode)
+  .stickyChatButton {
+    color: rgba(255, 255, 255, 0.75);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.95);
+    }
+  }
+
+  .stickyChatButtonActive {
+    background: rgba(255, 127, 22, 0.5);
+    color: #ff7f16;
   }
 
   :global {


### PR DESCRIPTION
## Description

<img width="1880" height="1214" alt="聊天模块固定" src="https://github.com/user-attachments/assets/4dca9638-90cd-41e8-91ca-0a62499aa9da" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
