### PR TITLE
fix(feishu): detect silent WebSocket connection loss in Feishu channel

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -2058,11 +2058,10 @@ class FeishuChannel(BaseChannel):
 
                 # Patch SDK to track last-received timestamp for
                 # silent connection loss detection.
-                channel_self = self
                 original_handle = self._ws_client._handle_message
 
                 async def _patched_handle_message(msg: bytes) -> None:
-                    channel_self._last_ws_recv_time = time.time()
+                    self._last_ws_recv_time = time.time()
                     return await original_handle(msg)
 
                 self._ws_client._handle_message = _patched_handle_message
@@ -2089,7 +2088,7 @@ class FeishuChannel(BaseChannel):
                                 self._ws_loop.stop()
                             break
                         # No pong/data for too long → connection dead.
-                        last_recv = channel_self._last_ws_recv_time
+                        last_recv = self._last_ws_recv_time
                         if last_recv > 0:
                             silent_seconds = time.time() - last_recv
                             if silent_seconds > FEISHU_WS_RECV_TIMEOUT:

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -54,6 +54,7 @@ from .constants import (
     FEISHU_WS_BACKOFF_FACTOR,
     FEISHU_WS_INITIAL_RETRY_DELAY,
     FEISHU_WS_MAX_RETRY_DELAY,
+    FEISHU_WS_RECV_TIMEOUT,
 )
 from .utils import (
     build_interactive_content_chunks,
@@ -244,6 +245,9 @@ class FeishuChannel(BaseChannel):
         self._http_client: Any = None
         # Clock offset (ms) = server_time - local_time
         self._clock_offset: int = 0
+        # Last time data was received on the WS; used to detect silent
+        # connection loss (TCP half-dead / NAT timeout).
+        self._last_ws_recv_time: float = 0.0
 
         self._bot_open_id: Optional[str] = None
 
@@ -2052,6 +2056,17 @@ class FeishuChannel(BaseChannel):
                     ),
                 )
 
+                # Patch SDK to track last-received timestamp for
+                # silent connection loss detection.
+                channel_self = self
+                original_handle = self._ws_client._handle_message
+
+                async def _patched_handle_message(msg: bytes) -> None:
+                    channel_self._last_ws_recv_time = time.time()
+                    return await original_handle(msg)
+
+                self._ws_client._handle_message = _patched_handle_message
+
                 async def _select() -> None:
                     while True:
                         await asyncio.sleep(3600)
@@ -2073,6 +2088,22 @@ class FeishuChannel(BaseChannel):
                             if self._ws_loop and not self._ws_loop.is_closed():
                                 self._ws_loop.stop()
                             break
+                        # No pong/data for too long → connection dead.
+                        last_recv = channel_self._last_ws_recv_time
+                        if last_recv > 0:
+                            silent_seconds = time.time() - last_recv
+                            if silent_seconds > FEISHU_WS_RECV_TIMEOUT:
+                                logger.warning(
+                                    "feishu WebSocket no data received "
+                                    "for %.0fs, forcing reconnect...",
+                                    silent_seconds,
+                                )
+                                if (
+                                    self._ws_loop
+                                    and not self._ws_loop.is_closed()
+                                ):
+                                    self._ws_loop.stop()
+                                break
 
                 async def _drive_connection() -> None:
                     nonlocal connection_started

--- a/src/qwenpaw/app/channels/feishu/constants.py
+++ b/src/qwenpaw/app/channels/feishu/constants.py
@@ -26,3 +26,7 @@ FEISHU_STALE_MSG_THRESHOLD_MS = 20 * 1000
 FEISHU_WS_INITIAL_RETRY_DELAY = 1.0  # seconds
 FEISHU_WS_MAX_RETRY_DELAY = 60.0  # seconds
 FEISHU_WS_BACKOFF_FACTOR = 2
+
+# If no data (including pong) received for this many seconds, force reconnect.
+# SDK pings every ~120s, so 240s ≈ 2 missed cycles.
+FEISHU_WS_RECV_TIMEOUT = 240


### PR DESCRIPTION
## Description

Detect TCP half-dead / NAT timeout scenarios where the Feishu SDK WebSocket connection silently stops receiving data but _conn remains non-None and _conn.open stays True.

Changes:

- Monkey-patch the SDK's _handle_message to track _last_ws_recv_time — updated on every frame received from the server (including pong responses to heartbeat pings).
- Enhance _monitor_connection_health to check the elapsed time since last received data. If no data has been received for FEISHU_WS_RECV_TIMEOUT (360s ≈ 3 missed ping/pong cycles at the SDK's default 120s interval), force a reconnect.
- Add FEISHU_WS_RECV_TIMEOUT constant in constants.py.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
