### PR TITLE
Protect backup routes when auth is disabled

### DIFF
--- a/src/qwenpaw/app/routers/backup.py
+++ b/src/qwenpaw/app/routers/backup.py
@@ -9,7 +9,15 @@ import tempfile
 import time
 from pathlib import Path
 
-from fastapi import APIRouter, Form, HTTPException, Request, UploadFile, File
+from fastapi import (
+    APIRouter,
+    Depends,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+    File,
+)
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from ...backup import (
@@ -30,11 +38,40 @@ from ...backup.models import (
     DeleteBackupsResponse,
     RestoreBackupRequest,
 )
+from ...config import load_config
 from ...constant import BACKUP_DIR
+from ..auth import has_registered_users, is_auth_enabled
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/backups", tags=["backups"])
+
+def _require_backup_operator(request: Request) -> None:
+    """Allow backup APIs only for authenticated or trusted-local callers."""
+    if is_auth_enabled() and has_registered_users():
+        # AuthMiddleware already protects non-public /api/* routes. If a
+        # request reaches this router in auth-enabled mode, it was either
+        # authenticated or matched the explicit no-auth host allowlist.
+        return
+
+    client_host = request.client.host if request.client else ""
+    allowed_hosts = load_config().security.allow_no_auth_hosts
+    if client_host in allowed_hosts:
+        return
+
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            "Backup operations require authentication or "
+            "a trusted local host"
+        ),
+    )
+
+
+router = APIRouter(
+    prefix="/backups",
+    tags=["backups"],
+    dependencies=[Depends(_require_backup_operator)],
+)
 
 _UPLOAD_TMP_MAX_AGE = 3600  # 1 hour
 

--- a/tests/unit/routers/test_backup_operator_gate.py
+++ b/tests/unit/routers/test_backup_operator_gate.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for backup route operator access checks."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.routers import backup as backup_router
+from qwenpaw.config import Config
+
+
+def _build_client(host: str) -> AsyncClient:
+    app = FastAPI()
+    app.include_router(backup_router.router, prefix="/api")
+    transport = ASGITransport(app=app, client=(host, 12345))
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+def _patch_backup_deps(monkeypatch, *, auth_enabled=False, has_users=False):
+    config = Config()
+    monkeypatch.setattr(
+        backup_router,
+        "is_auth_enabled",
+        lambda: auth_enabled,
+    )
+    monkeypatch.setattr(
+        backup_router,
+        "has_registered_users",
+        lambda: has_users,
+    )
+    monkeypatch.setattr(backup_router, "load_config", lambda: config)
+    monkeypatch.setattr(backup_router, "list_backups", _fake_list_backups)
+    return config
+
+
+async def _fake_list_backups():
+    return []
+
+
+async def test_backup_routes_reject_remote_callers_when_auth_is_disabled(
+    monkeypatch,
+):
+    _patch_backup_deps(monkeypatch, auth_enabled=False, has_users=False)
+
+    async with _build_client("198.51.100.7") as client:
+        resp = await client.get("/api/backups")
+
+    assert resp.status_code == 403
+    assert "require authentication" in resp.json()["detail"]
+
+
+async def test_backup_routes_allow_localhost_when_auth_is_disabled(
+    monkeypatch,
+):
+    _patch_backup_deps(monkeypatch, auth_enabled=False, has_users=False)
+
+    async with _build_client("127.0.0.1") as client:
+        resp = await client.get("/api/backups")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_backup_routes_allow_configured_trusted_host_without_auth(
+    monkeypatch,
+):
+    config = _patch_backup_deps(
+        monkeypatch,
+        auth_enabled=False,
+        has_users=False,
+    )
+    config.security.allow_no_auth_hosts = ["10.0.0.5"]
+
+    async with _build_client("10.0.0.5") as client:
+        resp = await client.get("/api/backups")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_backup_routes_defer_to_auth_middleware_when_auth_is_enabled(
+    monkeypatch,
+):
+    _patch_backup_deps(monkeypatch, auth_enabled=True, has_users=True)
+
+    async with _build_client("198.51.100.7") as client:
+        resp = await client.get("/api/backups")
+
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Description

Adds a route-level operator gate to the backup API so import, export, delete, and restore operations are available only when either normal web authentication is active or the caller host is explicitly trusted by `security.allow_no_auth_hosts`.

This keeps restore semantics unchanged: restoring a backup still restores the backup contents as-is, including security-related configuration. The fix instead protects the backup operation boundary when authentication is disabled or no user has been registered.

**Related Issue:** N/A

**Security Considerations:** This limits unauthenticated remote access to backup import/restore when web auth is disabled by allowing only configured trusted local hosts in that mode. It does not filter restored configuration, MCP settings, secrets, or workspace files, so full restore continues to mean restoring the backup state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the focused unit tests for the backup API operator gate:

```powershell
$env:PYTHONPATH = "src"
& "C:\Users\jinglin\AppData\Local\QwenPaw\python.exe" -m pytest tests/unit/routers/test_backup_operator_gate.py
```

The tests cover:

- remote callers are rejected when auth is disabled and no user is registered
- localhost callers remain allowed by the default trusted-host configuration
- explicitly trusted hosts from `security.allow_no_auth_hosts` remain allowed
- auth-enabled deployments continue to rely on the existing `AuthMiddleware`

## Local Verification Evidence

```powershell
& "C:\Users\jinglin\AppData\Local\QwenPaw\python.exe" -m pre_commit --version
# C:\Users\jinglin\AppData\Local\QwenPaw\python.exe: No module named pre_commit

.\.venv\Scripts\python.exe -m pre_commit --version
# C:\Users\jinglin\.codex\worktrees\c237\CoPaw\.venv\Scripts\python.exe: No module named pre_commit

$env:PYTHONPATH = "src"
& "C:\Users\jinglin\AppData\Local\QwenPaw\python.exe" -m pytest tests/unit/routers/test_backup_operator_gate.py
# 4 passed
```

## Additional Notes

This PR intentionally does not change backup archive validation or full-restore behavior. The security boundary is enforced before backup operations run, which keeps the change small and preserves the expected meaning of restore.
