### PR TITLE
fix(audio): surface local whisper model failures

### DIFF
--- a/src/qwenpaw/agents/utils/audio_transcription.py
+++ b/src/qwenpaw/agents/utils/audio_transcription.py
@@ -14,13 +14,25 @@ import logging
 import os
 import shutil
 import threading
+from pathlib import Path
 from typing import List, Optional, Tuple
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
 _LOCAL_WHISPER_MODEL_ENV = "QWENPAW_LOCAL_WHISPER_MODEL"
 _LOCAL_WHISPER_DOWNLOAD_ROOT_ENV = "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT"
 _DEFAULT_LOCAL_WHISPER_MODEL = "base"
+
+
+class AudioTranscriptionError(RuntimeError):
+    """Raised when transcription cannot run and the caller needs details."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
 
 # ------------------------------------------------------------------
 # Cached local-whisper model (lazy singleton)
@@ -40,6 +52,77 @@ def _local_whisper_model_settings() -> Tuple[str, Optional[str]]:
         os.environ.get(_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV, "").strip() or None
     )
     return model, download_root
+
+
+def _default_whisper_download_root() -> Path:
+    """Return openai-whisper's default model cache directory."""
+    return Path(os.path.expanduser("~")) / ".cache" / "whisper"
+
+
+def _whisper_model_cache_path(
+    whisper_module,
+    model_name: str,
+    download_root: Optional[str],
+) -> Optional[Path]:
+    """Return the expected local checkpoint path for a named Whisper model."""
+    if Path(model_name).is_file():
+        return Path(model_name)
+
+    model_urls = getattr(whisper_module, "_MODELS", {})
+    url = model_urls.get(model_name) if isinstance(model_urls, dict) else None
+    if not url:
+        return None
+
+    filename = Path(urlparse(url).path).name or f"{model_name}.pt"
+    root = (
+        Path(download_root)
+        if download_root
+        else _default_whisper_download_root()
+    )
+    return root / filename
+
+
+def _local_whisper_model_status(whisper_module) -> tuple[bool, Optional[str]]:
+    """Return whether the configured local Whisper model is already cached."""
+    model_name, download_root = _local_whisper_model_settings()
+    path = _whisper_model_cache_path(whisper_module, model_name, download_root)
+    if path is None:
+        return False, None
+    return path.is_file(), str(path)
+
+
+def _local_whisper_unavailable_message(status: dict) -> str:
+    """Build a user-actionable local Whisper availability message."""
+    if (
+        status.get("ffmpeg_installed")
+        and status.get("whisper_installed")
+        and not status.get("model_available")
+    ):
+        model = status.get("model") or _DEFAULT_LOCAL_WHISPER_MODEL
+        path = status.get("model_path") or "the Whisper cache directory"
+        return (
+            "Local Whisper dependencies are installed, but Whisper model "
+            f"'{model}' is not cached at {path}. "
+            "For offline use, pre-download the model on an online machine or "
+            f"set {_LOCAL_WHISPER_MODEL_ENV} to an existing model file and "
+            f"{_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV} to an existing cache "
+            "directory."
+        )
+
+    missing = []
+    if not status["ffmpeg_installed"]:
+        missing.append("ffmpeg")
+    if not status["whisper_installed"]:
+        missing.append("openai-whisper")
+
+    if not missing:
+        return "Local Whisper is unavailable."
+
+    return (
+        "Local Whisper is unavailable. Missing: "
+        f"{', '.join(missing)}. "
+        "Install the missing dependencies to use local transcription."
+    )
 
 
 def _get_local_whisper_model():
@@ -165,27 +248,48 @@ def check_local_whisper_available() -> dict:
             "available": bool,
             "ffmpeg_installed": bool,
             "whisper_installed": bool,
+            "offline_available": bool,
+            "model_available": bool,
         }
     """
     ffmpeg_ok = shutil.which("ffmpeg") is not None
 
     whisper_ok = False
+    whisper_module = None
     try:
-        import whisper as _whisper  # noqa: F401
+        import whisper as _whisper
 
         whisper_ok = True
+        whisper_module = _whisper
     except ImportError:
         pass
 
     model_name, download_root = _local_whisper_model_settings()
+    model_available = False
+    model_path = None
+    if whisper_module is not None:
+        model_available, model_path = _local_whisper_model_status(
+            whisper_module,
+        )
 
-    return {
+    status = {
         "available": ffmpeg_ok and whisper_ok,
+        "offline_available": ffmpeg_ok and whisper_ok and model_available,
         "ffmpeg_installed": ffmpeg_ok,
         "whisper_installed": whisper_ok,
+        "model_available": model_available,
         "model": model_name,
-        "download_root": download_root,
+        "model_path": model_path,
+        "download_root": (
+            download_root or str(_default_whisper_download_root())
+        ),
     }
+    if status["offline_available"]:
+        status["message"] = "Local Whisper is ready for offline use."
+    else:
+        status["message"] = _local_whisper_unavailable_message(status)
+
+    return status
 
 
 # ------------------------------------------------------------------
@@ -201,17 +305,12 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
     """
     status = check_local_whisper_available()
     if not status["available"]:
