### PR TITLE
fix(shell): honor envs path for commands

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -23,6 +23,15 @@ from ...config.context import (
     get_current_shell_command_timeout,
     get_current_workspace_dir,
 )
+from ...envs.store import load_envs
+
+
+_PROTECTED_SHELL_ENV_KEYS = frozenset(
+    {
+        "QWENPAW_WORKING_DIR",
+        "QWENPAW_SECRET_DIR",
+    },
+)
 
 
 def _kill_process_tree_win32(pid: int) -> None:
@@ -208,6 +217,41 @@ def _extract_powershell_command(cmd: str) -> tuple[str | None, str]:
     if len(inner) >= 2 and inner[0] == '"' and inner[-1] == '"':
         inner = inner[1:-1]
     return ps_exe, inner
+
+
+def _expand_path_placeholders(path_value: str, base_path: str) -> str:
+    """Expand common PATH placeholders in persisted env configuration."""
+    expanded = path_value
+    for placeholder in ("${PATH}", "$PATH", "%PATH%", "%Path%"):
+        expanded = expanded.replace(placeholder, base_path)
+    return expanded
+
+
+def _build_shell_env() -> dict[str, str]:
+    """Build the subprocess environment for ``execute_shell_command``."""
+    env = os.environ.copy()
+    process_path = env.get("PATH", "")
+
+    try:
+        persisted_env = load_envs()
+    except Exception:
+        persisted_env = {}
+
+    for key, value in persisted_env.items():
+        if key in _PROTECTED_SHELL_ENV_KEYS:
+            continue
+        if key == "PATH":
+            env["PATH"] = _expand_path_placeholders(value, process_path)
+        elif key not in env:
+            env[key] = value
+
+    python_bin_dir = str(Path(sys.executable).parent)
+    existing_path = env.get("PATH", "")
+    if existing_path:
+        env["PATH"] = python_bin_dir + os.pathsep + existing_path
+    else:
+        env["PATH"] = python_bin_dir
+    return env
 
 
 # pylint: disable=too-many-branches, too-many-statements
@@ -403,14 +447,8 @@ async def execute_shell_command(
     else:
         working_dir = get_current_workspace_dir() or WORKING_DIR
 
-    # Ensure the venv Python is on PATH for subprocesses
-    env = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    existing_path = env.get("PATH", "")
-    if existing_path:
-        env["PATH"] = python_bin_dir + os.pathsep + existing_path
-    else:
-        env["PATH"] = python_bin_dir
+    # Ensure envs.json PATH is honored and venv Python remains first.
+    env = _build_shell_env()
 
     shell_executable = (
         get_current_shell_command_executable()

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from qwenpaw.agents.tools import shell
+
+
+def test_build_shell_env_honors_persisted_path(monkeypatch) -> None:
+    process_path = os.pathsep.join(["/usr/local/bin", "/usr/bin"])
+    persisted_path = os.pathsep.join(["/home/user/.local/bin", "$PATH"])
+    monkeypatch.setenv("PATH", process_path)
+    monkeypatch.setattr(
+        shell,
+        "load_envs",
+        lambda: {
+            "PATH": persisted_path,
+            "CUSTOM_TOOL_HOME": "/home/user/.local",
+        },
+    )
+
+    env = shell._build_shell_env()
+
+    path_parts = env["PATH"].split(os.pathsep)
+    assert path_parts[0] == str(Path(sys.executable).parent)
+    assert path_parts[1] == "/home/user/.local/bin"
+    assert "/usr/local/bin" in path_parts
+    assert "/usr/bin" in path_parts
+    assert env["CUSTOM_TOOL_HOME"] == "/home/user/.local"
+
+
+def test_build_shell_env_keeps_protected_process_values(monkeypatch) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", "/runtime/workdir")
+    monkeypatch.delenv("QWENPAW_SECRET_DIR", raising=False)
+    monkeypatch.setattr(
+        shell,
+        "load_envs",
+        lambda: {
+            "QWENPAW_WORKING_DIR": "/persisted/workdir",
+            "QWENPAW_SECRET_DIR": "/persisted/secret",
+        },
+    )
+
+    env = shell._build_shell_env()
+
+    assert env["QWENPAW_WORKING_DIR"] == "/runtime/workdir"
+    assert "QWENPAW_SECRET_DIR" not in env
+
+
+def test_build_shell_env_falls_back_to_venv_path(monkeypatch) -> None:
+    monkeypatch.delenv("PATH", raising=False)
+    monkeypatch.setattr(shell, "load_envs", lambda: {})
+
+    env = shell._build_shell_env()
+
+    assert env["PATH"] == str(Path(sys.executable).parent)


### PR DESCRIPTION
## Summary
- build the shell subprocess environment through a tested helper
- honor PATH configured in envs.json while preserving process PATH placeholders like  and %PATH%
- keep the QwenPaw venv Python directory first on PATH and preserve protected bootstrap env keys

Fixes #4323

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\tools\test_shell.py -q
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\tools -q
- flake8 src\qwenpaw\agents\tools\shell.py tests\unit\agents\tools\test_shell.py --select=F401,F821,E999
- git diff --check