### PR TITLE
Fix(tool): read_file_safe allocation size

### DIFF
--- a/src/qwenpaw/agents/tools/utils.py
+++ b/src/qwenpaw/agents/tools/utils.py
@@ -8,6 +8,7 @@ import re
 import logging
 
 import aiofiles
+import aiofiles.os
 
 from ...constant import TRUNCATION_NOTICE_MARKER
 
@@ -219,6 +220,9 @@ async def read_file_safe(
     Returns:
         File content as string (up to max_bytes).
     """
+    stat_result = await aiofiles.os.stat(file_path)
+    read_size = min(stat_result.st_size, max_bytes)
+
     # Use utf-8-sig to auto-remove BOM if present, compatible with plain utf-8
     try:
         async with aiofiles.open(
@@ -226,7 +230,7 @@ async def read_file_safe(
             "r",
             encoding="utf-8-sig",
         ) as f:
-            return await f.read(max_bytes)
+            return await f.read(read_size)
     except UnicodeDecodeError:
         async with aiofiles.open(
             file_path,
@@ -234,4 +238,4 @@ async def read_file_safe(
             encoding="utf-8-sig",
             errors="ignore",
         ) as f:
-            return await f.read(max_bytes)
+            return await f.read(read_size)

--- a/tests/unit/agents/tools/test_utils.py
+++ b/tests/unit/agents/tools/test_utils.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[4] / "src/qwenpaw/agents/tools/utils.py"
+)
+PACKAGE_NAME = "qwenpaw.agents.tools"
+
+tools_package = types.ModuleType(PACKAGE_NAME)
+tools_package.__path__ = [str(MODULE_PATH.parent)]
+sys.modules.setdefault(PACKAGE_NAME, tools_package)
+
+spec = importlib.util.spec_from_file_location(
+    f"{PACKAGE_NAME}.utils",
+    MODULE_PATH,
+)
+assert spec is not None
+assert spec.loader is not None
+utils = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = utils
+spec.loader.exec_module(utils)
+
+
+class _FakeAsyncFile:
+    def __init__(self, reads: list[int], content: str = "ok"):
+        self._reads = reads
+        self._content = content
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self, size: int) -> str:
+        self._reads.append(size)
+        return self._content
+
+
+@pytest.mark.asyncio
+async def test_read_file_safe_uses_actual_file_size(monkeypatch):
+    reads: list[int] = []
+
+    async def fake_stat(_path: str):
+        return SimpleNamespace(st_size=4096)
+
+    def fake_open(*_args, **_kwargs):
+        return _FakeAsyncFile(reads)
+
+    monkeypatch.setattr(utils.aiofiles.os, "stat", fake_stat)
+    monkeypatch.setattr(utils.aiofiles, "open", fake_open)
+
+    content = await utils.read_file_safe("/tmp/small.txt")
+
+    assert content == "ok"
+    assert reads == [4096]
+
+
+@pytest.mark.asyncio
+async def test_read_file_safe_caps_actual_file_size_to_max_bytes(monkeypatch):
+    reads: list[int] = []
+
+    async def fake_stat(_path: str):
+        return SimpleNamespace(st_size=4096)
+
+    def fake_open(*_args, **_kwargs):
+        return _FakeAsyncFile(reads)
+
+    monkeypatch.setattr(utils.aiofiles.os, "stat", fake_stat)
+    monkeypatch.setattr(utils.aiofiles, "open", fake_open)
+
+    await utils.read_file_safe("/tmp/small.txt", max_bytes=128)
+
+    assert reads == [128]


### PR DESCRIPTION
## Description

This PR fixes `read_file_safe` so small files do not call `f.read()` with the 1GB default limit. It stats the file first and passes `min(actual_file_size, max_bytes)` to `read()`, preserving the existing max-byte cap while avoiding oversized read buffer requests for normal files.

**Related Issue:** Fixes #3932

**Security Considerations:** No security-sensitive behavior change. The file content cap is still enforced by `max_bytes`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/agents/tools/test_utils.py`
- `ruff check src/qwenpaw/agents/tools/utils.py tests/unit/agents/tools/test_utils.py`
- `pre-commit run --all-files`

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast: Passed
# check yaml/xml/toml/json/docstring/private-key/trailing-whitespace: Passed
# mypy: Passed
# black: Passed
# flake8: Passed
# pylint: Passed
# prettier: Passed

pytest tests/unit/agents/tools/test_utils.py
# collected 2 items
# tests/unit/agents/tools/test_utils.py .. [100%]
# 2 passed in 0.09s
```

## Additional Notes

The root cause is that CPython text reads with a large `size` can make the underlying buffered reader request that full size. With the previous 1GB default, high-frequency `read_file` usage could repeatedly trigger large buffer requests, which is especially costly on Windows due to committed memory behavior.