### PR TITLE
fix(cli): guard unauthenticated public app bind

### DIFF
--- a/deploy/config/supervisord.conf.template
+++ b/deploy/config/supervisord.conf.template
@@ -18,7 +18,7 @@ autorestart=true
 priority=30
 stderr_logfile=/var/log/app.err.log
 stdout_logfile=/var/log/app.out.log
-environment=DISPLAY=":1",PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/usr/bin/chromium",QWENPAW_RUNNING_IN_CONTAINER="1"
+environment=DISPLAY=":1",PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/usr/bin/chromium",QWENPAW_RUNNING_IN_CONTAINER="1",QWENPAW_AUTH_ENABLED="${QWENPAW_AUTH_ENABLED}",QWENPAW_TRUST_PROXY_AUTH="${QWENPAW_TRUST_PROXY_AUTH}"
 
 [program:xvfb]
 command=/bin/sh -c "rm -f /tmp/.X1-lock /tmp/.X11-unix/X1; mkdir -p /tmp/.X11-unix; exec /usr/bin/Xvfb :1 -screen 0 1280x800x24"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -14,7 +14,9 @@ else
 fi
 
 export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
-envsubst '${QWENPAW_PORT}' \
+export QWENPAW_AUTH_ENABLED="${QWENPAW_AUTH_ENABLED:-true}"
+export QWENPAW_TRUST_PROXY_AUTH="${QWENPAW_TRUST_PROXY_AUTH:-}"
+envsubst '${QWENPAW_PORT} ${QWENPAW_AUTH_ENABLED} ${QWENPAW_TRUST_PROXY_AUTH}' \
   < /etc/supervisor/conf.d/supervisord.conf.template \
   > /etc/supervisor/conf.d/supervisord.conf
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/src/qwenpaw/cli/app_cmd.py
+++ b/src/qwenpaw/cli/app_cmd.py
@@ -1,15 +1,58 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 
 import click
 import uvicorn
 
-from ..constant import LOG_LEVEL_ENV
+from ..constant import LOG_LEVEL_ENV, EnvVarLoader
 from ..config.utils import write_last_api
 from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