-        missing = []
-        if not status["ffmpeg_installed"]:
-            missing.append("ffmpeg")
-        if not status["whisper_installed"]:
-            missing.append("openai-whisper")
-        logger.warning(
-            "Local Whisper unavailable (missing: %s). "
-            "Install the missing dependencies to use local transcription.",
-            ", ".join(missing),
+        message = status["message"]
+        logger.warning(message)
+        raise AudioTranscriptionError(
+            "LOCAL_WHISPER_UNAVAILABLE",
+            message,
         )
-        return None
 
     def _run():
         model = _get_local_whisper_model()
@@ -232,13 +331,27 @@ async def _transcribe_local_whisper(file_path: str) -> Optional[str]:
             file_path,
         )
         return None
-    except Exception:
+    except AudioTranscriptionError:
+        raise
+    except Exception as exc:
+        status = check_local_whisper_available()
+        if status["available"] and not status.get("model_available"):
+            message = f"{status['message']} Original error: {exc}"
+            logger.warning(message, exc_info=True)
+            raise AudioTranscriptionError(
+                "LOCAL_WHISPER_MODEL_UNAVAILABLE",
+                message,
+            ) from exc
+
+        message = f"Local Whisper transcription failed for {file_path}: {exc}"
         logger.warning(
-            "Local Whisper transcription failed for %s",
-            file_path,
+            message,
             exc_info=True,
         )
-        return None
+        raise AudioTranscriptionError(
+            "LOCAL_WHISPER_TRANSCRIPTION_FAILED",
+            message,
+        ) from exc
 
 
 def _get_configured_provider_creds() -> Optional[Tuple[str, str]]:
@@ -333,14 +446,21 @@ async def _transcribe_whisper_api(file_path: str) -> Optional[str]:
 # ------------------------------------------------------------------
 
 
-async def transcribe_audio(file_path: str) -> Optional[str]:
+async def transcribe_audio(
+    file_path: str,
+    *,
+    raise_errors: bool = False,
+) -> Optional[str]:
     """Transcribe an audio file to text.
 
     Dispatches to either the Whisper API or local Whisper based on the
     ``transcription_provider_type`` config setting.  When the setting is
     ``"disabled"`` (the default), returns ``None`` immediately.
 
-    Returns the transcribed text, or ``None`` on failure.
+    Returns the transcribed text, or ``None`` on failure.  When
+    ``raise_errors`` is true, local Whisper setup/runtime failures are raised
+    as :class:`AudioTranscriptionError` so API callers can surface actionable
+    messages instead of a generic transcription failure.
     """
     from ...config import load_config
 
@@ -350,7 +470,12 @@ async def transcribe_audio(file_path: str) -> Optional[str]:
         logger.debug("Transcription is disabled; skipping")
         return None
     if provider_type == "local_whisper":
-        return await _transcribe_local_whisper(file_path)
+        try:
+            return await _transcribe_local_whisper(file_path)
+        except AudioTranscriptionError:
+            if raise_errors:
+                raise
+            return None
     if provider_type == "whisper_api":
         return await _transcribe_whisper_api(file_path)
 

--- a/src/qwenpaw/agents/utils/audio_transcription.py
+++ b/src/qwenpaw/agents/utils/audio_transcription.py
@@ -11,30 +11,67 @@ Transcription is only attempted when explicitly enabled via the
 
 import asyncio
 import logging
+import os
 import shutil
 import threading
 from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+_LOCAL_WHISPER_MODEL_ENV = "QWENPAW_LOCAL_WHISPER_MODEL"
+_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV = "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT"
+_DEFAULT_LOCAL_WHISPER_MODEL = "base"
+
 # ------------------------------------------------------------------
 # Cached local-whisper model (lazy singleton)
 # ------------------------------------------------------------------
 _local_whisper_model = None
+_local_whisper_model_key: Tuple[str, Optional[str]] | None = None
 _local_whisper_lock = threading.Lock()
+
+
+def _local_whisper_model_settings() -> Tuple[str, Optional[str]]:
+    """Return the configured local Whisper model and optional cache root."""
+    model = (
+        os.environ.get(_LOCAL_WHISPER_MODEL_ENV, "").strip()
+        or _DEFAULT_LOCAL_WHISPER_MODEL
+    )
+    download_root = (
+        os.environ.get(_LOCAL_WHISPER_DOWNLOAD_ROOT_ENV, "").strip() or None
+    )
+    return model, download_root
 
 
 def _get_local_whisper_model():
     """Return a cached whisper model, loading it on first call."""
