### PR TITLE
fix: add LLM call timeout and task watchdog to prevent stuck sessions

### DIFF
--- a/src/qwenpaw/app/runner/task_tracker.py
+++ b/src/qwenpaw/app/runner/task_tracker.py
@@ -20,6 +20,12 @@ from typing import Any, AsyncGenerator, Callable, Coroutine, Optional
 
 logger = logging.getLogger(__name__)
 
+# Maximum time (seconds) a task can run before the watchdog force-cancels it.
+# Default: 5 minutes. Set via QWENPAW_LLM_TASK_TIMEOUT env var.
+_TASK_TIMEOUT = float(
+    __import__("os").environ.get("QWENPAW_LLM_TASK_TIMEOUT", "300")
+)
+
 _SENTINEL = None
 
 
@@ -47,6 +53,7 @@ class TaskTracker:
         self._runs: dict[str, _RunState] = {}
         self._global_last_run_at: Optional[datetime] = None
         self._global_last_finish_at: Optional[datetime] = None
+        self._watchdog_task: Optional[asyncio.Task] = None
 
     @property
     def lock(self) -> asyncio.Lock:
@@ -94,6 +101,85 @@ class TaskTracker:
                 if not state.task.done():
                     return True
             return False
+
+    # ------------------------------------------------------------------
+    # Watchdog: auto-cancel tasks that exceed the timeout
+    # ------------------------------------------------------------------
+
+    def start_watchdog(self, interval: float = 30.0) -> None:
+        """Start the background watchdog that cancels stuck tasks.
+
+        Args:
+            interval: How often (seconds) to check for stuck tasks.
+        """
+        if self._watchdog_task is not None:
+            return
+        self._watchdog_task = asyncio.create_task(
+            self._watchdog_loop(interval),
+            name="task_tracker_watchdog",
+        )
+        logger.info(
+            "Task watchdog started (timeout=%.0fs, interval=%.0fs)",
+            _TASK_TIMEOUT,
+            interval,
+        )
+
+    def stop_watchdog(self) -> None:
+        """Stop the background watchdog."""
+        if self._watchdog_task is not None:
+            self._watchdog_task.cancel()
+            self._watchdog_task = None
+            logger.info("Task watchdog stopped")
+
+    async def _watchdog_loop(self, interval: float) -> None:
+        """Background loop: cancel tasks running longer than _TASK_TIMEOUT."""
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                await self._cancel_stuck_tasks()
+        except asyncio.CancelledError:
+            return
+
+    async def _cancel_stuck_tasks(self) -> None:
+        """Find tasks running longer than _TASK_TIMEOUT and cancel them."""
+        now = datetime.now(timezone.utc)
+        to_cancel: list[str] = []
+
+        async with self._lock:
+            for run_key, state in self._runs.items():
+                if state.task.done() or state.start_time is None:
+                    continue
+                elapsed = (now - state.start_time).total_seconds()
+                if elapsed > _TASK_TIMEOUT:
+                    to_cancel.append(run_key)
+
+        for run_key in to_cancel:
+            async with self._lock:
+                state = self._runs.get(run_key)
+                if state is None or state.task.done():
+                    continue
+                elapsed = (now - state.start_time).total_seconds() if state.start_time else 0
+                logger.warning(
+                    "Watchdog: cancelling stuck task %s (running %.0fs > %.0fs limit)",
+                    run_key,
+                    elapsed,
+                    _TASK_TIMEOUT,
+                )
+                # Send error to subscribers so they disconnect cleanly
+                err_sse = (
+                    "data: "
+                    f'{{"error": "Task cancelled by watchdog: '
+                    f"exceeded {int(_TASK_TIMEOUT)}s timeout\"}}\n\n"
+                )
+                state.buffer.append(err_sse)
+                for q in state.queues:
+                    q.put_nowait(err_sse)
+                    q.put_nowait(_SENTINEL)
+                state.task.cancel()
+                finish_time = datetime.now(timezone.utc)
+                state.finish_time = finish_time
+                self._global_last_finish_at = finish_time
+            logger.info("Watchdog: stuck task %s cancelled", run_key)
 
     async def list_active_tasks(self) -> list[str]:
         """List all currently running task keys.

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -380,6 +380,10 @@ class Workspace:
             await self._service_manager.start_all()
 
             self._started = True
+
+            # Start the task watchdog to auto-cancel stuck tasks
+            self._task_tracker.start_watchdog()
+
             logger.info(f"Workspace started successfully: {self.agent_id}")
 
         except Exception as e:
@@ -452,6 +456,9 @@ class Workspace:
 
         # Stop all services via ServiceManager (handles reuse automatically)
         await self._service_manager.stop_all(final=final)
+
+        # Stop the task watchdog
+        self._task_tracker.stop_watchdog()
 
         self._started = False
         logger.info(f"Workspace stopped: {self.agent_id}")

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -266,6 +266,15 @@ LLM_MAX_RETRIES = EnvVarLoader.get_int(
     min_value=0,
 )
 
+# Per-call LLM API timeout (seconds). If a single LLM call does not return
+# within this duration, a TimeoutError is raised and the retry logic kicks
+# in. Set to 0 to disable (not recommended for proxied providers).
+LLM_CALL_TIMEOUT = EnvVarLoader.get_float(
+    "QWENPAW_LLM_CALL_TIMEOUT",
+    60.0,
+    min_value=0.0,
+)
+
 LLM_BACKOFF_BASE = EnvVarLoader.get_float(
     "QWENPAW_LLM_BACKOFF_BASE",
     1.0,

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -40,6 +40,7 @@ from ..constant import (
     LLM_ACQUIRE_TIMEOUT,
     LLM_BACKOFF_BASE,
     LLM_BACKOFF_CAP,
+    LLM_CALL_TIMEOUT,
     LLM_MAX_CONCURRENT,
     LLM_MAX_RETRIES,
     LLM_MAX_QPM,
@@ -144,6 +145,7 @@ def _is_retryable(exc: Exception) -> bool:
         _get_openai_retryable()
         + _get_anthropic_retryable()
         + _get_httpx_retryable()
+        + (asyncio.TimeoutError,)
     )
     if retryable and isinstance(exc, retryable):
         return True
@@ -389,7 +391,13 @@ class RetryChatModel(ChatModelBase):
                     ) from exc
 
                 try:
-                    result = await self._inner(*args, **kwargs)
+                    if LLM_CALL_TIMEOUT > 0:
+                        result = await asyncio.wait_for(
+                            self._inner(*args, **kwargs),
+                            timeout=LLM_CALL_TIMEOUT,
+                        )
+                    else:
+                        result = await self._inner(*args, **kwargs)
                 except Exception as inner_exc:
                     if not (
                         _is_missing_reasoning_content_error(inner_exc)
@@ -402,7 +410,13 @@ class RetryChatModel(ChatModelBase):
                         "on every assistant message. Injecting empty "
                         "values and retrying (learned for future calls).",
                     )
-                    result = await self._inner(*args, **kwargs)
+                    if LLM_CALL_TIMEOUT > 0:
+                        result = await asyncio.wait_for(
+                            self._inner(*args, **kwargs),
+                            timeout=LLM_CALL_TIMEOUT,
+                        )
+                    else:
+                        result = await self._inner(*args, **kwargs)
 
                 if isinstance(result, AsyncGenerator):
                     # Transfer semaphore ownership to _wrap_stream, which uses


### PR DESCRIPTION
## Problem

Sessions get permanently stuck in `running` state when LLM providers (especially proxied/multi-key setups) fail to respond. The root cause is:

1. **No per-call LLM timeout**: `RetryChatModel.__call__` awaits `self._inner()` with no timeout — if the provider hangs, the agent waits forever
2. **No task-level watchdog**: Even with per-call timeouts, tasks can get stuck for other reasons (tool calls, MCP issues, etc.) with no automatic cleanup

## Changes

### 1. LLM Call Timeout (`QWENPAW_LLM_CALL_TIMEOUT`)
- Default: **60 seconds** per individual LLM API call
- Wraps `self._inner()` calls in `asyncio.wait_for(timeout=...)`
- `asyncio.TimeoutError` added to retryable exceptions → triggers existing retry + backoff logic
- Configurable via `QWENPAW_LLM_CALL_TIMEOUT` env var (set to 0 to disable)

### 2. Task Watchdog (`QWENPAW_LLM_TASK_TIMEOUT`)
- Default: **300 seconds** (5 minutes) total task lifetime
- Background loop checks every 30s for tasks exceeding the timeout
- Auto-cancels stuck tasks and sends error to subscribers for clean disconnect
- Starts/stops automatically with workspace lifecycle
- Configurable via `QWENPAW_LLM_TASK_TIMEOUT` env var

## Files Changed

- `src/qwenpaw/constant.py` — Add `LLM_CALL_TIMEOUT` env var
- `src/qwenpaw/providers/retry_chat_model.py` — Wrap LLM calls with timeout, add `asyncio.TimeoutError` to retryable list
- `src/qwenpaw/app/runner/task_tracker.py` — Add watchdog with `start_watchdog()`/`stop_watchdog()`/`_cancel_stuck_tasks()`
- `src/qwenpaw/app/workspace/workspace.py` — Start/stop watchdog with workspace lifecycle

## Testing

With these changes, a stuck LLM call will:
1. Timeout after 60s → retry up to 3 times with exponential backoff
2. If all retries fail → error propagated, session released
3. If somehow still stuck → watchdog cancels after 5min total