+
+_LOOPBACK_HOSTNAMES = {"localhost"}
+_TRUTHY_ENV_VALUES = {"true", "1", "yes"}
+
+
+def _env_truthy(name: str) -> bool:
+    return EnvVarLoader.get_str(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _is_non_loopback_bind(host: str) -> bool:
+    normalized = (host or "").strip().lower().rstrip(".")
+    if normalized in _LOOPBACK_HOSTNAMES:
+        return False
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return not ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        # Hostnames can resolve to public interfaces, so require an explicit
+        # auth/proxy/override path unless it is a known loopback name.
+        return True
+
+
+def _guard_public_bind_without_auth(
+    host: str,
+    allow_unauth_public: bool,
+) -> None:
+    if allow_unauth_public or not _is_non_loopback_bind(host):
+        return
+    if _env_truthy("QWENPAW_AUTH_ENABLED"):
+        return
+    if _env_truthy("QWENPAW_TRUST_PROXY_AUTH"):
+        return
+
+    raise click.ClickException(
+        "Refusing to bind QwenPaw to non-loopback host "
+        f"'{host}' while authentication is disabled. Set "
+        "QWENPAW_AUTH_ENABLED=true, bind to 127.0.0.1 behind your "
+        "reverse proxy/Tailscale, set QWENPAW_TRUST_PROXY_AUTH=1 when "
+        "external auth terminates before QwenPaw, or pass "
+        "--allow-unauth-public to override.",
+    )
 
 
 @click.command("app")
@@ -45,6 +88,11 @@ from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
     help="Path substrings to hide from uvicorn access log (repeatable).",
 )
 @click.option(
+    "--allow-unauth-public",
+    is_flag=True,
+    help="Allow a non-loopback bind while built-in auth is disabled.",
+)
+@click.option(
     "--workers",
     type=int,
     default=None,
@@ -59,6 +107,7 @@ def app_cmd(
     workers: int,  # pylint: disable=unused-argument
     log_level: str,
     hide_access_paths: tuple[str, ...],
+    allow_unauth_public: bool,
 ) -> None:
     """Run QwenPaw FastAPI app."""
     # Handle deprecated --workers parameter
@@ -74,6 +123,8 @@ def app_cmd(
             err=True,
         )
         click.echo(err=True)
+
+    _guard_public_bind_without_auth(host, allow_unauth_public)
 
     # Persist last used host/port for other terminals
     if host == "0.0.0.0":

--- a/tests/unit/cli/test_cli_app_public_bind.py
+++ b/tests/unit/cli/test_cli_app_public_bind.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any
+
+from click.testing import CliRunner
+
+from qwenpaw.cli.app_cmd import app_cmd
+
+
+def _clear_public_auth_env(monkeypatch) -> None:
+    monkeypatch.delenv("QWENPAW_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("QWENPAW_TRUST_PROXY_AUTH", raising=False)
+
+
+def _patch_server_start(monkeypatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_uvicorn_run(*args: Any, **kwargs: Any) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr("qwenpaw.cli.app_cmd.uvicorn.run", fake_uvicorn_run)
+    monkeypatch.setattr(
+        "qwenpaw.cli.app_cmd.write_last_api",
+        lambda *args: None,
+    )
+    return captured
+
+
+def test_app_refuses_public_bind_when_auth_is_disabled(monkeypatch) -> None:
+    _clear_public_auth_env(monkeypatch)
+
+    result = CliRunner().invoke(app_cmd, ["--host", "0.0.0.0"])
+
+    assert result.exit_code != 0
+    assert "Refusing to bind QwenPaw to non-loopback host" in result.output
+    assert "QWENPAW_AUTH_ENABLED=true" in result.output
+    assert "--allow-unauth-public" in result.output
+
+
+def test_app_allows_public_bind_when_auth_is_enabled(monkeypatch) -> None:
+    _clear_public_auth_env(monkeypatch)
+    monkeypatch.setenv("QWENPAW_AUTH_ENABLED", "true")
+    captured = _patch_server_start(monkeypatch)
+
+    result = CliRunner().invoke(app_cmd, ["--host", "0.0.0.0"])
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["host"] == "0.0.0.0"
+
+
+def test_app_allows_public_bind_with_proxy_auth_marker(monkeypatch) -> None:
+    _clear_public_auth_env(monkeypatch)
+    monkeypatch.setenv("QWENPAW_TRUST_PROXY_AUTH", "1")
+    captured = _patch_server_start(monkeypatch)
+
+    result = CliRunner().invoke(app_cmd, ["--host", "192.0.2.10"])
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["host"] == "192.0.2.10"
+
+
+def test_app_allows_public_bind_with_explicit_override(monkeypatch) -> None:
+    _clear_public_auth_env(monkeypatch)
+    captured = _patch_server_start(monkeypatch)
+
+    result = CliRunner().invoke(
+        app_cmd,
+        ["--host", "::", "--allow-unauth-public"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["host"] == "::"
+
+
+def test_app_allows_loopback_bind_without_auth(monkeypatch) -> None:
+    _clear_public_auth_env(monkeypatch)
+    captured = _patch_server_start(monkeypatch)
+
+    result = CliRunner().invoke(app_cmd, ["--host", "localhost"])
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["host"] == "localhost"


### PR DESCRIPTION
## Summary
- refuse `qwenpaw app` startup when binding a non-loopback host while built-in auth is disabled
- allow explicit operator intent via `--allow-unauth-public` or `QWENPAW_TRUST_PROXY_AUTH=1` for externally authenticated deployments
- make Docker supervisor deployments default `QWENPAW_AUTH_ENABLED=true` so the existing `0.0.0.0` bind starts behind the registration/auth flow
- add CLI regression tests for public bind refusal and allowed auth/proxy/override paths

Closes #4037.

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\cli\test_cli_app_public_bind.py -q`
- `pre-commit run --files src/qwenpaw/cli/app_cmd.py deploy/entrypoint.sh deploy/config/supervisord.conf.template tests/unit/cli/test_cli_app_public_bind.py`
- `git diff --check`