### PR TITLE
chore(deps): upgrade agentscope to 1.0.20 and remove MCP JSON schema monkey-patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "QwenPaw is a **personal assistant** that runs in your own environ
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "agentscope==1.0.19.post1",
+    "agentscope==1.0.20",
     "agentscope-runtime==1.1.4",
     "httpx>=0.27.0",
     "packaging>=24.0",

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -20,7 +20,7 @@ import asyncio
 import logging
 from contextlib import AsyncExitStack
 from datetime import timedelta
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal
 
 import httpx
 from mcp import ClientSession
@@ -29,50 +29,6 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 
 from agentscope.mcp import StatefulClientBase
-
-# ---------------------------------------------------------------------------
-# Monkey-patch: replace agentscope's _extract_json_schema_from_mcp_tool with
-# a version that forwards the full inputSchema (including "$defs", "anyOf",
-# nested objects, etc.) instead of only copying "properties" and "required".
-# The patch must target the importing module (_mcp_function) rather than the
-# defining module (_utils._common) because Python's `from … import` creates
-# a local binding in the importer's namespace.
-# ---------------------------------------------------------------------------
-import agentscope.mcp._mcp_function as _mcp_fn_mod
-
-if TYPE_CHECKING:
-    from mcp.types import Tool as _Tool
-
-
-# TODO: delete this once after a new version of agentscope is released
-def _extract_json_schema_from_mcp_tool(tool: _Tool) -> dict[str, Any]:
-    """Extract JSON schema from MCP tool.
-
-    Preserves the full inputSchema structure (including ``$defs``, ``anyOf``,
-    nested objects, etc.) rather than flattening it to only ``properties`` and
-    ``required``.  Falls back to an empty-object schema when inputSchema is
-    absent.
-    """
-    parameters = dict(tool.inputSchema) if tool.inputSchema else {}
-    parameters.setdefault("type", "object")
-    parameters.setdefault("properties", {})
-    parameters.setdefault("required", [])
-
-    return {
-        "type": "function",
-        "function": {
-            "name": tool.name,
-            "description": tool.description or "",
-            "parameters": parameters,
-        },
-    }
-
-
-# pylint: disable=protected-access
-_mcp_fn_mod._extract_json_schema_from_mcp_tool = (
-    _extract_json_schema_from_mcp_tool
-)
-# ---------------------------------------------------------------------------
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

Bump agentscope from `1.0.19.post1` to `1.0.20`, which natively supports full MCP inputSchema forwarding (including `$defs`, `anyOf`, nested objects). Remove the now-unnecessary monkey-patch of `_extract_json_schema_from_mcp_tool` in `stateful_client.py`.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
