### PR TITLE
fix(onebot): route cron group dispatches

### DIFF
--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -627,6 +627,22 @@ class OneBotChannel(BaseChannel):
             meta.get("sender_id") or getattr(request, "user_id", "") or "",
         )
 
+    def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
+        user_id = str(user_id or "")
+        session_id = str(session_id or "")
+        if user_id.startswith("group:"):
+            return user_id
+
+        parts = session_id.split(":", 2)
+        if len(parts) == 3 and parts[0] == "onebot":
+            session_marker, session_target = parts[1], parts[2]
+            if session_marker == "g" and session_target:
+                return f"group:{session_target}"
+            if session_marker and session_target:
+                return f"group:{session_marker}"
+
+        return user_id
+
     # ------------------------------------------------------------------
     # Sending messages (To NapCat)
     # ------------------------------------------------------------------

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -363,6 +363,48 @@ class TestGetToHandle:
         assert ch.get_to_handle_from_request(req) == "12345"
 
 
+class TestToHandleFromTarget:
+    def test_shared_group_session_routes_to_group(self):
+        ch = _make_channel()
+        assert (
+            ch.to_handle_from_target(
+                user_id="67890",
+                session_id="onebot:g:67890",
+            )
+            == "group:67890"
+        )
+
+    def test_group_member_session_routes_to_group(self):
+        ch = _make_channel(share_session_in_group=False)
+        assert (
+            ch.to_handle_from_target(
+                user_id="12345",
+                session_id="onebot:67890:12345",
+            )
+            == "group:67890"
+        )
+
+    def test_explicit_group_handle_is_preserved(self):
+        ch = _make_channel()
+        assert (
+            ch.to_handle_from_target(
+                user_id="group:67890",
+                session_id="onebot:67890",
+            )
+            == "group:67890"
+        )
+
+    def test_private_session_falls_back_to_user_id(self):
+        ch = _make_channel()
+        assert (
+            ch.to_handle_from_target(
+                user_id="12345",
+                session_id="onebot:12345",
+            )
+            == "12345"
+        )
+
+
 # ===================================================================
 # Send methods
 # ===================================================================


### PR DESCRIPTION
## Summary
- route OneBot cron dispatch targets with group-encoded session ids to `group:<group_id>`
- preserve explicit `group:<group_id>` handles
- add unit coverage for shared group sessions, per-member group sessions, explicit group handles, and private fallback

## Root cause
Cron dispatch only passes `user_id` and `session_id` into `to_handle_from_target()`. OneBot inherited the base implementation, so group cron targets were sent with the numeric group id as a private `user_id`, which NapCat rejects or routes privately.

## Tests
- `PYTHONPATH=src pytest tests/unit/channels/test_onebot_channel.py -q`
- `pre-commit run --files src/qwenpaw/app/channels/onebot/channel.py tests/unit/channels/test_onebot_channel.py`
- `git diff --check`

Closes #3054