### PR TITLE
fix(cli): fail fast on occupied app port

### DIFF
--- a/src/qwenpaw/cli/app_cmd.py
+++ b/src/qwenpaw/cli/app_cmd.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import errno
 import logging
 import os
+import socket
 
 import click
 import uvicorn
@@ -10,6 +12,42 @@ import uvicorn
 from ..constant import LOG_LEVEL_ENV
 from ..config.utils import write_last_api
 from ..utils.logging import setup_logger, SuppressPathAccessLogFilter
+
+
+def _bind_preflight_error(host: str, port: int) -> OSError | None:
+    """Return address-in-use errors before the app startup side effects."""
+    try:
+        addr_infos = socket.getaddrinfo(
+            host,
+            port,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror:
+        return None
+
+    for family, socktype, proto, _canonname, sockaddr in addr_infos:
+        try:
+            with socket.socket(family, socktype, proto) as sock:
+                sock.bind(sockaddr)
+                sock.listen(1)
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
+                return exc
+    return None
+
+
+def _ensure_bind_available(host: str, port: int) -> None:
+    """Fail early when the configured HTTP bind is already occupied."""
+    bind_error = _bind_preflight_error(host, port)
+    if bind_error is None:
+        return
+
+    suggested_port = 8090 if port == 8088 else port + 1
+    raise click.ClickException(
+        f"Cannot start QwenPaw app because {host}:{port} is already in use. "
+        "Stop the existing service with `qwenpaw shutdown`, or choose another "
+        f"port such as `qwenpaw app --port {suggested_port}`.",
+    )
 
 
 @click.command("app")
@@ -64,8 +102,8 @@ def app_cmd(
     # Handle deprecated --workers parameter
     if workers is not None:
         click.echo(
-            "⚠️  WARNING: --workers option is deprecated and will be removed "
-            "in a future version.",
+            "WARNING: --workers option is deprecated and will be removed in "
+            "a future version.",
             err=True,
         )
         click.echo(
@@ -74,6 +112,8 @@ def app_cmd(
             err=True,
         )
         click.echo(err=True)
+
+    _ensure_bind_available(host, port)
 
     # Persist last used host/port for other terminals
     if host == "0.0.0.0":

--- a/tests/unit/cli/test_cli_app.py
+++ b/tests/unit/cli/test_cli_app.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import errno
+import socket
+
+import pytest
+from click.testing import CliRunner
+
+from qwenpaw.cli import app_cmd as app_cmd_module
+from qwenpaw.cli.main import cli
+
+
+def test_bind_preflight_detects_busy_port() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        bind_error = app_cmd_module._bind_preflight_error(
+            "127.0.0.1",
+            port,
+        )
+
+    assert bind_error is not None
+    assert bind_error.errno == errno.EADDRINUSE
+
+
+def test_app_command_reports_port_conflict_before_start(monkeypatch) -> None:
+    bind_error = OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(
+        app_cmd_module,
+        "_bind_preflight_error",
+        lambda _host, _port: bind_error,
+    )
+    monkeypatch.setattr(
+        app_cmd_module,
+        "write_last_api",
+        lambda _host, _port: pytest.fail("should not persist failed bind"),
+    )
+    monkeypatch.setattr(
+        app_cmd_module.uvicorn,
+        "run",
+        lambda *args, **kwargs: pytest.fail("should not start uvicorn"),
+    )
+
+    result = CliRunner().invoke(cli, ["app", "--port", "8088"])
+
+    assert result.exit_code != 0
+    assert "127.0.0.1:8088 is already in use" in result.output
+    assert "qwenpaw shutdown" in result.output
+    assert "qwenpaw app --port 8090" in result.output
+
+
+def test_app_command_starts_when_port_is_available(monkeypatch) -> None:
+    writes: list[tuple[str, int]] = []
+    runs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        app_cmd_module,
+        "_bind_preflight_error",
+        lambda _host, _port: None,
+    )
+    monkeypatch.setattr(app_cmd_module, "setup_logger", lambda _level: None)
+    monkeypatch.setattr(
+        app_cmd_module,
+        "write_last_api",
+        lambda host, port: writes.append((host, port)),
+    )
+    monkeypatch.setattr(
+        app_cmd_module.uvicorn,
+        "run",
+        lambda *args, **kwargs: runs.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["app", "--host", "0.0.0.0", "--port", "8090"],
+    )
+
+    assert result.exit_code == 0
+    assert writes == [("127.0.0.1", 8090)]
+    assert runs
+    kwargs = runs[0][1]
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 8090


### PR DESCRIPTION
## Description

Closes #2953.

`qwenpaw app` currently lets uvicorn import and start the FastAPI application before surfacing an address-in-use bind failure. That can leave users with the normal application shutdown logs at the end of output, which makes a failed start look like a successful start followed by a shutdown.

This PR adds an early TCP bind preflight for the requested `--host` / `--port`:

- if the port is already occupied, the CLI exits before persisting the last API endpoint or starting uvicorn
- the error tells the user which bind is busy and points to `qwenpaw shutdown` or an alternate `--port`
- invalid/unresolvable host errors are still left to uvicorn so existing behavior is preserved outside the port-conflict case

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] CLI
- [x] Tests

## Testing

```bash
PYTHONPATH=src pytest tests/unit/cli/test_cli_app.py -q
```

```bash
PYTHONPATH=src pre-commit run --files src/qwenpaw/cli/app_cmd.py tests/unit/cli/test_cli_app.py
```

```bash
git diff --check
```