### PR TITLE
fix(browser): bound external CDP connect

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -245,6 +245,7 @@ def _get_workspace_state(
 
 # Stop the browser after this many seconds of inactivity (default 10 minutes).
 _BROWSER_IDLE_TIMEOUT = 600.0
+_EXTERNAL_CDP_CONNECT_TIMEOUT = 15.0
 
 
 def _touch_activity(state: dict) -> None:
@@ -533,6 +534,31 @@ async def _wait_for_cdp_ready(
     raise RuntimeError(
         f"Timed out waiting for Chrome CDP endpoint on port {port}: {last_error}",
     )
+
+
+async def _connect_over_cdp_with_timeout(
+    pw: Any,
+    cdp_url: str,
+    timeout: float = _EXTERNAL_CDP_CONNECT_TIMEOUT,
+) -> Any:
+    """Connect to an external CDP endpoint without blocking indefinitely."""
+    return await asyncio.wait_for(
+        pw.chromium.connect_over_cdp(cdp_url),
+        timeout=timeout,
+    )
+
+
+async def _stop_playwright_after_failed_cdp_connect(pw: Any) -> None:
+    """Stop Playwright after a failed external CDP connection attempt."""
+    if pw is None:
+        return
+    try:
+        await pw.stop()
+    except Exception:
+        logger.debug(
+            "Failed to stop Playwright after CDP connect failure",
+            exc_info=True,
+        )
 
 
 async def _start_managed_cdp_browser(
@@ -3903,10 +3929,11 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolResponse:
             ),
         )
 
+    pw = None
     try:
         async_playwright = _ensure_playwright_async()
         pw = await async_playwright().start()
-        browser = await pw.chromium.connect_over_cdp(cdp_url)
+        browser = await _connect_over_cdp_with_timeout(pw, cdp_url)
         contexts = browser.contexts
         if contexts:
             context = contexts[0]
@@ -3947,7 +3974,23 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolResponse:
                 indent=2,
             ),
         )
+    except asyncio.TimeoutError:
+        await _stop_playwright_after_failed_cdp_connect(pw)
+        return _tool_response(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": (
+                        "CDP connect timed out after "
+                        f"{_EXTERNAL_CDP_CONNECT_TIMEOUT:g}s: {cdp_url}"
+                    ),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
     except Exception as e:
+        await _stop_playwright_after_failed_cdp_connect(pw)
         return _tool_response(
             json.dumps(
                 {"ok": False, "error": f"CDP connect failed: {e!s}"},

--- a/tests/unit/agents/tools/test_browser_control_cdp.py
+++ b/tests/unit/agents/tools/test_browser_control_cdp.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for browser CDP connection handling."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents.tools import browser_control
+
+
+def _response_text(response) -> str:
+    block = response.content[0]
+    if isinstance(block, dict):
+        return str(block["text"])
+    return str(block.text)
+
+
+@pytest.mark.asyncio
+async def test_connect_over_cdp_uses_bounded_timeout(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeChromium:
+        async def connect_over_cdp(self, cdp_url: str):
+            captured["cdp_url"] = cdp_url
+            return "browser"
+
+    async def fake_wait_for(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await awaitable
+
+    monkeypatch.setattr(browser_control.asyncio, "wait_for", fake_wait_for)
+
+    result = await browser_control._connect_over_cdp_with_timeout(
+        SimpleNamespace(chromium=FakeChromium()),
+        "http://127.0.0.1:9222",
+        timeout=3.5,
+    )
+
+    assert result == "browser"
+    assert captured == {
+        "cdp_url": "http://127.0.0.1:9222",
+        "timeout": 3.5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_connect_cdp_timeout_stops_playwright(monkeypatch, tmp_path):
+    class FakePlaywright:
+        def __init__(self):
+            self.stopped = False
+
+        async def stop(self):
+            self.stopped = True
+
+    class FakePlaywrightStarter:
+        def __init__(self, playwright):
+            self.playwright = playwright
+
+        async def start(self):
+            return self.playwright
+
+    playwright = FakePlaywright()
+
+    def fake_async_playwright():
+        return FakePlaywrightStarter(playwright)
+
+    async def raise_timeout(_pw, _cdp_url):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(
+        browser_control,
+        "_ensure_playwright_async",
+        lambda: fake_async_playwright,
+    )
+    monkeypatch.setattr(
+        browser_control,
+        "_connect_over_cdp_with_timeout",
+        raise_timeout,
+    )
+
+    state = browser_control._make_fresh_state("test", str(tmp_path))
+
+    response = await browser_control._action_connect_cdp(
+        state,
+        "http://127.0.0.1:9222",
+    )
+    payload = json.loads(_response_text(response))
+
+    assert payload["ok"] is False
+    assert "timed out after 15s" in payload["error"]
+    assert "http://127.0.0.1:9222" in payload["error"]
+    assert playwright.stopped is True
+    assert state["playwright"] is None


### PR DESCRIPTION
## Summary
- add a 15s timeout around external browser_use CDP connections
- stop the Playwright driver when CDP connection setup times out or fails before state is registered
- add regression coverage for bounded connect_over_cdp and timeout cleanup

## Tests
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\agents\\tools\\test_browser_control_cdp.py -q
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\agents\\tools -q
- flake8 src\\qwenpaw\\agents\\tools\\browser_control.py tests\\unit\\agents\\tools\\test_browser_control_cdp.py --select=F401,F821,E999
- git diff --check

Fixes #4309