### PR TITLE
fix(console): replace window.open calls with openExternalLink utility…

### DIFF
--- a/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
+++ b/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../../api/types";
 import { getWebsiteLang } from "../../../../layouts/constants";
 import styles from "../../../Control/Channels/index.module.less";
+import { openExternalLink } from "../../../../utils/openExternalLink";
 
 interface ACPDrawerProps {
   open: boolean;
@@ -217,13 +218,7 @@ export function ACPDrawer({
             type="text"
             size="small"
             icon={<LinkOutlined />}
-            onClick={() =>
-              window.open(
-                getACPDocsUrl(i18n.language),
-                "_blank",
-                "noopener,noreferrer",
-              )
-            }
+            onClick={() => openExternalLink(getACPDocsUrl(i18n.language))}
             title={t("acp.docsHelp")}
             className={styles.dingtalkDocBtn}
             style={{ color: "#FF7F16" }}

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -16,6 +16,7 @@ import { getChannelLabel, type ChannelKey } from "./constants";
 import { QrcodeAuthBlock } from "./QrcodeAuthBlock";
 import styles from "../index.module.less";
 import { useAgentStore } from "../../../../stores/agentStore";
+import { openExternalLink } from "../../../../utils/openExternalLink";
 
 const CHANNELS_WITH_ACCESS_CONTROL: ChannelKey[] = [
   "telegram",
@@ -1189,7 +1190,7 @@ export function ChannelDrawer({
                 isQwenPawDoc && currentLang === "zh"
                   ? CHANNEL_DOC_ZH_URLS[activeKey]!
                   : CHANNEL_DOC_EN_URLS[activeKey]!;
-              window.open(finalUrl, "_blank");
+              openExternalLink(finalUrl);
             }}
             className={styles.dingtalkDocBtn}
             style={{ color: "#FF7F16" }}
@@ -1202,9 +1203,7 @@ export function ChannelDrawer({
           type="text"
           size="small"
           icon={<LinkOutlined />}
-          onClick={() =>
-            window.open(TWILIO_CONSOLE_URL, "_blank", "noopener,noreferrer")
-          }
+          onClick={() => openExternalLink(TWILIO_CONSOLE_URL)}
           className={styles.dingtalkDocBtn}
           style={{ color: "#FF7F16" }}
         >

--- a/console/src/utils/openExternalLink.ts
+++ b/console/src/utils/openExternalLink.ts
@@ -1,0 +1,24 @@
+/**
+ * Open an external URL, using the pywebview bridge in desktop app or
+ * window.open in browser.
+ *
+ * @param url - The URL to open
+ * @param target - Target window name (default: "_blank")
+ * @param features - Window features string (default: "noopener,noreferrer")
+ */
+export function openExternalLink(
+  url: string,
+  target: string = "_blank",
+  features: string = "noopener,noreferrer",
+): void {
+  if (!url) return;
+
+  const pywebview = (window as any).pywebview;
+  if (pywebview?.api?.open_external_link) {
+    // Desktop app: use pywebview bridge to open in system browser
+    pywebview.api.open_external_link(url);
+  } else {
+    // Web browser: use standard window.open
+    window.open(url, target, features);
+  }
+}


### PR DESCRIPTION
… in ACPDrawer and ChannelDrawer components

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
