### PR TITLE
Fix(Provider): Fix anthropic provider max token handling

### DIFF
--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -175,12 +175,8 @@ class AnthropicProvider(Provider):
                 ),
             }
 
-        self.generate_kwargs = self.get_effective_generate_kwargs(model_id)
-
-        if "max_tokens" in self.generate_kwargs:
-            max_tokens = self.generate_kwargs.pop("max_tokens")
-        else:
-            max_tokens = 16384
+        effective_generate_kwargs = self.get_effective_generate_kwargs(model_id)
+        max_tokens = effective_generate_kwargs.pop("max_tokens", 16384)
 
         return AnthropicChatModel(
             model_name=model_id,
@@ -189,7 +185,7 @@ class AnthropicProvider(Provider):
             api_key=self.api_key,
             stream_tool_parsing=False,
             client_kwargs=client_kwargs,
-            generate_kwargs=self.get_effective_generate_kwargs(model_id),
+            generate_kwargs=effective_generate_kwargs,
         )
 
     async def probe_model_multimodal(

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -175,7 +175,9 @@ class AnthropicProvider(Provider):
                 ),
             }
 
-        effective_generate_kwargs = self.get_effective_generate_kwargs(model_id)
+        effective_generate_kwargs = self.get_effective_generate_kwargs(
+            model_id,
+        )
         max_tokens = effective_generate_kwargs.pop("max_tokens", 16384)
 
         return AnthropicChatModel(

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -66,6 +66,38 @@ def test_get_chat_model_instance_uses_default_max_tokens_when_unset(
     assert captured["max_tokens"] == 16384
 
 
+def test_get_chat_model_instance_does_not_mutate_generate_kwargs(
+    monkeypatch,
+) -> None:
+    captured: list[dict[str, object]] = []
+
+    class FakeAnthropicChatModel:
+        def __init__(self, **kwargs) -> None:
+            captured.append(kwargs)
+
+    monkeypatch.setattr(
+        "agentscope.model.AnthropicChatModel",
+        FakeAnthropicChatModel,
+    )
+
+    provider = _make_provider()
+    provider.generate_kwargs = {
+        "max_tokens": 32768,
+        "temperature": 0.2,
+    }
+
+    provider.get_chat_model_instance("claude-3-5-sonnet")
+    provider.get_chat_model_instance("claude-3-5-sonnet")
+
+    assert [call["max_tokens"] for call in captured] == [32768, 32768]
+    assert provider.generate_kwargs == {
+        "max_tokens": 32768,
+        "temperature": 0.2,
+    }
+    assert captured[0]["generate_kwargs"] == {"temperature": 0.2}
+    assert captured[1]["generate_kwargs"] == {"temperature": 0.2}
+
+
 async def test_check_connection_success(monkeypatch) -> None:
     provider = _make_provider()
     called = {"count": 0}


### PR DESCRIPTION
## Description

This pull request addresses a subtle bug in the `AnthropicProvider` implementation that could cause unintended mutation of the `generate_kwargs` dictionary when creating chat model instances. The changes ensure that the `max_tokens` parameter is handled safely and that the original configuration is preserved across multiple calls. Additionally, a new unit test is added to verify this behavior.

**Bug fix for parameter mutation:**

* Refactored `get_chat_model_instance` in `src/qwenpaw/providers/anthropic_provider.py` to avoid mutating the original `generate_kwargs` dictionary. The method now pops `max_tokens` from a local copy, ensuring the provider's configuration remains unchanged on repeated calls. [[1]](diffhunk://#diff-082a13edf9efdcb529d218b56b3b181795bd672c3301e69afe1a017a897d8dbbL178-R181) [[2]](diffhunk://#diff-082a13edf9efdcb529d218b56b3b181795bd672c3301e69afe1a017a897d8dbbL192-R190)

**Testing improvements:**

* Added a new unit test `test_get_chat_model_instance_does_not_mutate_generate_kwargs` in `tests/unit/providers/test_anthropic_provider.py` to confirm that `generate_kwargs` is not mutated and that repeated calls to `get_chat_model_instance` behave as expected.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