-    global _local_whisper_model  # noqa: PLW0603
-    if _local_whisper_model is not None:
+    global _local_whisper_model, _local_whisper_model_key  # noqa: PLW0603
+    model_name, download_root = _local_whisper_model_settings()
+    model_key = (model_name, download_root)
+
+    if (
+        _local_whisper_model is not None
+        and _local_whisper_model_key == model_key
+    ):
         return _local_whisper_model
     with _local_whisper_lock:
-        if _local_whisper_model is not None:
+        if (
+            _local_whisper_model is not None
+            and _local_whisper_model_key == model_key
+        ):
             return _local_whisper_model
         import whisper
 
-        _local_whisper_model = whisper.load_model("base")
+        kwargs = {}
+        if download_root:
+            kwargs["download_root"] = download_root
+
+        logger.info(
+            "Loading local Whisper model '%s'%s",
+            model_name,
+            (f" from cache root '{download_root}'" if download_root else ""),
+        )
+        _local_whisper_model = whisper.load_model(model_name, **kwargs)
+        _local_whisper_model_key = model_key
         return _local_whisper_model
 
 
@@ -140,10 +177,14 @@ def check_local_whisper_available() -> dict:
     except ImportError:
         pass
 
+    model_name, download_root = _local_whisper_model_settings()
+
     return {
         "available": ffmpeg_ok and whisper_ok,
         "ffmpeg_installed": ffmpeg_ok,
         "whisper_installed": whisper_ok,
+        "model": model_name,
+        "download_root": download_root,
     }
 
 

--- a/src/qwenpaw/app/routers/workspace.py
+++ b/src/qwenpaw/app/routers/workspace.py
@@ -486,7 +486,10 @@ async def post_transcribe_audio(
     file: UploadFile = File(..., description="Audio file to transcribe"),
 ) -> dict:
     """Transcribe uploaded audio file using configured Whisper provider."""
-    from ...agents.utils.audio_transcription import transcribe_audio
+    from ...agents.utils.audio_transcription import (
+        AudioTranscriptionError,
+        transcribe_audio,
+    )
 
     # Check transcription is enabled
     config = load_config()
@@ -550,7 +553,13 @@ async def post_transcribe_audio(
         tmp_path = tmp.name
 
     try:
-        text = await transcribe_audio(tmp_path)
+        try:
+            text = await transcribe_audio(tmp_path, raise_errors=True)
+        except AudioTranscriptionError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": exc.code, "message": exc.message},
+            ) from exc
         if text is None:
             raise HTTPException(
                 status_code=500,

--- a/tests/unit/agents/utils/test_audio_transcription.py
+++ b/tests/unit/agents/utils/test_audio_transcription.py
@@ -93,9 +93,17 @@ def test_local_whisper_cache_respects_env_changes(monkeypatch):
     ]
 
 
-def test_local_whisper_status_reports_model_settings(monkeypatch):
+def test_local_whisper_status_reports_model_settings(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "whisper-cache"
+    cache_dir.mkdir()
+    model_path = cache_dir / "small.pt"
+    model_path.write_bytes(b"cached model")
+
     monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_MODEL", "small")
-    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT", "/tmp/whisper")
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT",
+        str(cache_dir),
+    )
     monkeypatch.setattr(
         audio_transcription.shutil,
         "which",
@@ -104,13 +112,90 @@ def test_local_whisper_status_reports_model_settings(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "whisper",
-        SimpleNamespace(load_model=lambda *args, **kwargs: object()),
+        SimpleNamespace(
+            _MODELS={"small": "https://example.invalid/models/small.pt"},
+            load_model=lambda *args, **kwargs: object(),
+        ),
     )
 
     assert audio_transcription.check_local_whisper_available() == {
         "available": True,
+        "offline_available": True,
         "ffmpeg_installed": True,
         "whisper_installed": True,
+        "model_available": True,
         "model": "small",
-        "download_root": "/tmp/whisper",
+        "model_path": str(model_path),
+        "download_root": str(cache_dir),
+        "message": "Local Whisper is ready for offline use.",
     }
+
+
+def test_local_whisper_status_reports_missing_cached_model(
+    monkeypatch,
+    tmp_path,
+):
+    cache_dir = tmp_path / "whisper-cache"
+    cache_dir.mkdir()
+
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT",
+        str(cache_dir),
+    )
+    monkeypatch.setattr(
+        audio_transcription.shutil,
+        "which",
+        lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            _MODELS={"base": "https://example.invalid/models/base.pt"},
+            load_model=lambda *args, **kwargs: object(),
+        ),
+    )
+
+    status = audio_transcription.check_local_whisper_available()
+
+    assert status["available"] is True
+    assert status["offline_available"] is False
+    assert status["ffmpeg_installed"] is True
+    assert status["whisper_installed"] is True
+    assert status["model_available"] is False
+    assert status["model"] == "base"
+    assert status["model_path"] == str(cache_dir / "base.pt")
+    assert "Whisper model 'base'" in status["message"]
+
+
+async def test_local_whisper_transcription_raises_when_model_missing(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT",
+        str(tmp_path),
+    )
+    monkeypatch.setattr(
+        audio_transcription.shutil,
+        "which",
+        lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            _MODELS={"base": "https://example.invalid/models/base.pt"},
+            load_model=lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("network unreachable"),
+            ),
+        ),
+    )
+
+    with pytest.raises(audio_transcription.AudioTranscriptionError) as exc:
+        await audio_transcription._transcribe_local_whisper(
+            str(tmp_path / "audio.wav"),
+        )
+
+    assert exc.value.code == "LOCAL_WHISPER_MODEL_UNAVAILABLE"
+    assert "For offline use" in exc.value.message

