### PR TITLE
feat(WeCom): support tool_guard interactive card in streaming path

### DIFF
--- a/src/qwenpaw/app/channels/wecom/cards/dispatcher.py
+++ b/src/qwenpaw/app/channels/wecom/cards/dispatcher.py
@@ -121,8 +121,16 @@ class WecomCardHandler:
         to_handle: str,
         event: Any,
         send_meta: Dict[str, Any],
+        *,
+        skip_stream_detail: bool = False,
     ) -> bool:
         """Render ``event`` as a template card if any kind matches.
+
+        Args:
+            skip_stream_detail: When *True*, injects a transient flag
+                into ``send_meta`` so the render function skips streaming
+                the body text (caller already sent it, e.g. streaming
+                path).
 
         Returns ``True`` when a card was sent so the caller can skip
         the default text rendering.
@@ -133,6 +141,9 @@ class WecomCardHandler:
         kind = self._by_message_type.get(str(meta.get("message_type") or ""))
         if kind is None:
             return False
+
+        if skip_stream_detail:
+            send_meta["_skip_stream_detail"] = True
         try:
             return await kind.render(
                 self._channel,

--- a/src/qwenpaw/app/channels/wecom/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/wecom/cards/tool_guard.py
@@ -271,7 +271,9 @@ async def render(
         return False
 
     # Stream the guard details first, then post the button card.
-    await context.send_stream_detail(channel, frame, send_meta, body_text)
+    # Skip if the caller already streamed the content (streaming path).
+    if not send_meta.get("_skip_stream_detail"):
+        await context.send_stream_detail(channel, frame, send_meta, body_text)
     try:
         await channel._client.reply_template_card(
             frame,

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -1234,6 +1234,13 @@ class WecomChannel(BaseChannel):
                 stream_id[:20],
             )
 
+        await self._card_handler.try_send_card_for_event(
+            to_handle,
+            event,
+            send_meta,
+            skip_stream_detail=True,
+        )
+
     # ------------------------------------------------------------------
     # Interactive cards (tool_guard approval, etc.)
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Description

When streaming is enabled, tool_guard approval messages were already pushed
to the user via reply_stream deltas, but the interactive approval card was
never sent (it was only triggered in the non-streaming on_event_message_completed path).

### Changes:
- WecomChannel.on_streaming_end now calls try_send_card_for_event(skip_stream_detail=True)
  after finishing the stream segment to detect card-eligible events and send the card.
- WecomCardHandler.try_send_card_for_event accepts a keyword-only skip_stream_detail param;
  when True and a matching card kind is found, it injects _skip_stream_detail into send_meta
  before calling kind.render.
- tool_guard.render checks send_meta.get("_skip_stream_detail") to skip the redundant
  send_stream_detail call (content was already streamed).
- RenderFn type signature is unchanged; new card kinds are not affected.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
