### PR TITLE
fix(QA agent): bundle docs as package_data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,9 @@ pytest.ini
 
 # Frontend: exclude build artifacts; ship pre-built src/console/dist in image
 website
-!website/public/docs
+!website/
+!website/public/
+!website/public/docs/
 !website/public/docs/**
 console/node_modules
 console/dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,8 @@ pytest.ini
 
 # Frontend: exclude build artifacts; ship pre-built src/console/dist in image
 website
+!website/public/docs
+!website/public/docs/**
 console/node_modules
 console/dist
 console/.vite

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -47,6 +47,12 @@ jobs:
           mkdir -p src/qwenpaw/console
           cp -R console/dist/* src/qwenpaw/console/
 
+      - name: Bundle docs into package
+        run: |
+          rm -rf src/qwenpaw/docs
+          mkdir -p src/qwenpaw/docs
+          cp website/public/docs/*.md src/qwenpaw/docs/
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ console/.cursor/
 src/qwenpaw/console/dist/
 src/qwenpaw/console/
 
+# Docs bundled at build time (copied from website/public/docs/)
+src/qwenpaw/docs/
+
 # frontend (website)
 website/node_modules/
 website/.vite/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -85,6 +85,7 @@ ENV PATH="/app/venv/bin:$PATH"
 
 COPY pyproject.toml setup.py README.md ./
 COPY src ./src
+COPY website/public/docs/ ./src/qwenpaw/docs/
 # Inject console dist from build stage (repo does not commit dist).
 COPY --from=console-builder /app/console/dist/ ./src/qwenpaw/console/
 # Speed up Python package installation with uv.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ include-package-data = true
     "security/tool_guard/rules/**",
     "security/skill_scanner/rules/**",
     "security/skill_scanner/data/**",
-    "website/public/docs/*.md",
+    "docs/*.md",
 ]
 
 [build-system]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,22 +213,50 @@ cleanup_console() {
     fi
 }
 
+## Ensure docs are available in src/qwenpaw/docs/ for source installs.
+_DOCS_COPIED=0
+prepare_docs() {
+    local repo_dir="$1"
+    local docs_src="$repo_dir/website/public/docs"
+    local docs_dest="$repo_dir/src/qwenpaw/docs"
+
+    if [ -d "$docs_dest" ] && ls "$docs_dest"/*.md >/dev/null 2>&1; then
+        return
+    fi
+
+    if [ -d "$docs_src" ] && ls "$docs_src"/*.md >/dev/null 2>&1; then
+        mkdir -p "$docs_dest"
+        cp "$docs_src/"*.md "$docs_dest/"
+        _DOCS_COPIED=1
+    fi
+}
+
+cleanup_docs() {
+    local repo_dir="$1"
+    if [ "$_DOCS_COPIED" = 1 ]; then
+        rm -rf "$repo_dir/src/qwenpaw/docs"
+    fi
+}
+
 if [ "$FROM_SOURCE" = true ]; then
     if [ -n "$SOURCE_DIR" ]; then
         info "Installing QwenPaw from local source: $SOURCE_DIR"
         prepare_console "$SOURCE_DIR"
+        prepare_docs "$SOURCE_DIR"
         info "Installing package from source..."
         uv pip install "${SOURCE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --prerelease=allow --index-url "$PYPI_MIRROR"
         cleanup_console "$SOURCE_DIR"
+        cleanup_docs "$SOURCE_DIR"
     else
         info "Installing QwenPaw from source (GitHub)..."
         CLONE_DIR="$(mktemp -d)"
         trap 'rm -rf "$CLONE_DIR"' EXIT
         git clone --depth 1 "$QWENPAW_REPO" "$CLONE_DIR"
         prepare_console "$CLONE_DIR"
+        prepare_docs "$CLONE_DIR"
         info "Installing package from source..."
         uv pip install "${CLONE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --prerelease=allow --index-url "$PYPI_MIRROR"
-        # CLONE_DIR is cleaned up by trap; no need for cleanup_console
+        # CLONE_DIR is cleaned up by trap; no need for cleanup_console/cleanup_docs
     fi
 else
     PACKAGE="qwenpaw"

--- a/scripts/wheel_build.ps1
+++ b/scripts/wheel_build.ps1
@@ -28,6 +28,13 @@ if (Test-Path $ConsoleDest) {
 $ConsoleDist = Join-Path $ConsoleDir "dist"
 Copy-Item -Path (Join-Path $ConsoleDist "*") -Destination $ConsoleDest -Recurse -Force
 
+Write-Host "[wheel_build] Bundling website docs into package..."
+$DocsSrc = Join-Path $RepoRoot "website\public\docs"
+$DocsDest = Join-Path $RepoRoot "src\qwenpaw\docs"
+if (Test-Path $DocsDest) { Remove-Item -Recurse -Force $DocsDest }
+New-Item -ItemType Directory -Force -Path $DocsDest | Out-Null
+Copy-Item -Path (Join-Path $DocsSrc "*.md") -Destination $DocsDest -Force
+
 Write-Host "[wheel_build] Building wheel + sdist..."
 python -m pip install --quiet build
 $DistDir = Join-Path $RepoRoot "dist"

--- a/scripts/wheel_build.sh
+++ b/scripts/wheel_build.sh
@@ -19,6 +19,13 @@ rm -rf "$CONSOLE_DEST"/*
 mkdir -p "$CONSOLE_DEST"
 cp -R "$CONSOLE_DIR/dist/"* "$CONSOLE_DEST/"
 
+echo "[wheel_build] Bundling website docs into package..."
+DOCS_SRC="$REPO_ROOT/website/public/docs"
+DOCS_DEST="$REPO_ROOT/src/qwenpaw/docs"
+rm -rf "$DOCS_DEST"
+mkdir -p "$DOCS_DEST"
+cp "$DOCS_SRC/"*.md "$DOCS_DEST/"
+
 echo "[wheel_build] Building wheel + sdist..."
 python3 -m pip install --quiet build
 rm -rf dist/*

--- a/src/qwenpaw/agents/md_files/qa/en/AGENTS.md
+++ b/src/qwenpaw/agents/md_files/qa/en/AGENTS.md
@@ -20,7 +20,7 @@ Your core responsibilities:
 ### Key paths (record in MEMORY.md after discovery)
 
 - **Source root:** infer via `which qwenpaw`
-- **Official docs:** `<source-root>/website/public/docs/`
+- **Official docs:** prefer `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')"` ; fallback to `<source-root>/website/public/docs/`
 - **User data root:** **`WORKING_DIR`** (do **not** hard-code `~/.qwenpaw`; legacy installs may use **`~/.copaw`**)
 - **Per-agent workspaces:** `<WORKING_DIR>/workspaces/<agent_id>/`
 - **Global config:** `<WORKING_DIR>/config.json`; per-agent: `<WORKING_DIR>/workspaces/<agent_id>/agent.json`

--- a/src/qwenpaw/agents/md_files/qa/ru/AGENTS.md
+++ b/src/qwenpaw/agents/md_files/qa/ru/AGENTS.md
@@ -20,7 +20,7 @@ read_when:
 ### Ключевые пути (после обнаружения занесите в MEMORY.md)
 
 - **Корень исходников:** выведите через `which qwenpaw`
-- **Официальная документация:** `<корень-исходников>/website/public/docs/`
+- **Официальная документация:** предпочтительно через `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')"` ; fallback: `<корень-исходников>/website/public/docs/`
 - **Корень данных пользователя:** **`WORKING_DIR`** (не зашивайте `~/.qwenpaw`; старые установки могут использовать **`~/.copaw`**)
 - **Рабочие области агентов:** `<WORKING_DIR>/workspaces/<agent_id>/`
 - **Конфигурация:** `<WORKING_DIR>/config.json`; на агента: `<WORKING_DIR>/workspaces/<agent_id>/agent.json`

--- a/src/qwenpaw/agents/md_files/qa/zh/AGENTS.md
+++ b/src/qwenpaw/agents/md_files/qa/zh/AGENTS.md
@@ -20,7 +20,7 @@ read_when:
 ### 关键路径（发现后记录到 MEMORY.md）
 
 - **源码根目录**：通过 `which qwenpaw` 推导
-- **官方文档**：`<源码根目录>/website/public/docs/`
+- **官方文档**：优先通过 `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')"` 获取；fallback 到 `<源码根目录>/website/public/docs/`
 - **用户数据根目录**：即 **`WORKING_DIR`**（勿写死 `~/.qwenpaw`：`~/.copaw` 遗留安装会优先使用该目录）
 - **各 agent 工作区**：`<WORKING_DIR>/workspaces/<agent_id>/`
 - **全局配置**：`<WORKING_DIR>/config.json`；单 agent：`<WORKING_DIR>/workspaces/<agent_id>/agent.json`

--- a/src/qwenpaw/agents/skills/QA_source_index-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/QA_source_index-en/SKILL.md
@@ -2,7 +2,7 @@
 name: QA_source_index
 description: "Maps topics and keywords from user questions to QwenPaw official documentation paths and common source code entry points, reducing blind searching. Intended for the built-in QA Agent to quickly identify which files to read when answering questions about installation, configuration, skills, MCP, multi-agent, memory, CLI, etc."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🗂️"
     requires: {}
@@ -16,11 +16,12 @@ When answering questions about **installation, configuration, or behavioral prin
 
 1. Extract the topic from the user's question (match against the left column or synonyms in the table below).
 2. Resolve **`$QWENPAW_ROOT`**: use `which qwenpaw` to get the executable path. If it is `…/.qwenpaw/bin/qwenpaw`, the source root is three levels up (consistent with the **guidance** skill); otherwise, determine it from the user-provided installation path.
-3. **Read documentation first**: `website/public/docs/<topic>.<language>.md` (use the same language as the user: `zh` / `en` / `ru`, etc.). If that is insufficient, read the **source entry points** listed in the table.
+3. Resolve **`$DOC_DIR`** first (cross-install compatible): run `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`. If it returns a valid path, use it directly. Otherwise, fallback to `$QWENPAW_ROOT/website/public/docs/`.
+4. **Read documentation first**: `$DOC_DIR/<topic>.<language>.md` (use the same language as the user: `zh` / `en`.). If that is insufficient, read the **source entry points** listed in the table.
 
 ## Topic / Keywords → Preferred Documentation and Source Code
 
-| Topic or Keywords (examples) | Preferred Documentation (`website/public/docs/`) | Common Source Entry Points (relative to `$QWENPAW_ROOT`) |
+| Topic or Keywords (examples) | Preferred Documentation (`$DOC_DIR/`) | Common Source Entry Points (relative to `$QWENPAW_ROOT`) |
 |---------------------|-----------------------------------|-----------------------------------|
 | Installation, dependencies, getting started | `quickstart`, `intro` | `src/qwenpaw/cli/`, `pyproject.toml` |
 | Configuration, config.json, environment variables | `config` | `src/qwenpaw/config/config.py`, `src/qwenpaw/constant.py` |
@@ -41,7 +42,7 @@ When answering questions about **installation, configuration, or behavioral prin
 
 ## Conventions
 
-- Full documentation path: `$QWENPAW_ROOT/website/public/docs/<topic>.<language>.md` (fall back to `.en.md` if the corresponding language file does not exist).
+- Full documentation path: `$DOC_DIR/<topic>.<language>.md` (fall back to `.en.md` if the corresponding language file does not exist). Prefer `DOCS_DIR` from `qwenpaw.constant`; fallback to `$QWENPAW_ROOT/website/public/docs/`.
 - The **source entry points** in the table are starting points; use `read_file` or targeted `grep` to narrow down to specific symbols — do not read through an entire large directory listing at once.
 
 ## Notes

--- a/src/qwenpaw/agents/skills/QA_source_index-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/QA_source_index-en/SKILL.md
@@ -16,12 +16,12 @@ When answering questions about **installation, configuration, or behavioral prin
 
 1. Extract the topic from the user's question (match against the left column or synonyms in the table below).
 2. Resolve **`$QWENPAW_ROOT`**: use `which qwenpaw` to get the executable path. If it is `…/.qwenpaw/bin/qwenpaw`, the source root is three levels up (consistent with the **guidance** skill); otherwise, determine it from the user-provided installation path.
-3. Resolve **`$DOC_DIR`** first (cross-install compatible): run `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`. If it returns a valid path, use it directly. Otherwise, fallback to `$QWENPAW_ROOT/website/public/docs/`.
-4. **Read documentation first**: `$DOC_DIR/<topic>.<language>.md` (use the same language as the user: `zh` / `en`.). If that is insufficient, read the **source entry points** listed in the table.
+3. Resolve **`$DOCS_DIR`** first (cross-install compatible): run `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`. If it returns a valid path, use it directly. Otherwise, fallback to `$QWENPAW_ROOT/website/public/docs/`.
+4. **Read documentation first**: `$DOCS_DIR/<topic>.<language>.md` (use the same language as the user: `zh` / `en`.). If that is insufficient, read the **source entry points** listed in the table.
 
 ## Topic / Keywords → Preferred Documentation and Source Code
 
-| Topic or Keywords (examples) | Preferred Documentation (`$DOC_DIR/`) | Common Source Entry Points (relative to `$QWENPAW_ROOT`) |
+| Topic or Keywords (examples) | Preferred Documentation (`$DOCS_DIR/`) | Common Source Entry Points (relative to `$QWENPAW_ROOT`) |
 |---------------------|-----------------------------------|-----------------------------------|
 | Installation, dependencies, getting started | `quickstart`, `intro` | `src/qwenpaw/cli/`, `pyproject.toml` |
 | Configuration, config.json, environment variables | `config` | `src/qwenpaw/config/config.py`, `src/qwenpaw/constant.py` |
@@ -42,7 +42,7 @@ When answering questions about **installation, configuration, or behavioral prin
 
 ## Conventions
 
-- Full documentation path: `$DOC_DIR/<topic>.<language>.md` (fall back to `.en.md` if the corresponding language file does not exist). Prefer `DOCS_DIR` from `qwenpaw.constant`; fallback to `$QWENPAW_ROOT/website/public/docs/`.
+- Full documentation path: `$DOCS_DIR/<topic>.<language>.md` (fall back to `.en.md` if the corresponding language file does not exist). Prefer `DOCS_DIR` from `qwenpaw.constant`; fallback to `$QWENPAW_ROOT/website/public/docs/`.
 - The **source entry points** in the table are starting points; use `read_file` or targeted `grep` to narrow down to specific symbols — do not read through an entire large directory listing at once.
 
 ## Notes

--- a/src/qwenpaw/agents/skills/QA_source_index-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/QA_source_index-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: QA_source_index
 description: "将用户问题中的主题、关键词映射到 QwenPaw 官方文档路径与常见源码入口，减少盲目搜索。适用于内置 QA Agent 在回答安装、配置、技能、MCP、多智能体、记忆、CLI 等问题时快速选定要读的文件。"
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🗂️"
     requires: {}
@@ -16,11 +16,12 @@ metadata:
 
 1. 从用户问题中提取主题（对照下表左列或同类词）。
 2. 解析 **`$QWENPAW_ROOT`**：以 `which qwenpaw` 得到可执行路径，若为 `…/.qwenpaw/bin/qwenpaw` 则源码根为其上三级目录（与 **guidance** skill 一致）；否则结合用户给出的安装路径判断。
-3. **先读文档** `website/public/docs/<专题>.<语言>.md`（语言取与用户一致：`zh` / `en` / `ru` 等），仍不足再读表中 **源码入口**。
+3. 先解析 **`$DOC_DIR`**（兼容多种安装方式）：执行 `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`。若返回有效路径则直接使用；否则 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
+4. **先读文档** `$DOC_DIR/<专题>.<语言>.md`（语言取与用户一致：`zh` / `en`），仍不足再读表中 **源码入口**。
 
 ## 主题 / 关键词 → 优先文档与源码
 
-| 主题或关键词（示例） | 优先文档（`website/public/docs/`） | 常见源码入口（相对 `$QWENPAW_ROOT`） |
+| 主题或关键词（示例） | 优先文档（`$DOC_DIR/`） | 常见源码入口（相对 `$QWENPAW_ROOT`） |
 |---------------------|-----------------------------------|-----------------------------------|
 | 安装、依赖、首次使用 | `quickstart`、`intro` | `src/qwenpaw/cli/`、`pyproject.toml` |
 | 配置、config.json、环境变量 | `config` | `src/qwenpaw/config/config.py`、`src/qwenpaw/constant.py` |
@@ -41,7 +42,7 @@ metadata:
 
 ## 约定
 
-- 文档完整路径：`$QWENPAW_ROOT/website/public/docs/<专题>.<语言>.md`（无对应语言时用 `.en.md` 兜底）。
+- 文档完整路径：`$DOC_DIR/<专题>.<语言>.md`（无对应语言时用 `.en.md` 兜底）。优先使用 `qwenpaw.constant` 中的 `DOCS_DIR`，失败时 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
 - 表中 **源码入口** 为起点；应用 `read_file` 或局部 `grep` 缩小到具体符号，不要一次性通读大目录 listing。
 
 ## 注意

--- a/src/qwenpaw/agents/skills/QA_source_index-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/QA_source_index-zh/SKILL.md
@@ -16,12 +16,12 @@ metadata:
 
 1. 从用户问题中提取主题（对照下表左列或同类词）。
 2. 解析 **`$QWENPAW_ROOT`**：以 `which qwenpaw` 得到可执行路径，若为 `…/.qwenpaw/bin/qwenpaw` 则源码根为其上三级目录（与 **guidance** skill 一致）；否则结合用户给出的安装路径判断。
-3. 先解析 **`$DOC_DIR`**（兼容多种安装方式）：执行 `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`。若返回有效路径则直接使用；否则 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
-4. **先读文档** `$DOC_DIR/<专题>.<语言>.md`（语言取与用户一致：`zh` / `en`），仍不足再读表中 **源码入口**。
+3. 先解析 **`$DOCS_DIR`**（兼容多种安装方式）：执行 `python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null`。若返回有效路径则直接使用；否则 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
+4. **先读文档** `$DOCS_DIR/<专题>.<语言>.md`（语言取与用户一致：`zh` / `en`），仍不足再读表中 **源码入口**。
 
 ## 主题 / 关键词 → 优先文档与源码
 
-| 主题或关键词（示例） | 优先文档（`$DOC_DIR/`） | 常见源码入口（相对 `$QWENPAW_ROOT`） |
+| 主题或关键词（示例） | 优先文档（`$DOCS_DIR/`） | 常见源码入口（相对 `$QWENPAW_ROOT`） |
 |---------------------|-----------------------------------|-----------------------------------|
 | 安装、依赖、首次使用 | `quickstart`、`intro` | `src/qwenpaw/cli/`、`pyproject.toml` |
 | 配置、config.json、环境变量 | `config` | `src/qwenpaw/config/config.py`、`src/qwenpaw/constant.py` |
@@ -42,7 +42,7 @@ metadata:
 
 ## 约定
 
-- 文档完整路径：`$DOC_DIR/<专题>.<语言>.md`（无对应语言时用 `.en.md` 兜底）。优先使用 `qwenpaw.constant` 中的 `DOCS_DIR`，失败时 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
+- 文档完整路径：`$DOCS_DIR/<专题>.<语言>.md`（无对应语言时用 `.en.md` 兜底）。优先使用 `qwenpaw.constant` 中的 `DOCS_DIR`，失败时 fallback 到 `$QWENPAW_ROOT/website/public/docs/`。
 - 表中 **源码入口** 为起点；应用 `read_file` 或局部 `grep` 缩小到具体符号，不要一次性通读大目录 listing。
 
 ## 注意

--- a/src/qwenpaw/agents/skills/guidance-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/guidance-en/SKILL.md
@@ -2,7 +2,7 @@
 name: guidance
 description: "Answer user questions about QwenPaw installation and configuration: first locate and read local documentation, then distill the answer; if local information is insufficient, fall back to the official website documentation."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🧭"
     requires: {}
@@ -21,6 +21,16 @@ Core principles:
 ## Standard Flow
 
 ### Step 1: Locate the Documentation Directory
+
+**Use built-in path resolution (works for all install methods)**
+
+```bash
+DOC_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
+```
+
+If the above returns a non-empty path and the directory exists, use it directly and skip to Step 2.
+
+If it fails (e.g., older version without DOCS_DIR), fall back in the following order:
 
 **Check for documentation directory in memory**
 

--- a/src/qwenpaw/agents/skills/guidance-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/guidance-en/SKILL.md
@@ -25,7 +25,7 @@ Core principles:
 **Use built-in path resolution (works for all install methods)**
 
 ```bash
-DOC_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
+DOCS_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
 ```
 
 If the above returns a non-empty path and the directory exists, use it directly and skip to Step 2.
@@ -38,7 +38,7 @@ First, check whether there is a documentation directory in memory. If found, use
 
 ```bash
 # Get the documentation directory from memory
-DOC_DIR=$(find ~/.qwenpaw/memory/ -type d -name "docs")
+DOCS_DIR=$(find ~/.qwenpaw/memory/ -type d -name "docs")
 ```
 
 If there is no documentation directory in memory, continue with the following logic.
@@ -49,15 +49,15 @@ Run the following script logic to obtain the variable $QWENPAW_ROOT:
 
 ```bash
 # Get the absolute path of the binary
-COP_PATH=$(which qwenpaw 2>/dev/null || whereis qwenpaw | awk '{print $2}')
+QWENPAW_PATH=$(which qwenpaw 2>/dev/null || whereis qwenpaw | awk '{print $2}')
 
 # Logical deduction: if the path contains .qwenpaw/bin/qwenpaw, the root is three levels up
 # Example: /path/to/QwenPaw/.qwenpaw/bin/qwenpaw -> /path/to/QwenPaw
-if [[ "$COP_PATH" == *".qwenpaw/bin/qwenpaw" ]]; then
-    QWENPAW_ROOT=$(echo "$COP_PATH" | sed 's/\/\.qwenpaw\/bin\/qwenpaw//')
+if [[ "$QWENPAW_PATH" == *".qwenpaw/bin/qwenpaw" ]]; then
+    QWENPAW_ROOT=$(echo "$QWENPAW_PATH" | sed 's/\/\.qwenpaw\/bin\/qwenpaw//')
 else
     # Fallback: try to get the parent of the parent directory
-    QWENPAW_ROOT=$(dirname $(dirname "$COP_PATH") 2>/dev/null || echo ".")
+    QWENPAW_ROOT=$(dirname $(dirname "$QWENPAW_PATH") 2>/dev/null || echo ".")
 fi
 
 echo "Detected QwenPaw Root: $QWENPAW_ROOT"
@@ -68,11 +68,11 @@ Use the derived $QWENPAW_ROOT to locate the documentation:
 
 ```bash
 # Construct the standard documentation path
-DOC_DIR="$QWENPAW_ROOT/website/public/docs/"
+DOCS_DIR="$QWENPAW_ROOT/website/public/docs/"
 
 # Check if the path exists and list files
-if [ -d "$DOC_DIR" ]; then
-    find "$DOC_DIR" -type f -name "*.md" | head -n 100
+if [ -d "$DOCS_DIR" ]; then
+    find "$DOCS_DIR" -type f -name "*.md" | head -n 100
 else
     # If the derived path is incorrect, perform a global fuzzy search
     find "$QWENPAW_ROOT" -type d -name "docs" | grep "website/public/docs"
@@ -88,7 +88,7 @@ If documentation is still not found, search for available documentation content 
 FILE_PATH=$(find . -type f -name "faq.en.md" -o -name "config.zh.md" | head -n 1)
 if [ -n "$FILE_PATH" ]; then
     # Use dirname to get the directory containing the file
-    DOC_DIR=$(dirname "$FILE_PATH")
+    DOCS_DIR=$(dirname "$FILE_PATH")
 fi
 ```
 
@@ -96,7 +96,7 @@ If a documentation directory is found, save it in memory in this format:
 
 ```markdown
 # Documentation Directory
-$DOC_DIR = <doc_path>
+$DOCS_DIR = <doc_path>
 ```
 
 ### Step 2: Documentation Search and Matching
@@ -107,7 +107,7 @@ Use the find command to list all matching documents in the target directory, and
 
 ```bash
 # List all matching documents
-find $DOC_DIR -type f -name "*.md"
+find $DOCS_DIR -type f -name "*.md"
 ```
 
 If no suitable document is found, read all documentation contents in the next step.

--- a/src/qwenpaw/agents/skills/guidance-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/guidance-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: guidance
 description: "回答用户关于 QwenPaw 安装与配置的问题：优先定位并阅读本地文档，再提炼答案；若本地信息不足，兜底访问官网文档。"
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🧭"
     requires: {}
@@ -22,6 +22,16 @@ metadata:
 
 
 ### 第一步：定位文档位置
+
+**优先使用内置路径解析（适用于所有安装方式）**
+
+```bash
+DOC_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
+```
+
+如果上面获取到了非空路径且目录存在，直接使用，跳到第二步。
+
+如果获取失败（例如旧版本未包含 DOCS_DIR），按以下顺序 fallback：
 
 **查找记忆中的文档目录**
 

--- a/src/qwenpaw/agents/skills/guidance-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/guidance-zh/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 **优先使用内置路径解析（适用于所有安装方式）**
 
 ```bash
-DOC_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
+DOCS_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '')" 2>/dev/null)
 ```
 
 如果上面获取到了非空路径且目录存在，直接使用，跳到第二步。
@@ -39,7 +39,7 @@ DOC_DIR=$(python3 -c "from qwenpaw.constant import DOCS_DIR; print(DOCS_DIR or '
 
 ```bash
 # 获取memory中的文档目录
-DOC_DIR=$(find ~/.qwenpaw/memory/ -type d -name "docs")
+DOCS_DIR=$(find ~/.qwenpaw/memory/ -type d -name "docs")
 ```
 
 如果 memory 中没有文档目录，则继续执行下面的逻辑。
@@ -50,15 +50,15 @@ DOC_DIR=$(find ~/.qwenpaw/memory/ -type d -name "docs")
 
 ```bash
 # 获取二进制绝对路径
-COP_PATH=$(which qwenpaw 2>/dev/null || whereis qwenpaw | awk '{print $2}')
+QWENPAW_PATH=$(which qwenpaw 2>/dev/null || whereis qwenpaw | awk '{print $2}')
 
 # 逻辑推导：如果路径包含 .qwenpaw/bin/qwenpaw，则根目录在其上三层
 # 例如：/path/to/QwenPaw/.qwenpaw/bin/qwenpaw -> /path/to/QwenPaw
-if [[ "$COP_PATH" == *".qwenpaw/bin/qwenpaw" ]]; then
-    QWENPAW_ROOT=$(echo "$COP_PATH" | sed 's/\/\.qwenpaw\/bin\/qwenpaw//')
+if [[ "$QWENPAW_PATH" == *".qwenpaw/bin/qwenpaw" ]]; then
+    QWENPAW_ROOT=$(echo "$QWENPAW_PATH" | sed 's/\/\.qwenpaw\/bin\/qwenpaw//')
 else
     # 兜底：尝试获取所在目录的父目录
-    QWENPAW_ROOT=$(dirname $(dirname "$COP_PATH") 2>/dev/null || echo ".")
+    QWENPAW_ROOT=$(dirname $(dirname "$QWENPAW_PATH") 2>/dev/null || echo ".")
 fi
 
 echo "Detected QwenPaw Root: $QWENPAW_ROOT"
@@ -69,11 +69,11 @@ echo "Detected QwenPaw Root: $QWENPAW_ROOT"
 
 ```bash
 # 组合标准文档路径
-DOC_DIR="$QWENPAW_ROOT/website/public/docs/"
+DOCS_DIR="$QWENPAW_ROOT/website/public/docs/"
 
 # 检查路径是否存在并列出文件
-if [ -d "$DOC_DIR" ]; then
-    find "$DOC_DIR" -type f -name "*.md" | head -n 100
+if [ -d "$DOCS_DIR" ]; then
+    find "$DOCS_DIR" -type f -name "*.md" | head -n 100
 else
     # 如果推导路径不对，执行全局模糊搜索
     find "$QWENPAW_ROOT" -type d -name "docs" | grep "website/public/docs"
@@ -88,14 +88,14 @@ fi
 FILE_PATH=$(find . -type f -name "faq.en.md" -o -name "config.zh.md" | head -n 1)
 if [ -n "$FILE_PATH" ]; then
     # 使用 dirname 获取该文件所在的目录
-    DOC_DIR=$(dirname "$FILE_PATH")
+    DOCS_DIR=$(dirname "$FILE_PATH")
 fi
 ```
 如果找到了文档目录，请你记录在 memory 中，格式为：
 
 ```markdown
 # 文档目录
-$DOC_DIR = <doc_path>
+$DOCS_DIR = <doc_path>
 ```
 
 ### 第二步：文档检索与匹配
@@ -106,7 +106,7 @@ $DOC_DIR = <doc_path>
 
 ```bash
 # 列出所有符合后缀的文档
-find $DOC_DIR -type f -name "*.md"
+find $DOCS_DIR -type f -name "*.md"
 ```
 
 如果没有合适的文档，则在下一步阅读所有文档内容。

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -112,6 +112,22 @@ SECRET_DIR = (
 
 PROJECT_NAME = "QwenPaw"
 
+
+def _resolve_docs_dir() -> Path | None:
+    """Find QwenPaw documentation directory across all install methods."""
+    _pkg_docs = Path(__file__).resolve().parent / "docs"
+    if _pkg_docs.is_dir() and any(_pkg_docs.glob("*.md")):
+        return _pkg_docs
+    _src_docs = (
+        Path(__file__).resolve().parents[2] / "website" / "public" / "docs"
+    )
+    if _src_docs.is_dir() and any(_src_docs.glob("*.md")):
+        return _src_docs
+    return None
+
+
+DOCS_DIR: Path | None = _resolve_docs_dir()
+
 # Default media directory for channels (cross-platform)
 DEFAULT_MEDIA_DIR = WORKING_DIR / "media"
 


### PR DESCRIPTION
## Description

Fix docs not found by QA agent in pip/Docker/Desktop installs. The previous `data_files` approach
(`website/public/docs/*.md`) was non-functional because `package_data` paths are relative to the
package root, not the repo root.

**Approach:** Copy docs into `src/qwenpaw/docs/` at build time (same pattern as console frontend),
include via `package_data`, and add `DOCS_DIR` constant for reliable path resolution.


## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Skills
- [x] Scripts / Deploy

## Changes

- `pyproject.toml`: Fix package_data path (`docs/*.md`)
- `scripts/wheel_build.sh`: Copy docs before wheel build
- `deploy/Dockerfile`: COPY docs into package dir
- `src/qwenpaw/constant.py`: Add `DOCS_DIR` with multi-path fallback
- `guidance` skill v1.2→v1.3: Prioritize `DOCS_DIR` one-liner over shell heuristics

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
