### PR TITLE
fix(providers): convert anthropic file blocks to text

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -302,6 +302,32 @@ def _media_source_key(block: dict) -> str | None:
     return url
 
 
+def _format_file_block_as_text(block: dict) -> dict:
+    """Convert a QwenPaw file block into Anthropic-compatible text."""
+    source = block.get("source", {})
+    file_url = (
+        (source.get("url") if isinstance(source, dict) else "")
+        or block.get("file_url", "")
+        or block.get("url", "")
+        or block.get(
+            "path",
+            "",
+        )
+    )
+    filename = (
+        block.get("filename")
+        or block.get("name")
+        or file_url.rsplit("/", 1)[-1]
+        or "unknown"
+    )
+    readable_path = file_url.removeprefix("file://")
+    if readable_path:
+        text = f"File '{filename}' is available at: {readable_path}"
+    else:
+        text = f"File '{filename}' is available."
+    return {"type": "text", "text": text}
+
+
 def _format_anthropic_output_items(
     output: list,
     seen_media: set[str] | None = None,
@@ -321,21 +347,7 @@ def _format_anthropic_output_items(
             # Anthropic tool_result content only supports 'text' and 'image';
             # convert file blocks to a readable text placeholder so the
             # conversation history stays intact without triggering a 400 error.
-            source = item.get("source", {})
-            file_url = source.get("url", "")
-            filename = (
-                item.get("filename")
-                or file_url.rsplit("/", 1)[-1]
-                or "unknown"
-            )
-            readable_path = file_url.removeprefix("file://")
-            result.append(
-                {
-                    "type": "text",
-                    "text": f"File '{filename}' is available at:"
-                    f" {readable_path}",
-                },
-            )
+            result.append(_format_file_block_as_text(item))
             continue
 
         if item_type not in ("image", "video"):
@@ -394,6 +406,9 @@ def _format_anthropic_messages(  # pylint: disable=too-many-branches
                 content_blocks.append(
                     _format_anthropic_media_block(block),
                 )
+
+            elif typ == "file":
+                content_blocks.append(_format_file_block_as_text(block))
 
             elif typ == "tool_use":
                 content_blocks.append(

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -375,6 +375,100 @@ def test_anthropic_formatter_strips_extra_content(monkeypatch) -> None:
     assert "extra_content" not in normalized[0].content[0]
 
 
+def test_anthropic_formatter_converts_top_level_file_block() -> None:
+    """Anthropic payloads should not contain unsupported file blocks."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    formatted = model_factory._format_anthropic_messages(
+        [
+            Msg(
+                name="user",
+                role="user",
+                content=[
+                    {
+                        "type": "file",
+                        "source": {
+                            "type": "url",
+                            "url": "file:///tmp/report.md",
+                        },
+                        "filename": "report.md",
+                    },
+                ],
+            ),
+        ],
+    )
+
+    assert formatted == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "File 'report.md' is available at: " "/tmp/report.md"
+                    ),
+                },
+            ],
+        },
+    ]
+
+
+def test_anthropic_formatter_converts_tool_result_file_block() -> None:
+    """File outputs from send_file_to_user should stay as text history."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    formatted = model_factory._format_anthropic_messages(
+        [
+            Msg(
+                name="assistant",
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "call_file",
+                        "name": "send_file_to_user",
+                        "input": {"path": "/tmp/report.md"},
+                    },
+                ],
+            ),
+            Msg(
+                name="system",
+                role="system",
+                content=[
+                    ToolResultBlock(
+                        type="tool_result",
+                        id="call_file",
+                        name="send_file_to_user",
+                        output=[
+                            {
+                                "type": "file",
+                                "source": {
+                                    "type": "url",
+                                    "url": "file:///tmp/report.md",
+                                },
+                                "filename": "report.md",
+                            },
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    tool_result_msg = formatted[1]
+    tool_result_content = tool_result_msg["content"][0]
+    assert tool_result_content["type"] == "tool_result"
+    assert tool_result_content["tool_use_id"] == "call_file"
+    assert tool_result_content["content"] == [
+        {
+            "type": "text",
+            "text": "File 'report.md' is available at: /tmp/report.md",
+        },
+    ]
+
+
 def test_gemini_formatter_preserves_extra_content(monkeypatch) -> None:
     """Gemini formatter should keep extra_content on tool_use blocks."""
     if GeminiChatFormatter is None:


### PR DESCRIPTION
## Summary
- convert top-level QwenPaw file content blocks into Anthropic-compatible text blocks instead of dropping them
- reuse the same conversion helper for file blocks nested in tool_result output
- add regression coverage for top-level file blocks and send_file_to_user-style tool_result file output

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\test_model_factory_message_normalization.py -q`
- `pre-commit run --files src/qwenpaw/agents/model_factory.py tests/unit/agents/test_model_factory_message_normalization.py`
- `git diff --check`

Closes #2751