### PR TITLE
fix(chat): recover invalid chats json

### DIFF
--- a/src/qwenpaw/app/runner/repo/json_repo.py
+++ b/src/qwenpaw/app/runner/repo/json_repo.py
@@ -9,10 +9,30 @@ import shutil
 import uuid
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from .base import BaseChatRepository
 from ..models import ChatsFile
 
 logger = logging.getLogger(__name__)
+
+
+def _backup_invalid_chats_file(path: Path) -> Path:
+    backup_path = path.with_suffix(
+        path.suffix + f".{uuid.uuid4().hex[:8]}.invalid.bak",
+    )
+    shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def _write_chats_file(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    # Validate the serialized payload before it can replace the live file.
+    json.loads(text)
+    tmp_path.write_text(text, encoding="utf-8", newline="\n")
+    os.replace(tmp_path, path)
 
 
 class JsonChatRepository(BaseChatRepository):
@@ -50,8 +70,41 @@ class JsonChatRepository(BaseChatRepository):
         if not self._path.exists():
             return ChatsFile(version=1, chats=[])
 
-        data = json.loads(self._path.read_text(encoding="utf-8"))
-        return ChatsFile.model_validate(data)
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            return ChatsFile.model_validate(data)
+        except (
+            json.JSONDecodeError,
+            OSError,
+            UnicodeDecodeError,
+            ValidationError,
+        ) as exc:
+            backup_path = None
+            try:
+                backup_path = _backup_invalid_chats_file(self._path)
+            except OSError:
+                logger.exception(
+                    "Failed to back up invalid chats file: %s",
+                    self._path,
+                )
+
+            empty = ChatsFile(version=1, chats=[])
+            try:
+                _write_chats_file(self._path, empty.model_dump(mode="json"))
+            except OSError:
+                logger.exception(
+                    "Failed to repair invalid chats file: %s",
+                    self._path,
+                )
+
+            logger.error(
+                "Invalid chats file %s; recovered with an empty chat list "
+                "(backup: %s): %s",
+                self._path,
+                backup_path,
+                exc,
+            )
+            return empty
 
     async def save(self, chats_file: ChatsFile) -> None:
         """Save chat specs to JSON file atomically.
@@ -59,20 +112,8 @@ class JsonChatRepository(BaseChatRepository):
         Args:
             chats_file: ChatsFile to persist
         """
-        # Create parent directory if needed
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write to temp file first (atomic write)
-        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
         payload = chats_file.model_dump(mode="json")
-
-        tmp_path.write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-
-        # Atomic replace (shutil.move handles cross-disk on Windows)
-        shutil.move(str(tmp_path), str(self._path))
+        _write_chats_file(self._path, payload)
 
 
 def migrate_legacy_weixin_chats_file(chats_path: Path | str) -> None:

--- a/tests/unit/app/test_chat_repository.py
+++ b/tests/unit/app/test_chat_repository.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Tests for JSON chat repository recovery."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from qwenpaw.app.runner.models import ChatSpec, ChatsFile
+from qwenpaw.app.runner.repo.json_repo import JsonChatRepository
+
+
+@pytest.mark.asyncio
+async def test_load_repairs_invalid_chats_json_with_backup(tmp_path):
+    chats_path = tmp_path / "chats.json"
+    invalid_text = '{"version": 1, "chats": [{"id": "broken"},]}'
+    chats_path.write_text(invalid_text, encoding="utf-8")
+
+    repo = JsonChatRepository(chats_path)
+
+    loaded = await repo.load()
+
+    assert loaded == ChatsFile(version=1, chats=[])
+    assert json.loads(chats_path.read_text(encoding="utf-8")) == {
+        "version": 1,
+        "chats": [],
+    }
+    backups = list(tmp_path.glob("chats.json.*.invalid.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == invalid_text
+
+
+@pytest.mark.asyncio
+async def test_save_writes_valid_chats_json(tmp_path):
+    chats_path = tmp_path / "chats.json"
+    repo = JsonChatRepository(chats_path)
+    chats_file = ChatsFile(
+        version=1,
+        chats=[
+            ChatSpec(
+                id="chat-1",
+                name="Chat",
+                session_id="console:default",
+                user_id="default",
+                channel="console",
+            ),
+        ],
+    )
+
+    await repo.save(chats_file)
+
+    loaded = json.loads(chats_path.read_text(encoding="utf-8"))
+    assert loaded["version"] == 1
+    assert loaded["chats"][0]["id"] == "chat-1"


### PR DESCRIPTION
## Description

Adds recovery for corrupted `chats.json` so chat APIs/channels do not keep failing with 500 after manual or partial-file corruption:

- when `chats.json` is malformed or schema-invalid, back it up as `chats.json.<uuid>.invalid.bak`
- replace the active file with a valid empty `{version: 1, chats: []}` payload
- make saves atomic via `os.replace` and validate serialized JSON before replacing the active file
- add repository tests for recovery and valid-save behavior

**Related Issue:** Fixes #3178

**Security Considerations:** Low. The recovery path preserves the invalid file as a backup and avoids destructive deletion.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Focused repository tests plus related chat API/title/update suites.

## Local Verification Evidence

```bash
pytest tests/unit/app/test_chat_repository.py
# 2 passed

pytest tests/unit/app/test_chat_repository.py tests/unit/app/test_chat_updates.py tests/unit/app/test_title_generator.py
# 39 passed

pre-commit run --files src/qwenpaw/app/runner/repo/json_repo.py tests/unit/app/test_chat_repository.py
# passed

git diff --check
# no whitespace errors

git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'
# no output; no merge conflicts detected
```

## Additional Notes

`pre-commit run --all-files` was not run locally; targeted pre-commit and the relevant Python tests passed. CI for this PR is green and waiting on maintainer approval.