### PR TITLE
fix(audio): configure local whisper model path

### DIFF
--- a/src/qwenpaw/agents/utils/audio_transcription.py
+++ b/src/qwenpaw/agents/utils/audio_transcription.py
@@ -11,30 +11,67 @@ Transcription is only attempted when explicitly enabled via the
 
 import asyncio
 import logging
+import os
 import shutil
 import threading
 from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+_LOCAL_WHISPER_MODEL_ENV = "QWENPAW_LOCAL_WHISPER_MODEL"
+_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV = "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT"
+_DEFAULT_LOCAL_WHISPER_MODEL = "base"
+
 # ------------------------------------------------------------------
 # Cached local-whisper model (lazy singleton)
 # ------------------------------------------------------------------
 _local_whisper_model = None
+_local_whisper_model_key: Tuple[str, Optional[str]] | None = None
 _local_whisper_lock = threading.Lock()
+
+
+def _local_whisper_model_settings() -> Tuple[str, Optional[str]]:
+    """Return the configured local Whisper model and optional cache root."""
+    model = (
+        os.environ.get(_LOCAL_WHISPER_MODEL_ENV, "").strip()
+        or _DEFAULT_LOCAL_WHISPER_MODEL
+    )
+    download_root = (
+        os.environ.get(_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV, "").strip() or None
+    )
+    return model, download_root
 
 
 def _get_local_whisper_model():
     """Return a cached whisper model, loading it on first call."""
-    global _local_whisper_model  # noqa: PLW0603
-    if _local_whisper_model is not None:
+    global _local_whisper_model, _local_whisper_model_key  # noqa: PLW0603
+    model_name, download_root = _local_whisper_model_settings()
+    model_key = (model_name, download_root)
+
+    if (
+        _local_whisper_model is not None
+        and _local_whisper_model_key == model_key
+    ):
         return _local_whisper_model
     with _local_whisper_lock:
-        if _local_whisper_model is not None:
+        if (
+            _local_whisper_model is not None
+            and _local_whisper_model_key == model_key
+        ):
             return _local_whisper_model
         import whisper
 
-        _local_whisper_model = whisper.load_model("base")
+        kwargs = {}
+        if download_root:
+            kwargs["download_root"] = download_root
+
+        logger.info(
+            "Loading local Whisper model '%s'%s",
+            model_name,
+            (f" from cache root '{download_root}'" if download_root else ""),
+        )
+        _local_whisper_model = whisper.load_model(model_name, **kwargs)
+        _local_whisper_model_key = model_key
         return _local_whisper_model
 
 
@@ -140,10 +177,14 @@ def check_local_whisper_available() -> dict:
     except ImportError:
         pass
 
+    model_name, download_root = _local_whisper_model_settings()
+
     return {
         "available": ffmpeg_ok and whisper_ok,
         "ffmpeg_installed": ffmpeg_ok,
         "whisper_installed": whisper_ok,
+        "model": model_name,
+        "download_root": download_root,
     }
 
 

--- a/tests/unit/agents/utils/test_audio_transcription.py
+++ b/tests/unit/agents/utils/test_audio_transcription.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents.utils import audio_transcription
+
+
+@pytest.fixture(autouse=True)
+def reset_local_whisper_cache(monkeypatch):
+    monkeypatch.setattr(audio_transcription, "_local_whisper_model", None)
+    monkeypatch.setattr(audio_transcription, "_local_whisper_model_key", None)
+    monkeypatch.delenv("QWENPAW_LOCAL_WHISPER_MODEL", raising=False)
+    monkeypatch.delenv("QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT", raising=False)
+
+
+def test_local_whisper_loads_default_model(monkeypatch):
+    calls = []
+    fake_model = object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            load_model=lambda model, **kwargs: calls.append(
+                (model, kwargs),
+            )
+            or fake_model,
+        ),
+    )
+
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert calls == [("base", {})]
+
+
+def test_local_whisper_loads_configured_model_and_cache(monkeypatch):
+    calls = []
+    fake_model = object()
+
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_MODEL",
+        " C:/models/whisper/base.pt ",
+    )
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT",
+        " C:/models/whisper-cache ",
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            load_model=lambda model, **kwargs: calls.append(
+                (model, kwargs),
+            )
+            or fake_model,
+        ),
+    )
+
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert calls == [
+        (
+            "C:/models/whisper/base.pt",
+            {"download_root": "C:/models/whisper-cache"},
+        ),
+    ]
+
+
+def test_local_whisper_cache_respects_env_changes(monkeypatch):
+    calls = []
+
+    def fake_load_model(model, **kwargs):
+        loaded = {"model": model, "kwargs": kwargs}
+        calls.append(loaded)
+        return loaded
+
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(load_model=fake_load_model),
+    )
+
+    first = audio_transcription._get_local_whisper_model()
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_MODEL", "small")
+    second = audio_transcription._get_local_whisper_model()
+
+    assert first is not second
+    assert calls == [
+        {"model": "base", "kwargs": {}},
+        {"model": "small", "kwargs": {}},
+    ]
+
+
+def test_local_whisper_status_reports_model_settings(monkeypatch):
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_MODEL", "small")
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT", "/tmp/whisper")
+    monkeypatch.setattr(
+        audio_transcription.shutil,
+        "which",
+        lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(load_model=lambda *args, **kwargs: object()),
+    )
+
+    assert audio_transcription.check_local_whisper_available() == {
+        "available": True,
+        "ffmpeg_installed": True,
+        "whisper_installed": True,
+        "model": "small",
+        "download_root": "/tmp/whisper",
+    }


### PR DESCRIPTION
## Summary
- allow Local Whisper to load a configured model name/path via `QWENPAW_LOCAL_WHISPER_MODEL`
- allow Local Whisper to use an existing cache directory via `QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT`
- keep the cached Whisper model keyed by model/cache settings so env changes reload correctly
- expose the configured local Whisper model/cache in the status response

Fixes #4205

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\utils\test_audio_transcription.py -q`
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pre-commit run --files src\qwenpaw\agents\utils\audio_transcription.py tests\unit\agents\utils\test_audio_transcription.py`
- `git diff --check`