### PR TITLE
fix(channels): preserve raw final replies

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -19,6 +19,30 @@ from ...config.context import (
 )
 from ...constant import WORKING_DIR, TRUNCATION_NOTICE_MARKER
 
+_IMAGE_FILE_EXTENSIONS = {
+    ".apng",
+    ".avif",
+    ".bmp",
+    ".gif",
+    ".heic",
+    ".heif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+
+_IMAGE_FILE_SIGNATURES = (
+    b"\x89PNG\r\n\x1a\n",
+    b"\xff\xd8\xff",
+    b"GIF87a",
+    b"GIF89a",
+    b"BM",
+)
+
 
 def _resolve_file_path(file_path: str) -> str:
     """Resolve file path: use absolute path as-is,
@@ -61,6 +85,39 @@ def _get_encoding_for_file(file_path: str) -> str:
     # Default: UTF-8 without BOM (safe for all other files)
     # This includes: .sh, .yaml, .json, .py, .js, .md, etc.
     return "utf-8"
+
+
+def _is_image_file(file_path: str) -> bool:
+    """Return True for common image files that should not be read as text."""
+    path = Path(file_path)
+    if path.suffix.lower() in _IMAGE_FILE_EXTENSIONS:
+        return True
+
+    try:
+        with path.open("rb") as file:
+            header = file.read(16)
+    except OSError:
+        return False
+
+    return any(
+        header.startswith(signature) for signature in _IMAGE_FILE_SIGNATURES
+    ) or (header.startswith(b"RIFF") and header[8:12] == b"WEBP")
+
+
+def _image_read_error(file_path: str) -> ToolResponse:
+    return ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=(
+                    f"Error: {file_path} is an image file. "
+                    "`read_file` only reads text files and will not decode "
+                    "image bytes as text. Use a vision-capable model or an "
+                    "image-processing skill/tool for visual content."
+                ),
+            ),
+        ],
+    )
 
 
 async def read_file(  # pylint: disable=too-many-return-statements
@@ -130,6 +187,9 @@ async def read_file(  # pylint: disable=too-many-return-statements
                 ),
             ],
         )
+
+    if _is_image_file(file_path):
+        return _image_read_error(file_path)
 
     try:
         content = await read_file_safe(file_path)

--- a/src/qwenpaw/app/channels/renderer.py
+++ b/src/qwenpaw/app/channels/renderer.py
@@ -92,6 +92,9 @@ class MessageRenderer:
         content = getattr(message, "content", None) or []
         s = self.style
 
+        if isinstance(content, str):
+            content = [TextContent(text=content)] if content else []
+
         if s.filter_thinking and msg_type == MessageType.REASONING:
             return []
 

--- a/tests/unit/agents/tools/test_file_io.py
+++ b/tests/unit/agents/tools/test_file_io.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Tests for file I/O tools."""
+
+import pytest
+
+from qwenpaw.agents.tools.file_io import read_file
+
+
+def _response_text(response) -> str:
+    return response.content[0].get("text", "")
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_image_extension(tmp_path):
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00")
+
+    response = await read_file(str(image_path))
+
+    text = _response_text(response)
+    assert "is an image file" in text
+    assert "will not decode image bytes as text" in text
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_image_magic_without_extension(tmp_path):
+    image_path = tmp_path / "upload"
+    image_path.write_bytes(b"\xff\xd8\xff\xe0binary image bytes")
+
+    response = await read_file(str(image_path))
+
+    assert "is an image file" in _response_text(response)
+
+
+@pytest.mark.asyncio
+async def test_read_file_still_reads_text_files(tmp_path):
+    text_path = tmp_path / "notes.txt"
+    text_path.write_text("hello\nworld", encoding="utf-8")
+
+    response = await read_file(str(text_path))
+
+    assert _response_text(response) == "hello\nworld"

--- a/tests/unit/channels/test_renderer.py
+++ b/tests/unit/channels/test_renderer.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Tests for channel message rendering."""
+from types import SimpleNamespace
+
+from agentscope_runtime.engine.schemas.agent_schemas import (
+    ContentType,
+    MessageType,
+)
+
+from qwenpaw.app.channels.renderer import MessageRenderer
+
+
+def test_message_to_parts_preserves_raw_string_message_content():
+    """Raw final message text should be sent back to non-console channels."""
+    message = SimpleNamespace(
+        type=MessageType.MESSAGE,
+        content="Final answer for the channel",
+    )
+
+    parts = MessageRenderer().message_to_parts(message)
+
+    assert len(parts) == 1
+    assert parts[0].type == ContentType.TEXT
+    assert parts[0].text == "Final answer for the channel"


### PR DESCRIPTION
## Description

Fixes two symptoms reported for WeChat/non-console replies and accidental image reads:

- normalize raw string `message.content` in the channel renderer so final assistant replies are rendered as text for non-console channels instead of disappearing
- reject common image binaries in `read_file` by extension or magic bytes with clear guidance, instead of trying to decode them as text
- add focused regression coverage for both paths

**Related Issue:** Fixes #3173

**Security Considerations:** Low. This tightens file-read behavior for binary image content and avoids leaking garbled binary data into text processing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Focused renderer/file_io regression tests plus existing WeChat/base channel suites.

## Local Verification Evidence

```bash
pytest tests/unit/channels/test_renderer.py tests/unit/agents/tools/test_file_io.py
# 4 passed

pytest tests/unit/channels/test_wechat.py tests/unit/channels/test_base_core.py
# 146 passed, 1 skipped, 2 existing warnings

pre-commit run --files src/qwenpaw/app/channels/renderer.py src/qwenpaw/agents/tools/file_io.py tests/unit/channels/test_renderer.py tests/unit/agents/tools/test_file_io.py
# passed

git diff --check
# no whitespace errors

git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'
# no output; no merge conflicts detected
```

## Additional Notes

`pre-commit run --all-files` and `scripts/check-channels.sh` were not run locally. The CI channel suite for this PR is currently green and waiting on maintainer approval.