### PR TITLE
feat(auth): add provider OAuth extension

### DIFF
--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -69,14 +69,14 @@ export const providerApi = {
     ),
 
   getProviderAuthStatus: (providerId: string, flowId?: string) => {
-    const url = new URL(
-      `/models/${encodeURIComponent(providerId)}/auth/status`,
-      window.location.origin,
-    );
-    if (flowId) {
-      url.searchParams.set("flow_id", flowId);
+    const path = `/models/${encodeURIComponent(providerId)}/auth/status`;
+    if (!flowId) {
+      return request<AuthStatusResult>(path);
     }
-    return request<AuthStatusResult>(url.pathname + url.search);
+
+    const searchParams = new URLSearchParams();
+    searchParams.set("flow_id", flowId);
+    return request<AuthStatusResult>(`${path}?${searchParams.toString()}`);
   },
 
   logoutProviderAuth: (providerId: string) =>

--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -2,6 +2,9 @@ import { request } from "../request";
 import type {
   ProviderInfo,
   ProviderConfigRequest,
+  AuthStartRequest,
+  AuthStartResult,
+  AuthStatusResult,
   ActiveModelsInfo,
   GetActiveModelsRequest,
   ModelSlotRequest,
@@ -55,6 +58,32 @@ export const providerApi = {
       method: "PUT",
       body: JSON.stringify(body),
     }),
+
+  startProviderAuth: (providerId: string, body?: AuthStartRequest) =>
+    request<AuthStartResult>(
+      `/models/${encodeURIComponent(providerId)}/auth/start`,
+      {
+        method: "POST",
+        body: body ? JSON.stringify(body) : undefined,
+      },
+    ),
+
+  getProviderAuthStatus: (providerId: string, flowId?: string) => {
+    const url = new URL(
+      `/models/${encodeURIComponent(providerId)}/auth/status`,
+      window.location.origin,
+    );
+    if (flowId) {
+      url.searchParams.set("flow_id", flowId);
+    }
+    return request<AuthStatusResult>(url.pathname + url.search);
+  },
+
+  logoutProviderAuth: (providerId: string) =>
+    request<AuthStatusResult>(
+      `/models/${encodeURIComponent(providerId)}/auth/logout`,
+      { method: "POST" },
+    ),
 
   getActiveModels: (params?: GetActiveModelsRequest) => {
     const key = buildActiveModelQuery(params);

--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -9,6 +9,55 @@ export interface ModelInfo {
   generate_kwargs: Record<string, unknown>;
 }
 
+export type ProviderAuthType =
+  | "none"
+  | "api_key"
+  | "oauth_device_code"
+  | "oauth_authorization_code"
+  | "oauth_vendor_user_code";
+
+export type ProviderAuthStatus =
+  | "not_required"
+  | "not_configured"
+  | "pending"
+  | "authenticated"
+  | "expired"
+  | "error";
+
+export interface ProviderAuthInfo {
+  type: ProviderAuthType;
+  status: ProviderAuthStatus;
+  account_label?: string;
+  expires_at?: number | null;
+  scopes?: string[];
+  supports_logout?: boolean;
+  message?: string;
+}
+
+export interface AuthStartRequest {
+  redirect_uri?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuthStartResult {
+  flow_id: string;
+  flow_type: "device_code" | "authorization_code" | "vendor_user_code";
+  user_code?: string | null;
+  verification_uri?: string | null;
+  authorization_url?: string | null;
+  expires_at?: number | null;
+  interval?: number | null;
+  message?: string;
+}
+
+export interface AuthStatusResult {
+  status: ProviderAuthStatus;
+  account_label?: string;
+  expires_at?: number | null;
+  scopes?: string[];
+  message?: string;
+}
+
 export interface ProviderInfo {
   id: string;
   name: string;
@@ -28,6 +77,10 @@ export interface ProviderInfo {
   freeze_url: boolean;
   /** True when an API key is required for this provider. */
   require_api_key: boolean;
+  /** Authentication mechanism used by this provider. */
+  auth_type?: ProviderAuthType;
+  /** Safe provider authentication status metadata. */
+  auth?: ProviderAuthInfo | null;
   api_key: string;
   base_url: string;
   generate_kwargs: Record<string, unknown>;

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -65,10 +65,19 @@ async def get_provider_manager(request: Request) -> ProviderManager:
 
 
 def get_provider_auth_manager(
-    manager: ProviderManager,
+    request: Request,
+    manager: ProviderManager = Depends(get_provider_manager),
 ) -> ProviderAuthManager:
-    """Create the auth manager for provider auth endpoints."""
-    return ProviderAuthManager(manager)
+    """Get the shared auth manager for provider auth endpoints."""
+    auth_manager = getattr(
+        request.app.state,
+        "provider_auth_manager",
+        None,
+    )
+    if auth_manager is None:
+        auth_manager = ProviderAuthManager(manager)
+        request.app.state.provider_auth_manager = auth_manager
+    return auth_manager
 
 
 class ProviderConfigRequest(BaseModel):
@@ -193,11 +202,10 @@ async def list_all_providers(
     summary="Start provider authentication",
 )
 async def start_provider_auth(
-    manager: ProviderManager = Depends(get_provider_manager),
+    auth_manager: ProviderAuthManager = Depends(get_provider_auth_manager),
     provider_id: str = Path(...),
     body: AuthStartRequest = Body(default_factory=AuthStartRequest),
 ) -> AuthStartResult:
-    auth_manager = get_provider_auth_manager(manager)
     try:
         return await auth_manager.start(provider_id, body)
     except ProviderAuthError as exc:
@@ -213,11 +221,10 @@ async def start_provider_auth(
     summary="Get provider authentication status",
 )
 async def get_provider_auth_status(
-    manager: ProviderManager = Depends(get_provider_manager),
+    auth_manager: ProviderAuthManager = Depends(get_provider_auth_manager),
     provider_id: str = Path(...),
     flow_id: str | None = Query(default=None),
 ) -> AuthStatusResult:
-    auth_manager = get_provider_auth_manager(manager)
     try:
         return await auth_manager.get_status(provider_id, flow_id=flow_id)
     except ProviderAuthError as exc:
@@ -233,10 +240,9 @@ async def get_provider_auth_status(
     summary="Log out provider authentication",
 )
 async def logout_provider_auth(
-    manager: ProviderManager = Depends(get_provider_manager),
+    auth_manager: ProviderAuthManager = Depends(get_provider_auth_manager),
     provider_id: str = Path(...),
 ) -> AuthStatusResult:
-    auth_manager = get_provider_auth_manager(manager)
     try:
         return await auth_manager.logout(provider_id)
     except ProviderAuthError as exc:
@@ -252,12 +258,11 @@ async def logout_provider_auth(
     summary="Handle provider authentication callback",
 )
 async def provider_auth_callback(
-    manager: ProviderManager = Depends(get_provider_manager),
+    auth_manager: ProviderAuthManager = Depends(get_provider_auth_manager),
     provider_id: str = Path(...),
     state: str = Query(...),
     code: str = Query(...),
 ) -> AuthStatusResult:
-    auth_manager = get_provider_auth_manager(manager)
     try:
         return await auth_manager.handle_callback(provider_id, state, code)
     except ProviderAuthError as exc:

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Literal, Optional
 from copy import deepcopy
+from typing import List, Literal, Optional
+from urllib.parse import urlsplit
 
 from fastapi import (
     APIRouter,
@@ -78,6 +79,42 @@ def get_provider_auth_manager(
         auth_manager = ProviderAuthManager(manager)
         request.app.state.provider_auth_manager = auth_manager
     return auth_manager
+
+
+def _validate_auth_redirect_uri(
+    request: Request,
+    provider_id: str,
+    body: AuthStartRequest,
+) -> None:
+    """Ensure redirect_uri cannot target an attacker-controlled origin."""
+    if body.redirect_uri is None:
+        return
+
+    redirect_uri = urlsplit(body.redirect_uri)
+    callback_uri = urlsplit(
+        str(
+            request.url_for(
+                "provider_auth_callback",
+                provider_id=provider_id,
+            ),
+        ),
+    )
+    if (
+        redirect_uri.scheme.lower(),
+        redirect_uri.netloc.lower(),
+        redirect_uri.path,
+    ) != (
+        callback_uri.scheme.lower(),
+        callback_uri.netloc.lower(),
+        callback_uri.path,
+    ) or redirect_uri.fragment:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "redirect_uri must target this provider's auth callback "
+                "endpoint"
+            ),
+        )
 
 
 class ProviderConfigRequest(BaseModel):
@@ -202,10 +239,12 @@ async def list_all_providers(
     summary="Start provider authentication",
 )
 async def start_provider_auth(
+    request: Request,
     auth_manager: ProviderAuthManager = Depends(get_provider_auth_manager),
     provider_id: str = Path(...),
     body: AuthStartRequest = Body(default_factory=AuthStartRequest),
 ) -> AuthStartResult:
+    _validate_auth_redirect_uri(request, provider_id, body)
     try:
         return await auth_manager.start(provider_id, body)
     except ProviderAuthError as exc:

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -26,6 +26,13 @@ from ..agent_context import get_agent_for_request
 from ..utils import schedule_agent_reload
 from ...config.config import load_agent_config, save_agent_config
 from ...providers.provider import ProviderInfo, ModelInfo
+from ...providers.auth import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    ProviderAuthError,
+    ProviderAuthManager,
+)
 from ...config.config import ActiveModelsInfo
 from ...providers.provider_manager import ProviderManager
 from ...providers.openrouter_provider import OpenRouterProvider
@@ -55,6 +62,13 @@ async def get_provider_manager(request: Request) -> ProviderManager:
         request: FastAPI request object
     """
     return request.app.state.provider_manager
+
+
+def get_provider_auth_manager(
+    manager: ProviderManager,
+) -> ProviderAuthManager:
+    """Create the auth manager for provider auth endpoints."""
+    return ProviderAuthManager(manager)
 
 
 class ProviderConfigRequest(BaseModel):
@@ -171,6 +185,86 @@ async def list_all_providers(
     manager: ProviderManager = Depends(get_provider_manager),
 ) -> List[ProviderInfo]:
     return await manager.list_provider_info()
+
+
+@router.post(
+    "/{provider_id}/auth/start",
+    response_model=AuthStartResult,
+    summary="Start provider authentication",
+)
+async def start_provider_auth(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+    body: AuthStartRequest = Body(default_factory=AuthStartRequest),
+) -> AuthStartResult:
+    auth_manager = get_provider_auth_manager(manager)
+    try:
+        return await auth_manager.start(provider_id, body)
+    except ProviderAuthError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.message,
+        ) from exc
+
+
+@router.get(
+    "/{provider_id}/auth/status",
+    response_model=AuthStatusResult,
+    summary="Get provider authentication status",
+)
+async def get_provider_auth_status(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+    flow_id: str | None = Query(default=None),
+) -> AuthStatusResult:
+    auth_manager = get_provider_auth_manager(manager)
+    try:
+        return await auth_manager.get_status(provider_id, flow_id=flow_id)
+    except ProviderAuthError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.message,
+        ) from exc
+
+
+@router.post(
+    "/{provider_id}/auth/logout",
+    response_model=AuthStatusResult,
+    summary="Log out provider authentication",
+)
+async def logout_provider_auth(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+) -> AuthStatusResult:
+    auth_manager = get_provider_auth_manager(manager)
+    try:
+        return await auth_manager.logout(provider_id)
+    except ProviderAuthError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.message,
+        ) from exc
+
+
+@router.get(
+    "/{provider_id}/auth/callback",
+    response_model=AuthStatusResult,
+    summary="Handle provider authentication callback",
+)
+async def provider_auth_callback(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+    state: str = Query(...),
+    code: str = Query(...),
+) -> AuthStatusResult:
+    auth_manager = get_provider_auth_manager(manager)
+    try:
+        return await auth_manager.handle_callback(provider_id, state, code)
+    except ProviderAuthError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.message,
+        ) from exc
 
 
 @router.put(

--- a/src/qwenpaw/providers/auth/__init__.py
+++ b/src/qwenpaw/providers/auth/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Provider authentication infrastructure."""
+
+from .adapter import ProviderAuthAdapter
+from .credential_store import OAuthCredentialStore
+from .manager import ProviderAuthError, ProviderAuthManager
+from .models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    OAuthCredential,
+    ProviderAuthFlowType,
+    ProviderAuthInfo,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+from .registry import ProviderAuthRegistry, auth_registry
+
+__all__ = [
+    "AuthStartRequest",
+    "AuthStartResult",
+    "AuthStatusResult",
+    "OAuthCredential",
+    "OAuthCredentialStore",
+    "ProviderAuthAdapter",
+    "ProviderAuthError",
+    "ProviderAuthFlowType",
+    "ProviderAuthInfo",
+    "ProviderAuthManager",
+    "ProviderAuthRegistry",
+    "ProviderAuthStatus",
+    "ProviderAuthType",
+    "auth_registry",
+]

--- a/src/qwenpaw/providers/auth/adapter.py
+++ b/src/qwenpaw/providers/auth/adapter.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Provider authentication adapter interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from .models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    OAuthCredential,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+
+if TYPE_CHECKING:
+    from ..provider import Provider
+
+
+class ProviderAuthAdapter(ABC):
+    """Provider-specific implementation of an OAuth-style auth flow."""
+
+    provider_id: str
+    auth_type: ProviderAuthType
+
+    @abstractmethod
+    async def start(
+        self,
+        provider: Provider,
+        request: AuthStartRequest,
+    ) -> AuthStartResult:
+        """Start an authentication flow."""
+
+    async def poll(
+        self,
+        provider: Provider,
+        flow_id: str,
+    ) -> AuthStatusResult:
+        """Poll an in-progress auth flow."""
+        return AuthStatusResult(
+            status=ProviderAuthStatus.ERROR,
+            message="Polling is not supported for this auth flow",
+        )
+
+    async def handle_callback(
+        self,
+        provider: Provider,
+        state: str,
+        code: str,
+    ) -> OAuthCredential:
+        """Exchange callback data for an OAuth credential."""
+        raise NotImplementedError
+
+    async def refresh(
+        self,
+        provider: Provider,
+        credential: OAuthCredential,
+    ) -> OAuthCredential:
+        """Refresh a stored credential if the provider supports it."""
+        return credential
+
+    async def logout(
+        self,
+        provider: Provider,
+        credential: OAuthCredential | None,
+    ) -> None:
+        """Revoke or invalidate credentials with the remote provider."""
+        return None
+
+    async def get_status(
+        self,
+        provider: Provider,
+        credential: OAuthCredential | None,
+    ) -> AuthStatusResult:
+        """Return safe auth status metadata for frontend display."""
+        if credential and credential.access_token:
+            return AuthStatusResult(
+                status=ProviderAuthStatus.AUTHENTICATED,
+                account_label=credential.account_label,
+                expires_at=credential.expires_at,
+                scopes=credential.scopes,
+            )
+        return AuthStatusResult(status=ProviderAuthStatus.NOT_CONFIGURED)

--- a/src/qwenpaw/providers/auth/adapter.py
+++ b/src/qwenpaw/providers/auth/adapter.py
@@ -35,8 +35,8 @@ class ProviderAuthAdapter(ABC):
 
     async def poll(
         self,
-        provider: Provider,
-        flow_id: str,
+        provider: Provider,  # pylint: disable=unused-argument
+        flow_id: str,  # pylint: disable=unused-argument
     ) -> AuthStatusResult:
         """Poll an in-progress auth flow."""
         return AuthStatusResult(
@@ -55,7 +55,7 @@ class ProviderAuthAdapter(ABC):
 
     async def refresh(
         self,
-        provider: Provider,
+        provider: Provider,  # pylint: disable=unused-argument
         credential: OAuthCredential,
     ) -> OAuthCredential:
         """Refresh a stored credential if the provider supports it."""
@@ -63,15 +63,15 @@ class ProviderAuthAdapter(ABC):
 
     async def logout(
         self,
-        provider: Provider,
-        credential: OAuthCredential | None,
+        provider: Provider,  # pylint: disable=unused-argument
+        credential: OAuthCredential | None,  # pylint: disable=unused-argument
     ) -> None:
         """Revoke or invalidate credentials with the remote provider."""
         return None
 
     async def get_status(
         self,
-        provider: Provider,
+        provider: Provider,  # pylint: disable=unused-argument
         credential: OAuthCredential | None,
     ) -> AuthStatusResult:
         """Return safe auth status metadata for frontend display."""

--- a/src/qwenpaw/providers/auth/adapter.py
+++ b/src/qwenpaw/providers/auth/adapter.py
@@ -31,7 +31,12 @@ class ProviderAuthAdapter(ABC):
         provider: Provider,
         request: AuthStartRequest,
     ) -> AuthStartResult:
-        """Start an authentication flow."""
+        """Start an authentication flow.
+
+        Adapters must not trust arbitrary redirect URIs or metadata from the
+        client. If a redirect URI is used, it must match a configured callback
+        URI or a URI already validated by the API layer.
+        """
 
     async def poll(
         self,

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Encrypted local storage for OAuth provider credentials."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from ...constant import SECRET_DIR
+from ...security.secret_store import decrypt_dict_fields, encrypt_dict_fields
+from .models import OAuthCredential
+
+logger = logging.getLogger(__name__)
+
+OAUTH_SECRET_FIELDS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "client_secret",
+    },
+)
+
+
+class OAuthCredentialStore:
+    """Persist OAuth credentials under ``SECRET_DIR/providers/oauth``."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = Path(root) if root is not None else (
+            SECRET_DIR / "providers" / "oauth"
+        )
+
+    def save(self, credential: OAuthCredential) -> None:
+        """Save a credential with sensitive fields encrypted."""
+        if not credential.access_token:
+            raise ValueError("Cannot save OAuth credential without access token")
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._chmod_best_effort(self.root, 0o700)
+
+        data = credential.model_dump()
+        data["version"] = 1
+        encrypted = encrypt_dict_fields(data, OAUTH_SECRET_FIELDS)
+        path = self._path_for(credential.provider_id)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(encrypted, f, ensure_ascii=False, indent=2)
+        self._chmod_best_effort(path, 0o600)
+
+    def load(self, provider_id: str) -> OAuthCredential | None:
+        """Load and decrypt a credential, returning ``None`` on corruption."""
+        path = self._path_for(provider_id)
+        if not path.exists():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("Credential file is not a JSON object")
+            data.pop("version", None)
+            decrypted = decrypt_dict_fields(data, OAUTH_SECRET_FIELDS)
+            for field in OAUTH_SECRET_FIELDS:
+                value = decrypted.get(field)
+                if isinstance(value, str) and value.startswith("ENC:"):
+                    raise ValueError(f"Failed to decrypt field '{field}'")
+            return OAuthCredential.model_validate(decrypted)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load OAuth credential for provider '%s'; "
+                "ignoring corrupt credential file (%s)",
+                provider_id,
+                exc.__class__.__name__,
+            )
+            return None
+
+    def delete(self, provider_id: str) -> None:
+        """Delete a credential if it exists."""
+        try:
+            self._path_for(provider_id).unlink()
+        except FileNotFoundError:
+            return
+
+    def exists(self, provider_id: str) -> bool:
+        """Return whether a credential file exists."""
+        return self._path_for(provider_id).exists()
+
+    def _path_for(self, provider_id: str) -> Path:
+        return self.root / f"{provider_id}.json"
+
+    @staticmethod
+    def _chmod_best_effort(path: Path, mode: int) -> None:
+        try:
+            os.chmod(path, mode)
+        except OSError:
+            pass

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -28,14 +28,18 @@ class OAuthCredentialStore:
     """Persist OAuth credentials under ``SECRET_DIR/providers/oauth``."""
 
     def __init__(self, root: Path | None = None) -> None:
-        self.root = Path(root) if root is not None else (
-            SECRET_DIR / "providers" / "oauth"
+        self.root = (
+            Path(root)
+            if root is not None
+            else (SECRET_DIR / "providers" / "oauth")
         )
 
     def save(self, credential: OAuthCredential) -> None:
         """Save a credential with sensitive fields encrypted."""
         if not credential.access_token:
-            raise ValueError("Cannot save OAuth credential without access token")
+            raise ValueError(
+                "Cannot save OAuth credential without access token",
+            )
 
         self.root.mkdir(parents=True, exist_ok=True)
         self._chmod_best_effort(self.root, 0o700)

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -8,6 +8,8 @@ import logging
 import os
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from ...constant import SECRET_DIR
 from ...security.secret_store import decrypt_dict_fields, encrypt_dict_fields
 from .models import OAuthCredential
@@ -69,12 +71,18 @@ class OAuthCredentialStore:
                 if isinstance(value, str) and value.startswith("ENC:"):
                     raise ValueError(f"Failed to decrypt field '{field}'")
             return OAuthCredential.model_validate(decrypted)
-        except Exception as exc:
+        except (
+            json.JSONDecodeError,
+            OSError,
+            ValueError,
+            ValidationError,
+        ) as exc:
             logger.warning(
                 "Failed to load OAuth credential for provider '%s'; "
-                "ignoring corrupt credential file (%s)",
+                "ignoring unreadable or invalid credential file: %s",
                 provider_id,
-                exc.__class__.__name__,
+                exc,
+                exc_info=True,
             )
             return None
 

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -18,7 +18,6 @@ from .models import OAuthCredential
 logger = logging.getLogger(__name__)
 
 ProviderCredentialType = Literal["builtin", "plugin", "custom"]
-PROVIDER_CREDENTIAL_TYPES = frozenset({"builtin", "plugin", "custom"})
 
 OAUTH_SECRET_FIELDS = frozenset(
     {
@@ -49,7 +48,7 @@ class OAuthCredentialStore:
                 "Cannot save OAuth credential without access token",
             )
 
-        provider_dir = self._provider_dir(provider_type)
+        provider_dir = self.root / provider_type
         provider_dir.mkdir(parents=True, exist_ok=True)
         self._chmod_best_effort(provider_dir, 0o700)
 
@@ -129,14 +128,7 @@ class OAuthCredentialStore:
         provider_id: str,
         provider_type: ProviderCredentialType,
     ) -> Path:
-        return self._provider_dir(provider_type) / f"{provider_id}_oauth.json"
-
-    def _provider_dir(self, provider_type: ProviderCredentialType) -> Path:
-        if provider_type not in PROVIDER_CREDENTIAL_TYPES:
-            raise ValueError(
-                f"Unsupported provider credential type: {provider_type}",
-            )
-        return self.root / provider_type
+        return self.root / provider_type / f"{provider_id}_oauth.json"
 
     @staticmethod
     def _chmod_best_effort(path: Path, mode: int) -> None:

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -92,6 +92,14 @@ class OAuthCredentialStore:
             self._path_for(provider_id).unlink()
         except FileNotFoundError:
             return
+        except OSError as exc:
+            logger.warning(
+                "Failed to delete OAuth credential for provider '%s'; "
+                "ignoring cleanup error: %s",
+                provider_id,
+                exc,
+                exc_info=True,
+            )
 
     def exists(self, provider_id: str) -> bool:
         """Return whether a credential file exists."""

--- a/src/qwenpaw/providers/auth/credential_store.py
+++ b/src/qwenpaw/providers/auth/credential_store.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 from pydantic import ValidationError
 
@@ -15,6 +16,9 @@ from ...security.secret_store import decrypt_dict_fields, encrypt_dict_fields
 from .models import OAuthCredential
 
 logger = logging.getLogger(__name__)
+
+ProviderCredentialType = Literal["builtin", "plugin", "custom"]
+PROVIDER_CREDENTIAL_TYPES = frozenset({"builtin", "plugin", "custom"})
 
 OAUTH_SECRET_FIELDS = frozenset(
     {
@@ -27,36 +31,43 @@ OAUTH_SECRET_FIELDS = frozenset(
 
 
 class OAuthCredentialStore:
-    """Persist OAuth credentials under ``SECRET_DIR/providers/oauth``."""
+    """Persist OAuth credentials next to provider config directories."""
 
     def __init__(self, root: Path | None = None) -> None:
         self.root = (
-            Path(root)
-            if root is not None
-            else (SECRET_DIR / "providers" / "oauth")
+            Path(root) if root is not None else (SECRET_DIR / "providers")
         )
 
-    def save(self, credential: OAuthCredential) -> None:
+    def save(
+        self,
+        credential: OAuthCredential,
+        provider_type: ProviderCredentialType,
+    ) -> None:
         """Save a credential with sensitive fields encrypted."""
         if not credential.access_token:
             raise ValueError(
                 "Cannot save OAuth credential without access token",
             )
 
-        self.root.mkdir(parents=True, exist_ok=True)
-        self._chmod_best_effort(self.root, 0o700)
+        provider_dir = self._provider_dir(provider_type)
+        provider_dir.mkdir(parents=True, exist_ok=True)
+        self._chmod_best_effort(provider_dir, 0o700)
 
         data = credential.model_dump()
         data["version"] = 1
         encrypted = encrypt_dict_fields(data, OAUTH_SECRET_FIELDS)
-        path = self._path_for(credential.provider_id)
+        path = self._path_for(credential.provider_id, provider_type)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(encrypted, f, ensure_ascii=False, indent=2)
         self._chmod_best_effort(path, 0o600)
 
-    def load(self, provider_id: str) -> OAuthCredential | None:
+    def load(
+        self,
+        provider_id: str,
+        provider_type: ProviderCredentialType,
+    ) -> OAuthCredential | None:
         """Load and decrypt a credential, returning ``None`` on corruption."""
-        path = self._path_for(provider_id)
+        path = self._path_for(provider_id, provider_type)
         if not path.exists():
             return None
         try:
@@ -86,10 +97,14 @@ class OAuthCredentialStore:
             )
             return None
 
-    def delete(self, provider_id: str) -> None:
+    def delete(
+        self,
+        provider_id: str,
+        provider_type: ProviderCredentialType,
+    ) -> None:
         """Delete a credential if it exists."""
         try:
-            self._path_for(provider_id).unlink()
+            self._path_for(provider_id, provider_type).unlink()
         except FileNotFoundError:
             return
         except OSError as exc:
@@ -101,12 +116,27 @@ class OAuthCredentialStore:
                 exc_info=True,
             )
 
-    def exists(self, provider_id: str) -> bool:
+    def exists(
+        self,
+        provider_id: str,
+        provider_type: ProviderCredentialType,
+    ) -> bool:
         """Return whether a credential file exists."""
-        return self._path_for(provider_id).exists()
+        return self._path_for(provider_id, provider_type).exists()
 
-    def _path_for(self, provider_id: str) -> Path:
-        return self.root / f"{provider_id}.json"
+    def _path_for(
+        self,
+        provider_id: str,
+        provider_type: ProviderCredentialType,
+    ) -> Path:
+        return self._provider_dir(provider_type) / f"{provider_id}_oauth.json"
+
+    def _provider_dir(self, provider_type: ProviderCredentialType) -> Path:
+        if provider_type not in PROVIDER_CREDENTIAL_TYPES:
+            raise ValueError(
+                f"Unsupported provider credential type: {provider_type}",
+            )
+        return self.root / provider_type
 
     @staticmethod
     def _chmod_best_effort(path: Path, mode: int) -> None:

--- a/src/qwenpaw/providers/auth/manager.py
+++ b/src/qwenpaw/providers/auth/manager.py
@@ -133,12 +133,10 @@ class ProviderAuthManager:
         ):
             return AuthStatusResult(status=ProviderAuthStatus.NOT_REQUIRED)
         if auth_type == ProviderAuthType.API_KEY:
-            return AuthStatusResult(
-                status=(
-                    ProviderAuthStatus.AUTHENTICATED
-                    if bool(provider.api_key)
-                    else ProviderAuthStatus.NOT_CONFIGURED
-                ),
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' uses API key authentication "
+                "and does not support logout",
             )
 
         adapter = self._get_oauth_adapter_or_raise(provider)

--- a/src/qwenpaw/providers/auth/manager.py
+++ b/src/qwenpaw/providers/auth/manager.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""Provider authentication orchestration."""
+
+from __future__ import annotations
+
+from .credential_store import OAuthCredentialStore
+from .models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+from .registry import ProviderAuthRegistry, auth_registry
+
+
+class ProviderAuthError(Exception):
+    """Transport-neutral auth error for routers and CLIs to map."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+class ProviderAuthManager:
+    """Coordinate provider auth status, flows, and credential storage."""
+
+    def __init__(
+        self,
+        provider_manager,
+        credential_store: OAuthCredentialStore | None = None,
+        registry: ProviderAuthRegistry | None = None,
+    ) -> None:
+        self.provider_manager = provider_manager
+        self.credential_store = credential_store or OAuthCredentialStore()
+        self.registry = registry or auth_registry
+
+    async def get_status(
+        self,
+        provider_id: str,
+        flow_id: str | None = None,
+    ) -> AuthStatusResult:
+        provider = self._get_provider_or_raise(provider_id)
+        auth_type = provider.auth_type
+
+        if auth_type == ProviderAuthType.NONE or (
+            auth_type == ProviderAuthType.API_KEY
+            and not provider.require_api_key
+        ):
+            return AuthStatusResult(status=ProviderAuthStatus.NOT_REQUIRED)
+
+        if auth_type == ProviderAuthType.API_KEY:
+            return AuthStatusResult(
+                status=(
+                    ProviderAuthStatus.AUTHENTICATED
+                    if bool(provider.api_key)
+                    else ProviderAuthStatus.NOT_CONFIGURED
+                ),
+            )
+
+        adapter = self.registry.get(provider.id)
+        if adapter is None:
+            return AuthStatusResult(
+                status=ProviderAuthStatus.ERROR,
+                message=(
+                    f"Provider '{provider.id}' does not support OAuth "
+                    "authentication yet"
+                ),
+            )
+
+        if flow_id:
+            return await adapter.poll(provider, flow_id)
+
+        credential = self.credential_store.load(provider.id)
+        return await adapter.get_status(provider, credential)
+
+    async def start(
+        self,
+        provider_id: str,
+        request: AuthStartRequest,
+    ) -> AuthStartResult:
+        provider = self._get_provider_or_raise(provider_id)
+        auth_type = provider.auth_type
+
+        if auth_type == ProviderAuthType.NONE or (
+            auth_type == ProviderAuthType.API_KEY
+            and not provider.require_api_key
+        ):
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' does not require authentication",
+            )
+        if auth_type == ProviderAuthType.API_KEY:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' uses API key authentication",
+            )
+
+        adapter = self.registry.get(provider.id)
+        if adapter is None:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' does not support OAuth "
+                "authentication yet",
+            )
+        if adapter.auth_type != auth_type:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' auth adapter type mismatch",
+            )
+        return await adapter.start(provider, request)
+
+    async def handle_callback(
+        self,
+        provider_id: str,
+        state: str,
+        code: str,
+    ) -> AuthStatusResult:
+        provider = self._get_provider_or_raise(provider_id)
+        adapter = self._get_oauth_adapter_or_raise(provider)
+        credential = await adapter.handle_callback(provider, state, code)
+        self.credential_store.save(credential)
+        return await adapter.get_status(provider, credential)
+
+    async def logout(self, provider_id: str) -> AuthStatusResult:
+        provider = self._get_provider_or_raise(provider_id)
+        auth_type = provider.auth_type
+
+        if auth_type == ProviderAuthType.NONE or (
+            auth_type == ProviderAuthType.API_KEY
+            and not provider.require_api_key
+        ):
+            return AuthStatusResult(status=ProviderAuthStatus.NOT_REQUIRED)
+        if auth_type == ProviderAuthType.API_KEY:
+            return AuthStatusResult(
+                status=(
+                    ProviderAuthStatus.AUTHENTICATED
+                    if bool(provider.api_key)
+                    else ProviderAuthStatus.NOT_CONFIGURED
+                ),
+            )
+
+        adapter = self._get_oauth_adapter_or_raise(provider)
+        credential = self.credential_store.load(provider.id)
+        await adapter.logout(provider, credential)
+        self.credential_store.delete(provider.id)
+        return AuthStatusResult(status=ProviderAuthStatus.NOT_CONFIGURED)
+
+    def _get_provider_or_raise(self, provider_id: str):
+        provider = self.provider_manager.get_provider(provider_id)
+        if provider is None:
+            raise ProviderAuthError(
+                404,
+                f"Provider '{provider_id}' not found",
+            )
+        return provider
+
+    def _get_oauth_adapter_or_raise(self, provider):
+        if provider.auth_type in {
+            ProviderAuthType.NONE,
+            ProviderAuthType.API_KEY,
+        }:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' does not use OAuth authentication",
+            )
+        adapter = self.registry.get(provider.id)
+        if adapter is None:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' does not support OAuth "
+                "authentication yet",
+            )
+        if adapter.auth_type != provider.auth_type:
+            raise ProviderAuthError(
+                400,
+                f"Provider '{provider.id}' auth adapter type mismatch",
+            )
+        return adapter

--- a/src/qwenpaw/providers/auth/manager.py
+++ b/src/qwenpaw/providers/auth/manager.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
-from .credential_store import OAuthCredentialStore
+from typing import Any
+
+from .credential_store import OAuthCredentialStore, ProviderCredentialType
 from .models import (
     AuthStartRequest,
     AuthStartResult,
@@ -41,7 +43,9 @@ class ProviderAuthManager:
         provider_id: str,
         flow_id: str | None = None,
     ) -> AuthStatusResult:
-        provider = self._get_provider_or_raise(provider_id)
+        provider, provider_type = self._get_provider_record_or_raise(
+            provider_id,
+        )
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -72,7 +76,7 @@ class ProviderAuthManager:
         if flow_id:
             return await adapter.poll(provider, flow_id)
 
-        credential = self.credential_store.load(provider.id)
+        credential = self.credential_store.load(provider.id, provider_type)
         return await adapter.get_status(provider, credential)
 
     async def start(
@@ -80,7 +84,7 @@ class ProviderAuthManager:
         provider_id: str,
         request: AuthStartRequest,
     ) -> AuthStartResult:
-        provider = self._get_provider_or_raise(provider_id)
+        provider, _ = self._get_provider_record_or_raise(provider_id)
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -117,14 +121,18 @@ class ProviderAuthManager:
         state: str,
         code: str,
     ) -> AuthStatusResult:
-        provider = self._get_provider_or_raise(provider_id)
+        provider, provider_type = self._get_provider_record_or_raise(
+            provider_id,
+        )
         adapter = self._get_oauth_adapter_or_raise(provider)
         credential = await adapter.handle_callback(provider, state, code)
-        self.credential_store.save(credential)
+        self.credential_store.save(credential, provider_type)
         return await adapter.get_status(provider, credential)
 
     async def logout(self, provider_id: str) -> AuthStatusResult:
-        provider = self._get_provider_or_raise(provider_id)
+        provider, provider_type = self._get_provider_record_or_raise(
+            provider_id,
+        )
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -140,19 +148,34 @@ class ProviderAuthManager:
             )
 
         adapter = self._get_oauth_adapter_or_raise(provider)
-        credential = self.credential_store.load(provider.id)
+        credential = self.credential_store.load(provider.id, provider_type)
         await adapter.logout(provider, credential)
-        self.credential_store.delete(provider.id)
+        self.credential_store.delete(provider.id, provider_type)
         return AuthStatusResult(status=ProviderAuthStatus.NOT_CONFIGURED)
 
-    def _get_provider_or_raise(self, provider_id: str):
+    def _get_provider_record_or_raise(
+        self,
+        provider_id: str,
+    ) -> tuple[Any, ProviderCredentialType]:
+        resolver = getattr(
+            self.provider_manager,
+            "get_provider_with_storage_type",
+            None,
+        )
+        if callable(resolver):
+            resolved = resolver(provider_id)
+            if resolved is not None:
+                provider, provider_type = resolved
+                if provider_type in {"builtin", "plugin", "custom"}:
+                    return provider, provider_type
+
         provider = self.provider_manager.get_provider(provider_id)
         if provider is None:
             raise ProviderAuthError(
                 404,
                 f"Provider '{provider_id}' not found",
             )
-        return provider
+        return provider, "custom"
 
     def _get_oauth_adapter_or_raise(self, provider):
         if provider.auth_type in {

--- a/src/qwenpaw/providers/auth/manager.py
+++ b/src/qwenpaw/providers/auth/manager.py
@@ -3,9 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from .credential_store import OAuthCredentialStore, ProviderCredentialType
+from .credential_store import OAuthCredentialStore
 from .models import (
     AuthStartRequest,
     AuthStartResult,
@@ -43,9 +41,10 @@ class ProviderAuthManager:
         provider_id: str,
         flow_id: str | None = None,
     ) -> AuthStatusResult:
-        provider, provider_type = self._get_provider_record_or_raise(
-            provider_id,
-        )
+        (
+            provider,
+            provider_type,
+        ) = self.provider_manager.get_provider_with_storage_type(provider_id)
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -84,7 +83,9 @@ class ProviderAuthManager:
         provider_id: str,
         request: AuthStartRequest,
     ) -> AuthStartResult:
-        provider, _ = self._get_provider_record_or_raise(provider_id)
+        provider, _ = self.provider_manager.get_provider_with_storage_type(
+            provider_id,
+        )
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -121,18 +122,20 @@ class ProviderAuthManager:
         state: str,
         code: str,
     ) -> AuthStatusResult:
-        provider, provider_type = self._get_provider_record_or_raise(
-            provider_id,
-        )
-        adapter = self._get_oauth_adapter_or_raise(provider)
+        (
+            provider,
+            provider_type,
+        ) = self.provider_manager.get_provider_with_storage_type(provider_id)
+        adapter = self.registry.get(provider.id)
         credential = await adapter.handle_callback(provider, state, code)
         self.credential_store.save(credential, provider_type)
         return await adapter.get_status(provider, credential)
 
     async def logout(self, provider_id: str) -> AuthStatusResult:
-        provider, provider_type = self._get_provider_record_or_raise(
-            provider_id,
-        )
+        (
+            provider,
+            provider_type,
+        ) = self.provider_manager.get_provider_with_storage_type(provider_id)
         auth_type = provider.auth_type
 
         if auth_type == ProviderAuthType.NONE or (
@@ -147,55 +150,8 @@ class ProviderAuthManager:
                 "and does not support logout",
             )
 
-        adapter = self._get_oauth_adapter_or_raise(provider)
+        adapter = self.registry.get(provider.id)
         credential = self.credential_store.load(provider.id, provider_type)
         await adapter.logout(provider, credential)
         self.credential_store.delete(provider.id, provider_type)
         return AuthStatusResult(status=ProviderAuthStatus.NOT_CONFIGURED)
-
-    def _get_provider_record_or_raise(
-        self,
-        provider_id: str,
-    ) -> tuple[Any, ProviderCredentialType]:
-        resolver = getattr(
-            self.provider_manager,
-            "get_provider_with_storage_type",
-            None,
-        )
-        if callable(resolver):
-            resolved = resolver(provider_id)
-            if resolved is not None:
-                provider, provider_type = resolved
-                if provider_type in {"builtin", "plugin", "custom"}:
-                    return provider, provider_type
-
-        provider = self.provider_manager.get_provider(provider_id)
-        if provider is None:
-            raise ProviderAuthError(
-                404,
-                f"Provider '{provider_id}' not found",
-            )
-        return provider, "custom"
-
-    def _get_oauth_adapter_or_raise(self, provider):
-        if provider.auth_type in {
-            ProviderAuthType.NONE,
-            ProviderAuthType.API_KEY,
-        }:
-            raise ProviderAuthError(
-                400,
-                f"Provider '{provider.id}' does not use OAuth authentication",
-            )
-        adapter = self.registry.get(provider.id)
-        if adapter is None:
-            raise ProviderAuthError(
-                400,
-                f"Provider '{provider.id}' does not support OAuth "
-                "authentication yet",
-            )
-        if adapter.auth_type != provider.auth_type:
-            raise ProviderAuthError(
-                400,
-                f"Provider '{provider.id}' auth adapter type mismatch",
-            )
-        return adapter

--- a/src/qwenpaw/providers/auth/models.py
+++ b/src/qwenpaw/providers/auth/models.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Shared models for provider authentication flows."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ProviderAuthType(str, Enum):
+    NONE = "none"
+    API_KEY = "api_key"
+    OAUTH_DEVICE_CODE = "oauth_device_code"
+    OAUTH_AUTHORIZATION_CODE = "oauth_authorization_code"
+    OAUTH_VENDOR_USER_CODE = "oauth_vendor_user_code"
+
+
+class ProviderAuthStatus(str, Enum):
+    NOT_REQUIRED = "not_required"
+    NOT_CONFIGURED = "not_configured"
+    PENDING = "pending"
+    AUTHENTICATED = "authenticated"
+    EXPIRED = "expired"
+    ERROR = "error"
+
+
+class ProviderAuthFlowType(str, Enum):
+    DEVICE_CODE = "device_code"
+    AUTHORIZATION_CODE = "authorization_code"
+    VENDOR_USER_CODE = "vendor_user_code"
+
+
+class ProviderAuthInfo(BaseModel):
+    type: ProviderAuthType = ProviderAuthType.API_KEY
+    status: ProviderAuthStatus = ProviderAuthStatus.NOT_CONFIGURED
+    account_label: str = ""
+    expires_at: int | None = None
+    scopes: list[str] = Field(default_factory=list)
+    supports_logout: bool = False
+    message: str = ""
+
+
+class AuthStartRequest(BaseModel):
+    redirect_uri: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AuthStartResult(BaseModel):
+    flow_id: str
+    flow_type: ProviderAuthFlowType
+    user_code: str | None = None
+    verification_uri: str | None = None
+    authorization_url: str | None = None
+    expires_at: int | None = None
+    interval: int | None = None
+    message: str = ""
+
+
+class AuthStatusResult(BaseModel):
+    status: ProviderAuthStatus
+    account_label: str = ""
+    expires_at: int | None = None
+    scopes: list[str] = Field(default_factory=list)
+    message: str = ""
+
+
+class OAuthCredential(BaseModel):
+    provider_id: str
+    token_type: str = "Bearer"
+    access_token: str = ""
+    refresh_token: str = ""
+    id_token: str = ""
+    client_secret: str = ""
+    account_label: str = ""
+    expires_at: int | None = None
+    scopes: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: int
+    updated_at: int

--- a/src/qwenpaw/providers/auth/models.py
+++ b/src/qwenpaw/providers/auth/models.py
@@ -43,8 +43,20 @@ class ProviderAuthInfo(BaseModel):
 
 
 class AuthStartRequest(BaseModel):
-    redirect_uri: str | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    redirect_uri: str | None = Field(
+        default=None,
+        description=(
+            "Optional OAuth callback URI. API routes must validate this "
+            "against the configured callback endpoint before adapters use it."
+        ),
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Provider-specific non-sensitive flow metadata. Adapters must "
+            "validate any keys they consume."
+        ),
+    )
 
 
 class AuthStartResult(BaseModel):

--- a/src/qwenpaw/providers/auth/registry.py
+++ b/src/qwenpaw/providers/auth/registry.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""In-process registry for provider auth adapters."""
+
+from __future__ import annotations
+
+from .adapter import ProviderAuthAdapter
+
+
+class ProviderAuthRegistry:
+    """Small adapter registry keyed by provider id."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, ProviderAuthAdapter] = {}
+
+    def register(self, adapter: ProviderAuthAdapter) -> None:
+        self._adapters[adapter.provider_id] = adapter
+
+    def get(self, provider_id: str) -> ProviderAuthAdapter | None:
+        return self._adapters.get(provider_id)
+
+    def clear_for_test(self) -> None:
+        self._adapters.clear()
+
+
+auth_registry = ProviderAuthRegistry()

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -412,7 +412,7 @@ class Provider(ProviderInfo, ABC):
             and not self.is_custom,
             freeze_url=self.freeze_url,
             require_api_key=self.require_api_key,
-            auth_type=auth_info.type,
+            auth_type=self.auth_type,
             auth=auth_info,
             generate_kwargs=self.generate_kwargs,
             meta=self.meta or {},

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -10,6 +10,11 @@ from pydantic import ConfigDict
 
 from agentscope.model import ChatModelBase
 from qwenpaw.exceptions import ProviderError
+from qwenpaw.providers.auth.models import (
+    ProviderAuthInfo,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
 
 if TYPE_CHECKING:
     from .multimodal_prober import ProbeResult
@@ -114,6 +119,14 @@ class ProviderInfo(BaseModel):
     require_api_key: bool = Field(
         default=True,
         description="Whether this provider requires an API key",
+    )
+    auth_type: ProviderAuthType = Field(
+        default=ProviderAuthType.API_KEY,
+        description="Authentication mechanism used by this provider",
+    )
+    auth: ProviderAuthInfo | None = Field(
+        default=None,
+        description="Safe provider authentication status metadata",
     )
     is_custom: bool = Field(
         default=False,
@@ -236,6 +249,36 @@ class Provider(ProviderInfo, ABC):
                 for model in config["extra_models"]
             ]
 
+    def _build_default_auth_info(self) -> ProviderAuthInfo:
+        """Build safe default auth metadata without consulting token stores."""
+        if self.auth_type == ProviderAuthType.NONE:
+            return ProviderAuthInfo(
+                type=ProviderAuthType.NONE,
+                status=ProviderAuthStatus.NOT_REQUIRED,
+                supports_logout=False,
+            )
+        if self.auth_type == ProviderAuthType.API_KEY:
+            if not self.require_api_key:
+                return ProviderAuthInfo(
+                    type=ProviderAuthType.NONE,
+                    status=ProviderAuthStatus.NOT_REQUIRED,
+                    supports_logout=False,
+                )
+            return ProviderAuthInfo(
+                type=ProviderAuthType.API_KEY,
+                status=(
+                    ProviderAuthStatus.AUTHENTICATED
+                    if bool(self.api_key)
+                    else ProviderAuthStatus.NOT_CONFIGURED
+                ),
+                supports_logout=bool(self.api_key),
+            )
+        return ProviderAuthInfo(
+            type=self.auth_type,
+            status=ProviderAuthStatus.NOT_CONFIGURED,
+            supports_logout=True,
+        )
+
     def get_chat_model_cls(self) -> Type[ChatModelBase]:
         """Return the chat model class associated with this provider."""
         import agentscope.model
@@ -351,6 +394,7 @@ class Provider(ProviderInfo, ABC):
         # the class in its own module scope.  This avoids pydantic
         # class-identity mismatches when the same module is loaded
         # via two different import paths (e.g. PYTHONPATH + pip install).
+        auth_info = self._build_default_auth_info()
         return ProviderInfo(
             id=self.id,
             name=self.name,
@@ -368,6 +412,8 @@ class Provider(ProviderInfo, ABC):
             and not self.is_custom,
             freeze_url=self.freeze_url,
             require_api_key=self.require_api_key,
+            auth_type=auth_info.type,
+            auth=auth_info,
             generate_kwargs=self.generate_kwargs,
             meta=self.meta or {},
         )

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -258,12 +258,6 @@ class Provider(ProviderInfo, ABC):
                 supports_logout=False,
             )
         if self.auth_type == ProviderAuthType.API_KEY:
-            if not self.require_api_key:
-                return ProviderAuthInfo(
-                    type=ProviderAuthType.NONE,
-                    status=ProviderAuthStatus.NOT_REQUIRED,
-                    supports_logout=False,
-                )
             return ProviderAuthInfo(
                 type=ProviderAuthType.API_KEY,
                 status=(

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1067,6 +1067,14 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
     def get_provider(self, provider_id: str) -> Provider | None:
         # Return a provider instance by its ID. This will be used to create
         # chat model instances for the agent.
+        resolved = self.get_provider_with_storage_type(provider_id)
+        return resolved[0] if resolved else None
+
+    def get_provider_with_storage_type(
+        self,
+        provider_id: str,
+    ) -> tuple[Provider, str] | None:
+        """Resolve a provider and the storage bucket it was loaded from."""
         # Normalize provider ID for backward compatibility
         provider_id = self._normalize_provider_id(provider_id)
         # Check plugin providers first
@@ -1075,11 +1083,11 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             provider_info = plugin_provider["info"]
             provider_class = plugin_provider["class"]
             # Instantiate with **dict unpacking for Pydantic BaseModel
-            return provider_class(**provider_info.model_dump())
+            return provider_class(**provider_info.model_dump()), "plugin"
         if provider_id in self.builtin_providers:
-            return self.builtin_providers[provider_id]
+            return self.builtin_providers[provider_id], "builtin"
         if provider_id in self.custom_providers:
-            return self.custom_providers[provider_id]
+            return self.custom_providers[provider_id], "custom"
         return None
 
     async def get_provider_info(self, provider_id: str) -> ProviderInfo | None:
@@ -1225,6 +1233,9 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
             provider_path = self.custom_path / f"{provider_id}.json"
             if provider_path.exists():
                 os.remove(provider_path)
+            credential_path = self.custom_path / f"{provider_id}_oauth.json"
+            if credential_path.exists():
+                os.remove(credential_path)
             return True
         return False
 
@@ -1792,6 +1803,8 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                             ]
         # Load custom providers
         for provider_file in self.custom_path.glob("*.json"):
+            if provider_file.name.endswith("_oauth.json"):
+                continue
             provider = self.load_provider(provider_file.stem, is_builtin=False)
             if provider:
                 self.custom_providers[provider.id] = provider

--- a/tests/unit/providers/auth/test_auth_manager.py
+++ b/tests/unit/providers/auth/test_auth_manager.py
@@ -153,6 +153,22 @@ async def test_api_key_provider_status_not_configured(tmp_path: Path) -> None:
     assert status.status == ProviderAuthStatus.NOT_CONFIGURED
 
 
+async def test_api_key_provider_logout_is_not_supported(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(
+        tmp_path,
+        {"api": _provider("api", api_key="sk-test")},
+        ProviderAuthRegistry(),
+    )
+
+    with pytest.raises(ProviderAuthError) as exc_info:
+        await manager.logout("api")
+
+    assert exc_info.value.status_code == 400
+    assert "does not support logout" in exc_info.value.message
+
+
 async def test_provider_without_required_api_key_is_not_required(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/providers/auth/test_auth_manager.py
+++ b/tests/unit/providers/auth/test_auth_manager.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+"""Tests for provider auth manager orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.providers.auth.adapter import ProviderAuthAdapter
+from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
+from qwenpaw.providers.auth.manager import ProviderAuthError, ProviderAuthManager
+from qwenpaw.providers.auth.models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    OAuthCredential,
+    ProviderAuthFlowType,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+from qwenpaw.providers.auth.registry import ProviderAuthRegistry
+from qwenpaw.providers.openai_provider import OpenAIProvider
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_master_key(tmp_path: Path, monkeypatch):
+    import qwenpaw.security.secret_store as mod
+
+    test_key = bytes.fromhex(
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    )
+    monkeypatch.setattr(mod, "_cached_master_key", test_key)
+    monkeypatch.setattr(mod, "_cached_fernet", None)
+    monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path)
+
+
+class FakeProviderManager:
+    def __init__(self, providers):
+        self.providers = providers
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+
+class FakeAuthAdapter(ProviderAuthAdapter):
+    provider_id = "oauth"
+    auth_type = ProviderAuthType.OAUTH_DEVICE_CODE
+
+    def __init__(self) -> None:
+        self.poll_count = 0
+        self.logout_called = False
+
+    async def start(self, provider, request: AuthStartRequest) -> AuthStartResult:
+        return AuthStartResult(
+            flow_id="fake-flow",
+            flow_type=ProviderAuthFlowType.DEVICE_CODE,
+            user_code="ABCD-EFGH",
+            verification_uri="https://example.test/device",
+        )
+
+    async def poll(self, provider, flow_id: str) -> AuthStatusResult:
+        self.poll_count += 1
+        if self.poll_count == 1:
+            return AuthStatusResult(status=ProviderAuthStatus.PENDING)
+        return AuthStatusResult(
+            status=ProviderAuthStatus.AUTHENTICATED,
+            account_label="octocat",
+        )
+
+    async def handle_callback(
+        self,
+        provider,
+        state: str,
+        code: str,
+    ) -> OAuthCredential:
+        return OAuthCredential(
+            provider_id=provider.id,
+            access_token="oauth-access-token",
+            refresh_token="oauth-refresh-token",
+            account_label="octocat",
+            scopes=["read:user"],
+            created_at=1760000000,
+            updated_at=1760000001,
+        )
+
+    async def logout(self, provider, credential: OAuthCredential | None) -> None:
+        self.logout_called = True
+
+
+def _provider(
+    provider_id: str,
+    api_key: str = "",
+    require_api_key: bool = True,
+    auth_type: ProviderAuthType = ProviderAuthType.API_KEY,
+) -> OpenAIProvider:
+    return OpenAIProvider(
+        id=provider_id,
+        name=provider_id,
+        api_key=api_key,
+        require_api_key=require_api_key,
+        auth_type=auth_type,
+    )
+
+
+def _manager(tmp_path: Path, providers, registry: ProviderAuthRegistry):
+    return ProviderAuthManager(
+        FakeProviderManager(providers),
+        credential_store=OAuthCredentialStore(tmp_path / "oauth"),
+        registry=registry,
+    )
+
+
+async def test_api_key_provider_status_authenticated(tmp_path: Path) -> None:
+    manager = _manager(
+        tmp_path,
+        {"api": _provider("api", api_key="sk-test")},
+        ProviderAuthRegistry(),
+    )
+
+    status = await manager.get_status("api")
+
+    assert status.status == ProviderAuthStatus.AUTHENTICATED
+
+
+async def test_api_key_provider_status_not_configured(tmp_path: Path) -> None:
+    manager = _manager(
+        tmp_path,
+        {"api": _provider("api")},
+        ProviderAuthRegistry(),
+    )
+
+    status = await manager.get_status("api")
+
+    assert status.status == ProviderAuthStatus.NOT_CONFIGURED
+
+
+async def test_provider_without_required_api_key_is_not_required(
+    tmp_path: Path,
+) -> None:
+    provider = _provider("local", require_api_key=False)
+    manager = _manager(
+        tmp_path,
+        {"local": provider},
+        ProviderAuthRegistry(),
+    )
+
+    status = await manager.get_status("local")
+    info = await provider.get_info()
+
+    assert status.status == ProviderAuthStatus.NOT_REQUIRED
+    assert info.auth_type == ProviderAuthType.NONE
+    assert info.auth is not None
+    assert info.auth.status == ProviderAuthStatus.NOT_REQUIRED
+
+
+async def test_oauth_provider_without_adapter_start_is_unsupported(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(
+        tmp_path,
+        {
+            "oauth": _provider(
+                "oauth",
+                auth_type=ProviderAuthType.OAUTH_DEVICE_CODE,
+            ),
+        },
+        ProviderAuthRegistry(),
+    )
+
+    with pytest.raises(ProviderAuthError) as exc_info:
+        await manager.start("oauth", AuthStartRequest())
+
+    assert exc_info.value.status_code == 400
+    assert "does not support OAuth" in exc_info.value.message
+
+
+async def test_oauth_provider_with_adapter_starts_and_polls(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderAuthRegistry()
+    registry.register(FakeAuthAdapter())
+    manager = _manager(
+        tmp_path,
+        {
+            "oauth": _provider(
+                "oauth",
+                auth_type=ProviderAuthType.OAUTH_DEVICE_CODE,
+            ),
+        },
+        registry,
+    )
+
+    started = await manager.start("oauth", AuthStartRequest())
+    first = await manager.get_status("oauth", flow_id=started.flow_id)
+    second = await manager.get_status("oauth", flow_id=started.flow_id)
+
+    assert started.flow_id == "fake-flow"
+    assert started.flow_type == ProviderAuthFlowType.DEVICE_CODE
+    assert first.status == ProviderAuthStatus.PENDING
+    assert second.status == ProviderAuthStatus.AUTHENTICATED
+
+
+async def test_callback_saves_credential_and_status_exposes_no_token(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderAuthRegistry()
+    registry.register(FakeAuthAdapter())
+    store = OAuthCredentialStore(tmp_path / "oauth")
+    manager = ProviderAuthManager(
+        FakeProviderManager(
+            {
+                "oauth": _provider(
+                    "oauth",
+                    auth_type=ProviderAuthType.OAUTH_DEVICE_CODE,
+                ),
+            },
+        ),
+        credential_store=store,
+        registry=registry,
+    )
+
+    callback_status = await manager.handle_callback(
+        "oauth",
+        state="state",
+        code="code",
+    )
+    stored = store.load("oauth")
+    status = await manager.get_status("oauth")
+    status_payload = status.model_dump()
+
+    assert callback_status.status == ProviderAuthStatus.AUTHENTICATED
+    assert stored is not None
+    assert stored.access_token == "oauth-access-token"
+    assert status.status == ProviderAuthStatus.AUTHENTICATED
+    assert status.account_label == "octocat"
+    assert "access_token" not in status_payload
+    assert "refresh_token" not in status_payload
+
+
+async def test_logout_deletes_credential(tmp_path: Path) -> None:
+    adapter = FakeAuthAdapter()
+    registry = ProviderAuthRegistry()
+    registry.register(adapter)
+    store = OAuthCredentialStore(tmp_path / "oauth")
+    provider = _provider("oauth", auth_type=ProviderAuthType.OAUTH_DEVICE_CODE)
+    store.save(
+        OAuthCredential(
+            provider_id="oauth",
+            access_token="oauth-access-token",
+            created_at=1760000000,
+            updated_at=1760000001,
+        ),
+    )
+    manager = ProviderAuthManager(
+        FakeProviderManager({"oauth": provider}),
+        credential_store=store,
+        registry=registry,
+    )
+
+    status = await manager.logout("oauth")
+
+    assert adapter.logout_called is True
+    assert status.status == ProviderAuthStatus.NOT_CONFIGURED
+    assert store.load("oauth") is None

--- a/tests/unit/providers/auth/test_auth_manager.py
+++ b/tests/unit/providers/auth/test_auth_manager.py
@@ -9,7 +9,10 @@ import pytest
 
 from qwenpaw.providers.auth.adapter import ProviderAuthAdapter
 from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
-from qwenpaw.providers.auth.manager import ProviderAuthError, ProviderAuthManager
+from qwenpaw.providers.auth.manager import (
+    ProviderAuthError,
+    ProviderAuthManager,
+)
 from qwenpaw.providers.auth.models import (
     AuthStartRequest,
     AuthStartResult,
@@ -58,7 +61,11 @@ class FakeAuthAdapter(ProviderAuthAdapter):
         self.poll_count = 0
         self.logout_called = False
 
-    async def start(self, provider, request: AuthStartRequest) -> AuthStartResult:
+    async def start(
+        self,
+        provider,
+        request: AuthStartRequest,
+    ) -> AuthStartResult:
         return AuthStartResult(
             flow_id="fake-flow",
             flow_type=ProviderAuthFlowType.DEVICE_CODE,
@@ -91,7 +98,11 @@ class FakeAuthAdapter(ProviderAuthAdapter):
             updated_at=1760000001,
         )
 
-    async def logout(self, provider, credential: OAuthCredential | None) -> None:
+    async def logout(
+        self,
+        provider,
+        credential: OAuthCredential | None,
+    ) -> None:
         self.logout_called = True
 
 

--- a/tests/unit/providers/auth/test_auth_manager.py
+++ b/tests/unit/providers/auth/test_auth_manager.py
@@ -183,8 +183,9 @@ async def test_provider_without_required_api_key_is_not_required(
     info = await provider.get_info()
 
     assert status.status == ProviderAuthStatus.NOT_REQUIRED
-    assert info.auth_type == ProviderAuthType.NONE
+    assert info.auth_type == ProviderAuthType.API_KEY
     assert info.auth is not None
+    assert info.auth.type == ProviderAuthType.NONE
     assert info.auth.status == ProviderAuthStatus.NOT_REQUIRED
 
 

--- a/tests/unit/providers/auth/test_auth_manager.py
+++ b/tests/unit/providers/auth/test_auth_manager.py
@@ -46,11 +46,18 @@ def _isolate_master_key(tmp_path: Path, monkeypatch):
 
 
 class FakeProviderManager:
-    def __init__(self, providers):
+    def __init__(self, providers, storage_types=None):
         self.providers = providers
+        self.storage_types = storage_types or {}
 
     def get_provider(self, provider_id: str):
         return self.providers.get(provider_id)
+
+    def get_provider_with_storage_type(self, provider_id: str):
+        provider = self.providers.get(provider_id)
+        if provider is None:
+            return None
+        return provider, self.storage_types.get(provider_id, "custom")
 
 
 class FakeAuthAdapter(ProviderAuthAdapter):
@@ -124,7 +131,7 @@ def _provider(
 def _manager(tmp_path: Path, providers, registry: ProviderAuthRegistry):
     return ProviderAuthManager(
         FakeProviderManager(providers),
-        credential_store=OAuthCredentialStore(tmp_path / "oauth"),
+        credential_store=OAuthCredentialStore(tmp_path / "providers"),
         registry=registry,
     )
 
@@ -241,7 +248,7 @@ async def test_callback_saves_credential_and_status_exposes_no_token(
 ) -> None:
     registry = ProviderAuthRegistry()
     registry.register(FakeAuthAdapter())
-    store = OAuthCredentialStore(tmp_path / "oauth")
+    store = OAuthCredentialStore(tmp_path / "providers")
     manager = ProviderAuthManager(
         FakeProviderManager(
             {
@@ -260,7 +267,7 @@ async def test_callback_saves_credential_and_status_exposes_no_token(
         state="state",
         code="code",
     )
-    stored = store.load("oauth")
+    stored = store.load("oauth", "custom")
     status = await manager.get_status("oauth")
     status_payload = status.model_dump()
 
@@ -273,11 +280,37 @@ async def test_callback_saves_credential_and_status_exposes_no_token(
     assert "refresh_token" not in status_payload
 
 
+async def test_callback_saves_credential_in_provider_storage_bucket(
+    tmp_path: Path,
+) -> None:
+    registry = ProviderAuthRegistry()
+    registry.register(FakeAuthAdapter())
+    store = OAuthCredentialStore(tmp_path / "providers")
+    manager = ProviderAuthManager(
+        FakeProviderManager(
+            {
+                "oauth": _provider(
+                    "oauth",
+                    auth_type=ProviderAuthType.OAUTH_DEVICE_CODE,
+                ),
+            },
+            storage_types={"oauth": "builtin"},
+        ),
+        credential_store=store,
+        registry=registry,
+    )
+
+    await manager.handle_callback("oauth", state="state", code="code")
+
+    assert store.load("oauth", "builtin") is not None
+    assert store.load("oauth", "custom") is None
+
+
 async def test_logout_deletes_credential(tmp_path: Path) -> None:
     adapter = FakeAuthAdapter()
     registry = ProviderAuthRegistry()
     registry.register(adapter)
-    store = OAuthCredentialStore(tmp_path / "oauth")
+    store = OAuthCredentialStore(tmp_path / "providers")
     provider = _provider("oauth", auth_type=ProviderAuthType.OAUTH_DEVICE_CODE)
     store.save(
         OAuthCredential(
@@ -286,6 +319,7 @@ async def test_logout_deletes_credential(tmp_path: Path) -> None:
             created_at=1760000000,
             updated_at=1760000001,
         ),
+        "custom",
     )
     manager = ProviderAuthManager(
         FakeProviderManager({"oauth": provider}),
@@ -297,4 +331,4 @@ async def test_logout_deletes_credential(tmp_path: Path) -> None:
 
     assert adapter.logout_called is True
     assert status.status == ProviderAuthStatus.NOT_CONFIGURED
-    assert store.load("oauth") is None
+    assert store.load("oauth", "custom") is None

--- a/tests/unit/providers/auth/test_credential_store.py
+++ b/tests/unit/providers/auth/test_credential_store.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Tests for encrypted OAuth credential storage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
+from qwenpaw.providers.auth.models import OAuthCredential
+
+
+@pytest.fixture(autouse=True)
+def _isolate_master_key(tmp_path: Path, monkeypatch):
+    import qwenpaw.security.secret_store as mod
+
+    test_key = bytes.fromhex(
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    )
+    monkeypatch.setattr(mod, "_cached_master_key", test_key)
+    monkeypatch.setattr(mod, "_cached_fernet", None)
+    monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path)
+
+
+def _credential() -> OAuthCredential:
+    return OAuthCredential(
+        provider_id="fake-oauth",
+        access_token="access-secret",
+        refresh_token="refresh-secret",
+        account_label="octocat",
+        scopes=["read:user"],
+        created_at=1760000000,
+        updated_at=1760000001,
+    )
+
+
+def test_save_encrypts_and_load_restores_credential(tmp_path: Path) -> None:
+    store = OAuthCredentialStore(tmp_path / "oauth")
+    store.save(_credential())
+
+    path = tmp_path / "oauth" / "fake-oauth.json"
+    assert path.exists()
+    raw = path.read_text("utf-8")
+    assert "access-secret" not in raw
+    assert "refresh-secret" not in raw
+
+    data = json.loads(raw)
+    assert str(data["access_token"]).startswith("ENC:")
+    assert str(data["refresh_token"]).startswith("ENC:")
+
+    loaded = store.load("fake-oauth")
+    assert loaded is not None
+    assert loaded.provider_id == "fake-oauth"
+    assert loaded.access_token == "access-secret"
+    assert loaded.refresh_token == "refresh-secret"
+    assert loaded.account_label == "octocat"
+    assert loaded.scopes == ["read:user"]
+
+
+def test_delete_removes_credential_file(tmp_path: Path) -> None:
+    store = OAuthCredentialStore(tmp_path / "oauth")
+    store.save(_credential())
+    assert store.exists("fake-oauth")
+
+    store.delete("fake-oauth")
+
+    assert not store.exists("fake-oauth")
+    assert store.load("fake-oauth") is None
+
+
+def test_load_returns_none_for_corrupt_json(tmp_path: Path) -> None:
+    root = tmp_path / "oauth"
+    root.mkdir()
+    (root / "fake-oauth.json").write_text("{not-json", "utf-8")
+
+    assert OAuthCredentialStore(root).load("fake-oauth") is None
+
+
+def test_load_returns_none_when_secret_field_cannot_decrypt(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "oauth"
+    root.mkdir()
+    (root / "fake-oauth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider_id": "fake-oauth",
+                "access_token": "ENC:corrupt",
+                "created_at": 1760000000,
+                "updated_at": 1760000001,
+            },
+        ),
+        "utf-8",
+    )
+
+    assert OAuthCredentialStore(root).load("fake-oauth") is None
+
+
+def test_save_rejects_empty_access_token(tmp_path: Path) -> None:
+    credential = _credential()
+    credential.access_token = ""
+    store = OAuthCredentialStore(tmp_path / "oauth")
+
+    with pytest.raises(ValueError):
+        store.save(credential)
+
+    assert not (tmp_path / "oauth" / "fake-oauth.json").exists()

--- a/tests/unit/providers/auth/test_credential_store.py
+++ b/tests/unit/providers/auth/test_credential_store.py
@@ -37,10 +37,10 @@ def _credential() -> OAuthCredential:
 
 
 def test_save_encrypts_and_load_restores_credential(tmp_path: Path) -> None:
-    store = OAuthCredentialStore(tmp_path / "oauth")
-    store.save(_credential())
+    store = OAuthCredentialStore(tmp_path / "providers")
+    store.save(_credential(), "custom")
 
-    path = tmp_path / "oauth" / "fake-oauth.json"
+    path = tmp_path / "providers" / "custom" / "fake-oauth_oauth.json"
     assert path.exists()
     raw = path.read_text("utf-8")
     assert "access-secret" not in raw
@@ -50,7 +50,7 @@ def test_save_encrypts_and_load_restores_credential(tmp_path: Path) -> None:
     assert str(data["access_token"]).startswith("ENC:")
     assert str(data["refresh_token"]).startswith("ENC:")
 
-    loaded = store.load("fake-oauth")
+    loaded = store.load("fake-oauth", "custom")
     assert loaded is not None
     assert loaded.provider_id == "fake-oauth"
     assert loaded.access_token == "access-secret"
@@ -60,30 +60,63 @@ def test_save_encrypts_and_load_restores_credential(tmp_path: Path) -> None:
 
 
 def test_delete_removes_credential_file(tmp_path: Path) -> None:
-    store = OAuthCredentialStore(tmp_path / "oauth")
-    store.save(_credential())
-    assert store.exists("fake-oauth")
+    store = OAuthCredentialStore(tmp_path / "providers")
+    store.save(_credential(), "custom")
+    assert store.exists("fake-oauth", "custom")
 
-    store.delete("fake-oauth")
+    store.delete("fake-oauth", "custom")
 
-    assert not store.exists("fake-oauth")
-    assert store.load("fake-oauth") is None
+    assert not store.exists("fake-oauth", "custom")
+    assert store.load("fake-oauth", "custom") is None
 
 
 def test_load_returns_none_for_corrupt_json(tmp_path: Path) -> None:
-    root = tmp_path / "oauth"
-    root.mkdir()
-    (root / "fake-oauth.json").write_text("{not-json", "utf-8")
+    root = tmp_path / "providers"
+    custom = root / "custom"
+    custom.mkdir(parents=True)
+    (custom / "fake-oauth_oauth.json").write_text("{not-json", "utf-8")
 
-    assert OAuthCredentialStore(root).load("fake-oauth") is None
+    assert OAuthCredentialStore(root).load("fake-oauth", "custom") is None
+
+
+def test_same_provider_id_can_have_credentials_in_different_buckets(
+    tmp_path: Path,
+) -> None:
+    store = OAuthCredentialStore(tmp_path / "providers")
+    credential = _credential()
+
+    store.save(credential, "builtin")
+    credential.access_token = "plugin-access-secret"
+    store.save(credential, "plugin")
+
+    builtin_path = tmp_path / "providers" / "builtin" / "fake-oauth_oauth.json"
+    plugin_path = tmp_path / "providers" / "plugin" / "fake-oauth_oauth.json"
+    assert builtin_path.exists()
+    assert plugin_path.exists()
+
+    builtin = store.load("fake-oauth", "builtin")
+    plugin = store.load("fake-oauth", "plugin")
+
+    assert builtin is not None
+    assert plugin is not None
+    assert builtin.access_token == "access-secret"
+    assert plugin.access_token == "plugin-access-secret"
+
+
+def test_load_rejects_unknown_provider_type(tmp_path: Path) -> None:
+    store = OAuthCredentialStore(tmp_path / "providers")
+
+    with pytest.raises(ValueError):
+        store.load("fake-oauth", "invalid")  # type: ignore[arg-type]
 
 
 def test_load_returns_none_when_secret_field_cannot_decrypt(
     tmp_path: Path,
 ) -> None:
-    root = tmp_path / "oauth"
-    root.mkdir()
-    (root / "fake-oauth.json").write_text(
+    root = tmp_path / "providers"
+    custom = root / "custom"
+    custom.mkdir(parents=True)
+    (custom / "fake-oauth_oauth.json").write_text(
         json.dumps(
             {
                 "version": 1,
@@ -96,15 +129,17 @@ def test_load_returns_none_when_secret_field_cannot_decrypt(
         "utf-8",
     )
 
-    assert OAuthCredentialStore(root).load("fake-oauth") is None
+    assert OAuthCredentialStore(root).load("fake-oauth", "custom") is None
 
 
 def test_save_rejects_empty_access_token(tmp_path: Path) -> None:
     credential = _credential()
     credential.access_token = ""
-    store = OAuthCredentialStore(tmp_path / "oauth")
+    store = OAuthCredentialStore(tmp_path / "providers")
 
     with pytest.raises(ValueError):
-        store.save(credential)
+        store.save(credential, "custom")
 
-    assert not (tmp_path / "oauth" / "fake-oauth.json").exists()
+    assert not (
+        tmp_path / "providers" / "custom" / "fake-oauth_oauth.json"
+    ).exists()

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -170,6 +170,78 @@ async def test_add_custom_provider_and_reload_from_storage(
     assert isinstance(loaded_duplicate, OpenAIProvider)
 
 
+def test_custom_provider_loader_ignores_oauth_credential_files(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    credential_file = manager.custom_path / "custom-openai_oauth.json"
+    credential_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "provider_id": "custom-openai",
+                "access_token": "ENC:placeholder",
+                "created_at": 1760000000,
+                "updated_at": 1760000001,
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    reloaded = ProviderManager()
+
+    assert reloaded.get_provider("custom-openai_oauth") is None
+
+
+def test_provider_resolution_returns_storage_bucket(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    manager.custom_providers["custom-openai"] = OpenAIProvider(
+        id="custom-openai",
+        name="Custom OpenAI",
+    )
+    manager.plugin_providers["plugin-openai"] = {
+        "info": OpenAIProvider(
+            id="plugin-openai",
+            name="Plugin OpenAI",
+        ),
+        "class": OpenAIProvider,
+    }
+
+    plugin = manager.get_provider_with_storage_type("plugin-openai")
+    builtin = manager.get_provider_with_storage_type("openai")
+    custom = manager.get_provider_with_storage_type("custom-openai")
+
+    assert plugin is not None
+    assert builtin is not None
+    assert custom is not None
+    assert plugin[1] == "plugin"
+    assert builtin[1] == "builtin"
+    assert custom[1] == "custom"
+    assert manager.get_provider_with_storage_type("missing") is None
+
+
+def test_provider_resolution_storage_bucket_matches_duplicate_id_priority(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    manager.plugin_providers["openai"] = {
+        "info": OpenAIProvider(
+            id="openai",
+            name="Plugin OpenAI",
+        ),
+        "class": OpenAIProvider,
+    }
+
+    resolved = manager.get_provider_with_storage_type("openai")
+
+    assert resolved is not None
+    provider, storage_type = resolved
+    assert provider.name == "Plugin OpenAI"
+    assert storage_type == "plugin"
+
+
 async def test_activate_provider_persists_active_model(
     isolated_secret_dir,
     monkeypatch,

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -206,7 +206,12 @@ async def test_oauth_provider_start_returns_standard_schema(
     api_client,
 ) -> None:
     async with api_client:
-        response = await api_client.post("/api/models/oauth/auth/start")
+        response = await api_client.post(
+            "/api/models/oauth/auth/start",
+            json={
+                "redirect_uri": ("http://test/api/models/oauth/auth/callback"),
+            },
+        )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -219,6 +224,19 @@ async def test_oauth_provider_start_returns_standard_schema(
         "interval": None,
         "message": "",
     }
+
+
+async def test_oauth_provider_start_rejects_external_redirect_uri(
+    api_client,
+) -> None:
+    async with api_client:
+        response = await api_client.post(
+            "/api/models/oauth/auth/start",
+            json={"redirect_uri": "https://evil.test/callback"},
+        )
+
+    assert response.status_code == 400
+    assert "redirect_uri" in response.json()["detail"]
 
 
 async def test_status_and_logout_return_standard_schema(api_client) -> None:

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -193,6 +193,14 @@ async def test_api_key_provider_start_returns_400(api_client) -> None:
     assert "API key authentication" in response.json()["detail"]
 
 
+async def test_api_key_provider_logout_returns_400(api_client) -> None:
+    async with api_client:
+        response = await api_client.post("/api/models/api/auth/logout")
+
+    assert response.status_code == 400
+    assert "does not support logout" in response.json()["detail"]
+
+
 async def test_oauth_provider_start_returns_standard_schema(
     api_client,
 ) -> None:

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Route tests for provider auth endpoints."""
+
+from __future__ import annotations
+
+import sys
+import types
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+class _MockModule(types.ModuleType):
+    def __getattr__(self, name: str):
+        value = MagicMock(name=name)
+        setattr(self, name, value)
+        return value
+
+
+agent_context_module = _MockModule("qwenpaw.app.agent_context")
+agent_context_module.get_agent_for_request = MagicMock()
+sys.modules["qwenpaw.app.agent_context"] = agent_context_module
+
+app_utils_module = _MockModule("qwenpaw.app.utils")
+app_utils_module.schedule_agent_reload = MagicMock()
+sys.modules["qwenpaw.app.utils"] = app_utils_module
+
+routers_pkg = types.ModuleType("qwenpaw.app.routers")
+routers_pkg.__path__ = []
+sys.modules.setdefault("qwenpaw.app.routers", routers_pkg)
+
+_ROUTER_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "qwenpaw"
+    / "app"
+    / "routers"
+    / "providers.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "qwenpaw.app.routers.providers_auth_test",
+    _ROUTER_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+providers_router = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = providers_router
+_SPEC.loader.exec_module(providers_router)
+from qwenpaw.providers.auth.adapter import ProviderAuthAdapter
+from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
+from qwenpaw.providers.auth.manager import ProviderAuthManager
+from qwenpaw.providers.auth.models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    OAuthCredential,
+    ProviderAuthFlowType,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+from qwenpaw.providers.auth.registry import ProviderAuthRegistry
+from qwenpaw.providers.openai_provider import OpenAIProvider
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_master_key(tmp_path: Path, monkeypatch):
+    import qwenpaw.security.secret_store as mod
+
+    test_key = bytes.fromhex(
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    )
+    monkeypatch.setattr(mod, "_cached_master_key", test_key)
+    monkeypatch.setattr(mod, "_cached_fernet", None)
+    monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path)
+
+
+class FakeProviderManager:
+    def __init__(self, providers):
+        self.providers = providers
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+
+class FakeAuthAdapter(ProviderAuthAdapter):
+    provider_id = "oauth"
+    auth_type = ProviderAuthType.OAUTH_DEVICE_CODE
+
+    async def start(self, provider, request: AuthStartRequest) -> AuthStartResult:
+        return AuthStartResult(
+            flow_id="fake-flow",
+            flow_type=ProviderAuthFlowType.DEVICE_CODE,
+            user_code="ABCD-EFGH",
+            verification_uri="https://example.test/device",
+        )
+
+    async def handle_callback(
+        self,
+        provider,
+        state: str,
+        code: str,
+    ) -> OAuthCredential:
+        return OAuthCredential(
+            provider_id=provider.id,
+            access_token="oauth-access-token",
+            account_label="octocat",
+            created_at=1760000000,
+            updated_at=1760000001,
+        )
+
+    async def get_status(self, provider, credential) -> AuthStatusResult:
+        if credential:
+            return AuthStatusResult(
+                status=ProviderAuthStatus.AUTHENTICATED,
+                account_label=credential.account_label,
+            )
+        return AuthStatusResult(status=ProviderAuthStatus.NOT_CONFIGURED)
+
+
+def _provider(
+    provider_id: str,
+    auth_type: ProviderAuthType = ProviderAuthType.API_KEY,
+) -> OpenAIProvider:
+    return OpenAIProvider(
+        id=provider_id,
+        name=provider_id,
+        auth_type=auth_type,
+    )
+
+
+@pytest.fixture
+def api_client(tmp_path: Path, monkeypatch):
+    registry = ProviderAuthRegistry()
+    registry.register(FakeAuthAdapter())
+    fake_manager = FakeProviderManager(
+        {
+            "api": _provider("api"),
+            "oauth": _provider(
+                "oauth",
+                auth_type=ProviderAuthType.OAUTH_DEVICE_CODE,
+            ),
+        },
+    )
+
+    app = FastAPI()
+    app.state.provider_manager = fake_manager
+    app.include_router(providers_router.router, prefix="/api")
+
+    def _auth_manager(manager):
+        return ProviderAuthManager(
+            manager,
+            credential_store=OAuthCredentialStore(tmp_path / "oauth"),
+            registry=registry,
+        )
+
+    monkeypatch.setattr(
+        providers_router,
+        "get_provider_auth_manager",
+        _auth_manager,
+    )
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_missing_provider_returns_404(api_client) -> None:
+    async with api_client:
+        response = await api_client.get("/api/models/missing/auth/status")
+
+    assert response.status_code == 404
+
+
+async def test_api_key_provider_start_returns_400(api_client) -> None:
+    async with api_client:
+        response = await api_client.post("/api/models/api/auth/start")
+
+    assert response.status_code == 400
+    assert "API key authentication" in response.json()["detail"]
+
+
+async def test_oauth_provider_start_returns_standard_schema(
+    api_client,
+) -> None:
+    async with api_client:
+        response = await api_client.post("/api/models/oauth/auth/start")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "flow_id": "fake-flow",
+        "flow_type": "device_code",
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://example.test/device",
+        "authorization_url": None,
+        "expires_at": None,
+        "interval": None,
+        "message": "",
+    }
+
+
+async def test_status_and_logout_return_standard_schema(api_client) -> None:
+    async with api_client:
+        status_response = await api_client.get(
+            "/api/models/oauth/auth/status",
+        )
+        logout_response = await api_client.post(
+            "/api/models/oauth/auth/logout",
+        )
+
+    assert status_response.status_code == 200
+    assert status_response.json() == {
+        "status": "not_configured",
+        "account_label": "",
+        "expires_at": None,
+        "scopes": [],
+        "message": "",
+    }
+    assert logout_response.status_code == 200
+    assert logout_response.json() == {
+        "status": "not_configured",
+        "account_label": "",
+        "expires_at": None,
+        "scopes": [],
+        "message": "",
+    }

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -1,17 +1,33 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=unused-argument,redefined-outer-name
 """Route tests for provider auth endpoints."""
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 import types
-import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.providers.auth.adapter import ProviderAuthAdapter
+from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
+from qwenpaw.providers.auth.manager import ProviderAuthManager
+from qwenpaw.providers.auth.models import (
+    AuthStartRequest,
+    AuthStartResult,
+    AuthStatusResult,
+    OAuthCredential,
+    ProviderAuthFlowType,
+    ProviderAuthStatus,
+    ProviderAuthType,
+)
+from qwenpaw.providers.auth.registry import ProviderAuthRegistry
+from qwenpaw.providers.openai_provider import OpenAIProvider
 
 
 class _MockModule(types.ModuleType):
@@ -49,20 +65,6 @@ assert _SPEC is not None and _SPEC.loader is not None
 providers_router = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = providers_router
 _SPEC.loader.exec_module(providers_router)
-from qwenpaw.providers.auth.adapter import ProviderAuthAdapter
-from qwenpaw.providers.auth.credential_store import OAuthCredentialStore
-from qwenpaw.providers.auth.manager import ProviderAuthManager
-from qwenpaw.providers.auth.models import (
-    AuthStartRequest,
-    AuthStartResult,
-    AuthStatusResult,
-    OAuthCredential,
-    ProviderAuthFlowType,
-    ProviderAuthStatus,
-    ProviderAuthType,
-)
-from qwenpaw.providers.auth.registry import ProviderAuthRegistry
-from qwenpaw.providers.openai_provider import OpenAIProvider
 
 pytestmark = pytest.mark.anyio
 
@@ -96,7 +98,11 @@ class FakeAuthAdapter(ProviderAuthAdapter):
     provider_id = "oauth"
     auth_type = ProviderAuthType.OAUTH_DEVICE_CODE
 
-    async def start(self, provider, request: AuthStartRequest) -> AuthStartResult:
+    async def start(
+        self,
+        provider,
+        request: AuthStartRequest,
+    ) -> AuthStartResult:
         return AuthStartResult(
             flow_id="fake-flow",
             flow_type=ProviderAuthFlowType.DEVICE_CODE,

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -145,7 +145,7 @@ def _provider(
 
 
 @pytest.fixture
-def api_client(tmp_path: Path, monkeypatch):
+def api_client(tmp_path: Path):
     registry = ProviderAuthRegistry()
     registry.register(FakeAuthAdapter())
     fake_manager = FakeProviderManager(
@@ -160,20 +160,12 @@ def api_client(tmp_path: Path, monkeypatch):
 
     app = FastAPI()
     app.state.provider_manager = fake_manager
-    app.include_router(providers_router.router, prefix="/api")
-
-    def _auth_manager(manager):
-        return ProviderAuthManager(
-            manager,
-            credential_store=OAuthCredentialStore(tmp_path / "oauth"),
-            registry=registry,
-        )
-
-    monkeypatch.setattr(
-        providers_router,
-        "get_provider_auth_manager",
-        _auth_manager,
+    app.state.provider_auth_manager = ProviderAuthManager(
+        fake_manager,
+        credential_store=OAuthCredentialStore(tmp_path / "oauth"),
+        registry=registry,
     )
+    app.include_router(providers_router.router, prefix="/api")
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
 

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -37,18 +37,6 @@ class _MockModule(types.ModuleType):
         return value
 
 
-agent_context_module = _MockModule("qwenpaw.app.agent_context")
-agent_context_module.get_agent_for_request = MagicMock()
-sys.modules["qwenpaw.app.agent_context"] = agent_context_module
-
-app_utils_module = _MockModule("qwenpaw.app.utils")
-app_utils_module.schedule_agent_reload = MagicMock()
-sys.modules["qwenpaw.app.utils"] = app_utils_module
-
-routers_pkg = types.ModuleType("qwenpaw.app.routers")
-routers_pkg.__path__ = []
-sys.modules.setdefault("qwenpaw.app.routers", routers_pkg)
-
 _ROUTER_PATH = (
     Path(__file__).resolve().parents[3]
     / "src"
@@ -57,16 +45,36 @@ _ROUTER_PATH = (
     / "routers"
     / "providers.py"
 )
-_SPEC = importlib.util.spec_from_file_location(
-    "qwenpaw.app.routers.providers_auth_test",
-    _ROUTER_PATH,
-)
-assert _SPEC is not None and _SPEC.loader is not None
-providers_router = importlib.util.module_from_spec(_SPEC)
-sys.modules[_SPEC.name] = providers_router
-_SPEC.loader.exec_module(providers_router)
 
 pytestmark = pytest.mark.anyio
+
+
+def _load_providers_router(monkeypatch):
+    agent_context_module = _MockModule("qwenpaw.app.agent_context")
+    agent_context_module.get_agent_for_request = MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "qwenpaw.app.agent_context",
+        agent_context_module,
+    )
+
+    app_utils_module = _MockModule("qwenpaw.app.utils")
+    app_utils_module.schedule_agent_reload = MagicMock()
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.utils", app_utils_module)
+
+    routers_pkg = types.ModuleType("qwenpaw.app.routers")
+    routers_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.routers", routers_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "qwenpaw.app.routers.providers_auth_test",
+        _ROUTER_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    providers_router = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, providers_router)
+    spec.loader.exec_module(providers_router)
+    return providers_router
 
 
 @pytest.fixture
@@ -145,7 +153,8 @@ def _provider(
 
 
 @pytest.fixture
-def api_client(tmp_path: Path):
+def api_client(tmp_path: Path, monkeypatch):
+    providers_router = _load_providers_router(monkeypatch)
     registry = ProviderAuthRegistry()
     registry.register(FakeAuthAdapter())
     fake_manager = FakeProviderManager(

--- a/tests/unit/routers/test_provider_auth_routes.py
+++ b/tests/unit/routers/test_provider_auth_routes.py
@@ -171,7 +171,7 @@ def api_client(tmp_path: Path, monkeypatch):
     app.state.provider_manager = fake_manager
     app.state.provider_auth_manager = ProviderAuthManager(
         fake_manager,
-        credential_store=OAuthCredentialStore(tmp_path / "oauth"),
+        credential_store=OAuthCredentialStore(tmp_path / "providers"),
         registry=registry,
     )
     app.include_router(providers_router.router, prefix="/api")


### PR DESCRIPTION
## Description

Adds extensible provider authentication infrastructure for future OAuth providers.

- Adds shared provider auth models:
  - `ProviderAuthType`
  - `ProviderAuthStatus`
  - `ProviderAuthInfo`
  - auth start/status/credential schemas

- Extends `ProviderInfo` with safe auth metadata:
  - `auth_type`
  - `auth`

- Adds generic OAuth infrastructure:
  - `ProviderAuthAdapter`
  - `ProviderAuthRegistry`
  - `ProviderAuthManager`
  - encrypted `OAuthCredentialStore`

- Adds provider auth API endpoints:
  - `POST /models/{provider_id}/auth/start`
  - `GET /models/{provider_id}/auth/status`
  - `POST /models/{provider_id}/auth/logout`
  - `GET /models/{provider_id}/auth/callback`

- Adds minimal console API support:
  - provider auth TypeScript types
  - provider auth client methods

This PR does not implement any real OAuth provider yet. Future providers can be added by setting `auth_type`, implementing an adapter, and registering it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
