### PR TITLE
refactor(console): Inbox

### DIFF
--- a/console/src/pages/Inbox/hooks/useInboxData.ts
+++ b/console/src/pages/Inbox/hooks/useInboxData.ts
@@ -148,10 +148,41 @@ export const useInboxData = () => {
 
   useEffect(() => {
     void loadPushMessages();
-    const timer = window.setInterval(() => {
-      void loadPushMessages();
-    }, PUSH_POLLING_INTERVAL_MS);
-    return () => window.clearInterval(timer);
+
+    let timer: number | null = null;
+
+    const startPolling = () => {
+      if (timer) return;
+      timer = window.setInterval(() => {
+        void loadPushMessages();
+      }, PUSH_POLLING_INTERVAL_MS);
+    };
+
+    const stopPolling = () => {
+      if (timer) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void loadPushMessages();
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+
+    if (document.visibilityState === "visible") {
+      startPolling();
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [loadPushMessages]);
 
   const markMessageAsRead = useCallback((messageId: string) => {

--- a/console/src/pages/Inbox/hooks/useTraceViewer.ts
+++ b/console/src/pages/Inbox/hooks/useTraceViewer.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { message } from "antd";
+import { useTranslation } from "react-i18next";
+import api from "../../../api";
+import type { PushMessage } from "../types";
+import {
+  buildContentFallbackTrace,
+  buildTraceDisplayItems,
+  type TraceDisplayItem,
+} from "../utils/traceUtils";
+
+interface TraceData {
+  events: Array<{ at: number; event: Record<string, unknown> }>;
+}
+
+export interface TraceViewerState {
+  detailOpen: boolean;
+  selectedMessage: PushMessage | null;
+  traceLoading: boolean;
+  traceEvents: TraceDisplayItem[];
+  expandedTraceMap: Record<string, boolean>;
+  traceContainerRef: React.RefObject<HTMLDivElement>;
+  openMessageDetail: (messageItem: PushMessage) => void;
+  closeDetail: () => void;
+  toggleTracePanel: (key: string, active: boolean) => void;
+  copyTraceBlock: (text: string) => Promise<void>;
+  handleTraceScroll: (scrollTop: number) => void;
+}
+
+export function useTraceViewer(
+  markMessageAsRead: (id: string) => void,
+): TraceViewerState {
+  const { t } = useTranslation();
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedMessage, setSelectedMessage] = useState<PushMessage | null>(
+    null,
+  );
+  const [traceLoading, setTraceLoading] = useState(false);
+  const [traceData, setTraceData] = useState<TraceData | null>(null);
+  const [expandedTraceMap, setExpandedTraceMap] = useState<
+    Record<string, boolean>
+  >({});
+  const traceContainerRef = useRef<HTMLDivElement>(null);
+  const traceScrollTopByMessageRef = useRef<Record<string, number>>({});
+
+  const traceEvents = useMemo<TraceDisplayItem[]>(() => {
+    if (!traceData?.events?.length) return [];
+    return buildTraceDisplayItems(traceData.events);
+  }, [traceData]);
+
+  // Reset expanded state when trace data or modal open state changes
+  useEffect(() => {
+    setExpandedTraceMap({});
+  }, [traceData, detailOpen]);
+
+  // Auto-scroll to bottom (or saved position) when trace loads
+  useEffect(() => {
+    if (
+      !detailOpen ||
+      traceLoading ||
+      traceEvents.length <= 0 ||
+      !selectedMessage
+    ) {
+      return;
+    }
+    const messageId = selectedMessage.id;
+    const savedScrollTop = traceScrollTopByMessageRef.current[messageId];
+    const rafId = window.requestAnimationFrame(() => {
+      const container = traceContainerRef.current;
+      if (!container) return;
+      container.scrollTop =
+        typeof savedScrollTop === "number"
+          ? savedScrollTop
+          : container.scrollHeight;
+    });
+    return () => window.cancelAnimationFrame(rafId);
+  }, [detailOpen, selectedMessage, traceEvents.length, traceLoading]);
+
+  const openMessageDetail = useCallback(
+    (messageItem: PushMessage) => {
+      if (!messageItem.read) {
+        markMessageAsRead(messageItem.id);
+      }
+      setSelectedMessage(
+        messageItem.read ? messageItem : { ...messageItem, read: true },
+      );
+      setDetailOpen(true);
+
+      const runId =
+        typeof messageItem.metadata?.payload?.run_id === "string"
+          ? (messageItem.metadata.payload.run_id as string)
+          : undefined;
+      if (!runId) {
+        setTraceData(buildContentFallbackTrace(messageItem));
+        return;
+      }
+      setTraceLoading(true);
+      void api
+        .getInboxTrace(runId)
+        .then((trace) => {
+          setTraceData({ events: trace.events || [] });
+        })
+        .catch(() => {
+          setTraceData(buildContentFallbackTrace(messageItem));
+        })
+        .finally(() => setTraceLoading(false));
+    },
+    [markMessageAsRead],
+  );
+
+  const closeDetail = useCallback(() => {
+    setDetailOpen(false);
+  }, []);
+
+  const toggleTracePanel = useCallback((key: string, active: boolean) => {
+    setExpandedTraceMap((prev) => ({ ...prev, [key]: active }));
+  }, []);
+
+  const copyTraceBlock = useCallback(
+    async (text: string) => {
+      if (!text) return;
+      try {
+        await navigator.clipboard.writeText(text);
+        message.success(t("common.copied"));
+      } catch {
+        message.error(t("common.copyFailed"));
+      }
+    },
+    [t],
+  );
+
+  const handleTraceScroll = useCallback(
+    (scrollTop: number) => {
+      if (!selectedMessage) return;
+      traceScrollTopByMessageRef.current[selectedMessage.id] = scrollTop;
+    },
+    [selectedMessage],
+  );
+
+  return {
+    detailOpen,
+    selectedMessage,
+    traceLoading,
+    traceEvents,
+    expandedTraceMap,
+    traceContainerRef,
+    openMessageDetail,
+    closeDetail,
+    toggleTracePanel,
+    copyTraceBlock,
+    handleTraceScroll,
+  };
+}

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Tabs,
   Empty,
@@ -28,18 +28,22 @@ import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
 import { ApprovalCard as GlobalApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
-import api from "../../api";
 import { commandsApi } from "../../api/modules/commands";
 import { chatApi } from "../../api/modules/chat";
 import sessionApi from "../Chat/sessionApi";
 import { PushMessageCard } from "./components";
 import { useInboxData } from "./hooks/useInboxData";
-import type { PushMessage } from "./types";
+import { useTraceViewer } from "./hooks/useTraceViewer";
 import { useAgentStore } from "../../stores/agentStore";
 import {
   DEFAULT_AGENT_ID,
   getAgentDisplayName,
 } from "../../utils/agentDisplayName";
+import {
+  getDetailModalTitle,
+  formatToolInput,
+  formatToolBlockContent,
+} from "./utils/traceUtils";
 import styles from "./index.module.less";
 
 type TabKey = "approvals" | "messages";
@@ -57,233 +61,6 @@ const resolveInitialTab = (): TabKey => {
   return "messages";
 };
 
-const buildContentFallbackTrace = (messageItem: PushMessage) => ({
-  events: messageItem.content
-    ? [
-        {
-          at: messageItem.createdAt.getTime() / 1000,
-          event: {
-            role: "assistant",
-            name: "assistant",
-            content: [
-              {
-                type: "text",
-                text: messageItem.content,
-              },
-            ],
-          },
-        },
-      ]
-    : [],
-});
-
-const getPrimaryTraceBlock = (
-  event: Record<string, unknown>,
-): Record<string, unknown> | null => {
-  const content = event.content;
-  if (!Array.isArray(content) || !content.length) return null;
-  const first = content[0];
-  if (!first || typeof first !== "object") return null;
-  return first as Record<string, unknown>;
-};
-
-const isCollapsibleTraceEvent = (
-  kind: string,
-  event: Record<string, unknown>,
-): boolean => {
-  const lowerKind = kind.toLowerCase();
-  if (lowerKind.includes("thinking") || lowerKind.includes("tool")) {
-    return true;
-  }
-  const block = getPrimaryTraceBlock(event);
-  const blockType = String(block?.type || "").toLowerCase();
-  if (
-    blockType === "thinking" ||
-    blockType === "tool_use" ||
-    blockType === "tool_result"
-  ) {
-    return true;
-  }
-  return false;
-};
-
-const extractTraceText = (event: Record<string, unknown>): string => {
-  const block = getPrimaryTraceBlock(event);
-  if (!block) return "";
-  const blockType = String(block.type || "").toLowerCase();
-  if (blockType === "thinking") {
-    const thinking = block.thinking;
-    if (typeof thinking === "string" && thinking.trim()) {
-      return thinking.trim();
-    }
-  }
-  if (blockType === "text") {
-    const text = block.text;
-    if (typeof text === "string" && text.trim()) {
-      return text.trim();
-    }
-  }
-  if (blockType === "tool_result") {
-    const output = block.output;
-    if (Array.isArray(output)) {
-      const textChunks = output
-        .map((item) => {
-          if (!item || typeof item !== "object") return "";
-          const text = (item as Record<string, unknown>).text;
-          return typeof text === "string" ? text : "";
-        })
-        .filter(Boolean);
-      if (textChunks.length) return textChunks.join("\n");
-    }
-  }
-  if (blockType === "tool_use") {
-    const rawInput = block.raw_input;
-    if (typeof rawInput === "string" && rawInput.trim()) {
-      return rawInput.trim();
-    }
-  }
-  return "";
-};
-
-const normalizeTraceKind = (event: Record<string, unknown>): string => {
-  if (event.type === "response_completed") return "response_completed";
-  const block = getPrimaryTraceBlock(event);
-  const blockType = String(block?.type || "").toLowerCase();
-  if (blockType === "thinking") return "thinking";
-  if (blockType === "tool_use") return "tool_call";
-  if (blockType === "tool_result") return "tool_output";
-  if (blockType === "text") return "push_preview";
-  return "event";
-};
-
-type TraceDisplayItem = {
-  at: number;
-  eventType: string;
-  eventRecord: Record<string, unknown>;
-  traceText: string;
-  collapsible: boolean;
-  collapseTitle: string;
-  toolInput?: string;
-  toolOutput?: string;
-  renderKind: "tool_pair" | "normal";
-};
-
-const shouldHideTraceEvent = (
-  eventType: string,
-  eventRecord: Record<string, unknown>,
-): boolean => {
-  const lowerType = eventType.toLowerCase();
-  if (lowerType === "response_completed") return true;
-  if (
-    !extractTraceText(eventRecord) &&
-    !isCollapsibleTraceEvent(eventType, eventRecord)
-  ) {
-    return true;
-  }
-  return false;
-};
-
-const getTraceFoldTitle = (
-  eventType: string,
-  eventRecord: Record<string, unknown>,
-): string => {
-  const lowerType = eventType.toLowerCase();
-  if (lowerType.includes("thinking")) return "Thinking";
-  if (lowerType.includes("tool")) {
-    const block = getPrimaryTraceBlock(eventRecord);
-    const toolName = block?.name;
-    if (typeof toolName === "string" && toolName.trim()) {
-      return toolName;
-    }
-    return "Tool";
-  }
-  return "Details";
-};
-
-const getTraceFoldIcon = (eventType: string) => {
-  const lowerType = eventType.toLowerCase();
-  if (lowerType.includes("thinking")) {
-    return <BulbOutlined />;
-  }
-  if (lowerType.includes("tool")) {
-    return <ToolOutlined />;
-  }
-  return null;
-};
-
-const getToolFieldText = (
-  eventRecord: Record<string, unknown>,
-  field: "tool_input" | "tool_output",
-): string => {
-  const block = getPrimaryTraceBlock(eventRecord);
-  if (!block) return "";
-  const blockType = String(block.type || "").toLowerCase();
-  if (field === "tool_input" && blockType === "tool_use") {
-    const rawInput = block.raw_input;
-    if (typeof rawInput === "string" && rawInput.trim()) return rawInput;
-    const input = block.input;
-    if (input !== undefined) {
-      try {
-        return JSON.stringify(input, null, 2);
-      } catch {
-        return String(input);
-      }
-    }
-  }
-  if (field === "tool_output" && blockType === "tool_result") {
-    const output = block.output;
-    if (output !== undefined) {
-      try {
-        return JSON.stringify(output, null, 2);
-      } catch {
-        return String(output);
-      }
-    }
-  }
-  return "";
-};
-
-const formatToolInput = (text: string): string => {
-  if (!text.trim()) return "{}";
-  return text;
-};
-
-const formatToolBlockContent = (text: string): string => {
-  const normalized = text.trim();
-  if (!normalized) return "";
-  try {
-    const parsed = JSON.parse(normalized);
-    return JSON.stringify(parsed, null, 2);
-  } catch {
-    return text;
-  }
-};
-
-const normalizeDetailTaskName = (title: string): string => {
-  if (!title) return "-";
-  return title
-    .replace(/^(cron result|heartbeat result)\s*[:：]\s*/i, "")
-    .replace(/^(定时任务结果|心跳结果)\s*[:：]\s*/i, "")
-    .trim();
-};
-
-const getDetailModalTitle = (
-  messageItem: PushMessage | null,
-  t: (key: string, options?: Record<string, unknown>) => string,
-): string => {
-  if (!messageItem) return t("inbox.messageDetailTitle");
-  const sourceType = (messageItem.metadata?.sourceType || "").toLowerCase();
-  if (sourceType === "cron") {
-    return t("inbox.detailCronTitle", {
-      name: normalizeDetailTaskName(messageItem.title),
-    });
-  }
-  if (sourceType === "heartbeat") {
-    return t("inbox.detailHeartbeatTitle");
-  }
-  return messageItem.title || t("inbox.messageDetailTitle");
-};
-
 const renderMarkdownText = (text: string, className: string) => (
   <div className={className}>
     <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
@@ -297,21 +74,8 @@ export default function InboxPage() {
   const [selectedAgentFilter, setSelectedAgentFilter] = useState<
     string | undefined
   >(undefined);
-  const [detailOpen, setDetailOpen] = useState(false);
-  const [selectedMessage, setSelectedMessage] = useState<PushMessage | null>(
-    null,
-  );
-  const [traceLoading, setTraceLoading] = useState(false);
-  const [traceData, setTraceData] = useState<{
-    events: Array<{ at: number; event: Record<string, unknown> }>;
-  } | null>(null);
-  const [expandedTraceMap, setExpandedTraceMap] = useState<
-    Record<string, boolean>
-  >({});
   const [messagesPage, setMessagesPage] = useState(1);
   const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([]);
-  const traceContainerRef = useRef<HTMLDivElement | null>(null);
-  const traceScrollTopByMessageRef = useRef<Record<string, number>>({});
   const agents = useAgentStore((state) => state.agents);
   const { approvals: pendingApprovals, setApprovals } = useApprovalContext();
   const {
@@ -412,135 +176,19 @@ export default function InboxPage() {
       prev.filter((item) => item.root_session_id !== rootSessionId),
     );
   };
-  const traceEvents = useMemo<TraceDisplayItem[]>(() => {
-    if (!traceData) return [];
-    const normalized = traceData.events
-      .flatMap((item) => {
-        const eventRecord = (item.event || {}) as Record<string, unknown>;
-        const content = eventRecord.content;
-        if (Array.isArray(content) && content.length > 1) {
-          return content.map((block) => {
-            const blockRecord = {
-              ...eventRecord,
-              content: [block],
-            } as Record<string, unknown>;
-            return {
-              ...item,
-              eventRecord: blockRecord,
-              eventType: normalizeTraceKind(blockRecord),
-            };
-          });
-        }
-        const normalizedRecord =
-          Array.isArray(content) && content.length === 1
-            ? eventRecord
-            : ({ ...eventRecord } as Record<string, unknown>);
-        return [
-          {
-            ...item,
-            eventRecord: normalizedRecord,
-            eventType: normalizeTraceKind(normalizedRecord),
-          },
-        ];
-      })
-      .filter(
-        (item) => !shouldHideTraceEvent(item.eventType, item.eventRecord),
-      );
-    const grouped: TraceDisplayItem[] = [];
-    for (let i = 0; i < normalized.length; i += 1) {
-      const current = normalized[i];
-      const traceText = extractTraceText(current.eventRecord);
-      const collapsible = isCollapsibleTraceEvent(
-        current.eventType,
-        current.eventRecord,
-      );
-      const collapseTitle = getTraceFoldTitle(
-        current.eventType,
-        current.eventRecord,
-      );
-
-      if (current.eventType === "tool_call") {
-        const next = normalized[i + 1];
-        const currentToolName = String(current.eventRecord.tool_name || "");
-        const nextToolName = String(next?.eventRecord?.tool_name || "");
-        const canPair =
-          !!next &&
-          next.eventType === "tool_output" &&
-          (!!currentToolName || !!nextToolName)
-            ? currentToolName === nextToolName
-            : true;
-        const toolInput = getToolFieldText(current.eventRecord, "tool_input");
-        if (canPair && next) {
-          const nextTraceText = extractTraceText(next.eventRecord);
-          const toolOutput =
-            getToolFieldText(next.eventRecord, "tool_output") || nextTraceText;
-          grouped.push({
-            at: current.at,
-            eventType: "tool_call",
-            eventRecord: current.eventRecord,
-            traceText,
-            collapsible: true,
-            collapseTitle:
-              collapseTitle ||
-              getTraceFoldTitle(next.eventType, next.eventRecord),
-            toolInput,
-            toolOutput,
-            renderKind: "tool_pair",
-          });
-          i += 1;
-          continue;
-        }
-        grouped.push({
-          at: current.at,
-          eventType: current.eventType,
-          eventRecord: current.eventRecord,
-          traceText,
-          collapsible: true,
-          collapseTitle,
-          toolInput,
-          renderKind: "tool_pair",
-        });
-        continue;
-      }
-
-      if (current.eventType === "tool_output") {
-        const toolOutput =
-          getToolFieldText(current.eventRecord, "tool_output") || traceText;
-        grouped.push({
-          at: current.at,
-          eventType: current.eventType,
-          eventRecord: current.eventRecord,
-          traceText,
-          collapsible: true,
-          collapseTitle,
-          toolOutput,
-          renderKind: "tool_pair",
-        });
-        continue;
-      }
-
-      grouped.push({
-        at: current.at,
-        eventType: current.eventType,
-        eventRecord: current.eventRecord,
-        traceText,
-        collapsible,
-        collapseTitle,
-        renderKind: "normal",
-      });
-    }
-    return grouped;
-  }, [traceData]);
-
-  const copyTraceBlock = async (text: string) => {
-    if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      message.success(t("common.copied"));
-    } catch {
-      message.error(t("common.copyFailed"));
-    }
-  };
+  const {
+    detailOpen,
+    selectedMessage,
+    traceLoading,
+    traceEvents,
+    expandedTraceMap,
+    traceContainerRef,
+    openMessageDetail,
+    closeDetail,
+    toggleTracePanel,
+    copyTraceBlock,
+    handleTraceScroll,
+  } = useTraceViewer(markMessageAsRead);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -558,35 +206,10 @@ export default function InboxPage() {
     const validIdSet = new Set(pushMessages.map((item) => item.id));
     setSelectedMessageIds((prev) => prev.filter((id) => validIdSet.has(id)));
   }, [pushMessages]);
+
   useEffect(() => {
     setMessagesPage(1);
   }, [selectedAgentFilter]);
-
-  useEffect(() => {
-    setExpandedTraceMap({});
-  }, [traceData, detailOpen]);
-
-  useEffect(() => {
-    if (
-      !detailOpen ||
-      traceLoading ||
-      traceEvents.length <= 0 ||
-      !selectedMessage
-    ) {
-      return;
-    }
-    const messageId = selectedMessage.id;
-    const savedScrollTop = traceScrollTopByMessageRef.current[messageId];
-    const rafId = window.requestAnimationFrame(() => {
-      const container = traceContainerRef.current;
-      if (!container) return;
-      container.scrollTop =
-        typeof savedScrollTop === "number"
-          ? savedScrollTop
-          : container.scrollHeight;
-    });
-    return () => window.cancelAnimationFrame(rafId);
-  }, [detailOpen, selectedMessage, traceEvents.length, traceLoading]);
 
   const handleViewMessage = (messageId: string) => {
     const found = pushMessages.find((item) => item.id === messageId);
@@ -594,31 +217,7 @@ export default function InboxPage() {
       message.warning(t("inbox.messageNotFound"));
       return;
     }
-    if (!found.read) {
-      markMessageAsRead(found.id);
-    }
-    setSelectedMessage(found.read ? found : { ...found, read: true });
-    setDetailOpen(true);
-    const runId =
-      typeof found.metadata?.payload?.run_id === "string"
-        ? (found.metadata.payload.run_id as string)
-        : undefined;
-    if (!runId) {
-      setTraceData(buildContentFallbackTrace(found));
-      return;
-    }
-    setTraceLoading(true);
-    void api
-      .getInboxTrace(runId)
-      .then((trace) => {
-        setTraceData({
-          events: trace.events || [],
-        });
-      })
-      .catch(() => {
-        setTraceData(buildContentFallbackTrace(found));
-      })
-      .finally(() => setTraceLoading(false));
+    openMessageDetail(found);
   };
 
   const handleMarkAllRead = async () => {
@@ -845,7 +444,7 @@ export default function InboxPage() {
       </div>
       <Modal
         open={detailOpen}
-        onCancel={() => setDetailOpen(false)}
+        onCancel={closeDetail}
         footer={null}
         width={820}
         title={getDetailModalTitle(selectedMessage, t)}
@@ -899,12 +498,10 @@ export default function InboxPage() {
                 </div>
               ) : traceEvents.length > 0 ? (
                 <div
-                  ref={traceContainerRef}
+                  ref={traceContainerRef as React.RefObject<HTMLDivElement>}
                   className={styles.traceContainer}
                   onScroll={(event) => {
-                    if (!selectedMessage) return;
-                    traceScrollTopByMessageRef.current[selectedMessage.id] =
-                      event.currentTarget.scrollTop;
+                    handleTraceScroll(event.currentTarget.scrollTop);
                   }}
                 >
                   <div className={styles.traceTimeline}>
@@ -917,7 +514,13 @@ export default function InboxPage() {
                         collapseTitle,
                       } = item;
                       const kind = eventType;
-                      const foldIcon = getTraceFoldIcon(kind);
+                      const foldIcon = kind
+                        .toLowerCase()
+                        .includes("thinking") ? (
+                        <BulbOutlined />
+                      ) : kind.toLowerCase().includes("tool") ? (
+                        <ToolOutlined />
+                      ) : null;
                       const collapseKey = `trace-${item.at}-${index}`;
                       const isPanelActive = !!expandedTraceMap[collapseKey];
                       return (
@@ -945,10 +548,7 @@ export default function InboxPage() {
                                 const nextActive = Array.isArray(keys)
                                   ? keys.length > 0
                                   : Boolean(keys);
-                                setExpandedTraceMap((prev) => ({
-                                  ...prev,
-                                  [collapseKey]: nextActive,
-                                }));
+                                toggleTracePanel(collapseKey, nextActive);
                               }}
                               className={`${styles.traceCollapse} ${
                                 isPanelActive ? styles.traceCollapseActive : ""

--- a/console/src/pages/Inbox/utils/traceUtils.ts
+++ b/console/src/pages/Inbox/utils/traceUtils.ts
@@ -1,0 +1,342 @@
+import type { PushMessage } from "../types";
+
+export type TraceDisplayItem = {
+  at: number;
+  eventType: string;
+  eventRecord: Record<string, unknown>;
+  traceText: string;
+  collapsible: boolean;
+  collapseTitle: string;
+  toolInput?: string;
+  toolOutput?: string;
+  renderKind: "tool_pair" | "normal";
+};
+
+export const buildContentFallbackTrace = (messageItem: PushMessage) => ({
+  events: messageItem.content
+    ? [
+        {
+          at: messageItem.createdAt.getTime() / 1000,
+          event: {
+            role: "assistant",
+            name: "assistant",
+            content: [
+              {
+                type: "text",
+                text: messageItem.content,
+              },
+            ],
+          },
+        },
+      ]
+    : [],
+});
+
+export const getPrimaryTraceBlock = (
+  event: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  const content = event.content;
+  if (!Array.isArray(content) || !content.length) return null;
+  const first = content[0];
+  if (!first || typeof first !== "object") return null;
+  return first as Record<string, unknown>;
+};
+
+export const isCollapsibleTraceEvent = (
+  kind: string,
+  event: Record<string, unknown>,
+): boolean => {
+  const lowerKind = kind.toLowerCase();
+  if (lowerKind.includes("thinking") || lowerKind.includes("tool")) {
+    return true;
+  }
+  const block = getPrimaryTraceBlock(event);
+  const blockType = String(block?.type || "").toLowerCase();
+  if (
+    blockType === "thinking" ||
+    blockType === "tool_use" ||
+    blockType === "tool_result"
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const extractTraceText = (event: Record<string, unknown>): string => {
+  const block = getPrimaryTraceBlock(event);
+  if (!block) return "";
+  const blockType = String(block.type || "").toLowerCase();
+  if (blockType === "thinking") {
+    const thinking = block.thinking;
+    if (typeof thinking === "string" && thinking.trim()) {
+      return thinking.trim();
+    }
+  }
+  if (blockType === "text") {
+    const text = block.text;
+    if (typeof text === "string" && text.trim()) {
+      return text.trim();
+    }
+  }
+  if (blockType === "tool_result") {
+    const output = block.output;
+    if (Array.isArray(output)) {
+      const textChunks = output
+        .map((item) => {
+          if (!item || typeof item !== "object") return "";
+          const text = (item as Record<string, unknown>).text;
+          return typeof text === "string" ? text : "";
+        })
+        .filter(Boolean);
+      if (textChunks.length) return textChunks.join("\n");
+    }
+  }
+  if (blockType === "tool_use") {
+    const rawInput = block.raw_input;
+    if (typeof rawInput === "string" && rawInput.trim()) {
+      return rawInput.trim();
+    }
+  }
+  return "";
+};
+
+export const normalizeTraceKind = (event: Record<string, unknown>): string => {
+  if (event.type === "response_completed") return "response_completed";
+  const block = getPrimaryTraceBlock(event);
+  const blockType = String(block?.type || "").toLowerCase();
+  if (blockType === "thinking") return "thinking";
+  if (blockType === "tool_use") return "tool_call";
+  if (blockType === "tool_result") return "tool_output";
+  if (blockType === "text") return "push_preview";
+  return "event";
+};
+
+export const shouldHideTraceEvent = (
+  eventType: string,
+  eventRecord: Record<string, unknown>,
+): boolean => {
+  const lowerType = eventType.toLowerCase();
+  if (lowerType === "response_completed") return true;
+  if (
+    !extractTraceText(eventRecord) &&
+    !isCollapsibleTraceEvent(eventType, eventRecord)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const getTraceFoldTitle = (
+  eventType: string,
+  eventRecord: Record<string, unknown>,
+): string => {
+  const lowerType = eventType.toLowerCase();
+  if (lowerType.includes("thinking")) return "Thinking";
+  if (lowerType.includes("tool")) {
+    const block = getPrimaryTraceBlock(eventRecord);
+    const toolName = block?.name;
+    if (typeof toolName === "string" && toolName.trim()) {
+      return toolName;
+    }
+    return "Tool";
+  }
+  return "Details";
+};
+
+export const getToolFieldText = (
+  eventRecord: Record<string, unknown>,
+  field: "tool_input" | "tool_output",
+): string => {
+  const block = getPrimaryTraceBlock(eventRecord);
+  if (!block) return "";
+  const blockType = String(block.type || "").toLowerCase();
+  if (field === "tool_input" && blockType === "tool_use") {
+    const rawInput = block.raw_input;
+    if (typeof rawInput === "string" && rawInput.trim()) return rawInput;
+    const input = block.input;
+    if (input !== undefined) {
+      try {
+        return JSON.stringify(input, null, 2);
+      } catch {
+        return String(input);
+      }
+    }
+  }
+  if (field === "tool_output" && blockType === "tool_result") {
+    const output = block.output;
+    if (output !== undefined) {
+      try {
+        return JSON.stringify(output, null, 2);
+      } catch {
+        return String(output);
+      }
+    }
+  }
+  return "";
+};
+
+export const formatToolInput = (text: string): string => {
+  if (!text.trim()) return "{}";
+  return text;
+};
+
+export const formatToolBlockContent = (text: string): string => {
+  const normalized = text.trim();
+  if (!normalized) return "";
+  try {
+    const parsed = JSON.parse(normalized);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return text;
+  }
+};
+
+export const normalizeDetailTaskName = (title: string): string => {
+  if (!title) return "-";
+  return title
+    .replace(/^(cron result|heartbeat result)\s*[:：]\s*/i, "")
+    .replace(/^(定时任务结果|心跳结果)\s*[:：]\s*/i, "")
+    .trim();
+};
+
+export const getDetailModalTitle = (
+  messageItem: PushMessage | null,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string => {
+  if (!messageItem) return t("inbox.messageDetailTitle");
+  const sourceType = (messageItem.metadata?.sourceType || "").toLowerCase();
+  if (sourceType === "cron") {
+    return t("inbox.detailCronTitle", {
+      name: normalizeDetailTaskName(messageItem.title),
+    });
+  }
+  if (sourceType === "heartbeat") {
+    return t("inbox.detailHeartbeatTitle");
+  }
+  return messageItem.title || t("inbox.messageDetailTitle");
+};
+
+/**
+ * Parse raw trace events into grouped display items with tool-call pairing.
+ */
+export const buildTraceDisplayItems = (
+  rawEvents: Array<{ at: number; event: Record<string, unknown> }>,
+): TraceDisplayItem[] => {
+  if (!rawEvents.length) return [];
+
+  const normalized = rawEvents
+    .flatMap((item) => {
+      const eventRecord = (item.event || {}) as Record<string, unknown>;
+      const content = eventRecord.content;
+      if (Array.isArray(content) && content.length > 1) {
+        return content.map((block) => {
+          const blockRecord = {
+            ...eventRecord,
+            content: [block],
+          } as Record<string, unknown>;
+          return {
+            ...item,
+            eventRecord: blockRecord,
+            eventType: normalizeTraceKind(blockRecord),
+          };
+        });
+      }
+      const normalizedRecord =
+        Array.isArray(content) && content.length === 1
+          ? eventRecord
+          : ({ ...eventRecord } as Record<string, unknown>);
+      return [
+        {
+          ...item,
+          eventRecord: normalizedRecord,
+          eventType: normalizeTraceKind(normalizedRecord),
+        },
+      ];
+    })
+    .filter((item) => !shouldHideTraceEvent(item.eventType, item.eventRecord));
+
+  const grouped: TraceDisplayItem[] = [];
+  for (let i = 0; i < normalized.length; i += 1) {
+    const current = normalized[i];
+    const traceText = extractTraceText(current.eventRecord);
+    const collapsible = isCollapsibleTraceEvent(
+      current.eventType,
+      current.eventRecord,
+    );
+    const collapseTitle = getTraceFoldTitle(
+      current.eventType,
+      current.eventRecord,
+    );
+
+    if (current.eventType === "tool_call") {
+      const next = normalized[i + 1];
+      const currentToolName = String(current.eventRecord.tool_name || "");
+      const nextToolName = String(next?.eventRecord?.tool_name || "");
+      const canPair =
+        !!next &&
+        next.eventType === "tool_output" &&
+        (!!currentToolName || !!nextToolName)
+          ? currentToolName === nextToolName
+          : true;
+      const toolInput = getToolFieldText(current.eventRecord, "tool_input");
+      if (canPair && next) {
+        const nextTraceText = extractTraceText(next.eventRecord);
+        const toolOutput =
+          getToolFieldText(next.eventRecord, "tool_output") || nextTraceText;
+        grouped.push({
+          at: current.at,
+          eventType: "tool_call",
+          eventRecord: current.eventRecord,
+          traceText,
+          collapsible: true,
+          collapseTitle:
+            collapseTitle ||
+            getTraceFoldTitle(next.eventType, next.eventRecord),
+          toolInput,
+          toolOutput,
+          renderKind: "tool_pair",
+        });
+        i += 1;
+        continue;
+      }
+      grouped.push({
+        at: current.at,
+        eventType: current.eventType,
+        eventRecord: current.eventRecord,
+        traceText,
+        collapsible: true,
+        collapseTitle,
+        toolInput,
+        renderKind: "tool_pair",
+      });
+      continue;
+    }
+
+    if (current.eventType === "tool_output") {
+      const toolOutput =
+        getToolFieldText(current.eventRecord, "tool_output") || traceText;
+      grouped.push({
+        at: current.at,
+        eventType: current.eventType,
+        eventRecord: current.eventRecord,
+        traceText,
+        collapsible: true,
+        collapseTitle,
+        toolOutput,
+        renderKind: "tool_pair",
+      });
+      continue;
+    }
+
+    grouped.push({
+      at: current.at,
+      eventType: current.eventType,
+      eventRecord: current.eventRecord,
+      traceText,
+      collapsible,
+      collapseTitle,
+      renderKind: "normal",
+    });
+  }
+  return grouped;
+};


### PR DESCRIPTION
## Description

1.Extract all pure trace functions to pages/Inbox/utils/traceUtils.ts (for independent unit testing).

2.The trace-related states and side effects are encapsulated in a custom hook in pages/Inbox/hooks/useTraceViewer.ts.

3.Add a visibilitychange listener to the useInboxData polling: pause when the page is invisible, and immediately refresh and restart when it becomes visible again.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
