### PR TITLE
fix(deploy): use node lts for mcp runtime

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,10 @@
 # -----------------------------------------------------------------------------
 # Stage 1: build console frontend (dist not committed in repo).
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim AS console-builder
+# Keep Docker on an LTS Node release. Some npx-based MCP servers fail on
+# Node Current releases, for example Node 25.
+ARG NODE_IMAGE=node:22-bookworm-slim
+FROM ${NODE_IMAGE} AS console-builder
 WORKDIR /app
 COPY console /app/console
 RUN cd /app/console && npm ci --include=dev && npm run build
@@ -9,7 +12,7 @@ RUN cd /app/console && npm ci --include=dev && npm run build
 # -----------------------------------------------------------------------------
 # Stage 2: runtime image with Python, Chromium, and app.
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+FROM ${NODE_IMAGE}
 
 # ENV variables
 ENV NODE_ENV=production

--- a/website/public/docs/mcp.en.md
+++ b/website/public/docs/mcp.en.md
@@ -29,11 +29,13 @@ Both types can be used simultaneously without conflict.
 
 For local MCP servers, you need:
 
-- **Node.js** 18+ ([download](https://nodejs.org/))
+- **Node.js** 18+ ([download](https://nodejs.org/)). An active LTS release such as Node.js 22 is recommended for `npx`-based stdio MCP servers.
 
 ```bash
 node --version  # Check version
 ```
+
+> Use an active Node.js LTS release for local MCP servers. Node.js Current/non-LTS releases such as 25.x can break some MCP packages because their dependencies may rely on module resolution behavior that changed outside LTS.
 
 > Remote MCP servers require no local dependencies.
 
@@ -140,6 +142,8 @@ Tavily is an AI-optimized web search service that enables agents to perform real
 ```
 
 > **Built-in Support**: A `tavily_search` client is automatically created at system startup. It auto-enables when the `TAVILY_API_KEY` environment variable is set. You can also directly modify the tavily mcp configuration.
+
+> If Tavily fails to start with `ERR_UNSUPPORTED_DIR_IMPORT` or a `zod/v3` import error, switch the Docker or local runtime to Node.js 22 LTS and restart QwenPaw.
 
 #### Remote MCP Service
 

--- a/website/public/docs/mcp.zh.md
+++ b/website/public/docs/mcp.zh.md
@@ -29,11 +29,13 @@ QwenPaw 为智能体提供两类工具：
 
 使用本地 MCP 服务器需要：
 
-- **Node.js** 18+ （[下载](https://nodejs.org/)）
+- **Node.js** 18+（[下载](https://nodejs.org/)）。基于 `npx` 的 stdio MCP 服务器推荐使用 Node.js 22 等仍在维护的 LTS 版本。
 
 ```bash
 node --version  # 检查版本
 ```
+
+> 本地 MCP 服务器建议使用仍在维护的 Node.js LTS 版本。Node.js Current/非 LTS 版本（例如 25.x）可能因依赖包使用的模块解析行为变化而导致部分 MCP 包无法启动。
 
 > 远程 MCP 服务器无需本地依赖。
 
@@ -140,6 +142,8 @@ Tavily 是一个专为 AI 优化的网络搜索服务，可让智能体进行实
 ```
 
 > **内置支持**：系统启动时会自动创建名为 `tavily_search` 的客户端。如果环境变量中已设置 `TAVILY_API_KEY`，该客户端会自动启用。你也可以直接修改tavily mcp的配置。
+
+> 如果 Tavily 启动时报 `ERR_UNSUPPORTED_DIR_IMPORT` 或 `zod/v3` 导入错误，请将 Docker 或本地运行时切换到 Node.js 22 LTS 后重启 QwenPaw。
 
 #### 远程 MCP 服务
 


### PR DESCRIPTION
## Summary
- default Docker builds to Node.js 22 LTS instead of the floating Node current image
- document the Node LTS recommendation for local stdio MCP servers
- add Tavily troubleshooting guidance for Node 25 / zod import failures

Closes #2906.

## Tests
- pre-commit run --files deploy/Dockerfile website/public/docs/mcp.en.md website/public/docs/mcp.zh.md
- git diff --check

Note: Docker is not available in my local environment, so I could not run a full image build.