### PR TITLE
fix(skill): fix skill path, use safer path normalizer and refactor for function naming

### DIFF
--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -15,29 +15,30 @@ from .registry import (
     ensure_skill_pool_initialized,
 )
 from .store import (
-    _build_import_conflict,
-    _build_skill_metadata,
-    _copy_skill_dir,
-    _default_pool_manifest,
-    _default_workspace_manifest,
-    _extract_zip_skills,
-    _import_skill_dir,
-    _mutate_json,
-    _normalize_skill_dir_name,
-    _read_json,
-    _read_skill_from_dir,
-    _scan_skill_dir_or_raise,
-    _staged_skill_dir,
-    _validate_skill_content,
-    _write_skill_to_dir,
+    build_import_conflict,
+    build_skill_metadata,
+    copy_skill_dir,
+    default_pool_manifest,
+    default_workspace_manifest,
+    extract_zip_skills,
     get_pool_skill_manifest_path,
     get_skill_pool_dir,
     get_workspace_identity,
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
+    import_skill_dir,
+    mutate_json,
+    normalize_skill_dir_name,
+    read_json,
+    read_skill_from_dir,
     read_skill_manifest,
     read_skill_pool_manifest,
+    safe_skill_dir,
+    scan_skill_dir_or_raise,
+    staged_skill_dir,
     suggest_conflict_name,
+    validate_skill_content,
+    write_skill_to_dir,
 )
 
 
@@ -71,7 +72,7 @@ class SkillPoolService:
         pool_dir = get_skill_pool_dir()
         skills: list[SkillInfo] = []
         for skill_name, entry in sorted(manifest.get("skills", {}).items()):
-            skill = _read_skill_from_dir(
+            skill = read_skill_from_dir(
                 pool_dir / skill_name,
                 entry.get("source", "customized"),
             )
@@ -88,29 +89,29 @@ class SkillPoolService:
         extra_files: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
     ) -> str | None:
-        _validate_skill_content(content)
-        skill_name = _normalize_skill_dir_name(name)
+        validate_skill_content(content)
+        skill_name = normalize_skill_dir_name(name)
         pool_dir = get_skill_pool_dir()
-        skill_dir = pool_dir / skill_name
+        skill_dir = safe_skill_dir(pool_dir, skill_name)
         manifest = read_skill_pool_manifest()
         existing = manifest.get("skills", {}).get(skill_name)
         if existing is not None or skill_dir.exists():
             return None
 
