### PR TITLE
fix(console): support reverse proxy base path

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -31,6 +31,7 @@ const LoginPage = lazyImportWithRetry("./pages/Login/index");
 import { authApi } from "./api/modules/auth";
 import { languageApi } from "./api/modules/language";
 import { getApiUrl, getApiToken, clearAuthToken } from "./api/config";
+import { getRouterBasename, stripRuntimeBasePath } from "./utils/basePath";
 import "./styles/layout.css";
 import "./styles/form-override.css";
 
@@ -105,15 +106,15 @@ function AuthGuard({ children }: { children: React.ReactNode }) {
   if (status === "auth-required")
     return (
       <Navigate
-        to={`/login?redirect=${encodeURIComponent(window.location.pathname)}`}
+        to={`/login?redirect=${encodeURIComponent(
+          stripRuntimeBasePath(
+            `${window.location.pathname}${window.location.search}`,
+          ),
+        )}`}
         replace
       />
     );
   return <>{children}</>;
-}
-
-function getRouterBasename(pathname: string): string | undefined {
-  return /^\/console(?:\/|$)/.test(pathname) ? "/console" : undefined;
 }
 
 function AppInner() {

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -1,5 +1,6 @@
 import { getApiUrl, clearAuthToken } from "./config";
 import { buildAuthHeaders } from "./authHeaders";
+import { withRuntimeBasePath } from "../utils/basePath";
 
 function getErrorMessageFromBody(
   text: string,
@@ -73,8 +74,8 @@ export async function request<T = unknown>(
   if (!response.ok) {
     if (response.status === 401) {
       clearAuthToken();
-      if (window.location.pathname !== "/login") {
-        window.location.href = "/login";
+      if (!window.location.pathname.endsWith("/login")) {
+        window.location.href = withRuntimeBasePath("/login");
       }
       throw new Error("Not authenticated");
     }

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -21,6 +21,7 @@ import { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CopyOutlined, CheckOutlined, TagOutlined } from "@ant-design/icons";
+import { withBuildBasePath } from "../utils/basePath";
 
 const { Header: AntHeader } = Layout;
 
@@ -154,7 +155,9 @@ export default function Header() {
       <AntHeader className={styles.header}>
         <div className={styles.logoWrapper}>
           <img
-            src={isDark ? "/logo-dark.svg" : "/logo-light.svg"}
+            src={withBuildBasePath(
+              isDark ? "/logo-dark.svg" : "/logo-light.svg",
+            )}
             alt="QwenPaw"
             className={styles.logoImg}
           />

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -46,6 +46,7 @@ import { usePlugins } from "../plugins/PluginContext";
 import styles from "./index.module.less";
 import { useTheme } from "../contexts/ThemeContext";
 import { KEY_TO_PATH, DEFAULT_OPEN_KEYS } from "./constants";
+import { withRuntimeBasePath } from "../utils/basePath";
 
 // ── Layout ────────────────────────────────────────────────────────────────
 
@@ -116,7 +117,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       setAccountModalOpen(false);
       accountForm.resetFields();
       clearAuthToken();
-      window.location.href = "/login";
+      window.location.href = withRuntimeBasePath("/login");
     } catch (err: unknown) {
       const raw = err instanceof Error ? err.message : "";
       let msg = t("account.updateFailed");
@@ -515,7 +516,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
             icon={<SparkExitFullscreenLine size={16} />}
             onClick={() => {
               clearAuthToken();
-              window.location.href = "/login";
+              window.location.href = withRuntimeBasePath("/login");
             }}
             block
             className={`${styles.authBtn} ${

--- a/console/src/pages/Login/index.tsx
+++ b/console/src/pages/Login/index.tsx
@@ -7,6 +7,7 @@ import { LockOutlined, UserOutlined } from "@ant-design/icons";
 import { authApi } from "../../api/modules/auth";
 import { setAuthToken } from "../../api/config";
 import { useTheme } from "../../contexts/ThemeContext";
+import { withBuildBasePath } from "../../utils/basePath";
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -96,7 +97,9 @@ export default function LoginPage() {
       >
         <div style={{ textAlign: "center", marginBottom: 32 }}>
           <img
-            src={isDark ? "/logo-dark.svg" : "/logo-light.svg"}
+            src={withBuildBasePath(
+              isDark ? "/logo-dark.svg" : "/logo-light.svg",
+            )}
             alt="QwenPaw"
             style={{ height: 48, marginBottom: 12 }}
           />

--- a/console/src/utils/basePath.test.ts
+++ b/console/src/utils/basePath.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRouterBasename,
+  normalizeBasePath,
+  stripRuntimeBasePath,
+} from "./basePath";
+
+describe("basePath utilities", () => {
+  it("normalizes Vite base paths", () => {
+    expect(normalizeBasePath("/")).toBe("");
+    expect(normalizeBasePath("copaw/test-001/")).toBe("/copaw/test-001");
+    expect(normalizeBasePath("/copaw/test-001/")).toBe("/copaw/test-001");
+  });
+
+  it("uses configured build base for router basename", () => {
+    expect(getRouterBasename("/copaw/test-001/chat", "/copaw/test-001/")).toBe(
+      "/copaw/test-001",
+    );
+  });
+
+  it("preserves legacy /console alias when no build base is configured", () => {
+    expect(getRouterBasename("/console/chat", "/")).toBe("/console");
+  });
+
+  it("strips runtime base from redirect targets", () => {
+    expect(
+      stripRuntimeBasePath(
+        "/copaw/test-001/chat?session=1",
+        "/copaw/test-001/chat",
+        "/copaw/test-001/",
+      ),
+    ).toBe("/chat?session=1");
+  });
+});

--- a/console/src/utils/basePath.ts
+++ b/console/src/utils/basePath.ts
@@ -1,0 +1,45 @@
+export function normalizeBasePath(base = import.meta.env.BASE_URL): string {
+  const raw = (base || "").trim();
+  if (!raw || raw === "/") return "";
+  return `/${raw.replace(/^\/+|\/+$/g, "")}`;
+}
+
+export function getRuntimeBasePath(
+  pathname = typeof window !== "undefined" ? window.location.pathname : "",
+  buildBase = import.meta.env.BASE_URL,
+): string {
+  const configured = normalizeBasePath(buildBase);
+  if (configured) return configured;
+  return /^\/console(?:\/|$)/.test(pathname) ? "/console" : "";
+}
+
+export function getRouterBasename(
+  pathname: string,
+  buildBase = import.meta.env.BASE_URL,
+): string | undefined {
+  return getRuntimeBasePath(pathname, buildBase) || undefined;
+}
+
+export function stripRuntimeBasePath(
+  path: string,
+  pathname = typeof window !== "undefined" ? window.location.pathname : "",
+  buildBase = import.meta.env.BASE_URL,
+): string {
+  const base = getRuntimeBasePath(pathname, buildBase);
+  if (!base) return path || "/";
+  if (path === base) return "/";
+  if (path.startsWith(`${base}/`)) return path.slice(base.length) || "/";
+  return path || "/";
+}
+
+export function withRuntimeBasePath(path: string): string {
+  const base = getRuntimeBasePath();
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${base}${normalized}`;
+}
+
+export function withBuildBasePath(path: string): string {
+  const base = normalizeBasePath(import.meta.env.BASE_URL);
+  const normalized = path.replace(/^\/+/, "");
+  return base ? `${base}/${normalized}` : `/${normalized}`;
+}

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -14,13 +14,25 @@ const cssStubPlugin = {
   },
 };
 
+function normalizeBasePath(value?: string): string {
+  const raw = (value ?? "").trim();
+  if (!raw || raw === "/") return "/";
+  const normalized = `/${raw.replace(/^\/+|\/+$/g, "")}`;
+  return `${normalized}/`;
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const basePath = normalizeBasePath(
+    env.VITE_BASE_PATH || env.QWENPAW_BASE_PATH || env.COPAW_BASE_PATH,
+  );
   // Empty = same-origin; frontend and backend served together, no hardcoded host.
   // Use a dedicated Vite-prefixed key so unrelated shell BASE_URL values don't leak into the build.
-  const apiBaseUrl = env.VITE_API_BASE_URL ?? "";
+  const apiBaseUrl =
+    env.VITE_API_BASE_URL ?? (basePath === "/" ? "" : basePath.slice(0, -1));
 
   return {
+    base: basePath,
     define: {
       VITE_API_BASE_URL: JSON.stringify(apiBaseUrl),
       TOKEN: JSON.stringify(env.TOKEN || ""),

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -41,6 +41,11 @@ from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
 from .routers.approval import router as approval_router
 from .routers.voice import voice_router
+from .console_base_path import (
+    BasePathMiddleware,
+    CONSOLE_BASE_PATH_ENV,
+    resolve_console_base_path,
+)
 from ..envs import load_envs_into_environ
 from ..providers.provider_manager import ProviderManager
 from ..local_models.manager import LocalModelManager
@@ -556,6 +561,15 @@ if CORS_ORIGINS:
         allow_methods=["*"],
         allow_headers=["*"],
         expose_headers=["Content-Disposition"],
+    )
+
+_CONSOLE_BASE_PATH = resolve_console_base_path()
+if _CONSOLE_BASE_PATH:
+    app.add_middleware(BasePathMiddleware, base_path=_CONSOLE_BASE_PATH)
+    logger.info(
+        "%s=%s; serving app routes under this URL prefix as well.",
+        CONSOLE_BASE_PATH_ENV,
+        _CONSOLE_BASE_PATH,
     )
 
 

--- a/src/qwenpaw/app/console_base_path.py
+++ b/src/qwenpaw/app/console_base_path.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Console base-path helpers for reverse-proxy subpath deployments."""
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+from ..constant import EnvVarLoader
+
+CONSOLE_BASE_PATH_ENV = "QWENPAW_BASE_PATH"
+LEGACY_CONSOLE_BASE_PATH_ENV = "COPAW_BASE_PATH"
+
+
+def normalize_console_base_path(value: str | None) -> str:
+    """Return a normalized URL path prefix without a trailing slash."""
+    raw = (value or "").strip()
+    if not raw or raw == "/":
+        return ""
+
+    if "://" in raw or raw.startswith("//"):
+        raw = urlsplit(raw).path
+
+    raw = "/" + raw.strip("/")
+    if raw == "/":
+        return ""
+
+    segments = raw.split("/")[1:]
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise ValueError(
+            "console base path must not contain empty, '.', or '..' segments",
+        )
+    return raw
+
+
+def resolve_console_base_path() -> str:
+    """Read the configured console URL prefix from environment variables."""
+    value = EnvVarLoader.get_str(CONSOLE_BASE_PATH_ENV)
+    if not value:
+        value = EnvVarLoader.get_str(LEGACY_CONSOLE_BASE_PATH_ENV)
+    return normalize_console_base_path(value)
+
+
+class BasePathMiddleware:
+    """Strip a configured URL prefix before FastAPI route matching."""
+
+    def __init__(self, app, base_path: str):
+        self.app = app
+        self.base_path = normalize_console_base_path(base_path)
+        self._base_path_bytes = self.base_path.encode("ascii")
+
+    async def __call__(self, scope, receive, send):
+        if self.base_path and scope["type"] in {"http", "websocket"}:
+            path = scope.get("path") or ""
+            if path == self.base_path or path.startswith(
+                f"{self.base_path}/",
+            ):
+                scope = dict(scope)
+                stripped = path[len(self.base_path) :] or "/"
+                scope["path"] = stripped
+
+                raw_path = scope.get("raw_path")
+                if raw_path and raw_path.startswith(self._base_path_bytes):
+                    scope["raw_path"] = (
+                        raw_path[len(self._base_path_bytes) :] or b"/"
+                    )
+
+                root_path = (scope.get("root_path") or "").rstrip("/")
+                if not root_path.endswith(self.base_path):
+                    scope["root_path"] = f"{root_path}{self.base_path}"
+
+        await self.app(scope, receive, send)

--- a/tests/unit/app/test_console_base_path.py
+++ b/tests/unit/app/test_console_base_path.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.console_base_path import (
+    BasePathMiddleware,
+    normalize_console_base_path,
+)
+
+
+def test_normalize_console_base_path_accepts_common_forms():
+    assert normalize_console_base_path(None) == ""
+    assert normalize_console_base_path("") == ""
+    assert normalize_console_base_path("/") == ""
+    assert normalize_console_base_path("copaw/test-001/") == "/copaw/test-001"
+    assert (
+        normalize_console_base_path("https://example.com/copaw/test-001/")
+        == "/copaw/test-001"
+    )
+
+
+def test_normalize_console_base_path_rejects_traversal_segments():
+    try:
+        normalize_console_base_path("/copaw/../test")
+    except ValueError as exc:
+        assert "must not contain" in str(exc)
+    else:
+        raise AssertionError("expected invalid base path to raise")
+
+
+def test_base_path_middleware_strips_prefix_for_route_matching():
+    app = FastAPI()
+    app.add_middleware(BasePathMiddleware, base_path="/copaw/test-001")
+
+    @app.get("/api/version")
+    def version(request: Request):
+        return {
+            "path": request.scope["path"],
+            "root_path": request.scope["root_path"],
+        }
+
+    response = TestClient(app).get("/copaw/test-001/api/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "path": "/api/version",
+        "root_path": "/copaw/test-001",
+    }
+
+
+def test_base_path_middleware_requires_path_boundary():
+    app = FastAPI()
+    app.add_middleware(BasePathMiddleware, base_path="/copaw")
+
+    @app.get("/api/version")
+    def version():
+        return {"ok": True}
+
+    response = TestClient(app).get("/copawish/api/version")
+
+    assert response.status_code == 404

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -99,13 +99,14 @@ You can customize paths and behavior via environment variables:
 
 **Other configuration:**
 
-| Variable                             | Default         | Description                                                                 |
-| ------------------------------------ | --------------- | --------------------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)             |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                            |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                          |
-| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size) |
-| `QWENPAW_CONSOLE_STATIC_DIR`         | _(auto-detect)_ | Console frontend static files path                                          |
+| Variable                             | Default         | Description                                                                   |
+| ------------------------------------ | --------------- | ----------------------------------------------------------------------------- |
+| `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)               |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                              |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                            |
+| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)   |
+| `QWENPAW_CONSOLE_STATIC_DIR`         | _(auto-detect)_ | Console frontend static files path                                            |
+| `QWENPAW_BASE_PATH`                  | _(empty)_       | URL path prefix for reverse-proxy deployments (for example `/copaw/test-001`) |
 
 **Security & Authentication:**
 


### PR DESCRIPTION
## Summary
- add QWENPAW_BASE_PATH/COPAW_BASE_PATH support for reverse-proxy URL prefixes
- strip the configured prefix before backend route matching so /<prefix>/api, assets, and SPA fallback resolve consistently
- wire the console Vite base, API base, router basename, logo assets, and login redirects to the configured prefix
- document the new env var and add backend/frontend regression tests

Fixes #1853

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\app\test_console_base_path.py -q
- NODE_OPTIONS=--max-old-space-size=4096 npx vitest run src/utils/basePath.test.ts
- npx tsc -b --noEmit
- npx prettier --check src/utils/basePath.ts src/utils/basePath.test.ts src/App.tsx src/api/request.ts src/layouts/Header.tsx src/layouts/Sidebar.tsx src/pages/Login/index.tsx vite.config.ts
- pre-commit run --files src/qwenpaw/app/_app.py src/qwenpaw/app/console_base_path.py tests/unit/app/test_console_base_path.py website/public/docs/config.en.md console/vite.config.ts console/src/App.tsx console/src/api/request.ts console/src/layouts/Header.tsx console/src/layouts/Sidebar.tsx console/src/pages/Login/index.tsx console/src/utils/basePath.ts console/src/utils/basePath.test.ts
- git diff --check
- QWENPAW_BASE_PATH=/copaw/test-001 npx vite build --mode test