### PR TITLE
feat(app): support agentscope tracing env

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -69,6 +69,53 @@ mimetypes.add_type("application/wasm", ".wasm")
 load_envs_into_environ()
 
 
+_AGENTSCOPE_TRACING_URL_ENV = "AGENTSCOPE_TRACING_URL"
+_AGENTSCOPE_TRACING_PROJECT_ENV = "AGENTSCOPE_TRACING_PROJECT"
+_AGENTSCOPE_TRACING_NAME_ENV = "AGENTSCOPE_TRACING_NAME"
+_AGENTSCOPE_TRACING_RUN_ID_ENV = "AGENTSCOPE_TRACING_RUN_ID"
+
+
+def _env_str(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    value = value.strip()
+    return value or default
+
+
+def _init_agentscope_tracing_from_env() -> bool:
+    """Enable AgentScope tracing when AGENTSCOPE_TRACING_URL is configured."""
+    tracing_url = _env_str(_AGENTSCOPE_TRACING_URL_ENV)
+    if not tracing_url:
+        return False
+
+    try:
+        import agentscope
+
+        agentscope.init(
+            project=_env_str(
+                _AGENTSCOPE_TRACING_PROJECT_ENV,
+                PROJECT_NAME,
+            ),
+            name=_env_str(_AGENTSCOPE_TRACING_NAME_ENV, "qwenpaw-app"),
+            run_id=_env_str(_AGENTSCOPE_TRACING_RUN_ID_ENV),
+            logging_level=os.environ.get(LOG_LEVEL_ENV, "info").upper(),
+            tracing_url=tracing_url,
+        )
+    except Exception:
+        logger.warning(
+            "AgentScope tracing initialization skipped due to error",
+            exc_info=True,
+        )
+        return False
+
+    logger.info(
+        "AgentScope tracing enabled from %s",
+        _AGENTSCOPE_TRACING_URL_ENV,
+    )
+    return True
+
+
 # Dynamic runner that selects the correct workspace runner based on request
 class DynamicMultiAgentRunner:
     """Runner wrapper that dynamically routes to the correct workspace runner.
@@ -240,6 +287,8 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         )
         logger.error(message, exc_info=True)
         raise RuntimeError(f"{message} Original error: {exc}") from exc
+
+    _init_agentscope_tracing_from_env()
 
     auto_register_from_env()
 

--- a/tests/unit/app/test_agentscope_tracing.py
+++ b/tests/unit/app/test_agentscope_tracing.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from types import SimpleNamespace
+
+from qwenpaw.app import _app as app_module
+
+
+def test_agentscope_tracing_skips_when_url_missing(monkeypatch):
+    calls = []
+
+    monkeypatch.delenv("AGENTSCOPE_TRACING_URL", raising=False)
+    monkeypatch.setitem(
+        app_module.sys.modules,
+        "agentscope",
+        SimpleNamespace(init=lambda **kwargs: calls.append(kwargs)),
+    )
+
+    assert app_module._init_agentscope_tracing_from_env() is False
+    assert not calls
+
+
+def test_agentscope_tracing_init_reads_env(monkeypatch):
+    calls = []
+
+    monkeypatch.setenv("AGENTSCOPE_TRACING_URL", " http://phoenix/v1/traces ")
+    monkeypatch.setenv("AGENTSCOPE_TRACING_PROJECT", " demo-project ")
+    monkeypatch.setenv("AGENTSCOPE_TRACING_NAME", " desktop ")
+    monkeypatch.setenv("AGENTSCOPE_TRACING_RUN_ID", " run-1 ")
+    monkeypatch.setenv("QWENPAW_LOG_LEVEL", "debug")
+    monkeypatch.setitem(
+        app_module.sys.modules,
+        "agentscope",
+        SimpleNamespace(init=lambda **kwargs: calls.append(kwargs)),
+    )
+
+    assert app_module._init_agentscope_tracing_from_env() is True
+    assert calls == [
+        {
+            "project": "demo-project",
+            "name": "desktop",
+            "run_id": "run-1",
+            "logging_level": "DEBUG",
+            "tracing_url": "http://phoenix/v1/traces",
+        },
+    ]
+
+
+def test_agentscope_tracing_uses_defaults(monkeypatch):
+    calls = []
+
+    monkeypatch.setenv("AGENTSCOPE_TRACING_URL", "http://phoenix/v1/traces")
+    monkeypatch.delenv("AGENTSCOPE_TRACING_PROJECT", raising=False)
+    monkeypatch.delenv("AGENTSCOPE_TRACING_NAME", raising=False)
+    monkeypatch.delenv("AGENTSCOPE_TRACING_RUN_ID", raising=False)
+    monkeypatch.delenv("QWENPAW_LOG_LEVEL", raising=False)
+    monkeypatch.setitem(
+        app_module.sys.modules,
+        "agentscope",
+        SimpleNamespace(init=lambda **kwargs: calls.append(kwargs)),
+    )
+
+    assert app_module._init_agentscope_tracing_from_env() is True
+    assert calls == [
+        {
+            "project": "QwenPaw",
+            "name": "qwenpaw-app",
+            "run_id": None,
+            "logging_level": "INFO",
+            "tracing_url": "http://phoenix/v1/traces",
+        },
+    ]


### PR DESCRIPTION
## Summary
- initialize AgentScope tracing during app startup when `AGENTSCOPE_TRACING_URL` is set
- support optional `AGENTSCOPE_TRACING_PROJECT`, `AGENTSCOPE_TRACING_NAME`, and `AGENTSCOPE_TRACING_RUN_ID` metadata
- add unit coverage for disabled/default/custom tracing env behavior

Fixes #4057

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\app\test_agentscope_tracing.py -q`
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pre-commit run --files src\qwenpaw\app\_app.py tests\unit\app\test_agentscope_tracing.py`
- `git diff --check`