### PR TITLE
feat(providers): support custom HTTP headers

### DIFF
--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -30,6 +30,7 @@ export interface ProviderInfo {
   require_api_key: boolean;
   api_key: string;
   base_url: string;
+  headers?: Record<string, string>;
   generate_kwargs: Record<string, unknown>;
   /** Provider-specific metadata (e.g. base_url_options for region selection). */
   meta?: Record<string, unknown>;
@@ -44,6 +45,7 @@ export interface BaseUrlOption {
 export interface ProviderConfigRequest {
   api_key?: string;
   base_url?: string;
+  headers?: Record<string, string>;
   chat_model?: string;
   generate_kwargs?: Record<string, unknown>;
 }
@@ -77,6 +79,7 @@ export interface CreateCustomProviderRequest {
   id: string;
   name: string;
   default_base_url?: string;
+  headers?: Record<string, string>;
   api_key_prefix?: string;
   chat_model?: string;
   models?: ModelInfo[];
@@ -169,6 +172,7 @@ export interface TestConnectionResponse {
 export interface TestProviderRequest {
   api_key?: string;
   base_url?: string;
+  headers?: Record<string, string>;
   chat_model?: string;
   generate_kwargs?: Record<string, unknown>;
   include_extended?: boolean;

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -60,6 +60,7 @@ async def get_provider_manager(request: Request) -> ProviderManager:
 class ProviderConfigRequest(BaseModel):
     api_key: Optional[str] = Field(default=None)
     base_url: Optional[str] = Field(default=None)
+    headers: Optional[dict[str, str]] = Field(default=None)
     chat_model: Optional[ChatModelName] = Field(
         default=None,
         description="Chat model class name for protocol selection",
@@ -91,6 +92,7 @@ class CreateCustomProviderRequest(BaseModel):
     id: str = Field(...)
     name: str = Field(...)
     default_base_url: str = Field(default="")
+    headers: dict[str, str] = Field(default_factory=dict)
     api_key_prefix: str = Field(default="")
     chat_model: ChatModelName = Field(default="OpenAIChatModel")
     models: List[ModelInfo] = Field(default_factory=list)
@@ -188,6 +190,7 @@ async def configure_provider(
         {
             "api_key": body.api_key,
             "base_url": body.base_url,
+            "headers": body.headers,
             "chat_model": body.chat_model,
             "generate_kwargs": body.generate_kwargs,
         },
@@ -223,6 +226,7 @@ async def create_custom_provider_endpoint(
                 id=body.id,
                 name=body.name,
                 base_url=body.default_base_url,
+                headers=body.headers,
                 api_key_prefix=body.api_key_prefix,
                 chat_model=body.chat_model,
                 extra_models=body.models,
@@ -252,6 +256,10 @@ class TestProviderRequest(BaseModel):
         default=None,
         description="Optional chat model class to test protocol behavior",
     )
+    headers: Optional[dict[str, str]] = Field(
+        default=None,
+        description="Optional HTTP headers to test",
+    )
 
 
 class TestModelRequest(BaseModel):
@@ -270,6 +278,10 @@ class DiscoverModelsRequest(BaseModel):
     chat_model: Optional[ChatModelName] = Field(
         default=None,
         description="Optional chat model class to use for discovery",
+    )
+    headers: Optional[dict[str, str]] = Field(
+        default=None,
+        description="Optional HTTP headers to use for discovery",
     )
 
 
@@ -310,6 +322,8 @@ async def test_provider(
             tmp_provider.api_key = body.api_key
         if body and body.base_url:
             tmp_provider.base_url = body.base_url
+        if body and body.headers is not None:
+            tmp_provider.headers = body.headers
         ok, msg = await tmp_provider.check_connection()
         return TestConnectionResponse(
             success=ok,
@@ -352,6 +366,7 @@ async def discover_models(
             {
                 "api_key": body.api_key if body else None,
                 "base_url": body.base_url if body else None,
+                "headers": body.headers if body else None,
             },
         )
         if not ok:

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -46,10 +46,46 @@ else:
 class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
 
+    def default_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.base_url in DASHSCOPE_BASE_URLS:
+            headers["x-dashscope-agentapp"] = json.dumps(
+                {
+                    "agentType": "QwenPaw",
+                    "deployType": "UnKnown",
+                    "moduleCode": "model",
+                    "agentCode": "UnKnown",
+                },
+                ensure_ascii=False,
+            )
+        elif self.base_url == CODING_DASHSCOPE_BASE_URL:
+            headers["X-DashScope-Cdpl"] = json.dumps(
+                {
+                    "agentType": "QwenPaw",
+                    "deployType": "UnKnown",
+                    "moduleCode": "model",
+                    "agentCode": "UnKnown",
+                },
+                ensure_ascii=False,
+            )
+        elif self.base_url == TOKEN_PLAN_BASE_URL:
+            headers["X-DashScope-Cdpl"] = json.dumps(
+                {
+                    "agentType": "QwenPaw",
+                    "deployType": "UnKnown",
+                    "moduleCode": "model",
+                    "agentCode": "UnKnown",
+                },
+                ensure_ascii=False,
+            )
+        headers.update(self.headers or {})
+        return headers
+
     def _client(self, timeout: float = 5) -> AsyncOpenAI:
         return AsyncOpenAI(
             base_url=self.base_url,
             api_key=self.api_key,
+            default_headers=self.default_headers() or None,
             timeout=timeout,
         )
 
@@ -145,44 +181,10 @@ class OpenAIProvider(Provider):
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from .openai_chat_model_compat import OpenAIChatModelCompat
 
-        client_kwargs = {"base_url": self.base_url}
-
-        if self.base_url in DASHSCOPE_BASE_URLS:
-            client_kwargs["default_headers"] = {
-                "x-dashscope-agentapp": json.dumps(
-                    {
-                        "agentType": "QwenPaw",
-                        "deployType": "UnKnown",
-                        "moduleCode": "model",
-                        "agentCode": "UnKnown",
-                    },
-                    ensure_ascii=False,
-                ),
-            }
-        elif self.base_url == CODING_DASHSCOPE_BASE_URL:
-            client_kwargs["default_headers"] = {
-                "X-DashScope-Cdpl": json.dumps(
-                    {
-                        "agentType": "QwenPaw",
-                        "deployType": "UnKnown",
-                        "moduleCode": "model",
-                        "agentCode": "UnKnown",
-                    },
-                    ensure_ascii=False,
-                ),
-            }
-        elif self.base_url == TOKEN_PLAN_BASE_URL:
-            client_kwargs["default_headers"] = {
-                "X-DashScope-Cdpl": json.dumps(
-                    {
-                        "agentType": "QwenPaw",
-                        "deployType": "UnKnown",
-                        "moduleCode": "model",
-                        "agentCode": "UnKnown",
-                    },
-                    ensure_ascii=False,
-                ),
-            }
+        client_kwargs: dict[str, Any] = {"base_url": self.base_url}
+        default_headers = self.default_headers()
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
 
         return OpenAIChatModelCompat(
             model_name=model_id,

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -86,6 +86,10 @@ class ProviderInfo(BaseModel):
     name: str = Field(..., description="Human-readable provider name")
     base_url: str = Field(default="", description="API base URL")
     api_key: str = Field(default="", description="API key for authentication")
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional HTTP headers sent to provider API requests.",
+    )
     chat_model: str = Field(
         default="OpenAIChatModel",
         description="AgentScope ChatModel name (e.g., 'OpenAIChatModel')",
@@ -210,6 +214,16 @@ class Provider(ProviderInfo, ABC):
             self.base_url = str(config["base_url"]).strip()
         if "api_key" in config and config["api_key"] is not None:
             self.api_key = str(config["api_key"]).strip()
+        if (
+            "headers" in config
+            and config["headers"] is not None
+            and isinstance(config["headers"], dict)
+        ):
+            self.headers = {
+                str(key).strip(): str(value)
+                for key, value in config["headers"].items()
+                if str(key).strip()
+            }
         if (
             self.is_custom
             and "chat_model" in config
@@ -356,6 +370,7 @@ class Provider(ProviderInfo, ABC):
             name=self.name,
             base_url=self.base_url,
             api_key=api_key,
+            headers=self.headers,
             chat_model=self.chat_model,
             models=[m.model_dump() for m in self.models],
             extra_models=[m.model_dump() for m in self.extra_models],

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1712,6 +1712,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     ]
                 if not provider.freeze_url and "base_url" in config:
                     provider.base_url = config["base_url"]
+                if "headers" in config:
+                    provider.headers = config["headers"]
                 self._save_provider(provider, is_builtin=True)
             # Migrate custom providers
             for provider_id, data in custom_providers.items():
@@ -1720,6 +1722,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     name=data.get("name", provider_id),
                     base_url=data.get("base_url", ""),
                     api_key=data.get("api_key", ""),
+                    headers=data.get("headers", {}),
                     is_custom=True,
                 )
                 if "models" in data:
@@ -1763,6 +1766,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                 if not builtin.freeze_url:
                     builtin.base_url = provider.base_url
                 builtin.api_key = provider.api_key
+                builtin.headers = provider.headers
                 builtin_model_ids = {m.id for m in builtin.models}
                 builtin.extra_models = [
                     m
@@ -1953,6 +1957,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     provider_info.api_key = saved_config["api_key"]
                 if "base_url" in saved_config:
                     provider_info.base_url = saved_config["base_url"]
+                if "headers" in saved_config:
+                    provider_info.headers = saved_config["headers"]
                 if "generate_kwargs" in saved_config:
                     provider_info.generate_kwargs = saved_config[
                         "generate_kwargs"

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -158,6 +158,7 @@ async def test_update_config_updates_non_none_values_and_get_info() -> None:
             "api_key": "sk-new",
             "chat_model": "OpenAIChatModel",
             "api_key_prefix": "sk-",
+            "headers": {"User-Agent": "QwenPaw Test"},
             "generate_kwargs": {"temperature": 0.2, "top_p": 0.9},
         },
     )
@@ -169,12 +170,14 @@ async def test_update_config_updates_non_none_values_and_get_info() -> None:
     assert provider.api_key == "sk-new"
     assert provider.chat_model == "OpenAIChatModel"
     assert provider.api_key_prefix == "sk-"
+    assert provider.headers == {"User-Agent": "QwenPaw Test"}
     assert provider.generate_kwargs == {"temperature": 0.2, "top_p": 0.9}
     assert info.name == "OpenAI Custom"
     assert info.base_url == "https://new.example/v1"
     assert info.api_key == "sk-new"
     assert info.chat_model == "OpenAIChatModel"
     assert info.api_key_prefix == "sk-"
+    assert info.headers == {"User-Agent": "QwenPaw Test"}
     assert info.generate_kwargs == {"temperature": 0.2, "top_p": 0.9}
     assert info.is_custom
     assert not info.support_connection_check
@@ -183,6 +186,7 @@ async def test_update_config_updates_non_none_values_and_get_info() -> None:
 async def test_update_config_skips_none_values() -> None:  # noqa: E501
     provider = _make_provider()
     provider.api_key_prefix = "sk-"
+    provider.headers = {"User-Agent": "Existing"}
     provider.generate_kwargs = {"temperature": 0.1}
 
     provider.update_config(
@@ -192,6 +196,7 @@ async def test_update_config_skips_none_values() -> None:  # noqa: E501
             "api_key": None,
             "chat_model": None,
             "api_key_prefix": None,
+            "headers": None,
             "generate_kwargs": None,
         },
     )
@@ -203,13 +208,38 @@ async def test_update_config_skips_none_values() -> None:  # noqa: E501
     assert provider.api_key == "sk-test"
     assert provider.chat_model == "OpenAIChatModel"
     assert provider.api_key_prefix == "sk-"
+    assert provider.headers == {"User-Agent": "Existing"}
     assert provider.generate_kwargs == {"temperature": 0.1}
     assert info.name == "OpenAI"
     assert info.base_url == "https://mock-openai.local/v1"
     assert info.api_key == "sk-******"
     assert info.chat_model == "OpenAIChatModel"
     assert info.api_key_prefix == "sk-"
+    assert info.headers == {"User-Agent": "Existing"}
     assert info.generate_kwargs == {"temperature": 0.1}
+
+
+def test_default_headers_include_custom_headers() -> None:
+    provider = _make_provider()
+    provider.headers = {
+        "User-Agent": "Mozilla/5.0",
+        "X-Custom": "enabled",
+    }
+
+    assert provider.default_headers() == {
+        "User-Agent": "Mozilla/5.0",
+        "X-Custom": "enabled",
+    }
+
+
+def test_custom_headers_can_override_builtin_default_headers() -> None:
+    provider = _make_provider()
+    provider.base_url = openai_provider_module.DASHSCOPE_BASE_URLS[0]
+    provider.headers = {
+        "x-dashscope-agentapp": "custom",
+    }
+
+    assert provider.default_headers()["x-dashscope-agentapp"] == "custom"
 
 
 async def test_update_config_does_not_update_chat_model() -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -138,6 +138,7 @@ async def test_add_custom_provider_and_reload_from_storage(
         name="Custom OpenAI",
         base_url="https://custom.example/v1",
         api_key="sk-custom",
+        headers={"User-Agent": "QwenPaw Test"},
         models=[ModelInfo(id="custom-model", name="Custom Model")],
     )
 
@@ -163,6 +164,7 @@ async def test_add_custom_provider_and_reload_from_storage(
     assert loaded.is_custom is True
     assert loaded.base_url == "https://custom.example/v1"
     assert loaded.api_key == "sk-custom"
+    assert loaded.headers == {"User-Agent": "QwenPaw Test"}
     assert [m.id for m in loaded.models] == ["custom-model"]
     assert loaded_builtin_conflict is not None
     assert isinstance(loaded_builtin_conflict, OpenAIProvider)


### PR DESCRIPTION
## Summary
- add provider-level HTTP headers config and persist it for custom, built-in, and plugin providers
- pass merged default headers to OpenAI-compatible clients for connection checks, model discovery, and chat calls
- expose headers through provider config, test, and discovery API types with regression coverage

Fixes #3796

## Tests
- PYTHONPATH=src uv run pytest tests/unit/providers/test_openai_provider.py tests/unit/providers/test_provider_manager.py -q
- uv run pre-commit run --files src/qwenpaw/providers/provider.py src/qwenpaw/providers/openai_provider.py src/qwenpaw/providers/provider_manager.py src/qwenpaw/app/routers/providers.py tests/unit/providers/test_openai_provider.py tests/unit/providers/test_provider_manager.py console/src/api/types/provider.ts
- cd console && npx prettier --check src/api/types/provider.ts
- cd console && npx tsc -b --noEmit