### PR TITLE
feat(backup): add opt-in retention

### DIFF
--- a/src/qwenpaw/backup/_ops/create.py
+++ b/src/qwenpaw/backup/_ops/create.py
@@ -10,10 +10,11 @@ from typing import Any, AsyncGenerator
 
 from .._utils.constants import META_FILE, zip_path
 from .._utils.meta import finalize_backup_meta
-from ..models import BackupMeta, CreateBackupRequest
+from ..models import BackupMeta, CreateBackupRequest, DeleteBackupsResponse
 from ...config.utils import load_config
 from ...constant import BACKUP_DIR
 from .create_helpers import add_files_to_zip
+from .storage import _delete_sync, _list_sync
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,7 @@ async def create_stream(
         asyncio.to_thread(
             _create_with_progress,
             meta,
+            req.keep_last,
             req.agents,
             _put,
             stop_event,
@@ -115,6 +117,7 @@ def _write_meta_and_finalize(
 
 def _create_with_progress(
     meta: BackupMeta,
+    keep_last: int | None,
     req_agents: list[str],
     put: Any,
     stop_event: threading.Event,
@@ -133,7 +136,15 @@ def _create_with_progress(
         dest = zip_path(meta.id)
         tmp = dest.with_suffix(".tmp")
         try:
-            _compress_to_tmp(meta, req_agents, put, stop_event, tmp, dest)
+            _compress_to_tmp(
+                meta,
+                keep_last,
+                req_agents,
+                put,
+                stop_event,
+                tmp,
+                dest,
+            )
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise
@@ -146,6 +157,7 @@ def _create_with_progress(
 
 def _compress_to_tmp(
     meta: BackupMeta,
+    keep_last: int | None,
     req_agents: list[str],
     put: Any,
     stop_event: threading.Event,
@@ -213,6 +225,46 @@ def _compress_to_tmp(
         return
 
     tmp.replace(dest)  # atomic on both Windows and Linux
+    retention = _apply_backup_retention(keep_last, meta.id)
+    if retention.deleted or retention.failed:
+        put(
+            {
+                "type": "retention",
+                "deleted": retention.deleted,
+                "failed": retention.failed,
+                "percent": 95,
+            },
+        )
     put(
         {"type": "done", "meta": meta.model_dump(mode="json"), "percent": 100},
     )
+
+
+def _apply_backup_retention(
+    keep_last: int | None,
+    protected_backup_id: str,
+) -> DeleteBackupsResponse:
+    """Prune old backups when a create request opts into retention."""
+    if keep_last is None:
+        return DeleteBackupsResponse()
+
+    backups = _list_sync()
+    kept_ids = {protected_backup_id}
+    delete_ids: list[str] = []
+    for backup in backups:
+        if backup.id == protected_backup_id:
+            continue
+        if len(kept_ids) < keep_last:
+            kept_ids.add(backup.id)
+        else:
+            delete_ids.append(backup.id)
+
+    if not delete_ids:
+        return DeleteBackupsResponse()
+
+    logger.info(
+        "Applying backup retention keep_last=%d, deleting %d old backup(s)",
+        keep_last,
+        len(delete_ids),
+    )
+    return _delete_sync(delete_ids)

--- a/src/qwenpaw/backup/models.py
+++ b/src/qwenpaw/backup/models.py
@@ -64,6 +64,14 @@ class CreateBackupRequest(BaseModel):
         description="Agent IDs to include when scope.include_agents is True. "
         "Must be the explicit list (even for 'all agents').",
     )
+    keep_last: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Optional retention policy. When set, keep only the newest N "
+            "backup archives after this backup is created."
+        ),
+    )
 
 
 class RestoreBackupRequest(BaseModel):

--- a/tests/unit/backup/test_backup_retention.py
+++ b/tests/unit/backup/test_backup_retention.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from datetime import datetime, timedelta, timezone
+
+from qwenpaw.backup._ops import create as create_ops
+from qwenpaw.backup.models import BackupMeta, DeleteBackupsResponse
+
+
+def _meta(backup_id: str, minutes_ago: int) -> BackupMeta:
+    return BackupMeta(
+        id=backup_id,
+        name=backup_id,
+        created_at=datetime.now(timezone.utc) - timedelta(minutes=minutes_ago),
+    )
+
+
+def test_backup_retention_disabled_does_not_delete(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(create_ops, "_list_sync", lambda: [_meta("old", 10)])
+    monkeypatch.setattr(
+        create_ops,
+        "_delete_sync",
+        lambda ids: calls.append(ids) or DeleteBackupsResponse(deleted=ids),
+    )
+
+    result = create_ops._apply_backup_retention(
+        keep_last=None,
+        protected_backup_id="new",
+    )
+
+    assert result == DeleteBackupsResponse()
+    assert not calls
+
+
+def test_backup_retention_keeps_newest_and_protected_backup(monkeypatch):
+    deleted = []
+    backups = [
+        _meta("newest", 0),
+        _meta("middle", 5),
+        _meta("new", 10),
+        _meta("oldest", 20),
+    ]
+
+    monkeypatch.setattr(create_ops, "_list_sync", lambda: backups)
+    monkeypatch.setattr(
+        create_ops,
+        "_delete_sync",
+        lambda ids: deleted.extend(ids) or DeleteBackupsResponse(deleted=ids),
+    )
+
+    result = create_ops._apply_backup_retention(
+        keep_last=2,
+        protected_backup_id="new",
+    )
+
+    assert result.deleted == ["middle", "oldest"]
+    assert deleted == ["middle", "oldest"]
+
+
+def test_backup_retention_keep_one_preserves_created_backup(monkeypatch):
+    deleted = []
+    backups = [
+        _meta("newest", 0),
+        _meta("new", 5),
+        _meta("oldest", 10),
+    ]
+
+    monkeypatch.setattr(create_ops, "_list_sync", lambda: backups)
+    monkeypatch.setattr(
+        create_ops,
+        "_delete_sync",
+        lambda ids: deleted.extend(ids) or DeleteBackupsResponse(deleted=ids),
+    )
+
+    result = create_ops._apply_backup_retention(
+        keep_last=1,
+        protected_backup_id="new",
+    )
+
+    assert result.deleted == ["newest", "oldest"]
+    assert deleted == ["newest", "oldest"]


### PR DESCRIPTION
## Summary
- add opt-in `keep_last` retention to backup creation requests
- prune older backup archives only after the new backup has been written successfully
- emit a `retention` SSE event when cleanup deletes or fails to delete old archives
- add focused unit tests for disabled retention, protected backup handling, and keep-one behavior

Fixes #3864

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\backup\test_backup_retention.py -q`
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pre-commit run --files src\qwenpaw\backup\models.py src\qwenpaw\backup\_ops\create.py tests\unit\backup\test_backup_retention.py`
- `git diff --check`