--- a/tests/unit/agents/utils/test_audio_transcription.py
+++ b/tests/unit/agents/utils/test_audio_transcription.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents.utils import audio_transcription
+
+
+@pytest.fixture(autouse=True)
+def reset_local_whisper_cache(monkeypatch):
+    monkeypatch.setattr(audio_transcription, "_local_whisper_model", None)
+    monkeypatch.setattr(audio_transcription, "_local_whisper_model_key", None)
+    monkeypatch.delenv("QWENPAW_LOCAL_WHISPER_MODEL", raising=False)
+    monkeypatch.delenv("QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT", raising=False)
+
+
+def test_local_whisper_loads_default_model(monkeypatch):
+    calls = []
+    fake_model = object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            load_model=lambda model, **kwargs: calls.append(
+                (model, kwargs),
+            )
+            or fake_model,
+        ),
+    )
+
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert calls == [("base", {})]
+
+
+def test_local_whisper_loads_configured_model_and_cache(monkeypatch):
+    calls = []
+    fake_model = object()
+
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_MODEL",
+        " C:/models/whisper/base.pt ",
+    )
+    monkeypatch.setenv(
+        "QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT",
+        " C:/models/whisper-cache ",
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(
+            load_model=lambda model, **kwargs: calls.append(
+                (model, kwargs),
+            )
+            or fake_model,
+        ),
+    )
+
+    assert audio_transcription._get_local_whisper_model() is fake_model
+    assert calls == [
+        (
+            "C:/models/whisper/base.pt",
+            {"download_root": "C:/models/whisper-cache"},
+        ),
+    ]
+
+
+def test_local_whisper_cache_respects_env_changes(monkeypatch):
+    calls = []
+
+    def fake_load_model(model, **kwargs):
+        loaded = {"model": model, "kwargs": kwargs}
+        calls.append(loaded)
+        return loaded
+
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(load_model=fake_load_model),
+    )
+
+    first = audio_transcription._get_local_whisper_model()
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_MODEL", "small")
+    second = audio_transcription._get_local_whisper_model()
+
+    assert first is not second
+    assert calls == [
+        {"model": "base", "kwargs": {}},
+        {"model": "small", "kwargs": {}},
+    ]
+
+
+def test_local_whisper_status_reports_model_settings(monkeypatch):
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_MODEL", "small")
+    monkeypatch.setenv("QWENPAW_LOCAL_WHISPER_DOWNLOAD_ROOT", "/tmp/whisper")
+    monkeypatch.setattr(
+        audio_transcription.shutil,
+        "which",
+        lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "whisper",
+        SimpleNamespace(load_model=lambda *args, **kwargs: object()),
+    )
+
+    assert audio_transcription.check_local_whisper_available() == {
+        "available": True,
+        "ffmpeg_installed": True,
+        "whisper_installed": True,
+        "model": "small",
+        "download_root": "/tmp/whisper",
+    }


### PR DESCRIPTION
## Summary
- keep Local Whisper model/cache configurable for already-downloaded offline models
- report whether the configured Whisper model is cached via `model_available` / `offline_available`
- surface local Whisper setup and model-cache failures as structured `/workspace/transcribe` errors instead of a generic silent failure
- preserve online first-use behavior: if dependencies are installed but the model is not cached, Whisper can still download; only download/load failures are converted into actionable errors

Fixes #4205

## Maintainer feedback addressed
This updates the previous env-only approach from #4353. The root download-failure path now returns a concrete error when the model is not cached or cannot be loaded, so users are not left with a silent failure and no way to know what to fix.

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/agents/utils/test_audio_transcription.py -q`
- `pre-commit run --files src/qwenpaw/agents/utils/audio_transcription.py src/qwenpaw/app/routers/workspace.py tests/unit/agents/utils/test_audio_transcription.py`
- `git diff --check`