### PR TITLE
fix(app): preserve agent-scoped root session context

### DIFF
--- a/src/qwenpaw/app/routers/agent_scoped.py
+++ b/src/qwenpaw/app/routers/agent_scoped.py
@@ -22,7 +22,10 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         """Extract agentId and root_session_id from path/headers."""
         import logging
-        from ..agent_context import set_current_agent_id
+        from ..agent_context import (
+            set_current_agent_id,
+            set_current_root_session_id,
+        )
 
         logger = logging.getLogger(__name__)
         agent_id = None
@@ -49,10 +52,13 @@ class AgentContextMiddleware(BaseHTTPMiddleware):
         # Extract X-Root-Session-Id header for cross-session approval routing
         root_session_id = request.headers.get("X-Root-Session-Id")
         if root_session_id:
-            # Inject into request.request_context for runner access
-            if not hasattr(request, "request_context"):
-                request.request_context = {}
-            request.request_context["root_session_id"] = root_session_id
+            request_context = getattr(request.state, "request_context", None)
+            if not isinstance(request_context, dict):
+                request_context = {}
+                request.state.request_context = request_context
+            request_context["root_session_id"] = root_session_id
+            request.request_context = request_context
+            set_current_root_session_id(root_session_id)
             logger.debug(
                 "AgentContextMiddleware: root_session_id=%s from "
                 "X-Root-Session-Id header",

--- a/tests/unit/routers/test_agent_scoped.py
+++ b/tests/unit/routers/test_agent_scoped.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,redefined-outer-name
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app import agent_context
+from qwenpaw.app.agent_context import (
+    get_current_agent_id,
+    get_current_root_session_id,
+)
+from qwenpaw.app.routers.agent_scoped import (
+    AgentContextMiddleware,
+    create_agent_scoped_router,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_agent_context():
+    agent_context._current_agent_id.set(None)
+    agent_context._current_root_session_id.set(None)
+    yield
+    agent_context._current_agent_id.set(None)
+    agent_context._current_root_session_id.set(None)
+
+
+def build_test_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AgentContextMiddleware)
+
+    @app.get("/api/agents/{agent_id}/echo")
+    async def echo_agent_context(
+        request: Request,
+        agent_id: str,
+    ) -> dict[str, str | None]:
+        del agent_id
+        request_context = getattr(request.state, "request_context", {})
+        return {
+            "path_agent_id": getattr(request.state, "agent_id", None),
+            "current_agent_id": get_current_agent_id(),
+            "root_session_id": request_context.get("root_session_id"),
+            "current_root_session_id": get_current_root_session_id(),
+        }
+
+    @app.get("/api/header-only")
+    async def echo_header_context() -> dict[str, str]:
+        return {"current_agent_id": get_current_agent_id()}
+
+    return app
+
+
+async def test_middleware_prefers_agent_id_from_api_path() -> None:
+    app = build_test_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/api/agents/path-agent/echo",
+            headers={
+                "X-Agent-Id": "header-agent",
+                "X-Root-Session-Id": "root-session-1",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "path_agent_id": "path-agent",
+        "current_agent_id": "path-agent",
+        "root_session_id": "root-session-1",
+        "current_root_session_id": "root-session-1",
+    }
+
+
+async def test_middleware_uses_agent_id_header_without_agent_path() -> None:
+    app = build_test_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/api/header-only",
+            headers={"X-Agent-Id": "header-agent"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"current_agent_id": "header-agent"}
+
+
+def test_create_agent_scoped_router_mounts_expected_agent_routes() -> None:
+    router = create_agent_scoped_router()
+    paths = {getattr(route, "path", "") for route in router.routes}
+
+    assert "/agents/{agentId}/agent-status" in paths
+    assert "/agents/{agentId}/chats" in paths
+    assert "/agents/{agentId}/workspace/files" in paths
+    assert "/agents/{agentId}/tools" in paths


### PR DESCRIPTION
## Description

Adds agent-scoped router regression coverage and fixes the root-session propagation path found while writing the tests:

- path `/api/agents/{agentId}/...` takes priority over `X-Agent-Id`
- non-agent-scoped routes can still use `X-Agent-Id`
- `X-Root-Session-Id` is persisted through `BaseHTTPMiddleware` via `request.state.request_context`
- root session is also set in the agent context variable for downstream approval routing
- agent-scoped router mounts key agent routes under `/agents/{agentId}`

**Related Issue:** Relates to #4340

**Security Considerations:** Keeps existing agent isolation behavior and only preserves an already accepted request header in request state/context for downstream routing. No auth bypass or new trust source is introduced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Tests

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/routers/test_agent_scoped.py`
- `pytest tests/unit/routers`
- `pre-commit run --files src/qwenpaw/app/routers/agent_scoped.py tests/unit/routers/test_agent_scoped.py`
- `git diff --check`
- Merge-tree conflict scan against `origin/main`

## Local Verification Evidence

```bash
pytest tests/unit/routers/test_agent_scoped.py
# 3 passed

pytest tests/unit/routers
# 24 passed

pre-commit run --files src/qwenpaw/app/routers/agent_scoped.py tests/unit/routers/test_agent_scoped.py
# check python ast, docstring, encoding pragma, private key, trailing whitespace,
# trailing commas, mypy, black, flake8, pylint all passed

git diff --check
# no output
```

## Additional Notes

The first version of the new test showed `root_session_id` was lost because attributes assigned directly to the `Request` object do not survive the `BaseHTTPMiddleware` `call_next` boundary. Storing it on `request.state` keeps it available to downstream handlers.