### PR TITLE
fix(app): isolate agent context per request

### DIFF
--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -3,7 +3,7 @@
 
 Provides utilities to get the correct agent instance for each request.
 """
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from typing import Optional, TYPE_CHECKING
 from fastapi import Request
 from .multi_agent_manager import MultiAgentManager
@@ -131,13 +131,18 @@ def get_active_agent_id() -> str:
         return "default"
 
 
-def set_current_agent_id(agent_id: str) -> None:
+def set_current_agent_id(agent_id: str) -> Token:
     """Set current agent ID in context.
 
     Args:
         agent_id: Agent ID to set
     """
-    _current_agent_id.set(agent_id)
+    return _current_agent_id.set(agent_id)
+
+
+def reset_current_agent_id(token: Token) -> None:
+    """Restore the previous current agent ID context."""
+    _current_agent_id.reset(token)
 
 
 def get_current_agent_id() -> str:
@@ -152,21 +157,30 @@ def get_current_agent_id() -> str:
     return get_active_agent_id()
 
 
-def set_current_session_id(session_id: str) -> None:
-    _current_session_id.set(session_id)
+def set_current_session_id(session_id: str) -> Token:
+    return _current_session_id.set(session_id)
+
+
+def reset_current_session_id(token: Token) -> None:
+    _current_session_id.reset(token)
 
 
 def get_current_session_id() -> Optional[str]:
     return _current_session_id.get()
 
 
-def set_current_root_session_id(root_session_id: Optional[str]) -> None:
+def set_current_root_session_id(root_session_id: Optional[str]) -> Token:
     """Set current root session ID in context.
 
     Args:
         root_session_id: Root session ID to set
     """
-    _current_root_session_id.set(root_session_id)
+    return _current_root_session_id.set(root_session_id)
+
+
+def reset_current_root_session_id(token: Token) -> None:
+    """Restore the previous current root session ID context."""
+    _current_root_session_id.reset(token)
 
 
 def get_current_root_session_id() -> Optional[str]:

--- a/src/qwenpaw/app/routers/agent_scoped.py
+++ b/src/qwenpaw/app/routers/agent_scoped.py
@@ -22,10 +22,17 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         """Extract agentId and root_session_id from path/headers."""
         import logging
-        from ..agent_context import set_current_agent_id
+        from ..agent_context import (
+            reset_current_agent_id,
+            reset_current_root_session_id,
+            set_current_agent_id,
+            set_current_root_session_id,
+        )
 
         logger = logging.getLogger(__name__)
         agent_id = None
+        agent_token = None
+        root_session_token = None
 
         # Priority 1: Extract agentId from path: /api/agents/{agentId}/...
         path_parts = request.url.path.split("/")
@@ -44,7 +51,7 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
 
         # Set agent_id in context variable for use by runners
         if agent_id:
-            set_current_agent_id(agent_id)
+            agent_token = set_current_agent_id(agent_id)
 
         # Extract X-Root-Session-Id header for cross-session approval routing
         root_session_id = request.headers.get("X-Root-Session-Id")
@@ -53,14 +60,21 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
             if not hasattr(request, "request_context"):
                 request.request_context = {}
             request.request_context["root_session_id"] = root_session_id
+            root_session_token = set_current_root_session_id(root_session_id)
             logger.debug(
                 "AgentContextMiddleware: root_session_id=%s from "
                 "X-Root-Session-Id header",
                 root_session_id[:12],
             )
 
-        response = await call_next(request)
-        return response
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            if root_session_token is not None:
+                reset_current_root_session_id(root_session_token)
+            if agent_token is not None:
+                reset_current_agent_id(agent_token)
 
 
 def create_agent_scoped_router() -> APIRouter:

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -317,35 +317,51 @@ class AgentRunner(Runner):
         query = _get_last_user_text(msgs)
         session_id = getattr(request, "session_id", "") or ""
 
-        # Check if query is a command (including /approval)
-        logger.debug(f"Query: {query!r}, is_command: {_is_command(query)}")
-        if query and _is_command(query):
-            logger.info("Command path: %s", query.strip()[:50])
-            async for msg, last in run_command_path(request, msgs, self):
-                yield msg, last
-            return
-
         logger.debug(
             f"AgentRunner.stream_query: request={request}, "
             f"agent_id={self.agent_id}",
         )
 
-        # Set agent context for model creation
+        # Set agent context before command handling so control commands and
+        # tool approval paths do not fall back to another active agent.
         from ..agent_context import (
+            reset_current_agent_id,
+            reset_current_root_session_id,
+            reset_current_session_id,
             set_current_agent_id,
-            set_current_session_id,
             set_current_root_session_id,
+            set_current_session_id,
         )
 
-        set_current_agent_id(self.agent_id)
+        payload_root_session = getattr(request, "root_session_id", "")
+        if payload_root_session and isinstance(payload_root_session, str):
+            context_root_session_id = payload_root_session
+        else:
+            context_root_session_id = session_id
 
-        # Set session_id in context for token usage tracking
-        set_current_session_id(session_id)
+        agent_context_token = set_current_agent_id(self.agent_id)
+        session_context_token = set_current_session_id(session_id)
+        root_session_context_token = set_current_root_session_id(
+            context_root_session_id,
+        )
 
         agent = None
         chat = None
         session_state_loaded = False
+        base_request_context = {
+            "root_session_id": context_root_session_id,
+        }
         try:
+            # Check if query is a command (including /approval)
+            logger.debug(
+                f"Query: {query!r}, is_command: {_is_command(query)}",
+            )
+            if query and _is_command(query):
+                logger.info("Command path: %s", query.strip()[:50])
+                async for msg, last in run_command_path(request, msgs, self):
+                    yield msg, last
+                return
+
             session_id = request.session_id
             user_id = request.user_id
             channel = getattr(request, "channel", DEFAULT_CHANNEL)
@@ -415,10 +431,8 @@ class AgentRunner(Runner):
                 base_request_context.update(payload_context)
 
             # Extract root_session_id from request payload (agent chat)
-            payload_root_session = getattr(request, "root_session_id", "")
             if payload_root_session and isinstance(payload_root_session, str):
                 base_request_context["root_session_id"] = payload_root_session
-                set_current_root_session_id(payload_root_session)
                 root_preview = (
                     payload_root_session[:12]
                     if len(payload_root_session) >= 12
@@ -431,7 +445,6 @@ class AgentRunner(Runner):
             else:
                 # Current session is the root
                 base_request_context["root_session_id"] = session_id
-                set_current_root_session_id(session_id)
                 session_preview = (
                     session_id[:12] if len(session_id) >= 12 else session_id
                 )
@@ -826,16 +839,21 @@ class AgentRunner(Runner):
                     ) + converted.args[1:]
             raise converted from e
         finally:
-            if agent is not None and session_state_loaded:
-                await self.session.save_session_state(
-                    session_id=session_id,
-                    user_id=user_id,
-                    channel=channel,
-                    agent=agent,
-                )
+            try:
+                if agent is not None and session_state_loaded:
+                    await self.session.save_session_state(
+                        session_id=session_id,
+                        user_id=user_id,
+                        channel=channel,
+                        agent=agent,
+                    )
 
-            if self._chat_manager is not None and chat is not None:
-                await self._chat_manager.touch_chat(chat.id)
+                if self._chat_manager is not None and chat is not None:
+                    await self._chat_manager.touch_chat(chat.id)
+            finally:
+                reset_current_root_session_id(root_session_context_token)
+                reset_current_session_id(session_context_token)
+                reset_current_agent_id(agent_context_token)
 
     async def init_handler(self, *args, **kwargs):
         """

