### PR TITLE
fix(memory): default auto backend to local

### DIFF
--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -3,7 +3,6 @@
 import importlib.metadata
 import json
 import logging
-import platform
 import shutil
 import uuid
 from datetime import datetime
@@ -42,9 +41,8 @@ def _detect_memory_manager_backend() -> str:
     """Detect the memory store backend from environment variables.
 
     Resolves ``MEMORY_STORE_BACKEND`` with the following priority:
-    - ``local``: always used on Windows
-    - ``chroma``: used when ``chromadb`` is importable (non-Windows)
-    - falls back to ``local`` when ``chromadb`` is unavailable
+    - any explicit value is used as-is, including ``chroma``
+    - ``auto`` uses the pure-Python ``local`` backend
 
     Returns:
         Backend name string: ``"local"``, ``"chroma"``, or any explicitly
@@ -54,24 +52,7 @@ def _detect_memory_manager_backend() -> str:
     if backend_env != "auto":
         return backend_env
 
-    if platform.system() == "Windows":
-        return "local"
-
-    try:
-        import chromadb  # noqa: F401 pylint: disable=unused-import
-
-        return "chroma"
-    except Exception as e:
-        logger.warning(
-            f"""
-chromadb import failed, falling back to `local` backend.
-This is often caused by an outdated system SQLite (requires >= 3.35).
-Please upgrade your system SQLite to >= 3.35.
-See: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
-| Error: {e}
-            """,
-        )
-        return "local"
+    return "local"
 
 
 @memory_registry.register("remelight")

--- a/tests/unit/agents/memory/test_reme_light_memory_manager.py
+++ b/tests/unit/agents/memory/test_reme_light_memory_manager.py
@@ -30,6 +30,26 @@ for _mod in _MOCK_MODULES:
 _MOD = "qwenpaw.agents.memory.reme_light_memory_manager"
 
 
+class TestDetectMemoryManagerBackend:
+    """Backend auto-detection should avoid unsafe Chroma imports by default."""
+
+    def test_auto_defaults_to_local_backend(self):
+        with patch(f"{_MOD}.EnvVarLoader.get_str", return_value="auto"):
+            from qwenpaw.agents.memory.reme_light_memory_manager import (
+                _detect_memory_manager_backend,
+            )
+
+            assert _detect_memory_manager_backend() == "local"
+
+    def test_explicit_backend_is_preserved(self):
+        with patch(f"{_MOD}.EnvVarLoader.get_str", return_value="chroma"):
+            from qwenpaw.agents.memory.reme_light_memory_manager import (
+                _detect_memory_manager_backend,
+            )
+
+            assert _detect_memory_manager_backend() == "chroma"
+
+
 # ---------------------------------------------------------------------------
 # Helpers to build a minimal agent config mock
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make MEMORY_STORE_BACKEND=auto resolve to the pure-Python local backend by default
- preserve explicit MEMORY_STORE_BACKEND overrides such as chroma
- add regression coverage for auto/default and explicit backend behavior

Fixes #3854

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\memory\test_reme_light_memory_manager.py -q
- pre-commit run --files src/qwenpaw/agents/memory/reme_light_memory_manager.py tests/unit/agents/memory/test_reme_light_memory_manager.py
- git diff --check