### PR TITLE
feat(console): add pin/unpin functionality for chat session drawer with …

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1802,6 +1802,8 @@
     "chatHistoryTooltip": "Chat history",
     "allChats": "All Chats",
     "createNewChat": "Create New Chat",
+    "pinDrawer": "Pin",
+    "unpinDrawer": "Unpin",
     "statusIdle": "Idle",
     "statusInProgress": "In progress",
     "disclaimer": "Works for you, grows with you",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -112,6 +112,8 @@
     "chatHistoryTooltip": "Riwayat chat",
     "allChats": "Semua Chat",
     "createNewChat": "Buat Chat Baru",
+    "pinDrawer": "Sematkan",
+    "unpinDrawer": "Lepas sematan",
     "statusIdle": "Idle",
     "statusInProgress": "Sedang berjalan",
     "disclaimer": "Bekerja untuk Anda, berkembang bersama Anda",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1492,6 +1492,8 @@
     "chatHistoryTooltip": "チャット履歴",
     "allChats": "すべてのチャット",
     "createNewChat": "新しいチャットを作成",
+    "pinDrawer": "固定",
+    "unpinDrawer": "固定解除",
     "statusIdle": "待機",
     "statusInProgress": "処理中",
     "disclaimer": "あなたのために働き、あなたと共に成長します",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1680,6 +1680,8 @@
     "chatHistoryTooltip": "Chat history",
     "allChats": "Todos Chats",
     "createNewChat": "Criar Novo Chat",
+    "pinDrawer": "Fixar",
+    "unpinDrawer": "Desafixar",
     "statusIdle": "Idle",
     "statusInProgress": "In progress",
     "disclaimer": "Works for you, grows with you",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1507,6 +1507,8 @@
     "chatHistoryTooltip": "История чатов",
     "allChats": "Все чаты",
     "createNewChat": "Создать новый чат",
+    "pinDrawer": "Закрепить",
+    "unpinDrawer": "Открепить",
     "statusIdle": "Ожидание",
     "statusInProgress": "Выполняется",
     "disclaimer": "Работает для вас, растёт вместе с вами",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1665,6 +1665,8 @@
     "chatHistoryTooltip": "聊天历史",
     "allChats": "全部聊天",
     "createNewChat": "创建新聊天",
+    "pinDrawer": "固定",
+    "unpinDrawer": "取消固定",
     "statusIdle": "空闲",
     "statusInProgress": "进行中",
     "disclaimer": "懂你所需，伴你左右",

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -37,6 +37,7 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
 }) => {
   const { t } = useTranslation();
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyPinned, setHistoryPinned] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [planOpen, setPlanOpen] = useState(false);
   const { createSession } = useChatAnywhereSessions();
@@ -76,6 +77,8 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
       <ChatSessionDrawer
         open={historyOpen}
         onClose={() => setHistoryOpen(false)}
+        pinned={historyPinned}
+        onPinChange={setHistoryPinned}
       />
       <ChatSearchPanel open={searchOpen} onClose={() => setSearchOpen(false)} />
       {planEnabled && (

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -45,6 +45,10 @@
   gap: 12px;
 }
 
+.pinActive {
+  color: var(--color-primary, #ff9d4d);
+}
+
 /* Create new chat button area */
 .createSection {
   flex-shrink: 0;

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -5,10 +5,14 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Drawer, Spin } from "antd";
+import { Drawer, Spin, Tooltip } from "antd";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { IconButton } from "@agentscope-ai/design";
-import { SparkOperateRightLine } from "@agentscope-ai/icons";
+import {
+  SparkOperateRightLine,
+  SparkLockLine,
+  SparkLockFill,
+} from "@agentscope-ai/icons";
 import {
   useChatAnywhereSessionsState,
   useChatAnywhereSessions,
@@ -105,6 +109,10 @@ interface ChatSessionDrawerProps {
   open: boolean;
   /** Callback to close the drawer */
   onClose: () => void;
+  /** Whether the drawer is pinned (stays open) */
+  pinned?: boolean;
+  /** Callback to toggle the pinned state */
+  onPinChange?: (pinned: boolean) => void;
 }
 
 /** Format an ISO 8601 timestamp to YYYY-MM-DD HH:mm:ss */
@@ -212,7 +220,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     setSessions(list);
   }, [setSessions]);
 
-  /** Open drawer → refresh session list */
+  /** Open drawer → refresh session list and start polling */
   useEffect(() => {
     if (!props.open) return;
 
@@ -236,8 +244,20 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
 
     void fetchSessions();
 
+    const timer = setInterval(async () => {
+      try {
+        const list = await sessionApi.getSessionList();
+        if (!isCancelled) {
+          setSessions(list);
+        }
+      } catch {
+        // ignore polling errors
+      }
+    }, 3000);
+
     return () => {
       isCancelled = true;
+      clearInterval(timer);
     };
   }, [props.open, setSessions]);
 
@@ -423,12 +443,13 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   return (
     <Drawer
       open={props.open}
-      onClose={props.onClose}
-      destroyOnClose
+      onClose={props.pinned ? undefined : props.onClose}
+      destroyOnClose={!props.pinned}
       placement="right"
       width={360}
       closable={false}
       title={null}
+      mask={!props.pinned}
       styles={{
         header: { display: "none" },
         body: {
@@ -448,11 +469,28 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           <span className={styles.headerTitle}>{t("chat.allChats")}</span>
         </div>
         <div className={styles.headerRight}>
-          <IconButton
-            bordered={false}
-            icon={<SparkOperateRightLine />}
-            onClick={props.onClose}
-          />
+          <Tooltip
+            title={
+              props.pinned
+                ? t("chat.unpinDrawer", "Unpin")
+                : t("chat.pinDrawer", "Pin")
+            }
+            mouseEnterDelay={0.5}
+          >
+            <IconButton
+              bordered={false}
+              icon={props.pinned ? <SparkLockFill /> : <SparkLockLine />}
+              className={props.pinned ? styles.pinActive : undefined}
+              onClick={() => props.onPinChange?.(!props.pinned)}
+            />
+          </Tooltip>
+          {!props.pinned && (
+            <IconButton
+              bordered={false}
+              icon={<SparkOperateRightLine />}
+              onClick={props.onClose}
+            />
+          )}
         </div>
       </div>
 

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -143,11 +143,13 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
 
   const { createSession } = useChatAnywhereSessions();
 
-  /** Create a new session and close the drawer */
+  /** Create a new session; close the drawer only when not pinned */
   const handleCreateSession = useCallback(async () => {
     await createSession();
-    props.onClose();
-  }, [createSession, props.onClose]);
+    if (!props.pinned) {
+      props.onClose();
+    }
+  }, [createSession, props.onClose, props.pinned]);
 
   /** ID of the session currently being renamed */
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);

--- a/console/src/test/icons-mock.ts
+++ b/console/src/test/icons-mock.ts
@@ -24,6 +24,8 @@ export const SparkMarkLine = makeIcon("SparkMarkLine");
 export const SparkMarkFill = makeIcon("SparkMarkFill");
 export const SparkSearchLine = makeIcon("SparkSearchLine");
 export const SparkPlusLine = makeIcon("SparkPlusLine");
+export const SparkLockLine = makeIcon("SparkLockLine");
+export const SparkLockFill = makeIcon("SparkLockFill");
 // Language switcher icons
 export const SparkChinese02Line = makeIcon("SparkChinese02Line");
 export const SparkEnglish02Line = makeIcon("SparkEnglish02Line");


### PR DESCRIPTION
…localization updates

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
