### PR TITLE
fix(app): broaden agent config reload scope

### DIFF
--- a/src/qwenpaw/app/agent_config_watcher.py
+++ b/src/qwenpaw/app/agent_config_watcher.py
@@ -3,14 +3,15 @@
 
 Delegates to ``MultiAgentManager.reload_agent`` so disk-edit reloads
 go through the same atomic workspace swap as frontend saves and wait
-for in-flight tasks. Only triggers when ``channels`` or ``heartbeat``
-hashes change, so runtime bookkeeping rewrites (e.g. ``last_dispatch``)
-do not cause spurious reloads.
+for in-flight tasks. Only triggers when runtime-affecting sections
+change, so runtime bookkeeping rewrites (e.g. ``last_dispatch``) do not
+cause spurious reloads.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
@@ -27,18 +28,60 @@ logger = logging.getLogger(__name__)
 DEFAULT_POLL_INTERVAL = 2.0
 
 
+def _to_jsonable(value: Any) -> Any:
+    """Return a JSON-serializable representation for stable hashing."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {key: _to_jsonable(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _section_hash(value: Any) -> Optional[int]:
+    """Hash a config section after normalizing key order and models."""
+    if value is None:
+        return None
+    normalized = json.dumps(
+        _to_jsonable(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hash(normalized)
+
+
 def _channels_hash(channels: Any) -> Optional[int]:
     """Hash of channels section for change detection."""
-    if channels is None:
-        return None
-    return hash(str(channels.model_dump(mode="json")))
+    return _section_hash(channels)
 
 
-def _heartbeat_hash(hb: Optional["HeartbeatConfig"]) -> int:
+def _heartbeat_hash(hb: Optional["HeartbeatConfig"]) -> Optional[int]:
     """Hash of heartbeat config for change detection."""
-    if hb is None:
-        return hash("None")
-    return hash(str(hb.model_dump(mode="json")))
+    return _section_hash(hb)
+
+
+def _mcp_hash(mcp: Any) -> Optional[int]:
+    """Hash of MCP clients for change detection."""
+    if mcp is None:
+        return None
+    return _section_hash(getattr(mcp, "clients", None))
+
+
+def _skill_manifest_hash(manifest_path: Path) -> Optional[int]:
+    """Hash of workspace skill manifest for change detection."""
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = raw
+    return _section_hash(payload)
 
 
 class AgentConfigWatcher:
@@ -64,13 +107,16 @@ class AgentConfigWatcher:
         self._agent_id = agent_id
         self._workspace_dir = workspace_dir
         self._config_path = workspace_dir / "agent.json"
+        self._skill_manifest_path = workspace_dir / "skill.json"
         self._workspace = workspace
         self._poll_interval = poll_interval
         self._task: Optional[asyncio.Task] = None
 
-        self._last_mtime: float = 0.0
+        self._last_mtime: tuple[float, float] = (0.0, 0.0)
         self._last_channels_hash: Optional[int] = None
         self._last_heartbeat_hash: Optional[int] = None
+        self._last_mcp_hash: Optional[int] = None
+        self._last_skill_manifest_hash: Optional[int] = None
 
         # Set before triggering reload; poll loop checks this to stop.
         self._disabled: bool = False
@@ -109,12 +155,20 @@ class AgentConfigWatcher:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _read_mtime(self) -> float:
-        """Return current mtime of agent.json, 0.0 if missing."""
+    @staticmethod
+    def _path_mtime(path: Path) -> float:
+        """Return current mtime of a path, 0.0 if missing."""
         try:
-            return self._config_path.stat().st_mtime
+            return path.stat().st_mtime
         except FileNotFoundError:
             return 0.0
+
+    def _read_mtime(self) -> tuple[float, float]:
+        """Return current mtimes of agent.json and skill.json."""
+        return (
+            self._path_mtime(self._config_path),
+            self._path_mtime(self._skill_manifest_path),
+        )
 
     def _snapshot(self) -> None:
         """Record current mtime and section hashes as the new baseline."""
@@ -132,6 +186,12 @@ class AgentConfigWatcher:
         )
         self._last_heartbeat_hash = _heartbeat_hash(
             getattr(agent_config, "heartbeat", None),
+        )
+        self._last_mcp_hash = _mcp_hash(
+            getattr(agent_config, "mcp", None),
+        )
+        self._last_skill_manifest_hash = _skill_manifest_hash(
+            self._skill_manifest_path,
         )
 
     def _resolve_manager(self):
@@ -175,19 +235,31 @@ class AgentConfigWatcher:
         new_heartbeat_hash = _heartbeat_hash(
             getattr(agent_config, "heartbeat", None),
         )
+        new_mcp_hash = _mcp_hash(
+            getattr(agent_config, "mcp", None),
+        )
+        new_skill_manifest_hash = _skill_manifest_hash(
+            self._skill_manifest_path,
+        )
 
         old_channels_hash = self._last_channels_hash
         old_heartbeat_hash = self._last_heartbeat_hash
+        old_mcp_hash = self._last_mcp_hash
+        old_skill_manifest_hash = self._last_skill_manifest_hash
 
         changed = (
             new_channels_hash != old_channels_hash
             or new_heartbeat_hash != old_heartbeat_hash
+            or new_mcp_hash != old_mcp_hash
+            or new_skill_manifest_hash != old_skill_manifest_hash
         )
 
         # Refresh hashes regardless so non-meaningful rewrites
         # (e.g. last_dispatch) re-baseline silently.
         self._last_channels_hash = new_channels_hash
         self._last_heartbeat_hash = new_heartbeat_hash
+        self._last_mcp_hash = new_mcp_hash
+        self._last_skill_manifest_hash = new_skill_manifest_hash
 
         if not changed:
             return
@@ -207,7 +279,10 @@ class AgentConfigWatcher:
             f"AgentConfigWatcher ({self._agent_id}): "
             f"config changed, triggering graceful reload "
             f"(channels: {old_channels_hash} -> {new_channels_hash}, "
-            f"heartbeat: {old_heartbeat_hash} -> {new_heartbeat_hash})",
+            f"heartbeat: {old_heartbeat_hash} -> {new_heartbeat_hash}, "
+            f"mcp: {old_mcp_hash} -> {new_mcp_hash}, "
+            f"skills: {old_skill_manifest_hash} -> "
+            f"{new_skill_manifest_hash})",
         )
         try:
             await manager.reload_agent(self._agent_id)

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -109,13 +109,12 @@ async def create_channel_service(ws: "Workspace", _):
 
 
 async def create_agent_config_watcher(ws: "Workspace", _):
-    """Create agent config watcher if channel/cron exists.
+    """Create agent config watcher if reloadable services exist.
 
     The watcher only triggers reloads via ``MultiAgentManager`` and
     does not need direct references to channel/cron managers anymore.
-    Creation is still gated on having at least one of them, since
-    workspaces with neither have no externally-visible state that
-    benefits from auto-reload.
+    Creation is gated on services whose config changes benefit from
+    auto-reload, including channels, cron, MCP, and skills.
 
     Args:
         ws: Workspace instance
@@ -127,8 +126,9 @@ async def create_agent_config_watcher(ws: "Workspace", _):
     # pylint: disable=protected-access
     channel_mgr = ws._service_manager.services.get("channel_manager")
     cron_mgr = ws._service_manager.services.get("cron_manager")
+    mcp_mgr = ws._service_manager.services.get("mcp_manager")
 
-    if not (channel_mgr or cron_mgr):
+    if not (channel_mgr or cron_mgr or mcp_mgr):
         return None
 
     from ..agent_config_watcher import AgentConfigWatcher

--- a/tests/unit/app/test_agent_config_watcher.py
+++ b/tests/unit/app/test_agent_config_watcher.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import qwenpaw.app.agent_config_watcher as watcher_module
+from qwenpaw.app.agent_config_watcher import (
+    AgentConfigWatcher,
+    _mcp_hash,
+    _skill_manifest_hash,
+)
+
+
+class Dumpable:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def model_dump(self, mode: str = "json") -> dict[str, Any]:
+        assert mode == "json"
+        return self._payload
+
+
+def test_mcp_hash_tracks_client_config_changes() -> None:
+    mcp = SimpleNamespace(
+        clients={
+            "search": Dumpable(
+                {
+                    "name": "search",
+                    "enabled": True,
+                    "command": "npx",
+                },
+            ),
+        },
+    )
+    original_hash = _mcp_hash(mcp)
+
+    mcp.clients["search"] = Dumpable(
+        {
+            "name": "search",
+            "enabled": False,
+            "command": "npx",
+        },
+    )
+
+    assert _mcp_hash(mcp) != original_hash
+
+
+def test_skill_manifest_hash_ignores_json_whitespace(tmp_path) -> None:
+    manifest_path = tmp_path / "skill.json"
+    manifest_path.write_text(
+        '{"skills":{"news":{"enabled":true}}}',
+        encoding="utf-8",
+    )
+    original_hash = _skill_manifest_hash(manifest_path)
+
+    manifest_path.write_text(
+        '{\n  "skills": {\n    "news": {\n      "enabled": true\n    }\n  }\n}',
+        encoding="utf-8",
+    )
+    assert _skill_manifest_hash(manifest_path) == original_hash
+
+    manifest_path.write_text(
+        '{"skills":{"news":{"enabled":false}}}',
+        encoding="utf-8",
+    )
+    assert _skill_manifest_hash(manifest_path) != original_hash
+
+
+def test_read_mtime_tracks_agent_and_skill_files(tmp_path) -> None:
+    watcher = AgentConfigWatcher(
+        agent_id="default",
+        workspace_dir=tmp_path,
+        workspace=SimpleNamespace(),
+    )
+
+    assert watcher._read_mtime() == (0.0, 0.0)
+
+    (tmp_path / "agent.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "skill.json").write_text("{}", encoding="utf-8")
+
+    config_mtime, skill_mtime = watcher._read_mtime()
+    assert config_mtime > 0.0
+    assert skill_mtime > 0.0
+
+
+async def test_check_reloads_when_skill_manifest_changes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    class Manager:
+        def __init__(self) -> None:
+            self.reloaded_agents: list[str] = []
+
+        async def reload_agent(self, agent_id: str) -> None:
+            self.reloaded_agents.append(agent_id)
+
+    monkeypatch.setattr(
+        watcher_module,
+        "load_agent_config",
+        lambda _agent_id: SimpleNamespace(
+            channels=None,
+            heartbeat=None,
+            mcp=None,
+        ),
+    )
+
+    (tmp_path / "agent.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "skill.json").write_text('{"skills":{}}', encoding="utf-8")
+
+    manager = Manager()
+    watcher = AgentConfigWatcher(
+        agent_id="default",
+        workspace_dir=tmp_path,
+        workspace=SimpleNamespace(_manager=manager),
+    )
+    watcher._snapshot()
+
+    (tmp_path / "skill.json").write_text(
+        '{"skills":{"news":{"enabled":true}}}',
+        encoding="utf-8",
+    )
+    next_mtime = time.time() + 5
+    os.utime(tmp_path / "skill.json", (next_mtime, next_mtime))
+
+    await watcher._check()
+
+    assert manager.reloaded_agents == ["default"]
+    assert watcher._disabled is True


### PR DESCRIPTION
## Summary
- include MCP client config and workspace skill manifest hashes in AgentConfigWatcher reload detection
- watch both agent.json and skill.json mtimes so skill manifest updates can trigger reloads
- create the watcher for MCP-backed workspaces and cover the new hash/mtime behavior with unit tests

Fixes #4312

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\app\test_agent_config_watcher.py -q
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\app -q
- flake8 src\qwenpaw\app\agent_config_watcher.py src\qwenpaw\app\workspace\service_factories.py tests\unit\app\test_agent_config_watcher.py --select=F401,F821,E999
- git diff --check