### PR TITLE
fix(config): migrate legacy embedding config

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -562,6 +562,58 @@ class EmbeddingModelConfig(BaseModel):
     )
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return a model/dict value as a shallow dict."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(exclude_none=True)
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _embedding_config_has_user_values(value: Any) -> bool:
+    """Return True when an embedding config carries non-default values."""
+    data = _as_dict(value)
+    if not data:
+        return False
+
+    defaults = EmbeddingModelConfig().model_dump()
+    for key, val in data.items():
+        if key not in defaults or val is None:
+            continue
+        if isinstance(val, str):
+            if val.strip() and val != defaults[key]:
+                return True
+            continue
+        if val != defaults[key]:
+            return True
+    return False
+
+
+def _migrate_legacy_embedding_config(data: Any) -> Any:
+    """Copy legacy running.embedding_config into the current ReMe path."""
+    if not isinstance(data, dict):
+        return data
+
+    legacy = data.get("embedding_config")
+    if not _embedding_config_has_user_values(legacy):
+        return data
+
+    reme_config = _as_dict(data.get("reme_light_memory_config"))
+    current = reme_config.get("embedding_model_config")
+    if _embedding_config_has_user_values(current):
+        return data
+
+    migrated = dict(data)
+    migrated_reme = dict(reme_config)
+    migrated_embedding = EmbeddingModelConfig.model_validate(
+        _as_dict(legacy),
+    ).model_dump()
+    migrated_reme["embedding_model_config"] = migrated_embedding
+    migrated["reme_light_memory_config"] = migrated_reme
+    return migrated
+
+
 class ADBPGMemoryConfig(BaseModel):
     """ADBPG (AnalyticDB for PostgreSQL) memory configuration."""
 
@@ -818,6 +870,12 @@ class AgentsRunningConfig(BaseModel):
     """Agent runtime behavior configuration."""
 
     model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_embedding_config(cls, data: Any) -> Any:
+        """Preserve pre-ReMe embedding config from older agent.json files."""
+        return _migrate_legacy_embedding_config(data)
 
     max_iters: int = Field(
         default=100,

--- a/tests/unit/workspace/test_agent_model.py
+++ b/tests/unit/workspace/test_agent_model.py
@@ -286,6 +286,83 @@ def test_agent_running_config_llm_retry_persists(
     assert reloaded_config.running.llm_backoff_cap == 8.0
 
 
+def test_legacy_embedding_config_migrates_to_reme_light(
+    mock_agent_workspace,
+):  # pylint: disable=redefined-outer-name
+    """Legacy running.embedding_config is read through the new ReMe path."""
+    import json
+
+    agent_json_path = mock_agent_workspace / "agent.json"
+    with open(agent_json_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    raw_data["running"] = {
+        "embedding_config": {
+            "backend": "openai",
+            "api_key": "legacy-key",
+            "base_url": "https://embeddings.example.com/v1",
+            "model_name": "bge-m3",
+            "dimensions": 1024,
+            "enable_cache": False,
+            "use_dimensions": True,
+            "max_cache_size": 200,
+            "max_input_length": 4096,
+            "max_batch_size": 8,
+        },
+    }
+    with open(agent_json_path, "w", encoding="utf-8") as f:
+        json.dump(raw_data, f)
+
+    agent_config = load_agent_config("test_agent")
+    embedding = (
+        agent_config.running.reme_light_memory_config.embedding_model_config
+    )
+
+    assert embedding.api_key == "legacy-key"
+    assert embedding.base_url == "https://embeddings.example.com/v1"
+    assert embedding.model_name == "bge-m3"
+    assert embedding.enable_cache is False
+    assert embedding.use_dimensions is True
+    assert embedding.max_batch_size == 8
+
+
+def test_modern_embedding_config_wins_over_legacy_config(
+    mock_agent_workspace,
+):  # pylint: disable=redefined-outer-name
+    """A populated new ReMe embedding config is not overwritten."""
+    import json
+
+    agent_json_path = mock_agent_workspace / "agent.json"
+    with open(agent_json_path, "r", encoding="utf-8") as f:
+        raw_data = json.load(f)
+
+    raw_data["running"] = {
+        "embedding_config": {
+            "api_key": "legacy-key",
+            "base_url": "https://legacy.example.com/v1",
+            "model_name": "legacy-model",
+        },
+        "reme_light_memory_config": {
+            "embedding_model_config": {
+                "api_key": "modern-key",
+                "base_url": "https://modern.example.com/v1",
+                "model_name": "modern-model",
+            },
+        },
+    }
+    with open(agent_json_path, "w", encoding="utf-8") as f:
+        json.dump(raw_data, f)
+
+    agent_config = load_agent_config("test_agent")
+    embedding = (
+        agent_config.running.reme_light_memory_config.embedding_model_config
+    )
+
+    assert embedding.api_key == "modern-key"
+    assert embedding.base_url == "https://modern.example.com/v1"
+    assert embedding.model_name == "modern-model"
+
+
 def test_agent_running_config_rejects_backoff_cap_below_base():
     """Test that backoff cap cannot be lower than backoff base."""
     with pytest.raises(ConfigurationException):


### PR DESCRIPTION
## Description

Migrate legacy `running.embedding_config` values into `running.reme_light_memory_config.embedding_model_config` during `AgentsRunningConfig` validation.

This preserves embedding settings from older `agent.json` files after upgrade, while leaving an already-populated modern ReMe embedding config untouched.

**Related Issue:** Fixes #4018

**Security Considerations:** This only migrates local embedding provider config already present in the user's local `agent.json`; it does not expose or log secrets.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran scoped `pre-commit` locally on the changed files and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; compatibility-only config migration)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Added regression coverage for both upgrade paths:

- legacy `running.embedding_config` is exposed through the new ReMe path
- modern `reme_light_memory_config.embedding_model_config` wins if both paths exist

## Local Verification Evidence

```bash
pre-commit run --files src\qwenpaw\config\config.py tests\unit\workspace\test_agent_model.py
# Passed: python ast, docstring, encoding pragma, private key, whitespace,
# trailing commas, mypy, black, flake8, pylint

PYTHONPATH=src pytest tests\unit\workspace\test_agent_model.py tests\unit\agents\memory\test_reme_light_memory_manager.py -q
# 36 passed in 14.17s

git diff --check
# Passed (only local Windows LF/CRLF warnings)
```

## Additional Notes

The migration is guarded: it only copies legacy values when the current ReMe embedding config does not contain user-provided values.