### PR TITLE
fix(desktop): open file links externally

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -33,6 +33,10 @@ const LoginPage = lazyImportWithRetry("./pages/Login/index");
 import { authApi } from "./api/modules/auth";
 import { languageApi } from "./api/modules/language";
 import { getApiUrl, getApiToken, clearAuthToken } from "./api/config";
+import {
+  isOpenableExternalLink,
+  openExternalLink,
+} from "./utils/openExternalLink";
 import "./styles/layout.css";
 import "./styles/form-override.css";
 
@@ -162,6 +166,34 @@ function AppInner() {
       i18n.off("languageChanged", handleLanguageChanged);
     };
   }, [i18n]);
+
+  useEffect(() => {
+    const handleExternalLinkClick = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+
+      const target = event.target as Element | null;
+      const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
+      const rawHref = anchor?.getAttribute("href") ?? "";
+      if (!anchor || !isOpenableExternalLink(rawHref)) return;
+
+      event.preventDefault();
+      openExternalLink(anchor.href, anchor.target || "_blank");
+    };
+
+    document.addEventListener("click", handleExternalLinkClick, true);
+    return () => {
+      document.removeEventListener("click", handleExternalLinkClick, true);
+    };
+  }, []);
 
   // Wait for plugins to load before rendering routes that might be patched
   if (pluginsLoading) {

--- a/console/src/utils/openExternalLink.test.ts
+++ b/console/src/utils/openExternalLink.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { isOpenableExternalLink, openExternalLink } from "./openExternalLink";
+
+describe("openExternalLink", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as any).pywebview;
+  });
+
+  it("allows http, https, and file URLs", () => {
+    expect(isOpenableExternalLink("https://example.com")).toBe(true);
+    expect(isOpenableExternalLink("http://example.com")).toBe(true);
+    expect(isOpenableExternalLink("file:///Users/test/file.txt")).toBe(true);
+  });
+
+  it("rejects relative and script URLs", () => {
+    expect(isOpenableExternalLink("/chat")).toBe(false);
+    expect(isOpenableExternalLink("javascript:alert(1)")).toBe(false);
+  });
+
+  it("uses the pywebview bridge when available", () => {
+    const open = vi.fn();
+    (window as any).pywebview = {
+      api: {
+        open_external_link: open,
+      },
+    };
+
+    openExternalLink("file:///Users/test/file.txt");
+
+    expect(open).toHaveBeenCalledWith("file:///Users/test/file.txt");
+  });
+});

--- a/console/src/utils/openExternalLink.ts
+++ b/console/src/utils/openExternalLink.ts
@@ -1,3 +1,13 @@
+const OPEN_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "file:"]);
+
+export function isOpenableExternalLink(url: string): boolean {
+  try {
+    return OPEN_EXTERNAL_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Open an external URL, using the pywebview bridge in desktop app or
  * window.open in browser.
@@ -11,7 +21,7 @@ export function openExternalLink(
   target: string = "_blank",
   features: string = "noopener,noreferrer",
 ): void {
-  if (!url) return;
+  if (!isOpenableExternalLink(url)) return;
 
   const pywebview = (window as any).pywebview;
   if (pywebview?.api?.open_external_link) {

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -31,7 +31,7 @@ class WebViewAPI:
 
     def open_external_link(self, url: str) -> None:
         """Open URL in system's default browser."""
-        if not url.startswith(("http://", "https://")):
+        if not url.startswith(("http://", "https://", "file://")):
             return
         webbrowser.open(url)
 

--- a/tests/unit/cli/test_desktop_cmd.py
+++ b/tests/unit/cli/test_desktop_cmd.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from qwenpaw.cli.desktop_cmd import WebViewAPI
+
+
+def test_open_external_link_allows_file_urls(monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        "qwenpaw.cli.desktop_cmd.webbrowser.open",
+        opened.append,
+    )
+
+    WebViewAPI().open_external_link("file:///Users/test/token.txt")
+
+    assert opened == ["file:///Users/test/token.txt"]
+
+
+def test_open_external_link_rejects_script_urls(monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        "qwenpaw.cli.desktop_cmd.webbrowser.open",
+        opened.append,
+    )
+
+    WebViewAPI().open_external_link("javascript:alert(1)")
+
+    assert not opened


### PR DESCRIPTION
## Summary
- Route clicked absolute http/https/file links through the existing desktop external-link bridge
- Allow the pywebview bridge to open file:// links in the system default handler
- Add frontend and desktop bridge regression tests

Fixes #3816

## Testing
- npx vitest run src/utils/openExternalLink.test.ts
- PYTHONPATH=src uv run pytest tests/unit/cli/test_desktop_cmd.py -q
- npx tsc -b --noEmit
- uv run pre-commit run --files src/qwenpaw/cli/desktop_cmd.py tests/unit/cli/test_desktop_cmd.py console/src/App.tsx console/src/utils/openExternalLink.ts console/src/utils/openExternalLink.test.ts
- git diff --check