### PR TITLE
feat(mcp): support TLS verify config

### DIFF
--- a/console/src/api/types/mcp.ts
+++ b/console/src/api/types/mcp.ts
@@ -28,6 +28,10 @@ export interface MCPClientInfo {
   url: string;
   /** HTTP headers for remote transport */
   headers: Record<string, string>;
+  /** Whether TLS certificates are verified */
+  tls_verify: boolean;
+  /** Optional CA bundle path for remote transport */
+  ca_file: string;
   /** Command to launch the MCP server */
   command: string;
   /** Command-line arguments */
@@ -83,6 +87,10 @@ export interface MCPClientCreateRequest {
     url?: string;
     /** HTTP headers for remote transport */
     headers?: Record<string, string>;
+    /** Whether TLS certificates are verified */
+    tls_verify?: boolean;
+    /** Optional CA bundle path for remote transport */
+    ca_file?: string;
     /** Command to launch the MCP server */
     command?: string;
     /** Command-line arguments */
@@ -116,6 +124,10 @@ export interface MCPClientUpdateRequest {
   url?: string;
   /** HTTP headers for remote transport */
   headers?: Record<string, string>;
+  /** Whether TLS certificates are verified */
+  tls_verify?: boolean;
+  /** Optional CA bundle path for remote transport */
+  ca_file?: string;
   /** Command to launch the MCP server */
   command?: string;
   /** Command-line arguments */

--- a/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
@@ -30,6 +30,8 @@ interface MCPClientUpdate {
   transport?: "stdio" | "streamable_http" | "sse";
   url?: string;
   headers?: Record<string, string>;
+  tls_verify?: boolean;
+  ca_file?: string;
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;
@@ -106,11 +108,13 @@ export const MCPClientCard = React.memo(function MCPClientCard({
 
   const handleSaveJson = async () => {
     try {
-      const parsed = JSON.parse(editedJson);
-      const { key: _key, ...updates } = parsed;
+      const parsed = JSON.parse(editedJson) as MCPClientUpdate & {
+        key?: string;
+      };
+      delete parsed.key;
 
       // Send all updates directly to backend, let backend handle env masking check
-      const success = await onUpdate(client.key, updates);
+      const success = await onUpdate(client.key, parsed);
       if (success) {
         setJsonModalOpen(false);
         setIsEditing(false);
@@ -130,8 +134,8 @@ export const MCPClientCard = React.memo(function MCPClientCard({
       try {
         const data = await api.listMCPTools(client.key);
         setTools(data);
-      } catch (err: any) {
-        const msg = err?.message || "";
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "";
         if (msg.includes("connecting") || msg.includes("not ready")) {
           setToolsError(t("mcp.toolsConnecting"));
         } else {

--- a/console/src/pages/Agent/MCP/useMCP.ts
+++ b/console/src/pages/Agent/MCP/useMCP.ts
@@ -5,6 +5,13 @@ import type { MCPClientInfo } from "../../../api/types";
 import { useTranslation } from "react-i18next";
 import { useAgentStore } from "../../../stores/agentStore";
 
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
 export function useMCP() {
   const { t } = useTranslation();
   const { selectedAgent } = useAgentStore();
@@ -23,7 +30,7 @@ export function useMCP() {
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [message, t]);
 
   useEffect(() => {
     loadClients();
@@ -40,6 +47,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        tls_verify?: boolean;
+        ca_file?: string;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;
@@ -53,13 +62,13 @@ export function useMCP() {
         message.success(t("mcp.createSuccess"));
         await loadClients();
         return true;
-      } catch (error: any) {
-        const errorMsg = error?.message || t("mcp.createError");
+      } catch (error) {
+        const errorMsg = getErrorMessage(error, t("mcp.createError"));
         message.error(errorMsg);
         return false;
       }
     },
-    [t, loadClients],
+    [message, t, loadClients],
   );
 
   const updateClient = useCallback(
@@ -73,6 +82,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        tls_verify?: boolean;
+        ca_file?: string;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;
@@ -83,13 +94,13 @@ export function useMCP() {
         message.success(t("mcp.updateSuccess"));
         await loadClients();
         return true;
-      } catch (error: any) {
-        const errorMsg = error?.message || t("mcp.updateError");
+      } catch (error) {
+        const errorMsg = getErrorMessage(error, t("mcp.updateError"));
         message.error(errorMsg);
         return false;
       }
     },
-    [t, loadClients],
+    [message, t, loadClients],
   );
 
   const toggleEnabled = useCallback(
@@ -100,11 +111,11 @@ export function useMCP() {
           client.enabled ? t("mcp.disableSuccess") : t("mcp.enableSuccess"),
         );
         await loadClients();
-      } catch (error) {
+      } catch {
         message.error(t("mcp.toggleError"));
       }
     },
-    [t, loadClients],
+    [message, t, loadClients],
   );
 
   const deleteClient = useCallback(
@@ -113,11 +124,11 @@ export function useMCP() {
         await api.deleteMCPClient(client.key);
         message.success(t("mcp.deleteSuccess"));
         await loadClients();
-      } catch (error) {
+      } catch {
         message.error(t("mcp.deleteError"));
       }
     },
-    [t, loadClients],
+    [message, t, loadClients],
   );
 
   return {

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -685,11 +685,13 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 if raw_headers
                 else None
             )
+            client_kwargs = rebuild_info.get("client_kwargs") or {}
             rebuilt_client = HttpStatefulClient(
                 name=name,
                 transport=transport,
                 url=rebuild_info.get("url"),
                 headers=headers,
+                **client_kwargs,
             )
             setattr(rebuilt_client, "_qwenpaw_rebuild_info", rebuild_info)
             return rebuilt_client

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -243,8 +243,25 @@ class MCPClientManager:
         return result
 
     @staticmethod
+    def _http_client_kwargs(
+        client_config: "MCPClientConfig",
+    ) -> Dict[str, Any]:
+        """Build extra HTTP client kwargs for remote MCP transports."""
+        if not client_config.tls_verify:
+            return {"verify": False}
+
+        ca_file = client_config.ca_file.strip()
+        if ca_file:
+            return {"verify": os.path.expandvars(ca_file)}
+
+        return {}
+
+    @staticmethod
     def _build_client(client_config: "MCPClientConfig") -> Any:
         """Build MCP client instance by configured transport."""
+        http_client_kwargs = MCPClientManager._http_client_kwargs(
+            client_config,
+        )
         rebuild_info = {
             "name": client_config.name,
             "transport": client_config.transport,
@@ -254,6 +271,7 @@ class MCPClientManager:
             "args": list(client_config.args),
             "env": dict(client_config.env),
             "cwd": client_config.cwd or None,
+            "client_kwargs": dict(http_client_kwargs),
         }
 
         if client_config.transport == "stdio":
@@ -281,6 +299,7 @@ class MCPClientManager:
             transport=client_config.transport,
             url=client_config.url,
             headers=headers or None,
+            **http_client_kwargs,
         )
         setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
         return client

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -667,6 +667,29 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
         # Tool cache
         self._cached_tools = None
 
+    def _make_sse_httpx_client_factory(self):
+        """Create an SSE httpx factory that preserves custom client kwargs."""
+
+        def httpx_client_factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+        ) -> httpx.AsyncClient:
+            kwargs: dict[str, Any] = {
+                "follow_redirects": True,
+                **self.client_kwargs,
+            }
+            if headers is not None:
+                kwargs["headers"] = headers
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            if auth is not None:
+                kwargs["auth"] = auth
+
+            return httpx.AsyncClient(**kwargs)
+
+        return httpx_client_factory
+
     async def _setup_transport(
         self,
         stack: AsyncExitStack,
@@ -697,13 +720,19 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
                 streamable_http_client(url=self.url, http_client=http_client),
             )
         else:
+            sse_kwargs: dict[str, Any] = {}
+            if self.client_kwargs:
+                sse_kwargs["httpx_client_factory"] = (
+                    self._make_sse_httpx_client_factory()
+                )
+
             context = await stack.enter_async_context(
                 sse_client(
                     url=self.url,
                     headers=self.headers,
                     timeout=self.timeout,
                     sse_read_timeout=self.sse_read_timeout,
-                    **self.client_kwargs,
+                    **sse_kwargs,
                 ),
             )
         return context[0], context[1]

--- a/src/qwenpaw/app/routers/mcp.py
+++ b/src/qwenpaw/app/routers/mcp.py
@@ -45,6 +45,14 @@ class MCPClientInfo(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    tls_verify: bool = Field(
+        default=True,
+        description="Whether TLS certificates are verified",
+    )
+    ca_file: str = Field(
+        default="",
+        description="Optional CA bundle path for remote transport",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -88,6 +96,14 @@ class MCPClientCreateRequest(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    tls_verify: bool = Field(
+        default=True,
+        description="Whether TLS certificates are verified",
+    )
+    ca_file: str = Field(
+        default="",
+        description="Optional CA bundle path for remote transport",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -126,6 +142,14 @@ class MCPClientUpdateRequest(BaseModel):
     headers: Optional[Dict[str, str]] = Field(
         None,
         description="HTTP headers for remote transport",
+    )
+    tls_verify: Optional[bool] = Field(
+        None,
+        description="Whether TLS certificates are verified",
+    )
+    ca_file: Optional[str] = Field(
+        None,
+        description="Optional CA bundle path for remote transport",
     )
     command: Optional[str] = Field(
         None,
@@ -233,6 +257,8 @@ def _build_client_info(key: str, client: MCPClientConfig) -> MCPClientInfo:
         transport=client.transport,
         url=client.url,
         headers=masked_headers,
+        tls_verify=client.tls_verify,
+        ca_file=client.ca_file,
         command=client.command,
         args=client.args,
         env=masked_env,
@@ -393,6 +419,8 @@ async def create_mcp_client(
         transport=client.transport,
         url=client.url,
         headers=client.headers,
+        tls_verify=client.tls_verify,
+        ca_file=client.ca_file,
         command=client.command,
         args=client.args,
         env=client.env,

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1251,6 +1251,14 @@ class MCPClientConfig(BaseModel):
     transport: Literal["stdio", "streamable_http", "sse"] = "stdio"
     url: str = ""
     headers: Dict[str, str] = Field(default_factory=dict)
+    tls_verify: bool = Field(
+        default=True,
+        description="Whether remote MCP HTTP clients verify TLS certificates",
+    )
+    ca_file: str = Field(
+        default="",
+        description="Optional CA bundle path for remote MCP HTTP clients",
+    )
     command: str = ""
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)

--- a/tests/unit/app/test_mcp_tls_config.py
+++ b/tests/unit/app/test_mcp_tls_config.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Tests for MCP remote TLS verification configuration."""
+
+from __future__ import annotations
+
+import httpx
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.app.mcp.manager import MCPClientManager
+from qwenpaw.app.mcp.stateful_client import HttpStatefulClient
+from qwenpaw.app.routers.mcp import (
+    MCPClientCreateRequest,
+    MCPClientUpdateRequest,
+    _build_client_info,
+)
+from qwenpaw.config.config import MCPClientConfig
+
+
+def _remote_config(**overrides):
+    data = {
+        "name": "remote",
+        "transport": "streamable_http",
+        "url": "https://mcp.example.com/mcp",
+    }
+    data.update(overrides)
+    return MCPClientConfig(**data)
+
+
+def test_mcp_client_config_tls_defaults():
+    config = _remote_config()
+
+    assert config.tls_verify is True
+    assert config.ca_file == ""
+
+
+def test_mcp_router_models_expose_tls_fields():
+    info = _build_client_info(
+        "remote",
+        _remote_config(tls_verify=False, ca_file="/tmp/ca.pem"),
+    )
+    create = MCPClientCreateRequest(
+        name="remote",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
+        tls_verify=False,
+        ca_file="/tmp/ca.pem",
+    )
+    update = MCPClientUpdateRequest(tls_verify=False, ca_file="/tmp/ca.pem")
+
+    assert info.tls_verify is False
+    assert info.ca_file == "/tmp/ca.pem"
+    assert create.tls_verify is False
+    assert create.ca_file == "/tmp/ca.pem"
+    assert update.tls_verify is False
+    assert update.ca_file == "/tmp/ca.pem"
+
+
+def test_http_client_kwargs_disable_tls_verification():
+    config = _remote_config(tls_verify=False, ca_file="/tmp/ca.pem")
+
+    assert MCPClientManager._http_client_kwargs(config) == {"verify": False}
+
+
+def test_http_client_kwargs_uses_ca_file_when_verification_enabled():
+    config = _remote_config(ca_file="/tmp/ca.pem")
+
+    assert MCPClientManager._http_client_kwargs(config) == {
+        "verify": "/tmp/ca.pem",
+    }
+
+
+def test_build_client_passes_tls_kwargs_to_http_client():
+    client = MCPClientManager._build_client(_remote_config(tls_verify=False))
+
+    assert client.client_kwargs == {"verify": False}
+    assert client._qwenpaw_rebuild_info["client_kwargs"] == {
+        "verify": False,
+    }
+
+
+def test_rebuild_mcp_client_preserves_tls_kwargs():
+    client = MCPClientManager._build_client(_remote_config(tls_verify=False))
+
+    rebuilt = QwenPawAgent._rebuild_mcp_client(client)
+
+    assert rebuilt is not None
+    assert rebuilt.client_kwargs == {"verify": False}
+
+
+def test_sse_httpx_factory_receives_tls_kwargs(monkeypatch):
+    captured = {}
+
+    class DummyAsyncClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", DummyAsyncClient)
+    client = HttpStatefulClient(
+        name="remote",
+        transport="sse",
+        url="https://mcp.example.com/sse",
+        verify=False,
+    )
+
+    factory = client._make_sse_httpx_client_factory()
+    created = factory(
+        headers={"Authorization": "Bearer token"},
+        timeout=httpx.Timeout(30),
+    )
+
+    assert isinstance(created, DummyAsyncClient)
+    assert captured["verify"] is False
+    assert captured["follow_redirects"] is True
+    assert captured["headers"] == {"Authorization": "Bearer token"}


### PR DESCRIPTION
## Summary
- add tls_verify and ca_file to MCP client config/API models and console types
- pass the resulting httpx verify option into remote MCP clients
- preserve TLS client kwargs when MCP clients are rebuilt, including SSE via a custom httpx factory

## Tests
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\app\\test_mcp_tls_config.py -q
- flake8 src\\qwenpaw\\app\\mcp\\manager.py src\\qwenpaw\\app\\mcp\\stateful_client.py src\\qwenpaw\\agents\\react_agent.py src\\qwenpaw\\app\\routers\\mcp.py src\\qwenpaw\\config\\config.py tests\\unit\\app\\test_mcp_tls_config.py --select=F401,F821,E999
- cd console; npx prettier --check src/api/types/mcp.ts src/pages/Agent/MCP/components/MCPClientCard.tsx src/pages/Agent/MCP/useMCP.ts
- cd console; npx eslint src/api/types/mcp.ts src/pages/Agent/MCP/components/MCPClientCard.tsx src/pages/Agent/MCP/useMCP.ts
- cd console; NODE_OPTIONS=--max-old-space-size=4096 npx tsc -b --noEmit
- git diff --check

Fixes #4175