### PR TITLE
feat(providers): allow custom base URL for Anthropic provider

### DIFF
--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -874,7 +874,6 @@ PROVIDER_ANTHROPIC = AnthropicProvider(
     api_key_prefix="sk-ant-",
     models=ANTHROPIC_MODELS,
     chat_model="AnthropicChatModel",
-    freeze_url=True,
 )
 
 PROVIDER_GEMINI = GeminiProvider(

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -393,6 +393,21 @@ def test_update_provider_for_builtin_persists_to_builtin_path(
     assert persisted_azure.base_url == "https://azure-updated.example/v1"
     assert persisted_azure.api_key == "sk-azure-updated"
 
+    ok = manager.update_provider(
+        "anthropic",
+        {
+            "base_url": "https://anthropic-updated.example",
+            "api_key": "sk-ant-updated",
+        },
+    )
+    assert ok is True
+    persisted_anthropic = manager.load_provider("anthropic", is_builtin=True)
+    assert persisted_anthropic is not None
+    assert isinstance(persisted_anthropic, AnthropicProvider)
+    assert persisted_anthropic.freeze_url is False
+    assert persisted_anthropic.base_url == "https://anthropic-updated.example"
+    assert persisted_anthropic.api_key == "sk-ant-updated"
+
 
 def test_update_provider_for_unknown_returns_false(
     isolated_secret_dir,


### PR DESCRIPTION
## Description

Removes `freeze_url=True` from the built-in Anthropic provider so users can supply their own Anthropic-compatible base URL from the console, instead of being locked to `https://api.anthropic.com`.

`freeze_url` defaults to `False`, and the base-URL-editing path is already wired:
- `Provider.update_config()` only writes a new `base_url` when `not self.freeze_url`.
- `AnthropicProvider._client()` / `get_chat_model_instance()` already read `self.base_url`, so a custom URL flows through with no further changes.
- The console renders an editable input when `freeze_url` is false and there are no `base_url_options`.

This mirrors how the DashScope provider already exposes an editable base URL. Unlike DashScope, no `meta.base_url_options` is added since Anthropic has no fixed regional endpoints — the user gets a free-form input with `https://api.anthropic.com` as the default.

**Related Issue:** N/A

**Security Considerations:** Base URL is user-supplied config, stored via the existing encrypted provider config mechanism; no new handling introduced.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Added an `anthropic` block to `test_update_provider_for_builtin_persists_to_builtin_path` asserting that the built-in Anthropic provider has `freeze_url is False` and that a `base_url` update persists. This sits next to the `openai` (frozen, ignored) and `azure-openai` (unfrozen, accepted) cases.

To test manually: open the console provider settings for Anthropic — the Base URL field is now editable; set a custom URL and verify connection/model checks use it.

## Local Verification Evidence

\`\`\`bash
pre-commit run --files src/qwenpaw/providers/provider_manager.py tests/unit/providers/test_provider_manager.py
# all hooks Passed (mypy, black, flake8, pylint, ...)

pytest tests/unit/providers/
# 101 passed in 2.15s
\`\`\`

## Additional Notes

Note: `pre-commit` was run scoped to the changed files (the only files this PR touches).