### PR TITLE
fix(skill): fix skill hub import: fix www, add skill_hub retry

### DIFF
--- a/console/src/pages/Agent/Skills/components/ImportHubModal.tsx
+++ b/console/src/pages/Agent/Skills/components/ImportHubModal.tsx
@@ -28,21 +28,38 @@ type ValidationResult =
   | { ok: true; source: string }
   | { ok: false; messageKey: string };
 
+function normalizeHost(host: string): string {
+  return host.toLowerCase().replace(/^www\./, "");
+}
+
 function validateUrl(url: string): ValidationResult {
   const trimmed = url.trim();
   if (!trimmed) {
     return { ok: false, messageKey: "" };
   }
 
+  let parsedInput: URL;
   try {
-    new URL(trimmed);
+    parsedInput = new URL(trimmed);
   } catch {
     return { ok: false, messageKey: "skills.invalidUrl" };
   }
 
-  const source = skillMarkets.find((m) =>
-    trimmed.toLowerCase().startsWith(m.urlPrefix.toLowerCase()),
-  );
+  const inputHost = normalizeHost(parsedInput.host);
+  const inputPath = parsedInput.pathname.toLowerCase();
+
+  const source = skillMarkets.find((m) => {
+    let parsedPrefix: URL;
+    try {
+      parsedPrefix = new URL(m.urlPrefix);
+    } catch {
+      return false;
+    }
+    return (
+      inputHost === normalizeHost(parsedPrefix.host) &&
+      inputPath.startsWith(parsedPrefix.pathname.toLowerCase())
+    );
+  });
   if (!source) {
     return { ok: false, messageKey: "skills.invalidSkillUrlSource" };
   }

--- a/src/qwenpaw/agents/skill_system/hub.py
+++ b/src/qwenpaw/agents/skill_system/hub.py
@@ -2,6 +2,7 @@
 """Skills hub client and install helpers."""
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import os
@@ -277,13 +278,22 @@ def _read_response_bytes(
         _ensure_not_cancelled()
         chunk = resp.read(HTTP_READ_CHUNK_BYTES)
         if not chunk:
-            return bytes(body)
+            break
         body.extend(chunk)
         if max_bytes is not None and len(body) > max_bytes:
             raise SkillsError(
                 message=f"Response body too large from {full_url}: "
                 f"download exceeded limit {max_bytes}",
             )
+    if content_length is not None and len(body) != content_length:
+        # resp.read(N) does not raise IncompleteRead on truncation, so
+        # validate length explicitly. Raising HTTPException routes into
+        # the retry branch in _http_fetch.
+        raise http.client.IncompleteRead(
+            partial=bytes(body),
+            expected=content_length - len(body),
+        )
+    return bytes(body)
 
 
 # pylint: disable-next=too-many-branches,too-many-statements
@@ -371,6 +381,23 @@ def _http_fetch(
                 delay = _compute_backoff_seconds(attempt)
                 logger.warning(
                     "Hub URL error on %s (attempt %d/%d), "
+                    "retrying in %.2fs: %s",
+                    full_url,
+                    attempt,
+                    attempts,
+                    delay,
+                    e,
+                )
+                _ensure_not_cancelled()
+                time.sleep(delay)
+                continue
+            raise
+        except (http.client.HTTPException, ConnectionError) as e:
+            last_error = e
+            if attempt < attempts:
+                delay = _compute_backoff_seconds(attempt)
+                logger.warning(
+                    "Hub connection error on %s (attempt %d/%d), "
                     "retrying in %.2fs: %s",
                     full_url,
                     attempt,


### PR DESCRIPTION
## Description

Fix two issues when importing skills from external Hubs:                                                                      
                                                                                                                                
- **Frontend rejects `www.skills.sh` (and other `www.` subdomains) as "unsupported marketplace"**, even though the backend  already accepts both `host` and `www.host`. Switch validation from strict `startsWith` to URL parsing with host normalization (strip `www.`) + pathname prefix match.                                                                                       
- **Backend returns 500 on transient GitHub network errors**:
  - `http.client.RemoteDisconnected` isn't a `URLError` subclass, so RST'd connections bypassed the retry loop. Added `(http.client.HTTPException, ConnectionError)` branch.                                                                        
  - `resp.read(N)` doesn't raise `IncompleteRead`, so truncated responses returned silently and surfaced as cryptic           
`json.loads` errors. Validate `Content-Length` against bytes read; raise `IncompleteRead` on mismatch to route into the retry branch above.       

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
