### PR TITLE
feat: add timeout for keyring

### DIFF
--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -14,6 +14,7 @@ from legacy plaintext and transparently migrate on first access.
 from __future__ import annotations
 
 import base64
+import concurrent.futures
 import logging
 import os
 import secrets
@@ -68,25 +69,46 @@ def _should_skip_keyring() -> bool:
     return False
 
 
+_KEYRING_TIMEOUT = 10
+
+
 def _try_keyring_get() -> Optional[str]:
     """Read master key from OS keychain. Returns ``None`` on any failure.
 
     Skipped inside containers, headless Linux, and CI environments.
+    Uses a thread-based timeout to avoid hanging on systems that have
+    DISPLAY set but no keyring daemon running (e.g. Linux servers with
+    SSH X11 forwarding).
     """
     if _should_skip_keyring():
         return None
     try:
         import keyring
 
-        value = keyring.get_password(_KEYRING_SERVICE, _KEYRING_ACCOUNT)
-        if value:
-            return value
+        def _get() -> Optional[str]:
+            value = keyring.get_password(
+                _KEYRING_SERVICE,
+                _KEYRING_ACCOUNT,
+            )
+            if value:
+                return value
+            # Backward compatibility: read legacy CoPaw keyring entry.
+            return keyring.get_password(
+                _KEYRING_SERVICE_LEGACY,
+                _KEYRING_ACCOUNT,
+            )
 
