### PR TITLE
fix(agents): repair malformed tool raw input

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -58,7 +58,10 @@ from .tools import (
     view_video,
     write_file,
 )
-from .utils import process_file_and_media_blocks_in_message
+from .utils import (
+    _repair_empty_tool_inputs,
+    process_file_and_media_blocks_in_message,
+)
 from ..constant import (
     MEDIA_UNSUPPORTED_PLACEHOLDER,
     WORKING_DIR,
@@ -248,9 +251,11 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                     "delegate_external_agent",
                 }
                 async_execution_tools = {
-                    name: builtin_tools.get(name).async_execution
-                    if name in builtin_tools
-                    else False
+                    name: (
+                        builtin_tools.get(name).async_execution
+                        if name in builtin_tools
+                        else False
+                    )
                     for name in async_capable_tool_names
                 }
         except Exception as e:
@@ -1047,6 +1052,7 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                             "rejects_media",
                             True,
                         )
+                    _repair_empty_tool_inputs([msg])
                     return msg
                 finally:
                     self._set_formatter_media_strip(False)
@@ -1081,7 +1087,9 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
 
         msg = self._filter_plan_tools(msg, nb)
 
-        return await self._auto_continue_if_text_only(msg, tool_choice)
+        msg = await self._auto_continue_if_text_only(msg, tool_choice)
+        _repair_empty_tool_inputs([msg])
+        return msg
 
     # pylint: disable=too-many-branches
     async def _summarizing(self) -> Msg:

--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -7,7 +7,56 @@ paired and ordered to prevent API errors.
 import json
 import logging
 
+from json_repair import repair_json
+
 logger = logging.getLogger(__name__)
+
+
+def _normalize_raw_tool_input(
+    parsed: object,
+    tool_name: str | None = None,
+) -> dict | None:
+    """Return a usable tool input dict from parsed raw input."""
+    if not isinstance(parsed, dict) or not parsed:
+        return None
+
+    raw_name = parsed.get("name")
+    raw_arguments = parsed.get("arguments")
+    if isinstance(raw_name, str) and raw_arguments is not None:
+        if tool_name and raw_name and raw_name != tool_name:
+            return None
+        if isinstance(raw_arguments, dict) and raw_arguments:
+            return raw_arguments
+        if isinstance(raw_arguments, str):
+            return _parse_raw_tool_input(raw_arguments)
+        return None
+
+    return parsed
+
+
+def _parse_raw_tool_input(
+    raw_input: object,
+    tool_name: str | None = None,
+) -> dict | None:
+    """Parse raw tool input, accepting JSON and common malformed variants."""
+    if isinstance(raw_input, dict):
+        return _normalize_raw_tool_input(raw_input, tool_name)
+    if not isinstance(raw_input, str):
+        return None
+
+    raw = raw_input.strip()
+    if not raw or raw == "{}":
+        return None
+
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        try:
+            parsed = json.loads(repair_json(raw, stream_stable=True))
+        except (TypeError, ValueError):
+            return None
+
+    return _normalize_raw_tool_input(parsed, tool_name)
 
 
 def extract_tool_ids(msg) -> tuple[set[str], set[str]]:
@@ -286,26 +335,27 @@ def _repair_empty_tool_inputs(
 
                 # If input is empty but raw_input has content, try to parse
                 if not input_field and raw_input and raw_input != "{}":
-                    try:
-                        parsed = json.loads(raw_input)
-                        if isinstance(parsed, dict) and parsed:
-                            # Success! Update the input field
-                            block["input"] = parsed
-                            repaired = True
-                            logger.info(
-                                "Repaired tool_use input from raw_input: "
-                                "id=%s, name=%s, keys=%s",
-                                block.get("id"),
-                                block.get("name"),
-                                list(parsed.keys()),
-                            )
-                    except (json.JSONDecodeError, TypeError) as e:
-                        logger.warning(
-                            "Failed to repair tool_use input from raw_input: "
-                            "id=%s, name=%s, error=%s",
+                    parsed = _parse_raw_tool_input(
+                        raw_input,
+                        block.get("name"),
+                    )
+                    if isinstance(parsed, dict) and parsed:
+                        # Success! Update the input field
+                        block["input"] = parsed
+                        repaired = True
+                        logger.info(
+                            "Repaired tool_use input from raw_input: "
+                            "id=%s, name=%s, keys=%s",
                             block.get("id"),
                             block.get("name"),
-                            e,
+                            list(parsed.keys()),
+                        )
+                    else:
+                        logger.warning(
+                            "Failed to repair tool_use input from raw_input: "
+                            "id=%s, name=%s",
+                            block.get("id"),
+                            block.get("name"),
                         )
 
             new_blocks.append(block)

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -319,6 +319,75 @@ class TestRepairEmptyToolInputs:
         result = _repair_empty_tool_inputs([msg])
         assert result[0].content[0]["input"] == {}
 
+    def test_repairs_non_strict_json_from_raw_input(self):
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "write_file",
+                    "input": {},
+                    "raw_input": (
+                        '{file_path: "notes.txt", '
+                        'content: "body with {still: text}"}'
+                    ),
+                },
+            ],
+        )
+        result = _repair_empty_tool_inputs([msg])
+        assert result[0].content[0]["input"] == {
+            "file_path": "notes.txt",
+            "content": "body with {still: text}",
+        }
+
+    def test_repairs_full_tool_call_wrapper_from_raw_input(self):
+        raw = json.dumps(
+            {
+                "name": "write_file",
+                "arguments": {
+                    "file_path": "notes.txt",
+                    "content": "hello",
+                },
+            },
+        )
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "write_file",
+                    "input": {},
+                    "raw_input": raw,
+                },
+            ],
+        )
+        result = _repair_empty_tool_inputs([msg])
+        assert result[0].content[0]["input"] == {
+            "file_path": "notes.txt",
+            "content": "hello",
+        }
+
+    def test_skips_full_tool_call_wrapper_for_mismatched_name(self):
+        raw = json.dumps(
+            {
+                "name": "read_file",
+                "arguments": {"file_path": "notes.txt"},
+            },
+        )
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "write_file",
+                    "input": {},
+                    "raw_input": raw,
+                },
+            ],
+        )
+        result = _repair_empty_tool_inputs([msg])
+        assert result[0].content[0]["input"] == {}
+
     def test_returns_original_when_no_change(self):
         msgs = [_msg([_tool_use("id1")])]
         result = _repair_empty_tool_inputs(msgs)


### PR DESCRIPTION
## Summary
- repair empty tool inputs from malformed raw_input using json-repair, matching AgentScope's streaming JSON recovery behavior
- unwrap full tool-call payloads shaped as {name: ..., arguments: ...} before sending them back into tool execution/model history
- repair the latest reasoning message before acting so write_file/edit_file do not run with empty args when raw_input is recoverable

Fixes #4299.

## Tests
- PYTHONPATH=src pytest tests\unit\agents\utils\test_tool_message_utils.py tests\unit\agents\test_message_request_normalizer.py tests\unit\agents\test_cross_provider_normalization.py
- pre-commit run --files src\qwenpaw\agents\utils\tool_message_utils.py src\qwenpaw\agents\react_agent.py tests\unit\agents\utils\test_tool_message_utils.py