### PR TITLE
fix(console): order chats by latest activity

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -112,6 +112,7 @@ vi.mock("../ChatSessionItem", () => ({
   default: ({
     sessionId,
     name,
+    time,
     onClick,
     onEdit,
     onDelete,
@@ -121,6 +122,7 @@ vi.mock("../ChatSessionItem", () => ({
   }: any) => (
     <div data-testid="session-item">
       <span onClick={() => onClick?.(sessionId)}>{name}</span>
+      <span data-testid="session-time">{time}</span>
       <button data-testid="edit-btn" onClick={() => onEdit?.(sessionId, name)}>
         edit
       </button>
@@ -286,5 +288,36 @@ describe("ChatSessionDrawer", () => {
     const items = await screen.findAllByTestId("session-item");
     expect(items[0]).toHaveTextContent("Pinned");
     expect(items[1]).toHaveTextContent("Unpinned");
+  });
+
+  it("sorts and displays sessions by latest activity", async () => {
+    vi.mocked(useChatAnywhereSessionsState).mockReturnValue({
+      sessions: [
+        {
+          id: "s1",
+          name: "Created Later",
+          createdAt: "2026-05-03T10:00:00",
+          updatedAt: "2026-05-03T10:00:00",
+        },
+        {
+          id: "s2",
+          name: "Updated Later",
+          createdAt: "2026-05-01T10:00:00",
+          updatedAt: "2026-05-04T11:22:33",
+        },
+      ] as any,
+      currentSessionId: null,
+      setCurrentSessionId: mockSetCurrentSessionId,
+      setSessions: mockSetSessions,
+    } as any);
+
+    renderWithProviders(<ChatSessionDrawer {...defaultProps} />);
+
+    const items = await screen.findAllByTestId("session-item");
+    expect(items[0]).toHaveTextContent("Updated Later");
+    expect(items[1]).toHaveTextContent("Created Later");
+
+    const times = screen.getAllByTestId("session-time");
+    expect(times[0]).toHaveTextContent("2026-05-04 11:22:33");
   });
 });

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -59,13 +59,14 @@ const SessionRow = React.memo(function SessionRow({
     ? getChannelLabel(channelKey, data.t)
     : undefined;
   const isEditing = data.editingSessionId === session.id;
+  const activityTime = session.updatedAt ?? session.createdAt ?? null;
 
   return (
     <div style={style}>
       <ChatSessionItem
         sessionId={session.id!}
         name={session.name || "New Chat"}
-        time={formatCreatedAt(session.createdAt ?? null)}
+        time={formatCreatedAt(activityTime)}
         channelKey={channelKey || undefined}
         channelLabel={channelLabel}
         chatStatus={session.status}
@@ -94,6 +95,7 @@ interface ExtendedChatSession extends IAgentScopeRuntimeWebUISession {
   userId?: string;
   channel?: string;
   createdAt?: string | null;
+  updatedAt?: string | null;
   meta?: Record<string, unknown>;
   status?: ChatStatus;
   generating?: boolean;
@@ -188,7 +190,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     string | null
   >(null);
 
-  /** Sessions sorted by pinned first, then by createdAt descending */
+  /** Sessions sorted by pinned first, then by latest activity descending */
   const sortedSessions = useMemo(() => {
     return [...sessions].sort((a, b) => {
       const extA = a as ExtendedChatSession;
@@ -197,8 +199,8 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       if (extA.pinned && !extB.pinned) return -1;
       if (!extA.pinned && extB.pinned) return 1;
 
-      const aTime = extA.createdAt;
-      const bTime = extB.createdAt;
+      const aTime = extA.updatedAt ?? extA.createdAt;
+      const bTime = extB.updatedAt ?? extB.createdAt;
       if (!aTime && !bTime) return 0;
       if (!aTime) return 1;
       if (!bTime) return -1;

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -73,6 +73,8 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   status?: ChatStatus;
   /** ISO 8601 creation timestamp from backend. */
   createdAt?: string | null;
+  /** ISO 8601 last activity timestamp from backend. */
+  updatedAt?: string | null;
   /** Whether the backend is still generating a response for this session. */
   generating?: boolean;
   /** Whether the chat is pinned to the top. */
@@ -261,8 +263,16 @@ const chatSpecToSession = (chat: ChatSpec): ExtendedSession =>
     meta: chat.meta || {},
     status: chat.status ?? "idle",
     createdAt: chat.created_at ?? null,
+    updatedAt: chat.updated_at ?? null,
     pinned: chat.pinned ?? false,
   }) as ExtendedSession;
+
+const chatActivityTime = (chat: ChatSpec): number => {
+  const raw = chat.updated_at ?? chat.created_at;
+  if (!raw) return 0;
+  const time = new Date(raw).getTime();
+  return Number.isNaN(time) ? 0 : time;
+};
 
 /** Returns true when id is a pure numeric local timestamp (not a backend UUID). */
 const isLocalTimestamp = (id: string): boolean => /^\d+$/.test(id);
@@ -528,8 +538,8 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   ): IAgentScopeRuntimeWebUISession[] {
     const newList = chats
       .filter((c) => c.id && c.id !== "undefined" && c.id !== "null")
-      .map(chatSpecToSession)
-      .reverse();
+      .sort((a, b) => chatActivityTime(b) - chatActivityTime(a))
+      .map(chatSpecToSession);
 
     // Track which existing sessions have already been matched so that
     // sessions sharing the same sessionId (channel:user_id) don't all


### PR DESCRIPTION
## Summary
- carry backend `updated_at` into chat sessions as `updatedAt`
- sort session lists by latest activity instead of creation order
- display the latest activity timestamp in the chat drawer while keeping pinned sessions first
- add regression coverage for updated-at sorting/display

## Root cause
The chat drawer only used creation timestamps, so older chats with recent messages could appear below newer-but-inactive chats and showed the wrong date.

## Tests
- `npx vitest run src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx`
- `npx prettier --check src/pages/Chat/sessionApi/index.ts src/pages/Chat/components/ChatSessionDrawer/index.tsx src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx`
- `npx tsc -b --noEmit`
- `pre-commit run --files console/src/pages/Chat/sessionApi/index.ts console/src/pages/Chat/components/ChatSessionDrawer/index.tsx console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx`
- `git diff --check`

Closes #2982