### PR TITLE
fix(console): preserve interrupted user messages

### DIFF
--- a/console/src/pages/Chat/sessionApi/index.test.ts
+++ b/console/src/pages/Chat/sessionApi/index.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDeleteChat, mockGetChat, mockListChats } = vi.hoisted(() => ({
+  mockDeleteChat: vi.fn(),
+  mockGetChat: vi.fn(),
+  mockListChats: vi.fn(),
+}));
+
+vi.mock("../../../api", () => ({
+  default: {
+    deleteChat: mockDeleteChat,
+    getChat: mockGetChat,
+    listChats: mockListChats,
+  },
+}));
+
+import { SessionApi } from "./index";
+
+const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
+
+function chatHistory(messages: unknown[] = [], status = "idle") {
+  return {
+    id: "chat-1",
+    session_id: "console:default",
+    user_id: "default",
+    channel: "console",
+    status,
+    messages,
+  };
+}
+
+function chatSpec(id: string, sessionId = "console:default") {
+  return {
+    id,
+    name: "Chat",
+    session_id: sessionId,
+    user_id: "default",
+    channel: "console",
+    meta: {},
+    status: "idle",
+  };
+}
+
+function userMessage(text: string, id = text) {
+  return {
+    id,
+    role: "user",
+    content: [{ type: "text", text }],
+  };
+}
+
+interface RuntimeMessage {
+  role?: string;
+  cards?: Array<{
+    data?: {
+      input?: Array<{
+        content?: Array<{ text?: string }>;
+      }>;
+    };
+  }>;
+}
+
+function userTexts(session: { messages?: RuntimeMessage[] }): string[] {
+  return (session.messages || [])
+    .filter((message) => message.role === "user")
+    .map((message) =>
+      (message.cards?.[0]?.data?.input?.[0]?.content || [])
+        .map((part: { text?: string }) => part.text || "")
+        .join("\n"),
+    );
+}
+
+describe("SessionApi pending user messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockListChats.mockResolvedValue([]);
+  });
+
+  it("keeps interrupted user messages visible when backend history is empty", async () => {
+    const sessionApi = new SessionApi();
+    sessionApi.setLastUserMessage("chat-1", "original request");
+    mockGetChat.mockResolvedValue(chatHistory());
+
+    const session = await sessionApi.getSession("chat-1");
+
+    expect(userTexts(session)).toEqual(["original request"]);
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-1`)).toContain(
+      "original request",
+    );
+  });
+
+  it("clears cached user messages once backend history contains them", async () => {
+    const sessionApi = new SessionApi();
+    sessionApi.setLastUserMessage("chat-1", "persisted request");
+    mockGetChat.mockResolvedValue(
+      chatHistory([userMessage("persisted request")]),
+    );
+
+    const session = await sessionApi.getSession("chat-1");
+
+    expect(userTexts(session)).toEqual(["persisted request"]);
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-1`)).toBeNull();
+  });
+
+  it("preserves earlier interrupted messages when a retry reaches backend first", async () => {
+    const sessionApi = new SessionApi();
+    sessionApi.setLastUserMessage("chat-1", "original request");
+    sessionApi.setLastUserMessage("chat-1", "retry request");
+    mockGetChat.mockResolvedValue(chatHistory([userMessage("retry request")]));
+
+    const session = await sessionApi.getSession("chat-1");
+
+    expect(userTexts(session)).toEqual(["original request", "retry request"]);
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-1`)).toContain(
+      "original request",
+    );
+  });
+
+  it("moves cached messages from temporary ids to resolved backend ids", async () => {
+    const sessionApi = new SessionApi();
+    sessionApi.setLastUserMessage("123456789", "draft request");
+    mockListChats.mockResolvedValue([chatSpec("real-chat-id", "123456789")]);
+    mockGetChat.mockResolvedValue(chatHistory());
+
+    await sessionApi.updateSession({ id: "123456789" });
+    const session = await sessionApi.getSession("123456789");
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}123456789`)).toBeNull();
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}real-chat-id`)).toContain(
+      "draft request",
+    );
+    expect(userTexts(session)).toEqual(["draft request"]);
+  });
+});

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -320,18 +320,79 @@ const resolveRealId = (
 const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
 
 function savePendingUserMessage(sessionId: string, text: string): void {
+  const normalizedText = text.trim();
+  if (!normalizedText) return;
+
   try {
-    sessionStorage.setItem(`${STORAGE_PREFIX}${sessionId}`, text);
+    writePendingUserMessages(sessionId, [
+      ...loadPendingUserMessages(sessionId),
+      normalizedText,
+    ]);
   } catch {
     /* quota exceeded – ignore */
   }
 }
 
-function loadPendingUserMessage(sessionId: string): string {
+function parsePendingUserMessages(value: string | null): string[] {
+  if (!value) return [];
+
   try {
-    return sessionStorage.getItem(`${STORAGE_PREFIX}${sessionId}`) || "";
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (item): item is string =>
+          typeof item === "string" && item.trim().length > 0,
+      );
+    }
   } catch {
-    return "";
+    // Legacy storage used a plain string. Fall through and preserve it.
+  }
+
+  return value.trim() ? [value] : [];
+}
+
+function loadPendingUserMessages(sessionId: string): string[] {
+  try {
+    return parsePendingUserMessages(
+      sessionStorage.getItem(`${STORAGE_PREFIX}${sessionId}`),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writePendingUserMessages(sessionId: string, messages: string[]): void {
+  const normalizedMessages = messages
+    .map((message) => message.trim())
+    .filter(Boolean);
+
+  if (normalizedMessages.length === 0) {
+    clearPendingUserMessage(sessionId);
+    return;
+  }
+
+  sessionStorage.setItem(
+    `${STORAGE_PREFIX}${sessionId}`,
+    JSON.stringify(normalizedMessages),
+  );
+}
+
+function movePendingUserMessages(
+  fromSessionId: string,
+  toSessionId: string,
+): void {
+  if (!fromSessionId || !toSessionId || fromSessionId === toSessionId) return;
+
+  try {
+    const messages = loadPendingUserMessages(fromSessionId);
+    if (messages.length === 0) return;
+    writePendingUserMessages(toSessionId, [
+      ...loadPendingUserMessages(toSessionId),
+      ...messages,
+    ]);
+    clearPendingUserMessage(fromSessionId);
+  } catch {
+    /* ignore */
   }
 }
 
@@ -347,7 +408,7 @@ function clearPendingUserMessage(sessionId: string): void {
 // SessionApi
 // ---------------------------------------------------------------------------
 
-class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
+export class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   private sessionList: IAgentScopeRuntimeWebUISession[] = [];
 
   /**
@@ -440,44 +501,80 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   onSessionCreated: ((sessionId: string) => void) | null = null;
 
   /**
-   * When reconnecting to a running conversation, the backend history may not
-   * include the latest user message (it's only persisted after generation
-   * completes). If generating, look up the cached text from sessionStorage
-   * and patch it into the message list.
-   *
-   * When not generating the conversation is done — clear the cached entry.
+   * Patch user messages that the backend has not persisted yet. This covers
+   * interrupted chats as well as active generations.
    */
-  private patchLastUserMessage(
+  private buildPendingUserCard(text: string): IAgentScopeRuntimeWebUIMessage {
+    return buildUserCard({
+      content: [{ type: "text", text }],
+      role: ROLE_USER,
+    } as Message);
+  }
+
+  private getUserCardText(message: IAgentScopeRuntimeWebUIMessage): string {
+    return extractTextFromContent(
+      message?.cards?.[0]?.data?.input?.[0]?.content,
+    ).trim();
+  }
+
+  private patchPendingUserMessages(
     messages: IAgentScopeRuntimeWebUIMessage[],
-    generating: boolean,
     backendSessionId: string,
   ): void {
-    if (!generating) {
-      clearPendingUserMessage(backendSessionId);
-      return;
+    const pendingTexts = loadPendingUserMessages(backendSessionId);
+    if (pendingTexts.length === 0) return;
+
+    const patchedMessages: IAgentScopeRuntimeWebUIMessage[] = [];
+    let pendingIndex = 0;
+    let insertedMissingPending = false;
+
+    for (const message of messages) {
+      if (message.role !== ROLE_USER) {
+        patchedMessages.push(message);
+        continue;
+      }
+
+      const userText = this.getUserCardText(message);
+      if (!userText) {
+        if (pendingIndex < pendingTexts.length) {
+          patchedMessages.push(
+            this.buildPendingUserCard(pendingTexts[pendingIndex]),
+          );
+          pendingIndex += 1;
+          insertedMissingPending = true;
+        } else {
+          patchedMessages.push(message);
+        }
+        continue;
+      }
+
+      const matchedIndex = pendingTexts.indexOf(userText, pendingIndex);
+      if (matchedIndex >= 0) {
+        while (pendingIndex < matchedIndex) {
+          patchedMessages.push(
+            this.buildPendingUserCard(pendingTexts[pendingIndex]),
+          );
+          pendingIndex += 1;
+          insertedMissingPending = true;
+        }
+        pendingIndex = matchedIndex + 1;
+      }
+
+      patchedMessages.push(message);
     }
 
-    const cachedText = loadPendingUserMessage(backendSessionId);
-    if (!cachedText) return;
+    while (pendingIndex < pendingTexts.length) {
+      patchedMessages.push(
+        this.buildPendingUserCard(pendingTexts[pendingIndex]),
+      );
+      pendingIndex += 1;
+      insertedMissingPending = true;
+    }
 
-    const lastMsg = messages[messages.length - 1];
-    if (lastMsg?.role === ROLE_USER) {
-      const text = extractTextFromContent(
-        lastMsg?.cards?.[0]?.data?.input?.[0]?.content,
-      );
-      if (!text) {
-        lastMsg.cards = buildUserCard({
-          content: [{ type: "text", text: cachedText }],
-          role: ROLE_USER,
-        } as Message).cards;
-      }
-    } else {
-      messages.push(
-        buildUserCard({
-          content: [{ type: "text", text: cachedText }],
-          role: ROLE_USER,
-        } as Message),
-      );
+    messages.splice(0, messages.length, ...patchedMessages);
+
+    if (!insertedMissingPending) {
+      clearPendingUserMessage(backendSessionId);
     }
   }
 
@@ -633,7 +730,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const chatHistory = await api.getChat(backendId);
     const generating = isGenerating(chatHistory);
     const messages = convertMessages(chatHistory.messages || []);
-    this.patchLastUserMessage(messages, generating, backendId);
+    this.patchPendingUserMessages(messages, backendId);
 
     const session: ExtendedSession = {
       id: displayId,
@@ -703,6 +800,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const { list, realId } = resolveRealId(this.sessionList, tempId);
     this.sessionList = list;
     if (realId) {
+      movePendingUserMessages(tempId, realId);
       this.notifyRealIdResolved(tempId);
       this.onSessionIdResolved?.(tempId, realId);
     }


### PR DESCRIPTION
## Summary
- keep pending user messages as an ordered queue instead of a single latest string
- patch cached user bubbles back into chat history even after an interrupted/stopped run becomes idle
- move pending cache from temporary chat ids to resolved backend ids
- add sessionApi regression tests for stopped, persisted, retry, and temp-id resolution flows

## Related Issue
Fixes #3114

## Tests
- cd console && npx vitest run src/pages/Chat/sessionApi/index.test.ts
- cd console && npx tsc -b --noEmit
- cd console && npx eslint src/pages/Chat/sessionApi/index.ts src/pages/Chat/sessionApi/index.test.ts
- cd console && npx prettier --check src/pages/Chat/sessionApi/index.ts src/pages/Chat/sessionApi/index.test.ts
- git diff --check
- pre-commit run --files console/src/pages/Chat/sessionApi/index.ts console/src/pages/Chat/sessionApi/index.test.ts