-        with _staged_skill_dir(skill_name) as staged_dir:
-            _write_skill_to_dir(
+        with staged_skill_dir(skill_name) as staged_dir:
+            write_skill_to_dir(
                 staged_dir,
                 content,
                 references,
                 scripts,
                 extra_files,
             )
-            _scan_skill_dir_or_raise(staged_dir, skill_name)
-            _copy_skill_dir(staged_dir, skill_dir)
+            scan_skill_dir_or_raise(staged_dir, skill_name)
+            copy_skill_dir(staged_dir, skill_dir)
 
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
-            payload["skills"][skill_name] = _build_skill_metadata(
+            payload["skills"][skill_name] = build_skill_metadata(
                 skill_name,
                 skill_dir,
                 source="customized",
@@ -120,9 +121,9 @@ class SkillPoolService:
                 payload["skills"][skill_name]["config"] = dict(config)
 
         try:
-            _mutate_json(
+            mutate_json(
                 get_pool_skill_manifest_path(),
-                _default_pool_manifest(),
+                default_pool_manifest(),
                 _update,
             )
         except Exception as exc:
@@ -160,12 +161,12 @@ class SkillPoolService:
         rename_map: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         pool_dir = get_skill_pool_dir()
-        tmp_dir, found = _extract_zip_skills(data)
+        tmp_dir, found = extract_zip_skills(data)
         renames = rename_map or {}
         try:
             normalized_target = str(target_name or "").strip()
             if normalized_target:
-                normalized_target = _normalize_skill_dir_name(
+                normalized_target = normalize_skill_dir_name(
                     normalized_target,
                 )
                 if len(found) != 1:
@@ -177,7 +178,7 @@ class SkillPoolService:
                     )
                 found = [(found[0][0], normalized_target)]
             found = [
-                (d, _normalize_skill_dir_name(renames.get(n, n)))
+                (d, normalize_skill_dir_name(renames.get(n, n)))
                 for d, n in found
             ]
             manifest = read_skill_pool_manifest()
@@ -192,14 +193,14 @@ class SkillPoolService:
                 )
             )
             for skill_dir, skill_name in found:
-                _scan_skill_dir_or_raise(skill_dir, skill_name)
+                scan_skill_dir_or_raise(skill_dir, skill_name)
             conflicts: list[dict[str, Any]] = []
             planned: list[tuple[Path, str]] = []
             seen_names: set[str] = set()
             for skill_dir, skill_name in found:
                 if skill_name in seen_names:
                     conflicts.append(
-                        _build_import_conflict(
+                        build_import_conflict(
                             skill_name,
                             existing_pool_names,
                         ),
@@ -214,7 +215,7 @@ class SkillPoolService:
                 )
                 if occupied:
                     conflicts.append(
-                        _build_import_conflict(
+                        build_import_conflict(
                             skill_name,
                             existing_pool_names,
                         ),
@@ -229,7 +230,7 @@ class SkillPoolService:
                 }
             imported: list[str] = []
             for skill_dir, skill_name in planned:
-                if _import_skill_dir(
+                if import_skill_dir(
                     skill_dir,
                     pool_dir,
                     skill_name,
@@ -241,16 +242,16 @@ class SkillPoolService:
                 def _update(payload: dict[str, Any]) -> None:
                     payload.setdefault("skills", {})
                     for name in imported:
-                        payload["skills"][name] = _build_skill_metadata(
+                        payload["skills"][name] = build_skill_metadata(
                             name,
                             pool_dir / name,
                             source="customized",
                             protected=False,
                         )
 
-                _mutate_json(
+                mutate_json(
                     get_pool_skill_manifest_path(),
-                    _default_pool_manifest(),
+                    default_pool_manifest(),
                     _update,
                 )
             return {
@@ -262,13 +263,16 @@ class SkillPoolService:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
     def delete_skill(self, name: str) -> bool:
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return False
         manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return False
 
-        skill_dir = get_skill_pool_dir() / skill_name
+        skill_dir = safe_skill_dir(get_skill_pool_dir(), skill_name)
         if skill_dir.exists():
             shutil.rmtree(skill_dir)
 
@@ -276,9 +280,9 @@ class SkillPoolService:
             payload.get("skills", {}).pop(skill_name, None)
 
         try:
-            _mutate_json(
+            mutate_json(
                 get_pool_skill_manifest_path(),
-                _default_pool_manifest(),
+                default_pool_manifest(),
                 _update,
             )
         except Exception as exc:
@@ -300,7 +304,10 @@ class SkillPoolService:
         tags: list[str] | None,
     ) -> bool:
         """Update one pool skill's user tags."""
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return False
         normalized = tags or []
 
         def _update(payload: dict[str, Any]) -> bool:
@@ -310,9 +317,9 @@ class SkillPoolService:
             entry["tags"] = normalized
             return True
 
-        return _mutate_json(
+        return mutate_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
             _update,
         )
 
@@ -323,15 +330,19 @@ class SkillPoolService:
         target_name: str | None = None,
         overwrite: bool = False,
     ) -> dict[str, Any]:
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+            normalized_target = normalize_skill_dir_name(
+                target_name or skill_name,
+            )
+        except SkillsError:
+            return {"success": False, "reason": "not_found"}
         manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
 
         pool_names = set(manifest.get("skills", {}).keys())
-        normalized_target = _normalize_skill_dir_name(
-            target_name or skill_name,
-        )
         if normalized_target == skill_name:
             return {
                 "success": True,
@@ -365,7 +376,11 @@ class SkillPoolService:
         config: dict[str, Any] | None = None,
         overwrite: bool = False,
     ) -> dict[str, Any]:
-        _validate_skill_content(content)
+        validate_skill_content(content)
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+        except SkillsError:
+            return {"success": False, "reason": "not_found"}
         manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
@@ -403,7 +418,7 @@ class SkillPoolService:
         config: dict[str, Any] | None,
         entry: dict[str, Any],
     ) -> dict[str, Any]:
-        skill_dir = get_skill_pool_dir() / skill_name
+        skill_dir = safe_skill_dir(get_skill_pool_dir(), skill_name)
         new_config = (
             config if config is not None else entry.get("config") or {}
         )
@@ -421,14 +436,14 @@ class SkillPoolService:
             }
 
         if content_changed:
-            with _staged_skill_dir(skill_name) as staged_dir:
+            with staged_skill_dir(skill_name) as staged_dir:
                 if skill_dir.exists():
-                    _copy_skill_dir(skill_dir, staged_dir)
+                    copy_skill_dir(skill_dir, staged_dir)
                 (staged_dir / "SKILL.md").write_text(
                     content,
                     encoding="utf-8",
                 )
-                _scan_skill_dir_or_raise(staged_dir, skill_name)
+                scan_skill_dir_or_raise(staged_dir, skill_name)
             (skill_dir / "SKILL.md").write_text(
                 content,
                 encoding="utf-8",
@@ -443,7 +458,7 @@ class SkillPoolService:
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
             current_entry = payload["skills"].get(skill_name) or entry or {}
-            next_entry = _build_skill_metadata(
+            next_entry = build_skill_metadata(
                 skill_name,
                 skill_dir,
                 source=source,
@@ -470,9 +485,9 @@ class SkillPoolService:
                 next_entry["tags"] = existing_tags
             payload["skills"][skill_name] = next_entry
 
-        _mutate_json(
+        mutate_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
             _update,
         )
         return {
@@ -490,18 +505,19 @@ class SkillPoolService:
         config: dict[str, Any] | None,
         entry: dict[str, Any],
     ) -> dict[str, Any]:
-        skill_dir = get_skill_pool_dir() / final_name
-        old_skill_dir = get_skill_pool_dir() / skill_name
+        pool_dir = get_skill_pool_dir()
+        skill_dir = safe_skill_dir(pool_dir, final_name)
+        old_skill_dir = safe_skill_dir(pool_dir, skill_name)
 
-        with _staged_skill_dir(final_name) as staged_dir:
+        with staged_skill_dir(final_name) as staged_dir:
             if old_skill_dir.exists():
-                _copy_skill_dir(old_skill_dir, staged_dir)
+                copy_skill_dir(old_skill_dir, staged_dir)
             (staged_dir / "SKILL.md").write_text(
                 content,
                 encoding="utf-8",
             )
-            _scan_skill_dir_or_raise(staged_dir, final_name)
-            _copy_skill_dir(staged_dir, skill_dir)
+            scan_skill_dir_or_raise(staged_dir, final_name)
+            copy_skill_dir(staged_dir, skill_dir)
         if old_skill_dir.exists():
             shutil.rmtree(old_skill_dir)
 
@@ -512,7 +528,7 @@ class SkillPoolService:
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
             current_entry = payload["skills"].get(skill_name) or entry or {}
-            next_entry = _build_skill_metadata(
+            next_entry = build_skill_metadata(
                 final_name,
                 skill_dir,
                 source="customized",
@@ -525,9 +541,9 @@ class SkillPoolService:
             payload["skills"][final_name] = next_entry
             payload["skills"].pop(skill_name, None)
 
-        _mutate_json(
+        mutate_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
             _update,
         )
         return {
@@ -544,12 +560,19 @@ class SkillPoolService:
         overwrite: bool = False,
         preview_only: bool = False,
     ) -> dict[str, Any]:
-        source_dir = get_workspace_skills_dir(workspace_dir) / skill_name
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+            source_dir = safe_skill_dir(
+                get_workspace_skills_dir(workspace_dir),
+                skill_name,
+            )
+        except SkillsError:
+            return {"success": False, "reason": "not_found"}
         if not source_dir.exists():
             return {"success": False, "reason": "not_found"}
 
-        final_name = _normalize_skill_dir_name(skill_name)
-        target_dir = get_skill_pool_dir() / final_name
+        final_name = normalize_skill_dir_name(skill_name)
+        target_dir = safe_skill_dir(get_skill_pool_dir(), final_name)
         manifest = read_skill_pool_manifest()
         existing = manifest.get("skills", {}).get(final_name)
         if existing:
@@ -564,14 +587,14 @@ class SkillPoolService:
         if preview_only:
             return {"success": True, "name": final_name}
 
-        with _staged_skill_dir(final_name) as staged_dir:
-            _copy_skill_dir(source_dir, staged_dir)
-            _scan_skill_dir_or_raise(staged_dir, final_name)
-            _copy_skill_dir(staged_dir, target_dir)
+        with staged_skill_dir(final_name) as staged_dir:
+            copy_skill_dir(source_dir, staged_dir)
+            scan_skill_dir_or_raise(staged_dir, final_name)
+            copy_skill_dir(staged_dir, target_dir)
 
-        ws_manifest = _read_json(
+        ws_manifest = read_json(
             get_workspace_skill_manifest_path(workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
         )
         workspace_entry = ws_manifest.get("skills", {}).get(skill_name, {})
         ws_config = workspace_entry.get("config") or {}
@@ -579,7 +602,7 @@ class SkillPoolService:
 
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
-            pool_entry = _build_skill_metadata(
+            pool_entry = build_skill_metadata(
                 final_name,
                 target_dir,
                 source="customized",
@@ -591,9 +614,9 @@ class SkillPoolService:
                 pool_entry["tags"] = ws_tags
             payload["skills"][final_name] = pool_entry
 
-        _mutate_json(
+        mutate_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
             _update,
         )
 
@@ -639,10 +662,15 @@ class SkillPoolService:
                         "current_language": ws_lang,
                     }
                 if pool_lang and not ws_lang:
-                    pool_md = get_skill_pool_dir() / final_name / "SKILL.md"
+                    pool_md = (
+                        safe_skill_dir(get_skill_pool_dir(), final_name)
+                        / "SKILL.md"
+                    )
                     ws_md = (
-                        get_workspace_skills_dir(workspace_dir)
-                        / final_name
+                        safe_skill_dir(
+                            get_workspace_skills_dir(workspace_dir),
+                            final_name,
+                        )
                         / "SKILL.md"
                     )
                     try:
@@ -706,9 +734,9 @@ class SkillPoolService:
             if ws_entry is not None:
                 ws_entry["builtin_language"] = language
 
-        _mutate_json(
+        mutate_json(
             get_workspace_skill_manifest_path(workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _patch,
         )
 
@@ -719,14 +747,21 @@ class SkillPoolService:
         *,
         overwrite: bool = False,
     ) -> dict[str, Any]:
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+        except SkillsError:
+            return {"success": False, "reason": "not_found"}
         manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:
             return {"success": False, "reason": "not_found"}
 
-        source_dir = get_skill_pool_dir() / skill_name
-        final_name = _normalize_skill_dir_name(skill_name)
-        target_dir = get_workspace_skills_dir(workspace_dir) / final_name
+        source_dir = safe_skill_dir(get_skill_pool_dir(), skill_name)
+        final_name = normalize_skill_dir_name(skill_name)
+        target_dir = safe_skill_dir(
+            get_workspace_skills_dir(workspace_dir),
+            final_name,
+        )
         workspace_manifest = read_skill_manifest(workspace_dir)
         existing = workspace_manifest.get("skills", {}).get(final_name)
         workspace_identity = get_workspace_identity(workspace_dir)
@@ -748,17 +783,17 @@ class SkillPoolService:
                 return conflict
 
         target_dir.parent.mkdir(parents=True, exist_ok=True)
-        with _staged_skill_dir(final_name) as staged_dir:
-            _copy_skill_dir(source_dir, staged_dir)
-            _scan_skill_dir_or_raise(staged_dir, final_name)
-            _copy_skill_dir(staged_dir, target_dir)
+        with staged_skill_dir(final_name) as staged_dir:
+            copy_skill_dir(source_dir, staged_dir)
+            scan_skill_dir_or_raise(staged_dir, final_name)
+            copy_skill_dir(staged_dir, target_dir)
 
         pool_config = entry.get("config") or {}
         pool_tags = entry.get("tags")
 
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
-            metadata = _build_skill_metadata(
+            metadata = build_skill_metadata(
                 final_name,
                 target_dir,
                 source="builtin"
@@ -784,9 +819,9 @@ class SkillPoolService:
                 ws_entry["tags"] = pool_tags
             payload["skills"][final_name] = ws_entry
 
-        _mutate_json(
+        mutate_json(
             get_workspace_skill_manifest_path(workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
         return {
@@ -808,7 +843,7 @@ class SkillPoolService:
         if entry is None:
             return {"success": False, "reason": "not_found"}
 
-        final_name = _normalize_skill_dir_name(skill_name)
+        final_name = normalize_skill_dir_name(skill_name)
         workspace_manifest = read_skill_manifest(workspace_dir)
         existing = workspace_manifest.get("skills", {}).get(final_name)
         workspace_identity = get_workspace_identity(workspace_dir)

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -21,29 +21,30 @@ from .models import (
     BuiltinSkillVariant,
 )
 from .store import (
-    _build_skill_metadata,
-    _classify_pool_skill_source,
-    _copy_skill_dir,
-    _default_pool_manifest,
-    _default_workspace_manifest,
-    _extract_version,
-    _is_pool_builtin_entry,
-    _mutate_json,
-    _normalize_skill_manifest_entry,
-    _read_frontmatter_safe_from_path,
-    _read_json,
-    _write_json_atomic,
+    build_skill_metadata,
+    classify_pool_skill_source,
+    copy_skill_dir,
+    default_pool_manifest,
+    default_workspace_manifest,
+    extract_version,
     get_pool_skill_manifest_path,
     get_skill_pool_dir,
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
+    is_pool_builtin_entry,
+    mutate_json,
+    normalize_skill_manifest_entry,
+    read_frontmatter_safe_from_path,
+    read_json,
     read_skill_manifest,
     read_skill_pool_manifest,
+    safe_skill_dir,
+    write_json_atomic,
 )
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_SKILL_LANGUAGES = ("en", "zh")
+BUILTIN_SKILL_LANGUAGES = ("en", "zh")
 _BUILTIN_SKILL_DIR_RE = re.compile(
     r"^(?P<name>.+)-(?P<language>en|zh)$",
 )
@@ -55,17 +56,22 @@ _builtin_cache: dict[str, Any] = {}
 _BUILTIN_CACHE_LOCK = threading.Lock()
 
 
+# ---------------------------------------------------------------------------
+# Builtin skill language preference
+# ---------------------------------------------------------------------------
+
+
 def _normalize_builtin_skill_language(
     language: str | None,
     *,
     fallback: str = "en",
 ) -> str:
     normalized = str(language or "").strip().lower()
-    if normalized in _BUILTIN_SKILL_LANGUAGES:
+    if normalized in BUILTIN_SKILL_LANGUAGES:
         return normalized
     if fallback == "":
         return ""
-    return fallback if fallback in _BUILTIN_SKILL_LANGUAGES else "en"
+    return fallback if fallback in BUILTIN_SKILL_LANGUAGES else "en"
 
 
 def get_builtin_skill_language_preference() -> str:
@@ -105,6 +111,11 @@ def set_builtin_skill_language_preference(language: str) -> None:
         ] = _normalize_builtin_skill_language(
             language,
         )
+
+
+# ---------------------------------------------------------------------------
+# Packaged builtin discovery + variant selection
+# ---------------------------------------------------------------------------
 
 
 def _parse_builtin_skill_identity(
@@ -148,7 +159,7 @@ def _iter_packaged_builtin_variants() -> Iterator[BuiltinSkillVariant]:
         if identity is None:
             continue
 
-        post = _read_frontmatter_safe_from_path(
+        post = read_frontmatter_safe_from_path(
             skill_md_path,
             identity.name,
         )
@@ -159,7 +170,7 @@ def _iter_packaged_builtin_variants() -> Iterator[BuiltinSkillVariant]:
             skill_dir=skill_dir,
             skill_md_path=skill_md_path,
             description=str(post.get("description", "") or ""),
-            version_text=_extract_version(post),
+            version_text=extract_version(post),
         )
 
 
@@ -209,7 +220,7 @@ def _iter_packaged_builtin_dirs() -> Iterator[Path]:
             yield skill_dir
 
 
-def _get_packaged_builtin_versions() -> dict[str, str]:
+def get_packaged_builtin_versions() -> dict[str, str]:
     """Return packaged builtin names mapped to their version text."""
     registry = _get_packaged_builtin_registry()
     versions: dict[str, str] = {}
@@ -222,6 +233,11 @@ def _get_packaged_builtin_versions() -> dict[str, str]:
 def get_builtin_skills_dir() -> Path:
     """Return the packaged built-in skill directory."""
     return Path(__file__).resolve().parent.parent / "skills"
+
+
+# ---------------------------------------------------------------------------
+# Skill config -> environment variable overrides
+# ---------------------------------------------------------------------------
 
 
 def _stringify_skill_env_value(value: Any) -> str:
@@ -370,6 +386,11 @@ def apply_skill_config_env_overrides(
             _release_skill_env_key(env_key)
 
 
+# ---------------------------------------------------------------------------
+# Builtin import candidate building
+# ---------------------------------------------------------------------------
+
+
 def _resolve_pool_builtin_language(
     skill_name: str,
     entry: dict[str, Any],
@@ -480,7 +501,7 @@ def _build_builtin_import_candidate(
     pref = preferred_language or get_builtin_skill_language_preference()
     canonical_name = _canonical_builtin_skill_name(skill_name, registry)
     variants = registry.get(canonical_name) or {}
-    current = _normalize_skill_manifest_entry(
+    current = normalize_skill_manifest_entry(
         pool_skills.get(canonical_name),
     )
     current_version_text = str(current.get("version_text", "") or "")
@@ -628,6 +649,11 @@ def _collect_builtin_import_conflicts(
     return conflicts
 
 
+# ---------------------------------------------------------------------------
+# Builtin import execution + pool initialization
+# ---------------------------------------------------------------------------
+
+
 def import_builtin_skills(
     imports: list[dict[str, Any]] | None = None,
     *,
@@ -705,18 +731,18 @@ def import_builtin_skills(
     updated: list[str] = []
     unchanged: list[str] = []
     manifest_path = get_pool_skill_manifest_path()
-    manifest_default = _default_pool_manifest()
+    manifest_default = default_pool_manifest()
 
     def _process(payload: dict[str, Any]) -> dict[str, list[Any]]:
         skills = payload.setdefault("skills", {})
         payload["builtin_skill_names"] = sorted(registry.keys())
         for skill_name, language in normalized_imports:
             variant = registry[skill_name][language]
-            target = pool_dir / skill_name
+            target = safe_skill_dir(pool_dir, skill_name)
             existing = skills.get(skill_name) or {}
 
             if not target.exists():
-                _copy_skill_dir(variant.skill_dir, target)
+                copy_skill_dir(variant.skill_dir, target)
                 imported.append(skill_name)
             elif (
                 existing.get("source") == "builtin"
@@ -734,10 +760,10 @@ def import_builtin_skills(
             ):
                 unchanged.append(skill_name)
             else:
-                _copy_skill_dir(variant.skill_dir, target)
+                copy_skill_dir(variant.skill_dir, target)
                 updated.append(skill_name)
 
-            entry = _build_skill_metadata(
+            entry = build_skill_metadata(
                 skill_name,
                 target,
                 source="builtin",
@@ -758,7 +784,7 @@ def import_builtin_skills(
             "conflicts": conflicts,
         }
 
-    return _mutate_json(
+    return mutate_json(
         manifest_path,
         manifest_default,
         _process,
@@ -777,7 +803,7 @@ def migrate_pool_builtin_language_fields() -> bool:
         skills = payload.setdefault("skills", {})
         changed = False
         for skill_name, entry in skills.items():
-            if not _is_pool_builtin_entry(entry):
+            if not is_pool_builtin_entry(entry):
                 continue
             variants = registry.get(skill_name) or {}
             if not variants:
@@ -804,9 +830,9 @@ def migrate_pool_builtin_language_fields() -> bool:
         return changed
 
     return bool(
-        _mutate_json(
+        mutate_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
             _update,
         ),
     )
@@ -822,7 +848,7 @@ def ensure_skill_pool_initialized() -> bool:
 
     manifest_path = get_pool_skill_manifest_path()
     if not manifest_path.exists():
-        _write_json_atomic(manifest_path, _default_pool_manifest())
+        write_json_atomic(manifest_path, default_pool_manifest())
         created = True
 
     if created:
@@ -830,6 +856,11 @@ def ensure_skill_pool_initialized() -> bool:
     else:
         migrate_pool_builtin_language_fields()
     return created
+
+
+# ---------------------------------------------------------------------------
+# Manifest reconciliation (pool + workspace)
+# ---------------------------------------------------------------------------
 
 
 def reconcile_pool_manifest() -> dict[str, Any]:
@@ -848,7 +879,7 @@ def reconcile_pool_manifest() -> dict[str, Any]:
     pool_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = get_pool_skill_manifest_path()
     if not manifest_path.exists():
-        _write_json_atomic(manifest_path, _default_pool_manifest())
+        write_json_atomic(manifest_path, default_pool_manifest())
 
     registry = _get_packaged_builtin_registry()
     pref = get_builtin_skill_language_preference()
@@ -867,7 +898,7 @@ def reconcile_pool_manifest() -> dict[str, Any]:
 
         for skill_name, skill_dir in sorted(discovered.items()):
             raw_existing = skills.get(skill_name)
-            existing = _normalize_skill_manifest_entry(raw_existing)
+            existing = normalize_skill_manifest_entry(raw_existing)
             if raw_existing not in (None, existing):
                 logger.warning(
                     (
@@ -877,7 +908,7 @@ def reconcile_pool_manifest() -> dict[str, Any]:
                     skill_name,
                 )
             try:
-                source, protected = _classify_pool_skill_source(
+                source, protected = classify_pool_skill_source(
                     skill_name,
                     skill_dir,
                     existing,
@@ -886,13 +917,13 @@ def reconcile_pool_manifest() -> dict[str, Any]:
                 has_config = "config" in existing
                 config = existing.get("config") if has_config else None
                 existing_tags = existing.get("tags")
-                new_entry = _build_skill_metadata(
+                new_entry = build_skill_metadata(
                     skill_name,
                     skill_dir,
                     source=source,
                     protected=protected,
                 )
-                if source == "builtin" or _is_pool_builtin_entry(existing):
+                if source == "builtin" or is_pool_builtin_entry(existing):
                     language = _resolve_pool_builtin_language(
                         skill_name,
                         existing or new_entry,
@@ -923,9 +954,9 @@ def reconcile_pool_manifest() -> dict[str, Any]:
 
         return payload
 
-    return _mutate_json(
+    return mutate_json(
         manifest_path,
-        _default_pool_manifest(),
+        default_pool_manifest(),
         _update,
     )
 
@@ -951,10 +982,10 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
     workspace_skills_dir = get_workspace_skills_dir(workspace_dir)
     workspace_skills_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = get_workspace_skill_manifest_path(workspace_dir)
-    builtin_versions = _get_packaged_builtin_versions()
+    builtin_versions = get_packaged_builtin_versions()
 
     if not manifest_path.exists():
-        _write_json_atomic(manifest_path, _default_workspace_manifest())
+        write_json_atomic(manifest_path, default_workspace_manifest())
 
     def _update(payload: dict[str, Any]) -> dict[str, Any]:
         payload.setdefault("skills", {})
@@ -968,7 +999,7 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
 
         for skill_name, skill_dir in sorted(discovered.items()):
             raw_existing = skills.get(skill_name)
-            existing = _normalize_skill_manifest_entry(raw_existing)
+            existing = normalize_skill_manifest_entry(raw_existing)
             if raw_existing not in (None, existing):
                 logger.warning(
                     (
@@ -993,7 +1024,7 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
                         else "customized"
                     )
 
-                metadata = _build_skill_metadata(
+                metadata = build_skill_metadata(
                     skill_name,
                     skill_dir,
                     source=source,
@@ -1028,11 +1059,16 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
 
         return payload
 
-    return _mutate_json(
+    return mutate_json(
         manifest_path,
-        _default_workspace_manifest(),
+        default_workspace_manifest(),
         _update,
     )
+
+
+# ---------------------------------------------------------------------------
+# Workspace listing + runtime skill resolution
+# ---------------------------------------------------------------------------
 
 
 def list_workspaces() -> list[dict[str, str]]:
@@ -1093,6 +1129,11 @@ def ensure_skills_initialized(workspace_dir: Path) -> None:
     reconcile_workspace_manifest(workspace_dir)
 
 
+# ---------------------------------------------------------------------------
+# Builtin sync status + update notices
+# ---------------------------------------------------------------------------
+
+
 def get_pool_builtin_sync_status(
     *,
     pool_skills: dict[str, Any] | None = None,
@@ -1113,15 +1154,15 @@ def get_pool_builtin_sync_status(
 
     pref = get_builtin_skill_language_preference()
     if pool_skills is None:
-        manifest = _read_json(
+        manifest = read_json(
             get_pool_skill_manifest_path(),
-            _default_pool_manifest(),
+            default_pool_manifest(),
         )
         pool_skills = manifest.get("skills", {})
     result: dict[str, dict[str, Any]] = {}
     for name, variants in registry.items():
         pool_entry = pool_skills.get(name)
-        if pool_entry is None or not _is_pool_builtin_entry(pool_entry):
+        if pool_entry is None or not is_pool_builtin_entry(pool_entry):
             continue
         language = _resolve_pool_builtin_language(
             name,
@@ -1153,7 +1194,7 @@ def get_pool_builtin_sync_status(
                 "available_languages": sorted(variants.keys()),
             }
     for name, pool_entry in pool_skills.items():
-        if not _is_pool_builtin_entry(pool_entry):
+        if not is_pool_builtin_entry(pool_entry):
             continue
         if name in registry:
             continue
@@ -1188,9 +1229,9 @@ def get_pool_builtin_update_notice() -> dict[str, Any]:
     """
     registry = _get_packaged_builtin_registry()
     pref = get_builtin_skill_language_preference()
-    manifest = _read_json(
+    manifest = read_json(
         get_pool_skill_manifest_path(),
-        _default_pool_manifest(),
+        default_pool_manifest(),
     )
     pool_skills = manifest.get("skills", {})
 
@@ -1329,7 +1370,7 @@ def update_single_builtin(
 
     manifest = read_skill_pool_manifest()
     existing = manifest.get("skills", {}).get(canonical_name)
-    if existing is None or not _is_pool_builtin_entry(existing):
+    if existing is None or not is_pool_builtin_entry(existing):
         raise SkillsError(
             message=f"'{canonical_name}' is not a builtin pool skill",
         )
@@ -1359,9 +1400,9 @@ def update_single_builtin(
     target = pool_dir / canonical_name
 
     def _update(payload: dict[str, Any]) -> dict[str, Any]:
-        _copy_skill_dir(variant.skill_dir, target)
+        copy_skill_dir(variant.skill_dir, target)
         payload.setdefault("skills", {})
-        entry = _build_skill_metadata(
+        entry = build_skill_metadata(
             canonical_name,
             target,
             source="builtin",
@@ -1377,8 +1418,8 @@ def update_single_builtin(
         payload["skills"][canonical_name] = entry
         return entry
 
-    return _mutate_json(
+    return mutate_json(
         get_pool_skill_manifest_path(),
-        _default_pool_manifest(),
+        default_pool_manifest(),
         _update,
     )

--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -48,26 +48,9 @@ _MAX_ZIP_BYTES = 200 * 1024 * 1024
 _REQUIREMENTS_METADATA_NAMESPACES = ("openclaw", "qwenpaw", "clawdbot")
 
 
-def _read_frontmatter_safe_from_path(
-    skill_md_path: Path,
-    skill_name: str = "",
-) -> dict[str, Any]:
-    if not skill_name:
-        skill_name = skill_md_path.parent.name
-
-    try:
-        return frontmatter.loads(
-            read_text_file_with_encoding_fallback(skill_md_path),
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to read SKILL frontmatter for '%s' at %s: %s. "
-            "Using fallback values.",
-            skill_name,
-            skill_md_path,
-            e,
-        )
-        return {"name": skill_name, "description": ""}
+# ---------------------------------------------------------------------------
+# Path getters
+# ---------------------------------------------------------------------------
 
 
 def get_skill_pool_dir() -> Path:
@@ -117,7 +100,63 @@ def get_pool_skill_manifest_path() -> Path:
     return get_skill_pool_dir() / "skill.json"
 
 
-def _get_skill_mtime(skill_dir: Path) -> str:
+# ---------------------------------------------------------------------------
+# Frontmatter + directory introspection
+# ---------------------------------------------------------------------------
+
+
+def read_frontmatter_safe_from_path(
+    skill_md_path: Path,
+    skill_name: str = "",
+) -> dict[str, Any]:
+    """Read SKILL.md frontmatter by path with a graceful fallback."""
+    if not skill_name:
+        skill_name = skill_md_path.parent.name
+
+    try:
+        return frontmatter.loads(
+            read_text_file_with_encoding_fallback(skill_md_path),
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to read SKILL frontmatter for '%s' at %s: %s. "
+            "Using fallback values.",
+            skill_name,
+            skill_md_path,
+            e,
+        )
+        return {"name": skill_name, "description": ""}
+
+
+def _read_frontmatter(skill_dir: Path) -> Any:
+    """Read and parse SKILL.md frontmatter from a skill directory."""
+    return frontmatter.loads(
+        read_text_file_with_encoding_fallback(skill_dir / "SKILL.md"),
+    )
+
+
+def _read_frontmatter_safe(
+    skill_dir: Path,
+    skill_name: str = "",
+) -> dict[str, Any]:
+    """Read SKILL.md frontmatter with a fallback on any read/parse error."""
+    if not skill_name:
+        skill_name = skill_dir.name
+
+    try:
+        return _read_frontmatter(skill_dir)
+    except Exception as e:
+        logger.warning(
+            "Failed to read SKILL.md frontmatter for '%s' at %s: %s. "
+            "Using fallback values.",
+            skill_name,
+            skill_dir,
+            e,
+        )
+        return {"name": skill_name, "description": ""}
+
+
+def get_skill_mtime(skill_dir: Path) -> str:
     """Return the latest mtime across the skill directory as ISO string.
 
     Scans SKILL.md and the directory itself.  Returns an empty string
@@ -152,49 +191,7 @@ def _directory_tree(directory: Path) -> dict[str, Any]:
     return tree
 
 
-def _read_frontmatter(skill_dir: Path) -> Any:
-    """Read and parse SKILL.md frontmatter.
-
-    Args:
-        skill_dir: Path to skill directory containing SKILL.md
-
-    Returns:
-        Parsed frontmatter as dict-like object
-    """
-    return frontmatter.loads(
-        read_text_file_with_encoding_fallback(skill_dir / "SKILL.md"),
-    )
-
-
-def _read_frontmatter_safe(
-    skill_dir: Path,
-    skill_name: str = "",
-) -> dict[str, Any]:
-    """Safely read SKILL.md frontmatter with fallback on errors.
-
-    Args:
-        skill_dir: Path to skill directory containing SKILL.md
-        skill_name: Optional skill name for logging (defaults to dir name)
-
-    Returns:
-        Parsed frontmatter dict, or fallback dict with name/description
-        on any error (file not found, YAML syntax error, etc.)
-    """
-    if not skill_name:
-        skill_name = skill_dir.name
-
-    try:
-        return _read_frontmatter(skill_dir)
-    except Exception as e:
-        logger.warning(
-            f"Failed to read SKILL.md frontmatter for '{skill_name}' "
-            f"at {skill_dir}: {e}. Using fallback values.",
-        )
-        # Return minimal valid frontmatter
-        return {"name": skill_name, "description": ""}
-
-
-def _extract_version(post: Any) -> str:
+def extract_version(post: Any) -> str:
     metadata = post.get("metadata") or {}
     for value in (
         post.get("version"),
@@ -206,6 +203,11 @@ def _extract_version(post: Any) -> str:
     return ""
 
 
+# ---------------------------------------------------------------------------
+# Skill directory copy
+# ---------------------------------------------------------------------------
+
+
 _IGNORED_SKILL_ARTIFACTS = {
     "__pycache__",
     "__MACOSX",
@@ -215,7 +217,7 @@ _IGNORED_SKILL_ARTIFACTS = {
 }
 
 
-def _copy_skill_dir(source: Path, target: Path) -> None:
+def copy_skill_dir(source: Path, target: Path) -> None:
     """Replace *target* with a copy of *source*.
 
     We intentionally filter only well-known OS/cache artifacts so skill
@@ -233,6 +235,11 @@ def _copy_skill_dir(source: Path, target: Path) -> None:
         target,
         ignore=_ignore,
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-process JSON locking + atomic I/O
+# ---------------------------------------------------------------------------
 
 
 def _lock_path_for(json_path: Path) -> Path:
@@ -269,12 +276,12 @@ def _read_json_unlocked(path: Path, default: dict[str, Any]) -> dict[str, Any]:
         return json.loads(json.dumps(default))
 
 
-def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+def read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
     with _file_write_lock(_lock_path_for(path)):
         return _read_json_unlocked(path, default)
 
 
-def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     temp_path: Path | None = None
     payload = dict(payload)
     payload["version"] = max(
@@ -299,7 +306,7 @@ def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
             temp_path.unlink(missing_ok=True)
 
 
-def _mutate_json(
+def mutate_json(
     path: Path,
     default: dict[str, Any],
     mutator: Callable[[dict[str, Any]], _RegistryResult],
@@ -308,11 +315,16 @@ def _mutate_json(
         payload = _read_json_unlocked(path, default)
         result = mutator(payload)
         if result is not False:
-            _write_json_atomic(path, payload)
+            write_json_atomic(path, payload)
         return result
 
 
-def _default_workspace_manifest() -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# Manifest defaults + entry normalization
+# ---------------------------------------------------------------------------
+
+
+def default_workspace_manifest() -> dict[str, Any]:
     return {
         "schema_version": "workspace-skill-manifest.v1",
         "version": 0,
@@ -320,7 +332,7 @@ def _default_workspace_manifest() -> dict[str, Any]:
     }
 
 
-def _default_pool_manifest() -> dict[str, Any]:
+def default_pool_manifest() -> dict[str, Any]:
     return {
         "schema_version": "skill-pool-manifest.v1",
         "version": 0,
@@ -329,7 +341,7 @@ def _default_pool_manifest() -> dict[str, Any]:
     }
 
 
-def _normalize_skill_manifest_entry(entry: Any) -> dict[str, Any]:
+def normalize_skill_manifest_entry(entry: Any) -> dict[str, Any]:
     """Return a manifest entry as a dict, or an empty dict for legacy junk."""
     return entry if isinstance(entry, dict) else {}
 
@@ -339,16 +351,16 @@ def _is_builtin_skill(skill_name: str, builtin_names: list[str]) -> bool:
     return skill_name in builtin_names
 
 
-def _is_pool_builtin_entry(entry: dict[str, Any] | None) -> bool:
+def is_pool_builtin_entry(entry: dict[str, Any] | None) -> bool:
     """Return whether one pool manifest entry represents a builtin slot."""
-    normalized = _normalize_skill_manifest_entry(entry)
+    normalized = normalize_skill_manifest_entry(entry)
     return (
         bool(normalized)
         and str(normalized.get("source", "") or "") == "builtin"
     )
 
 
-def _classify_pool_skill_source(
+def classify_pool_skill_source(
     skill_name: str,
     skill_dir: Path,
     existing: dict[str, Any],
@@ -360,7 +372,7 @@ def _classify_pool_skill_source(
     already exists. This lets an outdated builtin remain a builtin slot,
     while same-name customized copies stay customized.
     """
-    if existing and _is_pool_builtin_entry(existing):
+    if existing and is_pool_builtin_entry(existing):
         return "builtin", False
 
     if not _is_builtin_skill(skill_name, builtin_names):
@@ -369,12 +381,17 @@ def _classify_pool_skill_source(
     if existing:
         return "customized", False
 
-    pool_version = _extract_version(
+    pool_version = extract_version(
         _read_frontmatter_safe(skill_dir, skill_name),
     )
     if pool_version:
         return "builtin", False
     return "customized", False
+
+
+# ---------------------------------------------------------------------------
+# Zip handling + path-safety helpers
+# ---------------------------------------------------------------------------
 
 
 def _is_hidden(name: str) -> bool:
@@ -425,7 +442,7 @@ def _safe_child_path(base_dir: Path, relative_name: str) -> Path:
     return path
 
 
-def _normalize_skill_dir_name(name: str) -> str:
+def normalize_skill_dir_name(name: str) -> str:
     """Normalize and validate a skill directory name."""
     normalized = str(name or "").strip()
     if not normalized:
@@ -441,6 +458,23 @@ def _normalize_skill_dir_name(name: str) -> str:
     return normalized
 
 
+def safe_skill_dir(base_dir: Path, name: str) -> Path:
+    """Normalize a skill name and resolve it inside ``base_dir``.
+
+    Layered defense: ``normalize_skill_dir_name`` already rejects empty,
+    NUL, ``.``, ``..``, ``/`` and ``\\``; the resolve + ``is_relative_to``
+    check guards against future relaxations and platform-specific quirks.
+    """
+    normalized = normalize_skill_dir_name(name)
+    candidate = (base_dir / normalized).resolve()
+    base_resolved = base_dir.resolve()
+    if not candidate.is_relative_to(base_resolved):
+        raise SkillsError(
+            message=f"Unsafe skill path outside root: {name}",
+        )
+    return candidate
+
+
 def _create_files_from_tree(base_dir: Path, tree: dict[str, Any]) -> None:
     for name, value in (tree or {}).items():
         path = _safe_child_path(base_dir, name)
@@ -454,6 +488,11 @@ def _create_files_from_tree(base_dir: Path, tree: dict[str, Any]) -> None:
             raise SkillsError(
                 message=f"Invalid tree value for {name}: {type(value)}",
             )
+
+
+# ---------------------------------------------------------------------------
+# Skill metadata building
+# ---------------------------------------------------------------------------
 
 
 def _resolve_skill_name(skill_dir: Path) -> str:
@@ -513,7 +552,7 @@ def _extract_requirements(post: dict[str, Any]) -> SkillRequirements:
         return SkillRequirements()
 
 
-def _build_skill_metadata(
+def build_skill_metadata(
     skill_name: str,
     skill_dir: Path,
     *,
@@ -531,13 +570,18 @@ def _build_skill_metadata(
     return {
         "name": skill_name,
         "description": str(post.get("description", "") or ""),
-        "version_text": _extract_version(post),
+        "version_text": extract_version(post),
         "commit_text": "",
         "source": source,
         "protected": protected,
         "requirements": requirements.model_dump(),
-        "updated_at": _get_skill_mtime(skill_dir),
+        "updated_at": get_skill_mtime(skill_dir),
     }
+
+
+# ---------------------------------------------------------------------------
+# Conflict-name suggestion
+# ---------------------------------------------------------------------------
 
 
 _TIMESTAMP_SUFFIX_RE = re.compile(r"(-\d{14})+$")
@@ -566,7 +610,7 @@ def suggest_conflict_name(
     return f"{base}-{suffix}"
 
 
-def _build_import_conflict(
+def build_import_conflict(
     skill_name: str,
     existing_names: set[str] | None = None,
 ) -> dict[str, Any]:
@@ -578,6 +622,11 @@ def _build_import_conflict(
             existing_names,
         ),
     }
+
+
+# ---------------------------------------------------------------------------
+# Manifest readers
+# ---------------------------------------------------------------------------
 
 
 @lru_cache(maxsize=256)
@@ -612,13 +661,18 @@ def read_skill_manifest(
 ) -> dict[str, Any]:
     """Return the workspace skill manifest, cached by file mtime."""
     path = get_workspace_skill_manifest_path(workspace_dir)
-    return _read_json_mtime_cached(path, _default_workspace_manifest())
+    return _read_json_mtime_cached(path, default_workspace_manifest())
 
 
 def read_skill_pool_manifest() -> dict[str, Any]:
     """Return the pool skill manifest, cached by file mtime."""
     path = get_pool_skill_manifest_path()
-    return _read_json_mtime_cached(path, _default_pool_manifest())
+    return _read_json_mtime_cached(path, default_pool_manifest())
+
+
+# ---------------------------------------------------------------------------
+# Skill content reading, validation, and import
+# ---------------------------------------------------------------------------
 
 
 def _extract_emoji_from_metadata(metadata: Any) -> str:
@@ -631,7 +685,7 @@ def _extract_emoji_from_metadata(metadata: Any) -> str:
     return ""
 
 
-def _read_skill_from_dir(skill_dir: Path, source: str) -> SkillInfo | None:
+def read_skill_from_dir(skill_dir: Path, source: str) -> SkillInfo | None:
     if not skill_dir.is_dir():
         return None
 
@@ -665,7 +719,7 @@ def _read_skill_from_dir(skill_dir: Path, source: str) -> SkillInfo | None:
         return SkillInfo(
             name=skill_dir.name,
             description=description,
-            version_text=_extract_version(post),
+            version_text=extract_version(post),
             content=content,
             source=source,
             references=references,
@@ -677,7 +731,7 @@ def _read_skill_from_dir(skill_dir: Path, source: str) -> SkillInfo | None:
         return None
 
 
-def _validate_skill_content(content: str) -> tuple[str, str]:
+def validate_skill_content(content: str) -> tuple[str, str]:
     post = frontmatter.loads(content)
     skill_name = str(post.get("name") or "").strip()
     skill_description = str(post.get("description") or "").strip()
@@ -691,7 +745,7 @@ def _validate_skill_content(content: str) -> tuple[str, str]:
     return skill_name, skill_description
 
 
-def _import_skill_dir(
+def import_skill_dir(
     src_dir: Path,
     target_root: Path,
     skill_name: str,
@@ -712,11 +766,11 @@ def _import_skill_dir(
     target_dir = target_root / skill_name
     if target_dir.exists():
         return False
-    _copy_skill_dir(src_dir, target_dir)
+    copy_skill_dir(src_dir, target_dir)
     return True
 
 
-def _write_skill_to_dir(
+def write_skill_to_dir(
     skill_dir: Path,
     content: str,
     references: dict[str, Any] | None = None,
@@ -737,7 +791,7 @@ def _write_skill_to_dir(
         _create_files_from_tree(script_dir, scripts)
 
 
-def _extract_zip_skills(data: bytes) -> tuple[Path, list[tuple[Path, str]]]:
+def extract_zip_skills(data: bytes) -> tuple[Path, list[tuple[Path, str]]]:
     """Extract and validate a skill zip.
 
     Returns ``(tmp_dir, found_skills)``.
@@ -780,12 +834,12 @@ def _extract_zip_skills(data: bytes) -> tuple[Path, list[tuple[Path, str]]]:
     return tmp_dir, found
 
 
-def _scan_skill_dir_or_raise(skill_dir: Path, skill_name: str) -> None:
+def scan_skill_dir_or_raise(skill_dir: Path, skill_name: str) -> None:
     scan_skill_directory(skill_dir, skill_name=skill_name)
 
 
 @contextmanager
-def _staged_skill_dir(skill_name: str) -> Iterator[Path]:
+def staged_skill_dir(skill_name: str) -> Iterator[Path]:
     """Create a temporary skill directory used for staged writes."""
     temp_root = Path(
         tempfile.mkdtemp(prefix=f"qwenpaw_skill_stage_{skill_name}_"),

--- a/src/qwenpaw/agents/skill_system/workspace_service.py
+++ b/src/qwenpaw/agents/skill_system/workspace_service.py
@@ -11,28 +11,29 @@ from ...exceptions import SkillsError
 from ..utils.file_handling import read_text_file_with_encoding_fallback
 from .models import SkillInfo
 from .registry import (
-    _get_packaged_builtin_versions,
+    get_packaged_builtin_versions,
     reconcile_workspace_manifest,
     resolve_effective_skills,
 )
 from .store import (
-    _build_import_conflict,
-    _build_skill_metadata,
-    _copy_skill_dir,
-    _default_workspace_manifest,
-    _extract_zip_skills,
-    _import_skill_dir,
-    _mutate_json,
-    _normalize_skill_dir_name,
-    _read_skill_from_dir,
-    _scan_skill_dir_or_raise,
-    _staged_skill_dir,
-    _validate_skill_content,
-    _write_skill_to_dir,
+    build_import_conflict,
+    build_skill_metadata,
+    copy_skill_dir,
+    default_workspace_manifest,
+    extract_zip_skills,
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
+    import_skill_dir,
+    mutate_json,
+    normalize_skill_dir_name,
+    read_skill_from_dir,
     read_skill_manifest,
+    safe_skill_dir,
+    scan_skill_dir_or_raise,
+    staged_skill_dir,
     suggest_conflict_name,
+    validate_skill_content,
+    write_skill_to_dir,
 )
 
 
@@ -69,7 +70,7 @@ class SkillService:
         for skill_name, entry in sorted(manifest.get("skills", {}).items()):
             skill_dir = skill_root / skill_name
             source = entry.get("source", "customized")
-            skill = _read_skill_from_dir(skill_dir, source)
+            skill = read_skill_from_dir(skill_dir, source)
             if skill is not None:
                 skills.append(skill)
         return skills
@@ -83,7 +84,7 @@ class SkillService:
             "console",
         ):
             entry = manifest.get("skills", {}).get(skill_name, {})
-            skill = _read_skill_from_dir(
+            skill = read_skill_from_dir(
                 skill_root / skill_name,
                 "builtin"
                 if entry.get("source", "customized") == "builtin"
@@ -103,35 +104,35 @@ class SkillService:
         config: dict[str, Any] | None = None,
         enable: bool = False,
     ) -> str | None:
-        _validate_skill_content(content)
-        skill_name = _normalize_skill_dir_name(name)
+        validate_skill_content(content)
+        skill_name = normalize_skill_dir_name(name)
         skill_root = get_workspace_skills_dir(self.workspace_dir)
         skill_root.mkdir(parents=True, exist_ok=True)
-        skill_dir = skill_root / skill_name
+        skill_dir = safe_skill_dir(skill_root, skill_name)
         if skill_dir.exists():
             return None
 
-        with _staged_skill_dir(skill_name) as staged_dir:
-            _write_skill_to_dir(
+        with staged_skill_dir(skill_name) as staged_dir:
+            write_skill_to_dir(
                 staged_dir,
                 content,
                 references,
                 scripts,
                 extra_files,
             )
-            _scan_skill_dir_or_raise(staged_dir, skill_name)
-            _copy_skill_dir(staged_dir, skill_dir)
+            scan_skill_dir_or_raise(staged_dir, skill_name)
+            copy_skill_dir(staged_dir, skill_dir)
 
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
             entry = payload["skills"].get(skill_name) or {}
             if "source" in entry:
                 source = entry["source"]
-            elif skill_name in _get_packaged_builtin_versions():
+            elif skill_name in get_packaged_builtin_versions():
                 source = "builtin"
             else:
                 source = "customized"
-            metadata = _build_skill_metadata(
+            metadata = build_skill_metadata(
                 skill_name,
                 skill_dir,
                 source=source,
@@ -152,9 +153,9 @@ class SkillService:
             }
 
         try:
-            _mutate_json(
+            mutate_json(
                 get_workspace_skill_manifest_path(self.workspace_dir),
-                _default_workspace_manifest(),
+                default_workspace_manifest(),
                 _update,
             )
         except Exception as exc:
@@ -203,7 +204,11 @@ class SkillService:
         overwrite: bool = False,
     ) -> dict[str, Any]:
         """Edit-in-place or rename-save a workspace skill."""
-        final_name = _normalize_skill_dir_name(target_name or skill_name)
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+            final_name = normalize_skill_dir_name(target_name or skill_name)
+        except SkillsError:
+            return {"success": False, "reason": "not_found"}
         manifest = self._read_manifest()
         old_entry = manifest.get("skills", {}).get(skill_name)
         if old_entry is None:
@@ -218,7 +223,7 @@ class SkillService:
             )
 
         skill_root = get_workspace_skills_dir(self.workspace_dir)
-        target_dir = skill_root / final_name
+        target_dir = safe_skill_dir(skill_root, final_name)
         if target_dir.exists() and not overwrite:
             existing = (
                 {p.name for p in skill_root.iterdir() if p.is_dir()}
@@ -254,7 +259,7 @@ class SkillService:
         )
         skill_root = get_workspace_skills_dir(self.workspace_dir)
         skill_root.mkdir(parents=True, exist_ok=True)
-        skill_dir = skill_root / skill_name
+        skill_dir = safe_skill_dir(skill_root, skill_name)
 
         old_md = (
             (skill_dir / "SKILL.md").read_text(encoding="utf-8")
@@ -272,14 +277,14 @@ class SkillService:
             }
 
         if content_changed:
-            with _staged_skill_dir(skill_name) as staged_dir:
+            with staged_skill_dir(skill_name) as staged_dir:
                 if skill_dir.exists():
-                    _copy_skill_dir(skill_dir, staged_dir)
+                    copy_skill_dir(skill_dir, staged_dir)
                 (staged_dir / "SKILL.md").write_text(
                     content,
                     encoding="utf-8",
                 )
-                _scan_skill_dir_or_raise(staged_dir, skill_name)
+                scan_skill_dir_or_raise(staged_dir, skill_name)
             (skill_dir / "SKILL.md").write_text(
                 content,
                 encoding="utf-8",
@@ -289,7 +294,7 @@ class SkillService:
             if content_changed
             else old_entry.get("source", "customized")
         )
-        metadata = _build_skill_metadata(
+        metadata = build_skill_metadata(
             skill_name,
             skill_dir,
             source=source,
@@ -315,9 +320,9 @@ class SkillService:
                 next_entry["tags"] = existing_tags
             payload["skills"][skill_name] = next_entry
 
-        _mutate_json(
+        mutate_json(
             get_workspace_skill_manifest_path(self.workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _edit,
         )
         return {
@@ -336,23 +341,23 @@ class SkillService:
         old_entry: dict[str, Any],
     ) -> dict[str, Any]:
         skill_root = get_workspace_skills_dir(self.workspace_dir)
-        target_dir = skill_root / final_name
-        old_dir = skill_root / skill_name
+        target_dir = safe_skill_dir(skill_root, final_name)
+        old_dir = safe_skill_dir(skill_root, skill_name)
 
-        with _staged_skill_dir(final_name) as staged_dir:
-            _copy_skill_dir(old_dir, staged_dir)
+        with staged_skill_dir(final_name) as staged_dir:
+            copy_skill_dir(old_dir, staged_dir)
             (staged_dir / "SKILL.md").write_text(
                 content,
                 encoding="utf-8",
             )
-            _scan_skill_dir_or_raise(staged_dir, final_name)
-            _copy_skill_dir(staged_dir, target_dir)
+            scan_skill_dir_or_raise(staged_dir, final_name)
+            copy_skill_dir(staged_dir, target_dir)
 
         old_config = (
             config if config is not None else old_entry.get("config") or {}
         )
         old_channels = old_entry.get("channels") or ["all"]
-        metadata = _build_skill_metadata(
+        metadata = build_skill_metadata(
             final_name,
             target_dir,
             source="customized",
@@ -379,9 +384,9 @@ class SkillService:
             payload["skills"][final_name] = next_entry
             payload["skills"].pop(skill_name, None)
 
-        _mutate_json(
+        mutate_json(
             get_workspace_skill_manifest_path(self.workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _rename_entry,
         )
         if old_dir.exists():
@@ -402,12 +407,12 @@ class SkillService:
     ) -> dict[str, Any]:
         skill_root = get_workspace_skills_dir(self.workspace_dir)
         skill_root.mkdir(parents=True, exist_ok=True)
-        tmp_dir, found = _extract_zip_skills(data)
+        tmp_dir, found = extract_zip_skills(data)
         renames = rename_map or {}
         try:
             normalized_target = str(target_name or "").strip()
             if normalized_target:
-                normalized_target = _normalize_skill_dir_name(
+                normalized_target = normalize_skill_dir_name(
                     normalized_target,
                 )
                 if len(found) != 1:
@@ -419,7 +424,7 @@ class SkillService:
                     )
                 found = [(found[0][0], normalized_target)]
             found = [
-                (d, _normalize_skill_dir_name(renames.get(n, n)))
+                (d, normalize_skill_dir_name(renames.get(n, n)))
                 for d, n in found
             ]
             existing_on_disk = (
@@ -431,10 +436,10 @@ class SkillService:
             planned: list[tuple[Path, str]] = []
             seen_names: set[str] = set()
             for skill_dir, skill_name in found:
-                _scan_skill_dir_or_raise(skill_dir, skill_name)
+                scan_skill_dir_or_raise(skill_dir, skill_name)
                 if skill_name in seen_names:
                     conflicts.append(
-                        _build_import_conflict(
+                        build_import_conflict(
                             skill_name,
                             existing_on_disk,
                         ),
@@ -444,7 +449,7 @@ class SkillService:
                 exists = (skill_root / skill_name).exists()
                 if exists:
                     conflicts.append(
-                        _build_import_conflict(
+                        build_import_conflict(
                             skill_name,
                             existing_on_disk,
                         ),
@@ -460,7 +465,7 @@ class SkillService:
                 }
             imported: list[str] = []
             for skill_dir, skill_name in planned:
-                if _import_skill_dir(
+                if import_skill_dir(
                     skill_dir,
                     skill_root,
                     skill_name,
@@ -493,7 +498,15 @@ class SkillService:
         # Example:
         # if ``skills/docx`` was edited after creation and now violates scan
         # policy, enable returns a scan failure instead of trusting old state.
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return {
+                "success": False,
+                "updated_workspaces": [],
+                "failed": [self.workspace_dir.name],
+                "reason": "not_found",
+            }
         if (
             target_workspaces
             and self.workspace_dir.name not in target_workspaces
@@ -506,7 +519,10 @@ class SkillService:
             }
 
         manifest_path = get_workspace_skill_manifest_path(self.workspace_dir)
-        skill_dir = get_workspace_skills_dir(self.workspace_dir) / skill_name
+        skill_dir = safe_skill_dir(
+            get_workspace_skills_dir(self.workspace_dir),
+            skill_name,
+        )
         if not skill_dir.exists():
             return {
                 "success": False,
@@ -514,7 +530,7 @@ class SkillService:
                 "failed": [self.workspace_dir.name],
                 "reason": "not_found",
             }
-        _scan_skill_dir_or_raise(skill_dir, skill_name)
+        scan_skill_dir_or_raise(skill_dir, skill_name)
 
         def _update(payload: dict[str, Any]) -> bool:
             entry = payload.get("skills", {}).get(skill_name)
@@ -524,9 +540,9 @@ class SkillService:
             entry.setdefault("channels", ["all"])
             return True
 
-        updated = _mutate_json(
+        updated = mutate_json(
             manifest_path,
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
         if not updated:
@@ -545,7 +561,10 @@ class SkillService:
         }
 
     def disable_skill(self, name: str) -> dict[str, Any]:
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return {"success": False, "updated_workspaces": []}
         manifest_path = get_workspace_skill_manifest_path(self.workspace_dir)
 
         def _update(payload: dict[str, Any]) -> bool:
@@ -555,9 +574,9 @@ class SkillService:
             entry["enabled"] = False
             return True
 
-        updated = _mutate_json(
+        updated = mutate_json(
             manifest_path,
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
         if not updated:
@@ -574,7 +593,10 @@ class SkillService:
         channels: list[str] | None,
     ) -> bool:
         """Update one workspace skill's channel scope."""
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return False
         manifest_path = get_workspace_skill_manifest_path(self.workspace_dir)
         normalized = channels or ["all"]
 
@@ -585,9 +607,9 @@ class SkillService:
             entry["channels"] = normalized
             return True
 
-        updated = _mutate_json(
+        updated = mutate_json(
             manifest_path,
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
         return updated
@@ -598,7 +620,10 @@ class SkillService:
         tags: list[str] | None,
     ) -> bool:
         """Update one workspace skill's user tags."""
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return False
         manifest_path = get_workspace_skill_manifest_path(
             self.workspace_dir,
         )
@@ -611,20 +636,26 @@ class SkillService:
             entry["tags"] = normalized
             return True
 
-        return _mutate_json(
+        return mutate_json(
             manifest_path,
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
 
     def delete_skill(self, name: str) -> bool:
-        skill_name = str(name or "")
+        try:
+            skill_name = normalize_skill_dir_name(name)
+        except SkillsError:
+            return False
         manifest = self._read_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None or entry.get("enabled", False):
             return False
 
-        skill_dir = get_workspace_skills_dir(self.workspace_dir) / skill_name
+        skill_dir = safe_skill_dir(
+            get_workspace_skills_dir(self.workspace_dir),
+            skill_name,
+        )
         if skill_dir.exists():
             shutil.rmtree(skill_dir)
 
@@ -632,9 +663,9 @@ class SkillService:
             payload.get("skills", {}).pop(skill_name, None)
 
         try:
-            _mutate_json(
+            mutate_json(
                 get_workspace_skill_manifest_path(self.workspace_dir),
-                _default_workspace_manifest(),
+                default_workspace_manifest(),
                 _update,
             )
         except Exception as exc:
@@ -659,23 +690,28 @@ class SkillService:
         file_path: str,
     ) -> str | None:
         normalized = file_path.replace("\\", "/")
-        if ".." in normalized or normalized.startswith("/"):
-            return None
-        if not (
-            normalized.startswith("references/")
-            or normalized.startswith("scripts/")
+        if (
+            ".." in normalized
+            or normalized.startswith("/")
+            or not (
+                normalized.startswith("references/")
+                or normalized.startswith("scripts/")
+            )
         ):
             return None
-
-        manifest = self._read_manifest()
-        if skill_name not in manifest.get("skills", {}):
+        try:
+            skill_name = normalize_skill_dir_name(skill_name)
+            base_dir = safe_skill_dir(
+                get_workspace_skills_dir(self.workspace_dir),
+                skill_name,
+            )
+        except SkillsError:
             return None
-
-        base_dir = get_workspace_skills_dir(self.workspace_dir) / skill_name
+        if skill_name not in self._read_manifest().get("skills", {}):
+            return None
         if not base_dir.exists():
             return None
-
-        full_path = base_dir / normalized
-        if not full_path.exists() or not full_path.is_file():
+        full_path = (base_dir / normalized).resolve()
+        if not full_path.is_relative_to(base_dir) or not full_path.is_file():
             return None
         return read_text_file_with_encoding_fallback(full_path)

--- a/src/qwenpaw/app/migration.py
+++ b/src/qwenpaw/app/migration.py
@@ -343,12 +343,12 @@ def _do_migrate_legacy_skills() -> bool:
     from ..agents.skill_system import ensure_skill_pool_initialized
     from ..agents.skill_system.registry import reconcile_workspace_manifest
     from ..agents.skill_system.store import (
-        _copy_skill_dir,
-        _default_workspace_manifest,
-        _mutate_json,
+        copy_skill_dir,
+        default_workspace_manifest,
         get_pool_skill_manifest_path,
         get_workspace_skill_manifest_path,
         get_workspace_skills_dir,
+        mutate_json,
     )
 
     import hashlib
@@ -420,7 +420,7 @@ def _do_migrate_legacy_skills() -> bool:
                 target_dir,
             )
             return False
-        _copy_skill_dir(source_dir, target_dir)
+        copy_skill_dir(source_dir, target_dir)
         return True
 
     # --- Phase 1: Initialize pool ---
@@ -613,9 +613,9 @@ def _do_migrate_legacy_skills() -> bool:
                     changed += 1
             return changed
 
-        _mutate_json(
+        mutate_json(
             get_workspace_skill_manifest_path(workspace_dir),
-            _default_workspace_manifest(),
+            default_workspace_manifest(),
             _update,
         )
 

--- a/src/qwenpaw/app/routers/skills.py
+++ b/src/qwenpaw/app/routers/skills.py
@@ -36,9 +36,9 @@ from ...agents.skill_system import (
 )
 from ...agents.skill_system.models import SkillInfo
 from ...agents.skill_system.registry import (
-    _BUILTIN_SKILL_LANGUAGES,
-    get_pool_builtin_update_notice,
+    BUILTIN_SKILL_LANGUAGES,
     get_pool_builtin_sync_status,
+    get_pool_builtin_update_notice,
     import_builtin_skills,
     list_builtin_import_candidates,
     list_workspaces,
@@ -47,18 +47,18 @@ from ...agents.skill_system.registry import (
     update_single_builtin,
 )
 from ...agents.skill_system.store import (
-    _default_pool_manifest,
-    _default_workspace_manifest,
-    _get_skill_mtime,
-    _mutate_json,
-    _normalize_skill_manifest_entry,
-    _read_skill_from_dir,
+    default_pool_manifest,
+    default_workspace_manifest,
     get_pool_skill_manifest_path,
+    get_skill_mtime,
     get_skill_pool_dir,
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
-    read_skill_pool_manifest,
+    mutate_json,
+    normalize_skill_manifest_entry,
+    read_skill_from_dir,
     read_skill_manifest,
+    read_skill_pool_manifest,
     suggest_conflict_name,
 )
 from ...security.skill_scanner import SkillScanError
@@ -336,9 +336,9 @@ def _restore_workspace_skill(snapshot: dict[str, Any]) -> None:
             return
         payload["skills"][skill_name] = copy.deepcopy(entry)
 
-    _mutate_json(
+    mutate_json(
         get_workspace_skill_manifest_path(workspace_dir),
-        _default_workspace_manifest(),
+        default_workspace_manifest(),
         _restore,
     )
     reconcile_workspace_manifest(workspace_dir)
@@ -516,7 +516,7 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
     skill_root = get_workspace_skills_dir(workspace_dir)
     specs: list[SkillSpec] = []
     for skill_name, raw_entry in sorted(entries.items()):
-        entry = _normalize_skill_manifest_entry(raw_entry)
+        entry = normalize_skill_manifest_entry(raw_entry)
         if raw_entry not in (None, entry):
             logger.warning(
                 "Skipping malformed workspace skill entry '%s' in manifest",
@@ -525,7 +525,7 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
         try:
             source = entry.get("source", "customized")
             skill_dir = skill_root / skill_name
-            skill = _read_skill_from_dir(skill_dir, source)
+            skill = read_skill_from_dir(skill_dir, source)
             if skill is None:
                 continue
             dump = skill.model_dump()
@@ -536,7 +536,7 @@ def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
                     enabled=entry.get("enabled", False),
                     channels=entry.get("channels") or ["all"],
                     config=entry.get("config") or {},
-                    last_updated=_get_skill_mtime(skill_dir),
+                    last_updated=get_skill_mtime(skill_dir),
                 ),
             )
         except Exception:
@@ -555,7 +555,7 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
     sync_info = get_pool_builtin_sync_status(pool_skills=entries)
     specs: list[PoolSkillSpec] = []
     for skill_name, raw_entry in sorted(entries.items()):
-        entry = _normalize_skill_manifest_entry(raw_entry)
+        entry = normalize_skill_manifest_entry(raw_entry)
         if raw_entry not in (None, entry):
             logger.warning(
                 "Skipping malformed pool skill entry '%s' in manifest",
@@ -564,7 +564,7 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
         try:
             source = entry.get("source", "customized")
             skill_dir = pool_dir / skill_name
-            skill = _read_skill_from_dir(skill_dir, source)
+            skill = read_skill_from_dir(skill_dir, source)
             if skill is None:
                 continue
             info = sync_info.get(skill_name, {})
@@ -593,7 +593,7 @@ def _build_pool_skill_specs() -> list[PoolSkillSpec]:
                         if str(language)
                     ],
                     config=entry.get("config") or {},
-                    last_updated=_get_skill_mtime(skill_dir),
+                    last_updated=get_skill_mtime(skill_dir),
                 ),
             )
         except Exception:
@@ -1141,11 +1141,11 @@ async def update_pool_builtin(
     body: UpdateBuiltinRequest | None = Body(default=None),
 ) -> dict[str, Any]:
     language = body.language if body is not None else ""
-    if language and language not in _BUILTIN_SKILL_LANGUAGES:
+    if language and language not in BUILTIN_SKILL_LANGUAGES:
         raise HTTPException(
             status_code=400,
             detail=f"Invalid language '{language}', "
-            f"must be one of {_BUILTIN_SKILL_LANGUAGES}",
+            f"must be one of {BUILTIN_SKILL_LANGUAGES}",
         )
     try:
         return update_single_builtin(skill_name, language=language or None)
@@ -1187,7 +1187,7 @@ async def update_pool_skill_config(
         entry["config"] = dict(body.config)
         return True
 
-    updated = _mutate_json(manifest_path, _default_pool_manifest(), _update)
+    updated = mutate_json(manifest_path, default_pool_manifest(), _update)
     if not updated:
         raise HTTPException(status_code=404, detail="Pool skill not found")
     return {"updated": True}
@@ -1204,7 +1204,7 @@ async def delete_pool_skill_config(skill_name: str) -> dict[str, Any]:
         entry.pop("config", None)
         return True
 
-    updated = _mutate_json(manifest_path, _default_pool_manifest(), _update)
+    updated = mutate_json(manifest_path, default_pool_manifest(), _update)
     if not updated:
         raise HTTPException(status_code=404, detail="Pool skill not found")
     return {"cleared": True}
@@ -1508,9 +1508,9 @@ async def update_skill_config_endpoint(
         entry["config"] = dict(body.config)
         return True
 
-    updated = _mutate_json(
+    updated = mutate_json(
         manifest_path,
-        _default_workspace_manifest(),
+        default_workspace_manifest(),
         _update,
     )
     if not updated:
@@ -1533,9 +1533,9 @@ async def delete_skill_config_endpoint(
         entry.pop("config", None)
         return True
 
-    updated = _mutate_json(
+    updated = mutate_json(
         manifest_path,
-        _default_workspace_manifest(),
+        default_workspace_manifest(),
         _update,
     )
     if not updated:

--- a/src/qwenpaw/cli/skills_cmd.py
+++ b/src/qwenpaw/cli/skills_cmd.py
@@ -17,7 +17,7 @@ from ..agents.skill_system import (
     reconcile_workspace_manifest,
 )
 from ..agents.skill_system.registry import list_workspaces
-from ..agents.skill_system.store import _validate_skill_content
+from ..agents.skill_system.store import validate_skill_content
 from ..agents.skill_system.hub import (
     import_pool_skill_from_hub,
     install_skill_from_hub,
@@ -115,7 +115,7 @@ def _validate_skill_frontmatter(skill_dir: Path) -> None:
 
     content = read_text_file_with_encoding_fallback(skill_md)
     try:
-        _validate_skill_content(content)
+        validate_skill_content(content)
     except SkillsError as exc:
         raise click.ClickException(str(exc))
     except Exception as exc:


### PR DESCRIPTION
## Description

1. Added a centralized `safe_skill_dir()` helper (normalize → resolve() → is_relative_to()) and routed every skill create/save/delete/load path construction in both workspace and pool services through it, while the existing `_safe_child_path` already guarded the references/scripts/extra_files tree.
2. Refactor for function naming. Change _func to func for external calling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
