### PR TITLE
fix(providers): preserve MiMo reasoning content

### DIFF
--- a/src/qwenpaw/providers/anthropic_chat_model_compat.py
+++ b/src/qwenpaw/providers/anthropic_chat_model_compat.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Compatibility helpers for Anthropic-compatible chat models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, AsyncIterable, Type
+
+from agentscope.model import AnthropicChatModel, ChatResponse
+from pydantic import BaseModel
+
+
+_ANTHROPIC_DELTA_TYPES = {
+    "text_delta",
+    "thinking_delta",
+    "signature_delta",
+    "input_json_delta",
+}
+
+
+def _value(obj: Any, key: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _text_or_none(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _content_block_delta_event(event: Any, delta: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="content_block_delta",
+        index=_value(event, "index"),
+        delta=delta,
+    )
+
+
+async def _normalize_openai_style_reasoning_deltas(
+    response: AsyncIterable[Any],
+) -> AsyncGenerator[Any, None]:
+    """Map MiMo/OpenAI-style Anthropic deltas into native Anthropic deltas."""
+    async for event in response:
+        if _value(event, "type") != "content_block_delta":
+            yield event
+            continue
+
+        delta = _value(event, "delta")
+        delta_type = _value(delta, "type")
+        if delta_type in _ANTHROPIC_DELTA_TYPES:
+            yield event
+            continue
+
+        reasoning_content = _text_or_none(_value(delta, "reasoning_content"))
+        content = _text_or_none(_value(delta, "content"))
+        if not reasoning_content and not content:
+            yield event
+            continue
+
+        if reasoning_content:
+            yield _content_block_delta_event(
+                event,
+                SimpleNamespace(
+                    type="thinking_delta",
+                    thinking=reasoning_content,
+                ),
+            )
+        if content:
+            yield _content_block_delta_event(
+                event,
+                SimpleNamespace(
+                    type="text_delta",
+                    text=content,
+                ),
+            )
+
+
+class AnthropicChatModelCompat(AnthropicChatModel):
+    """Anthropic model wrapper for compatible-provider stream quirks."""
+
+    async def _parse_anthropic_stream_completion_response(
+        self,
+        start_datetime: datetime,
+        response: AsyncIterable[Any],
+        structured_model: Type[BaseModel] | None = None,
+    ) -> AsyncGenerator[ChatResponse, None]:
+        normalized_response = _normalize_openai_style_reasoning_deltas(
+            response,
+        )
+        async for chunk in super()._parse_anthropic_stream_completion_response(
+            start_datetime,
+            normalized_response,
+            structured_model,
+        ):
+            yield chunk

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -18,6 +18,9 @@ from qwenpaw.providers.multimodal_prober import (
     _is_media_keyword_error,
     evaluate_image_probe_answer,
 )
+from qwenpaw.providers.anthropic_chat_model_compat import (
+    AnthropicChatModelCompat,
+)
 from qwenpaw.providers.provider import ModelInfo, Provider
 
 logger = logging.getLogger(__name__)
@@ -135,8 +138,6 @@ class AnthropicProvider(Provider):
             )
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
-        from agentscope.model import AnthropicChatModel
-
         client_kwargs = {"base_url": self.base_url}
         if self.base_url in DASHSCOPE_BASE_URLS:
             client_kwargs["default_headers"] = {
@@ -182,7 +183,7 @@ class AnthropicProvider(Provider):
         else:
             max_tokens = 16384
 
-        return AnthropicChatModel(
+        return AnthropicChatModelCompat(
             model_name=model_id,
             max_tokens=max_tokens,
             stream=True,

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -173,11 +173,25 @@ def _is_missing_reasoning_content_error(exc: Exception) -> bool:
     return "reasoning_content" in str(exc)
 
 
+def _extract_reasoning_content(msg: dict[str, Any]) -> str:
+    """Return preserved thinking text for providers that require it."""
+    content = msg.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "thinking":
+                continue
+            for key in ("thinking", "reasoning_content", "text"):
+                value = block.get(key)
+                if isinstance(value, str) and value:
+                    return value
+    return " "
+
+
 def _inject_reasoning_content(
     args: tuple,
     kwargs: dict[str, Any],
 ) -> bool:
-    """Add ``reasoning_content = " "`` to assistant messages that lack it.
+    """Add ``reasoning_content`` to assistant messages that lack it.
 
     Modifies the formatted message dicts **in-place** so the subsequent
     retry sees the updated values.  Returns *True* when at least one
@@ -199,7 +213,7 @@ def _inject_reasoning_content(
             and msg.get("role") == "assistant"
             and "reasoning_content" not in msg
         ):
-            msg["reasoning_content"] = " "
+            msg["reasoning_content"] = _extract_reasoning_content(msg)
             modified = True
 
     return modified

--- a/tests/unit/providers/test_anthropic_chat_model_compat.py
+++ b/tests/unit/providers/test_anthropic_chat_model_compat.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qwenpaw.providers.anthropic_chat_model_compat import (
+    AnthropicChatModelCompat,
+)
+
+
+async def _aiter_events(*events: Any):
+    for event in events:
+        yield event
+
+
+def _message_start():
+    return SimpleNamespace(
+        type="message_start",
+        message=SimpleNamespace(
+            id="msg_1",
+            usage=SimpleNamespace(input_tokens=3, output_tokens=0),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_parser_preserves_openai_style_reasoning_content():
+    model = AnthropicChatModelCompat(
+        model_name="mimo",
+        api_key="test",
+        stream=True,
+        stream_tool_parsing=False,
+    )
+    stream = _aiter_events(
+        _message_start(),
+        SimpleNamespace(
+            type="content_block_delta",
+            index=0,
+            delta={
+                "content": "",
+                "reasoning_content": "Need memory before answering.",
+            },
+        ),
+        SimpleNamespace(
+            type="content_block_start",
+            index=1,
+            content_block=SimpleNamespace(
+                type="tool_use",
+                id="toolu_1",
+                name="memory_search",
+            ),
+        ),
+        SimpleNamespace(
+            type="content_block_delta",
+            index=1,
+            delta=SimpleNamespace(
+                type="input_json_delta",
+                partial_json='{"query":"preferences"}',
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in model._parse_anthropic_stream_completion_response(
+            datetime.now(),
+            stream,
+        )
+    ]
+
+    final_content = chunks[-1].content
+    assert final_content[0]["type"] == "thinking"
+    assert final_content[0]["thinking"] == "Need memory before answering."
+    assert final_content[1]["type"] == "tool_use"
+    assert final_content[1]["input"] == {"query": "preferences"}
+
+
+@pytest.mark.asyncio
+async def test_stream_parser_maps_openai_style_content_delta_to_text():
+    model = AnthropicChatModelCompat(
+        model_name="mimo",
+        api_key="test",
+        stream=True,
+        stream_tool_parsing=False,
+    )
+    stream = _aiter_events(
+        _message_start(),
+        SimpleNamespace(
+            type="content_block_delta",
+            index=0,
+            delta={
+                "content": "Hello",
+                "reasoning_content": "",
+            },
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in model._parse_anthropic_stream_completion_response(
+            datetime.now(),
+            stream,
+        )
+    ]
+
+    assert chunks[-1].content == [{"type": "text", "text": "Hello"}]

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -28,7 +28,8 @@ def test_get_chat_model_instance_uses_configured_max_tokens(
             captured.update(kwargs)
 
     monkeypatch.setattr(
-        "agentscope.model.AnthropicChatModel",
+        anthropic_provider_module,
+        "AnthropicChatModelCompat",
         FakeAnthropicChatModel,
     )
 
@@ -54,7 +55,8 @@ def test_get_chat_model_instance_uses_default_max_tokens_when_unset(
             captured.update(kwargs)
 
     monkeypatch.setattr(
-        "agentscope.model.AnthropicChatModel",
+        anthropic_provider_module,
+        "AnthropicChatModelCompat",
         FakeAnthropicChatModel,
     )
 

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from qwenpaw.providers.retry_chat_model import _inject_reasoning_content
+
+
+def test_inject_reasoning_content_preserves_thinking_block() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Need to inspect memory before answering.",
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "memory_search",
+                    "input": {"query": "preferences"},
+                },
+            ],
+        },
+    ]
+
+    assert _inject_reasoning_content((), {"messages": messages})
+    assert (
+        messages[0]["reasoning_content"]
+        == "Need to inspect memory before answering."
+    )
+
+
+def test_inject_reasoning_content_uses_placeholder_without_thinking() -> None:
+    messages = [{"role": "assistant", "content": "Plain response"}]
+
+    assert _inject_reasoning_content((messages,), {})
+    assert messages[0]["reasoning_content"] == " "
+
+
+def test_inject_reasoning_content_does_not_overwrite_existing_value() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "Newly formatted thought"},
+            ],
+            "reasoning_content": "Already preserved thought",
+        },
+    ]
+
+    assert not _inject_reasoning_content((), {"messages": messages})
+    assert messages[0]["reasoning_content"] == "Already preserved thought"


### PR DESCRIPTION
## Summary
- preserve complete thinking text when retrying providers that require `reasoning_content`
- parse MiMo/OpenAI-style `delta.reasoning_content` chunks from Anthropic-compatible streams into native thinking blocks
- keep existing Anthropic delta handling untouched and add regression coverage for MiMo-style tool-call histories

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/providers/test_anthropic_chat_model_compat.py tests/unit/providers/test_retry_chat_model.py -q` (PowerShell: `$env:PYTHONPATH='src'; ...`)
- `PYTHONPATH=src python -m pytest tests/unit/providers -q` (105 passed)
- `pre-commit run --files src/qwenpaw/providers/anthropic_chat_model_compat.py src/qwenpaw/providers/anthropic_provider.py tests/unit/providers/test_anthropic_chat_model_compat.py tests/unit/providers/test_retry_chat_model.py tests/unit/providers/test_anthropic_provider.py`
- `git diff --check`

Fixes #4314