### PR TITLE
fix(tool): browser implement activity tracking, crash monitoring, and lifecycle management

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -756,13 +756,14 @@ def _attach_page_listeners(state: dict, page, page_id: str) -> None:
                 "resourceType": getattr(req, "resource_type", None),
             },
         )
+
     def on_crash(_p):
         logger.error("Browser page crashed: %s", page_id)
 
     page.on("crash", on_crash)
 
-    requests_list = state["network_requests"].setdefault(page_id, [])
-    
+    requests_list = state["network_requests"].setdefault(page_id, []))
+
     def on_response(res):
         for r in requests_list:
             if r.get("url") == res.url and "status" not in r:
@@ -4249,8 +4250,8 @@ async def browser_use(  # pylint: disable=R0911,R0912
     _ws_id = _cwd.name if _cwd else "default"
     _ws_dir = str(_cwd) if _cwd else ""
     state = _get_workspace_state(_ws_id, _ws_dir)
-    _touch_activity(state)
-    
+    _touch_activity(state))
+
     action = (action or "").strip().lower()
     if not action:
         return _tool_response(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -756,7 +756,13 @@ def _attach_page_listeners(state: dict, page, page_id: str) -> None:
                 "resourceType": getattr(req, "resource_type", None),
             },
         )
+    def on_crash(_p):
+        logger.error("Browser page crashed: %s", page_id)
 
+    page.on("crash", on_crash)
+
+    requests_list = state["network_requests"].setdefault(page_id, [])
+    
     def on_response(res):
         for r in requests_list:
             if r.get("url") == res.url and "status" not in r:
@@ -829,21 +835,47 @@ async def _ensure_browser(
             f"CDP connection lost (was: {cdp_url}). "
             "Reconnect with action='connect_cdp'."
         )
+        _reset_browser_state(state)
         return False
 
     # Check browser state based on mode
     if _USE_SYNC_PLAYWRIGHT:
-        if state["_sync_context"] is not None and (
-            state["_sync_browser"] is not None or state["user_data_dir"]
-        ):
-            _touch_activity(state)
-            return True
+        if state["_sync_context"] is not None:
+            # Check if sync browser is still connected
+            browser = state.get("_sync_browser")
+            is_connected = True
+            if browser:
+                try:
+                    is_connected = browser.is_connected()
+                except Exception:
+                    is_connected = False
+
+            if is_connected:
+                _touch_activity(state)
+                return True
+            else:
+                logger.warning(
+                    "Sync browser process disconnected, resetting state",
+                )
+                _reset_browser_state(state)
     else:
         # Accept both regular context (browser+context) and persistent context
         # (context only, no separate browser object)
         if state["context"] is not None:
-            _touch_activity(state)
-            return True
+            # Check if async browser is still connected
+            browser = state.get("browser")
+            is_connected = True
+            if browser:
+                is_connected = browser.is_connected()
+
+            if is_connected:
+                _touch_activity(state)
+                return True
+            else:
+                logger.warning(
+                    "Async browser process disconnected, resetting state",
+                )
+                _reset_browser_state(state)
 
     try:
         if _USE_SYNC_PLAYWRIGHT:
@@ -3955,6 +3987,27 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolResponse:
                 indent=2,
             ),
         )
+async def stop_all_browsers() -> None:
+    """Gracefully stop all active browser instances across all workspaces.
+
+    This should be called during application shutdown to ensure no zombie
+    browser processes are left behind.
+    """
+    if not _workspace_states:
+        return
+
+    logger.info("Stopping all browser instances...")
+    # Use list() to avoid mutation during iteration if stop resets state
+    for state in list(_workspace_states.values()):
+        if _is_browser_running(state):
+            try:
+                await _action_stop(state)
+            except Exception as e:
+                logger.error(
+                    "Failed to stop browser for workspace %s: %s",
+                    state.get("workspace_id", "unknown"),
+                    e,
+                )
 
 
 async def browser_use(  # pylint: disable=R0911,R0912
@@ -4194,7 +4247,8 @@ async def browser_use(  # pylint: disable=R0911,R0912
     _ws_id = _cwd.name if _cwd else "default"
     _ws_dir = str(_cwd) if _cwd else ""
     state = _get_workspace_state(_ws_id, _ws_dir)
-
+    _touch_activity(state)
+    
     action = (action or "").strip().lower()
     if not action:
         return _tool_response(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -762,7 +762,7 @@ def _attach_page_listeners(state: dict, page, page_id: str) -> None:
 
     page.on("crash", on_crash)
 
-    requests_list = state["network_requests"].setdefault(page_id, []))
+    requests_list = state["network_requests"].setdefault(page_id, [])
 
     def on_response(res):
         for r in requests_list:

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -746,7 +746,6 @@ def _attach_page_listeners(state: dict, page, page_id: str) -> None:
         logs.append({"level": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-    requests_list = state["network_requests"].setdefault(page_id, [])
 
     def on_request(req):
         requests_list.append(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -4250,7 +4250,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
     _ws_id = _cwd.name if _cwd else "default"
     _ws_dir = str(_cwd) if _cwd else ""
     state = _get_workspace_state(_ws_id, _ws_dir)
-    _touch_activity(state))
+    _touch_activity(state)
 
     action = (action or "").strip().lower()
     if not action:

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -3987,6 +3987,8 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolResponse:
                 indent=2,
             ),
         )
+
+
 async def stop_all_browsers() -> None:
     """Gracefully stop all active browser instances across all workspaces.
 

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -533,6 +533,14 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         except Exception as e:
             logger.error(f"Error stopping TokenUsageManager: {e}")
 
+        # Stop all browser instances
+        from ..agents.tools.browser_control import stop_all_browsers
+
+        try:
+            await stop_all_browsers()
+        except Exception as e:
+            logger.error(f"Error stopping browsers during shutdown: {e}")
+
         logger.info("Application shutdown complete")
 
 


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

Add _touch_activity in browser_use to prevent premature idle timeout
Add crash listener to log browser page crashes for better diagnostics.
Strengthen health check in _ensure_browser with real-time connectivity verification.
Implement stop_all_browsers and integrate into app lifespan for clean shutdown.

**Related Issue:** Fixes #4257

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ✅] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ✅] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ✅] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