-        # Backward compatibility: read legacy CoPaw keyring entry.
-        return keyring.get_password(
-            _KEYRING_SERVICE_LEGACY,
-            _KEYRING_ACCOUNT,
-        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(_get)
+            try:
+                return future.result(timeout=_KEYRING_TIMEOUT)
+            except concurrent.futures.TimeoutError:
+                logger.debug(
+                    "keyring get timed out after %ds, "
+                    "falling back to file storage",
+                    _KEYRING_TIMEOUT,
+                )
+                return None
     except Exception:
         return None
 
@@ -95,14 +117,33 @@ def _try_keyring_set(key_hex: str) -> bool:
     """Store master key in OS keychain. Returns success flag.
 
     Skipped inside containers where no desktop keyring service exists.
+    Uses a thread-based timeout to avoid hanging when the keyring daemon
+    is unavailable.
     """
     if _should_skip_keyring():
         return False
     try:
         import keyring
 
-        keyring.set_password(_KEYRING_SERVICE, _KEYRING_ACCOUNT, key_hex)
-        return True
+        def _set() -> None:
+            keyring.set_password(
+                _KEYRING_SERVICE,
+                _KEYRING_ACCOUNT,
+                key_hex,
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(_set)
+            try:
+                future.result(timeout=_KEYRING_TIMEOUT)
+                return True
+            except concurrent.futures.TimeoutError:
+                logger.debug(
+                    "keyring set timed out after %ds, "
+                    "falling back to file storage",
+                    _KEYRING_TIMEOUT,
+                )
+                return False
     except Exception:
         logger.debug("keyring unavailable, falling back to file storage")
         return False

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -14,7 +14,6 @@ from legacy plaintext and transparently migrate on first access.
 from __future__ import annotations
 
 import base64
-import concurrent.futures
 import logging
 import os
 import secrets
@@ -72,11 +71,43 @@ def _should_skip_keyring() -> bool:
 _KEYRING_TIMEOUT = 10
 
 
+def _call_with_timeout(fn, timeout):
+    """Run *fn* in a daemon thread and wait at most *timeout* seconds.
+
+    Returns ``(result, timed_out)``.  When the call times out the
+    daemon thread is abandoned and ``(None, True)`` is returned
+    immediately — the main thread is never blocked beyond *timeout*.
+
+    Using a daemon thread avoids the ``ThreadPoolExecutor`` trap where
+    ``shutdown(wait=True)`` on context-manager exit blocks until the
+    hung thread finishes, negating the intended timeout.
+    """
+    result_holder = [None]
+    exc_holder = [None]
+    done = threading.Event()
+
+    def _worker():
+        try:
+            result_holder[0] = fn()
+        except Exception as _exc:  # pylint: disable=broad-except
+            exc_holder[0] = _exc
+        finally:
+            done.set()
+
+    threading.Thread(target=_worker, daemon=True).start()
+    if not done.wait(timeout=timeout):
+        return None, True
+    exc = exc_holder[0]
+    if exc is not None:
+        raise exc
+    return result_holder[0], False
+
+
 def _try_keyring_get() -> Optional[str]:
     """Read master key from OS keychain. Returns ``None`` on any failure.
 
     Skipped inside containers, headless Linux, and CI environments.
-    Uses a thread-based timeout to avoid hanging on systems that have
+    Uses a daemon-thread timeout to avoid hanging on systems that have
     DISPLAY set but no keyring daemon running (e.g. Linux servers with
     SSH X11 forwarding).
     """
@@ -85,7 +116,7 @@ def _try_keyring_get() -> Optional[str]:
     try:
         import keyring
 
-        def _get() -> Optional[str]:
+        def _get():
             value = keyring.get_password(
                 _KEYRING_SERVICE,
                 _KEYRING_ACCOUNT,
@@ -98,17 +129,15 @@ def _try_keyring_get() -> Optional[str]:
                 _KEYRING_ACCOUNT,
             )
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            future = ex.submit(_get)
-            try:
-                return future.result(timeout=_KEYRING_TIMEOUT)
-            except concurrent.futures.TimeoutError:
-                logger.debug(
-                    "keyring get timed out after %ds, "
-                    "falling back to file storage",
-                    _KEYRING_TIMEOUT,
-                )
-                return None
+        result, timed_out = _call_with_timeout(_get, _KEYRING_TIMEOUT)
+        if timed_out:
+            logger.debug(
+                "keyring get timed out after %ds, "
+                "falling back to file storage",
+                _KEYRING_TIMEOUT,
+            )
+            return None
+        return result
     except Exception:
         return None
 
@@ -117,33 +146,30 @@ def _try_keyring_set(key_hex: str) -> bool:
     """Store master key in OS keychain. Returns success flag.
 
     Skipped inside containers where no desktop keyring service exists.
-    Uses a thread-based timeout to avoid hanging when the keyring daemon
-    is unavailable.
+    Uses a daemon-thread timeout to avoid hanging when the keyring
+    daemon is unavailable.
     """
     if _should_skip_keyring():
         return False
     try:
         import keyring
 
-        def _set() -> None:
+        def _set():
             keyring.set_password(
                 _KEYRING_SERVICE,
                 _KEYRING_ACCOUNT,
                 key_hex,
             )
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            future = ex.submit(_set)
-            try:
-                future.result(timeout=_KEYRING_TIMEOUT)
-                return True
-            except concurrent.futures.TimeoutError:
-                logger.debug(
-                    "keyring set timed out after %ds, "
-                    "falling back to file storage",
-                    _KEYRING_TIMEOUT,
-                )
-                return False
+        _, timed_out = _call_with_timeout(_set, _KEYRING_TIMEOUT)
+        if timed_out:
+            logger.debug(
+                "keyring set timed out after %ds, "
+                "falling back to file storage",
+                _KEYRING_TIMEOUT,
+            )
+            return False
+        return True
     except Exception:
         logger.debug("keyring unavailable, falling back to file storage")
         return False

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -51,6 +51,19 @@ def _should_skip_keyring() -> bool:
 
     Covers Docker containers, headless Linux servers, and CI
     environments where attempting keyring access could hang on D-Bus.
+
+    Note:
+        This function cannot catch every edge case.  A common false
+        negative is SSH X11 forwarding (``ssh -X``): the SSH client
+        automatically sets ``DISPLAY=localhost:10.0`` even though no
+        desktop keyring daemon is running on the remote server.  Other
+        similar situations include systemd user services, ``tmux``/
+        ``screen`` sessions inherited from a desktop login, and Docker
+        containers started with ``-e DISPLAY``.  For these cases a
+        daemon-thread timeout in ``_call_with_timeout`` acts as the
+        safety net so the caller is never blocked for more than
+        ``_KEYRING_TIMEOUT`` seconds regardless of what this function
+        returns.
     """
     if EnvVarLoader.get_bool("QWENPAW_RUNNING_IN_CONTAINER"):
         return True


### PR DESCRIPTION
## Description

<img width="1463" height="919" alt="image" src="https://github.com/user-attachments/assets/c28e845b-a386-42fe-a42f-d911a8d5262d" />


On some Linux servers, the `DISPLAY` environment variable is set (for example via SSH X11 forwarding or systemd user services), so `_should_skip_keyring()` returns `False`.

However, in these environments, GNOME Keyring or KWallet daemon may not actually be running.

As a result, `keyring.get_password()` attempts to access the keyring service over D-Bus. When no keyring daemon is available, the D-Bus request may hang for several minutes before timing out. In the example shown in the screenshot, it blocks for about 4 minutes (`10:34:29 -> 10:38:30`).

## Fix

Add an explicit timeout to the keyring access path so that we fail fast when the keyring backend is unavailable, instead of blocking for several minutes.

## Why

Relying on `DISPLAY` alone is not sufficient to determine whether a usable desktop keyring service is actually available. In headless or semi-headless Linux environments, this can lead to unexpectedly long hangs.

This change improves responsiveness and avoids prolonged blocking when no keyring daemon is running.