### PR TITLE
fix(console): improve assistant file previews

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -130,6 +130,19 @@
   [class*="bubble-user"] [class*="markdown"] {
     white-space: pre-wrap;
   }
+
+  [class*="bubble-image"] {
+    max-width: min(320px, 100%);
+  }
+
+  [class*="bubble-image"] [class$="-image"],
+  [class*="bubble-image"] [class*="-image-img"],
+  [class*="bubble-image"] img {
+    width: min(320px, 100%) !important;
+    height: auto !important;
+    max-height: 360px;
+    object-fit: contain !important;
+  }
 }
 
 /* Dark mode scrollbar for disabled overlay */

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -9,7 +9,7 @@ import api, {
   type ChatStatus,
   type Message,
 } from "../../../api";
-import { toDisplayUrl } from "../utils";
+import { normalizeDisplayContentPart } from "../utils";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -99,23 +99,7 @@ const extractTextFromContent = (content: unknown): string => {
 };
 
 function resolveContentItemUrl(c: ContentItem): ContentItem {
-  if (c.type === "image" && c.image_url) {
-    return { ...c, image_url: toDisplayUrl(c.image_url as string) };
-  }
-  if (c.type === "audio" && c.data) {
-    return { ...c, data: toDisplayUrl(c.data as string) };
-  }
-  if (c.type === "video" && c.video_url) {
-    return { ...c, video_url: toDisplayUrl(c.video_url as string) };
-  }
-  if (c.type === "file" && (c.file_url || c.file_id)) {
-    return {
-      ...c,
-      file_url: toDisplayUrl((c.file_url as string) || (c.file_id as string)),
-      file_name: (c.filename as string) || (c.file_name as string) || "file",
-    };
-  }
-  return c;
+  return normalizeDisplayContentPart(c) as ContentItem;
 }
 
 /** Map backend message content to request card content (text + image + file). */
@@ -141,7 +125,9 @@ function contentToRequestParts(
 function normalizeOutputMessageContent(content: unknown): unknown {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return content;
-  return content as ContentItem[];
+  return (content as ContentItem[]).map(
+    (c) => normalizeDisplayContentPart(c) as ContentItem,
+  );
 }
 
 /**

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -5,6 +5,8 @@ import {
   buildModelError,
   toStoredName,
   normalizeContentUrls,
+  normalizeDisplayContentPart,
+  getFileNameFromUrl,
   toDisplayUrl,
 } from "./utils";
 import type { CopyableResponse } from "./utils";
@@ -241,5 +243,54 @@ describe("toDisplayUrl", () => {
     expect(toDisplayUrl("file:///uploads/img.png")).toBe(
       "http://localhost:8000/uploads/img.png",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// display media normalization
+// ---------------------------------------------------------------------------
+describe("getFileNameFromUrl", () => {
+  it("extracts file name from URL path", () => {
+    expect(getFileNameFromUrl("http://host/files/preview/report.pdf")).toBe(
+      "report.pdf",
+    );
+  });
+
+  it("strips query string and decodes URL encoding", () => {
+    expect(
+      getFileNameFromUrl("/files/preview/%E6%8A%A5%E5%91%8A.pdf?token=abc"),
+    ).toBe("报告.pdf");
+  });
+
+  it("handles Windows-style paths", () => {
+    expect(getFileNameFromUrl("C:\\tmp\\image.png")).toBe("image.png");
+  });
+});
+
+describe("normalizeDisplayContentPart", () => {
+  it("normalizes file URL and preserves filename aliases", () => {
+    const result = normalizeDisplayContentPart({
+      type: "file",
+      file_url: "/reports/output.pdf",
+      filename: "output.pdf",
+    });
+    expect(result.file_url).toBe("http://localhost:8000/reports/output.pdf");
+    expect(result.file_name).toBe("output.pdf");
+  });
+
+  it("derives file_name from file_url when backend omits it", () => {
+    const result = normalizeDisplayContentPart({
+      type: "file",
+      file_url: "/reports/output.pdf?token=abc",
+    });
+    expect(result.file_name).toBe("output.pdf");
+  });
+
+  it("normalizes image URLs for assistant output", () => {
+    const result = normalizeDisplayContentPart({
+      type: "image",
+      image_url: "/images/result.png",
+    });
+    expect(result.image_url).toBe("http://localhost:8000/images/result.png");
   });
 });

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -184,6 +184,43 @@ export function toDisplayUrl(url: string | undefined): string {
   return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
 }
 
+/** Extract a readable filename from a path or URL. */
+export function getFileNameFromUrl(url: string | undefined): string {
+  if (!url) return "";
+  const withoutQuery = url.split(/[?#]/, 1)[0].replace(/\\/g, "/");
+  const fileName = withoutQuery.split("/").filter(Boolean).pop() || "";
+  try {
+    return decodeURIComponent(fileName);
+  } catch {
+    return fileName;
+  }
+}
+
+/** Normalize backend media content so the chat renderer can show it well. */
+export function normalizeDisplayContentPart(part: any): any {
+  const p = { ...part };
+  if (p.type === "image" && typeof p.image_url === "string") {
+    p.image_url = toDisplayUrl(p.image_url);
+  }
+  if (p.type === "file" && (p.file_url || p.file_id)) {
+    const sourceUrl = (p.file_url as string | undefined) || p.file_id;
+    p.file_url = toDisplayUrl(sourceUrl);
+    p.file_name =
+      p.file_name ||
+      p.fileName ||
+      p.filename ||
+      getFileNameFromUrl(sourceUrl) ||
+      "file";
+  }
+  if (p.type === "audio" && typeof p.data === "string") {
+    p.data = toDisplayUrl(p.data);
+  }
+  if (p.type === "video" && typeof p.video_url === "string") {
+    p.video_url = toDisplayUrl(p.video_url);
+  }
+  return p;
+}
+
 // ---------------------------------------------------------------------------
 // DOM utilities
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize assistant media content before rendering so file messages get `file_name` from `file_name`, `fileName`, `filename`, or the URL basename
- resolve assistant media URLs consistently through the console preview endpoint
- enlarge assistant image previews in chat bubbles while preserving aspect ratio

Closes #4260

## Testing
- `$env:NODE_OPTIONS='--max-old-space-size=4096'; npx vitest run src/pages/Chat/utils.test.ts`
- `npx prettier --check src/pages/Chat/utils.ts src/pages/Chat/utils.test.ts src/pages/Chat/sessionApi/index.ts src/pages/Chat/index.module.less`
- `git diff --check`
- `npm run build`