### PR TITLE
fix(agent): continue past thinking-only replies

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -798,11 +798,29 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         "需要操作时勿只输出计划或代码块。"
         "</system-hint>"
     )
+    _AUTO_CONTINUE_NO_TEXT_HINT_EN = (
+        "<system-hint>"
+        "Your previous assistant turn contained reasoning/thinking but no "
+        "user-visible text answer. Use the latest tool result and "
+        "conversation to provide a concise visible answer now. Do not stop "
+        "with thinking only."
+        "</system-hint>"
+    )
+    _AUTO_CONTINUE_NO_TEXT_HINT_ZH = (
+        "<system-hint>"
+        "上轮助手只有思考内容，没有用户可见的文字回答。请结合最新工具结果"
+        "和上下文，立即给出简短的可见回答。不要只输出思考内容。"
+        "</system-hint>"
+    )
 
-    def _auto_continue_system_hint(self) -> str:
+    def _auto_continue_system_hint(self, has_visible_text: bool = True) -> str:
         """Pick hint by agent language (zh vs others)."""
         raw_lang = getattr(self._agent_config, "language", None)
         lang = (raw_lang or "").strip().lower()
+        if not has_visible_text:
+            if lang == "zh":
+                return self._AUTO_CONTINUE_NO_TEXT_HINT_ZH
+            return self._AUTO_CONTINUE_NO_TEXT_HINT_EN
         if lang == "zh":
             return self._AUTO_CONTINUE_HINT_ZH
         return self._AUTO_CONTINUE_HINT_EN
@@ -818,20 +836,26 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             return text
         return text[-max_chars:].lstrip()
 
+    @staticmethod
+    def _auto_continue_has_visible_text(msg: Msg) -> bool:
+        return bool((msg.get_text_content() or "").strip())
+
     async def _auto_continue_if_text_only(
         self,
         msg: Msg,
         tool_choice: Literal["auto", "none", "required"] | None,
     ) -> Msg:
-        """Nudge the model when it returns text-only mid-task.
+        """Nudge the model when it returns no-tool output mid-task.
 
         Injects a language-matched hint (with a trailing excerpt of the
         assistant text for self-review) and runs up to
         ``_AUTO_CONTINUE_MAX_EXTRA`` extra ``_reasoning`` passes until a
         tool_use appears or the cap is
-        hit.  Uses the original ``tool_choice`` unchanged (no switching).
-        If an extra pass still returns text-only, keep the prior response to
-        avoid repeated duplicated answers.
+        hit.  Uses the original ``tool_choice`` unchanged (no switching). If
+        the prior response already had visible text and an extra pass still
+        returns text-only, keep the prior response to avoid duplicated
+        answers. If the prior response was thinking-only and an extra pass
+        returns visible text, keep the visible answer.
         """
         from ..plan.hints import should_skip_auto_continue
 
@@ -849,12 +873,13 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         while extra < self._AUTO_CONTINUE_MAX_EXTRA:
             if msg.has_content_blocks("tool_use"):
                 break
+            had_visible_text = self._auto_continue_has_visible_text(msg)
             extra += 1
             tail = self._auto_continue_tail_context(
                 msg,
                 self._AUTO_CONTINUE_TAIL_CHARS,
             )
-            hint_body = self._auto_continue_system_hint()
+            hint_body = self._auto_continue_system_hint(had_visible_text)
             if tail:
                 hint_body += (
                     "\n\n<previous-assistant-tail>\n"
@@ -882,6 +907,15 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
             if next_msg.has_content_blocks("tool_use"):
                 msg = next_msg
                 continue
+            if not had_visible_text and self._auto_continue_has_visible_text(
+                next_msg,
+            ):
+                logger.info(
+                    "Auto-continue extra _reasoning produced visible text; "
+                    "replacing thinking-only response",
+                )
+                msg = next_msg
+                break
             logger.info(
                 "Auto-continue extra _reasoning still text-only; "
                 "keeping prior response",

--- a/tests/unit/agents/test_auto_continue_thinking_only.py
+++ b/tests/unit/agents/test_auto_continue_thinking_only.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import Msg
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.agents.tool_guard_mixin import ToolGuardMixin
+
+
+class _MemoryRecorder:
+    def __init__(self) -> None:
+        self.added: list[tuple[Msg, object]] = []
+
+    async def add(self, msg: Msg, marks=None) -> None:
+        self.added.append((msg, marks))
+
+
+def _make_agent() -> QwenPawAgent:
+    agent = object.__new__(QwenPawAgent)
+    agent._agent_config = SimpleNamespace(
+        language="en",
+        running=SimpleNamespace(auto_continue_on_text_only=True),
+    )
+    agent.memory = _MemoryRecorder()
+    agent.plan_notebook = None
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_auto_continue_replaces_thinking_only_with_visible_text(
+    monkeypatch,
+) -> None:
+    agent = _make_agent()
+    thinking_only = Msg(
+        "assistant",
+        [{"type": "thinking", "thinking": "I should answer now."}],
+        "assistant",
+    )
+    visible_answer = Msg("assistant", "Done.", "assistant")
+
+    async def fake_reasoning(
+        self,
+        tool_choice=None,
+    ):  # pylint: disable=unused-argument
+        return visible_answer
+
+    monkeypatch.setattr(ToolGuardMixin, "_reasoning", fake_reasoning)
+
+    result = await agent._auto_continue_if_text_only(thinking_only, "auto")
+
+    assert result is visible_answer
+    assert "no user-visible text answer" in agent.memory.added[0][0].content
+
+
+@pytest.mark.asyncio
+async def test_auto_continue_keeps_original_visible_text_on_text_retry(
+    monkeypatch,
+) -> None:
+    agent = _make_agent()
+    original_answer = Msg("assistant", "First answer.", "assistant")
+    retry_answer = Msg("assistant", "Second answer.", "assistant")
+
+    async def fake_reasoning(
+        self,
+        tool_choice=None,
+    ):  # pylint: disable=unused-argument
+        return retry_answer
+
+    monkeypatch.setattr(ToolGuardMixin, "_reasoning", fake_reasoning)
+
+    result = await agent._auto_continue_if_text_only(original_answer, "auto")
+
+    assert result is original_answer
+    assert "previous assistant turn had text only" in (
+        agent.memory.added[0][0].content
+    )


### PR DESCRIPTION
## Summary
- add a no-visible-text auto-continue hint for assistant turns that only contain thinking/reasoning blocks
- replace the original thinking-only response when the retry produces visible text
- keep the existing behavior for text-only retries to avoid duplicated answers
- add regression coverage for thinking-only replacement and existing text-only preservation

Closes #4367.

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\test_auto_continue_thinking_only.py -q`
- `pre-commit run --files src/qwenpaw/agents/react_agent.py tests/unit/agents/test_auto_continue_thinking_only.py`
- `git diff --check`