--- a/tests/unit/app/test_agent_context.py
+++ b/tests/unit/app/test_agent_context.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Tests for request-scoped agent context handling."""
+from types import SimpleNamespace
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+import pytest
+
+from qwenpaw.app import agent_context
+from qwenpaw.app.routers.agent_scoped import AgentContextMiddleware
+from qwenpaw.app.runner import runner as runner_module
+from qwenpaw.app.runner.runner import AgentRunner
+
+
+def test_agent_context_reset_restores_previous_agent(monkeypatch):
+    monkeypatch.setattr(agent_context, "get_active_agent_id", lambda: "active")
+
+    outer_token = agent_context.set_current_agent_id("default")
+    try:
+        inner_token = agent_context.set_current_agent_id("worker")
+        assert agent_context.get_current_agent_id() == "worker"
+
+        agent_context.reset_current_agent_id(inner_token)
+        assert agent_context.get_current_agent_id() == "default"
+    finally:
+        agent_context.reset_current_agent_id(outer_token)
+
+    assert agent_context.get_current_agent_id() == "active"
+
+
+def test_session_context_reset_restores_previous_values():
+    outer_session = agent_context.set_current_session_id("session-a")
+    outer_root = agent_context.set_current_root_session_id("root-a")
+    try:
+        inner_session = agent_context.set_current_session_id("session-b")
+        inner_root = agent_context.set_current_root_session_id("root-b")
+
+        assert agent_context.get_current_session_id() == "session-b"
+        assert agent_context.get_current_root_session_id() == "root-b"
+
+        agent_context.reset_current_root_session_id(inner_root)
+        agent_context.reset_current_session_id(inner_session)
+
+        assert agent_context.get_current_session_id() == "session-a"
+        assert agent_context.get_current_root_session_id() == "root-a"
+    finally:
+        agent_context.reset_current_root_session_id(outer_root)
+        agent_context.reset_current_session_id(outer_session)
+
+
+@pytest.mark.asyncio
+async def test_agent_context_middleware_resets_after_request(monkeypatch):
+    monkeypatch.setattr(agent_context, "get_active_agent_id", lambda: "active")
+    middleware = AgentContextMiddleware(
+        app=lambda _scope, _receive, _send: None,
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/agents/worker/chats",
+        "headers": [(b"x-root-session-id", b"root-b")],
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+    }
+    request = Request(scope)
+
+    outer_agent = agent_context.set_current_agent_id("default")
+    outer_root = agent_context.set_current_root_session_id("root-a")
+    observed = {}
+
+    async def call_next(inner_request):
+        observed["agent_id"] = agent_context.get_current_agent_id()
+        observed[
+            "root_session_id"
+        ] = agent_context.get_current_root_session_id()
+        observed["state_agent_id"] = inner_request.state.agent_id
+        observed["request_root_session_id"] = inner_request.request_context[
+            "root_session_id"
+        ]
+        return Response("ok")
+
+    try:
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 200
+        assert observed == {
+            "agent_id": "worker",
+            "root_session_id": "root-b",
+            "state_agent_id": "worker",
+            "request_root_session_id": "root-b",
+        }
+        assert agent_context.get_current_agent_id() == "default"
+        assert agent_context.get_current_root_session_id() == "root-a"
+    finally:
+        agent_context.reset_current_root_session_id(outer_root)
+        agent_context.reset_current_agent_id(outer_agent)
+
+    assert agent_context.get_current_agent_id() == "active"
+    assert agent_context.get_current_root_session_id() is None
+
+
+@pytest.mark.asyncio
+async def test_runner_sets_agent_context_for_command_path(monkeypatch):
+    monkeypatch.setattr(agent_context, "get_active_agent_id", lambda: "active")
+    monkeypatch.setattr(runner_module, "_is_command", lambda _query: True)
+
+    observed = {}
+
+    async def fake_run_command_path(_request, _msgs, _runner):
+        observed["agent_id"] = agent_context.get_current_agent_id()
+        observed["session_id"] = agent_context.get_current_session_id()
+        observed[
+            "root_session_id"
+        ] = agent_context.get_current_root_session_id()
+        yield object(), True
+
+    monkeypatch.setattr(
+        runner_module,
+        "run_command_path",
+        fake_run_command_path,
+    )
+
+    request = SimpleNamespace(
+        session_id="session-b",
+        user_id="user-b",
+        channel="console",
+    )
+    outer_agent = agent_context.set_current_agent_id("default")
+    outer_session = agent_context.set_current_session_id("session-a")
+    outer_root = agent_context.set_current_root_session_id("root-a")
+    try:
+        results = []
+        async for item in AgentRunner(agent_id="worker").query_handler(
+            [{"content": "/clear"}],
+            request=request,
+        ):
+            results.append(item)
+
+        assert len(results) == 1
+        assert results[0][1] is True
+        assert observed == {
+            "agent_id": "worker",
+            "session_id": "session-b",
+            "root_session_id": "session-b",
+        }
+        assert agent_context.get_current_agent_id() == "default"
+        assert agent_context.get_current_session_id() == "session-a"
+        assert agent_context.get_current_root_session_id() == "root-a"
+    finally:
+        agent_context.reset_current_root_session_id(outer_root)
+        agent_context.reset_current_session_id(outer_session)
+        agent_context.reset_current_agent_id(outer_agent)
+
+    assert agent_context.get_current_agent_id() == "active"
+    assert agent_context.get_current_session_id() is None
+    assert agent_context.get_current_root_session_id() is None


### PR DESCRIPTION
## Summary
- return context tokens from agent/session/root context setters and add reset helpers
- reset agent-scoped HTTP context after each request
- set runner context before command handling and always reset it after query handling
- add regression tests for context restoration and command-path agent context

## Related Issue
Fixes #3957

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\app\test_agent_context.py tests\unit\agents\tools\test_agent_management.py -q
- pre-commit run --files src\qwenpaw\app\agent_context.py src\qwenpaw\app\routers\agent_scoped.py src\qwenpaw\app\runner\runner.py tests\unit\app\test_agent_context.py
- git diff --check