### PR TITLE
ci: add spam gate to auto-close issues/PRs when open count exceeds 10

### DIFF
--- a/.github/workflows/channel-tests.yml
+++ b/.github/workflows/channel-tests.yml
@@ -24,11 +24,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  spam-gate:
+    name: PR Spam Gate
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-spam-gate.yml
+    with:
+      author: ${{ github.event.pull_request.user.login }}
+
   # ===========================================================================
   # Phase 1: Detect Changed Files and Determine Test Scope
   ############################################################################
   detect-changes:
     name: Detect Changes
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     outputs:
       base_changed: ${{ steps.check-base.outputs.changed }}

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -13,8 +13,19 @@ on:
       - '.github/workflows/frontend-tests.yml'
 
 jobs:
+  spam-gate:
+    name: PR Spam Gate
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-spam-gate.yml
+    with:
+      author: ${{ github.event.pull_request.user.login }}
+
   vitest:
     name: Vitest Unit Tests
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -30,6 +30,128 @@ jobs:
             const issueTitle = context.payload.issue.title;
             const issueBody = context.payload.issue.body || '';
 
+            // ---------------------------------------------------------------
+            // Spam gate: close if author has >10 open issues in this repo.
+            // Bypassed for repo maintainers and admins.
+            // per_page=1 is sufficient — we only need total_count.
+            // ---------------------------------------------------------------
+            try {
+              // Bypass for repo maintainers / admins.
+              try {
+                const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+                if (['admin', 'maintain'].includes(perm.permission)) {
+                  console.log(`@${author} is a repo ${perm.permission} — bypassing spam gate`);
+                  // Fall through to normal welcome flow.
+                  throw new Error('__bypass__');
+                }
+              } catch (permErr) {
+                if (permErr.message === '__bypass__') throw permErr;
+                // 404 = not a collaborator, proceed with spam check.
+                if (permErr.status !== 404) {
+                  console.log(`Permission check warning: ${permErr.message} — proceeding with spam check`);
+                }
+              }
+
+              const { data: openResult } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} type:issue is:open author:${author}`,
+                per_page: 1,
+              });
+              const openCount = openResult.total_count;
+              console.log(`@${author} has ${openCount} open issue(s) in this repo`);
+
+              if (openCount > 10) {
+                // Ensure the label exists (create it if missing)
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: 'Close-and-review-later',
+                    color: 'e4e669',
+                    description: 'Closed automatically for later review',
+                  });
+                } catch (labelErr) {
+                  // 422 = label already exists, that's fine
+                  if (labelErr.status !== 422) console.log(`Label creation warning: ${labelErr.message}`);
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['Close-and-review-later'],
+                });
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                });
+
+                const warningComment = [
+                  `<div align="center">`,
+                  ``,
+                  `<img src="https://img.alicdn.com/imgextra/i2/O1CN01eSmIfy1hJImze8NN8_!!6000000004256-2-tps-1858-1858.png" width="80" height="80" />`,
+                  ``,
+                  `</div>`,
+                  ``,
+                  `Hi @${author},`,
+                  ``,
+                  `This issue has been **automatically closed** because you currently have more than **10 open issues** in this repository.`,
+                  ``,
+                  `> **Why this happened**`,
+                  `> Our [contribution policy](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333) asks contributors to maintain a manageable number of active issues to ensure fair use of maintainer resources. A high volume of simultaneous open issues — especially those that are AI-generated and submitted without personal verification — places a significant burden on maintainers.`,
+                  ``,
+                  `**What you can do:**`,
+                  `1. Review your open issues and close any that are no longer relevant, duplicated, or have not been personally verified.`,
+                  `2. Once you have fewer than 10 open issues, you are welcome to reopen this issue or file a new one.`,
+                  `3. Please ensure every issue you file has been **personally reproduced** and includes all required information per our issue templates.`,
+                  ``,
+                  `This issue has been labeled \`Close-and-review-later\` and may be revisited by a maintainer.`,
+                  ``,
+                  `Thank you for your understanding. 🐾`,
+                  ``,
+                  `---`,
+                  ``,
+                  `你好 @${author}，`,
+                  ``,
+                  `由于你目前在本仓库有超过 **10 个处于 open 状态的 issue**，此 issue 已被**自动关闭**。`,
+                  ``,
+                  `> **原因说明**`,
+                  `> 根据我们的[贡献规范](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333)，为保障维护者资源的合理使用，我们要求贡献者控制活跃 issue 的数量。大量未经人工验证的 open issue（尤其是 AI 生成内容）会给维护者带来沉重负担。`,
+                  ``,
+                  `**你可以采取以下措施：**`,
+                  `1. 检查并关闭不再相关、重复或未经本人验证的 open issue。`,
+                  `2. 当你的 open issue 数量少于 10 个时，欢迎重新开启此 issue 或提交新的 issue。`,
+                  `3. 请确保每个 issue 均经过**本人亲自复现**，并按照 issue 模板填写所有必填信息。`,
+                  ``,
+                  `此 issue 已被标记为 \`Close-and-review-later\`，维护者可能会在后续进行审核。`,
+                  ``,
+                  `感谢你的理解与配合。🐾`,
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: warningComment,
+                });
+
+                console.log(`Closed issue #${issueNumber} for @${author} — open issue limit exceeded (${openCount} open)`);
+                return;
+              }
+            } catch (spamErr) {
+              if (spamErr.message !== '__bypass__') {
+                // Fail open: if the check itself errors, don't block legitimate contributors.
+                console.log(`Spam gate check failed: ${spamErr.message} — continuing with normal welcome`);
+              }
+            }
+            // ---------------------------------------------------------------
+
             // Check if Chinese characters exist in title
             const hasChinese = /[\u4e00-\u9fff]/.test(issueTitle);
 

--- a/.github/workflows/npm-format.yml
+++ b/.github/workflows/npm-format.yml
@@ -3,8 +3,19 @@ name: NPM Format (website & console)
 on: [push, pull_request]
 
 jobs:
+  spam-gate:
+    name: PR Spam Gate
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-spam-gate.yml
+    with:
+      author: ${{ github.event.pull_request.user.login }}
+
   website:
     name: website format check
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,6 +43,10 @@ jobs:
 
   console:
     name: console format check
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/pr-spam-gate.yml
+++ b/.github/workflows/pr-spam-gate.yml
@@ -1,0 +1,65 @@
+name: PR Spam Gate
+
+# Reusable workflow: checks if a PR author has more than 10 open PRs in this repo.
+# Uses the Search API with per_page=1 to read total_count directly — no pagination needed.
+# Called by other workflows to skip expensive jobs when a PR is auto-closed for spam.
+
+on:
+  workflow_call:
+    inputs:
+      author:
+        description: "GitHub login of the PR author"
+        required: true
+        type: string
+    outputs:
+      blocked:
+        description: "'true' if the author has >10 open PRs and should be blocked, 'false' otherwise"
+        value: ${{ jobs.gate.outputs.blocked }}
+
+jobs:
+  gate:
+    name: Check Open PR Count
+    runs-on: ubuntu-latest
+    outputs:
+      blocked: ${{ steps.check.outputs.blocked }}
+    steps:
+      - name: Count author's open PRs in this repo
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = '${{ inputs.author }}';
+
+            // Bypass for repo maintainers and admins.
+            try {
+              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              if (['admin', 'maintain'].includes(perm.permission)) {
+                console.log(`@${author} is a repo ${perm.permission} — bypassing spam gate`);
+                core.setOutput('blocked', 'false');
+                return;
+              }
+            } catch (permErr) {
+              // 404 = not a collaborator, proceed with the check.
+              if (permErr.status !== 404) {
+                console.log(`Permission check warning: ${permErr.message} — proceeding with spam check`);
+              }
+            }
+
+            try {
+              // per_page=1 is enough — we only need total_count, not the actual items.
+              const { data } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} type:pr is:open author:${author}`,
+                per_page: 1,
+              });
+              const count = data.total_count;
+              console.log(`@${author} has ${count} open PR(s) in this repo`);
+              core.setOutput('blocked', count > 10 ? 'true' : 'false');
+            } catch (err) {
+              // On API error (e.g. rate-limit), fail open — don't block legitimate contributors.
+              console.log(`Gate check failed for @${author}: ${err.message} — allowing through`);
+              core.setOutput('blocked', 'false');
+            }

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   welcome:
@@ -20,6 +21,127 @@ jobs:
             const prNumber = context.payload.pull_request.number;
             const prTitle = context.payload.pull_request.title;
             const prBody = context.payload.pull_request.body || '';
+
+            // ---------------------------------------------------------------
+            // Spam gate: close if author has >10 open PRs in this repo.
+            // Bypassed for repo maintainers and admins.
+            // per_page=1 is sufficient — we only need total_count.
+            // ---------------------------------------------------------------
+            try {
+              // Bypass for repo maintainers / admins.
+              try {
+                const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+                if (['admin', 'maintain'].includes(perm.permission)) {
+                  console.log(`@${author} is a repo ${perm.permission} — bypassing spam gate`);
+                  throw new Error('__bypass__');
+                }
+              } catch (permErr) {
+                if (permErr.message === '__bypass__') throw permErr;
+                // 404 = not a collaborator, proceed with spam check.
+                if (permErr.status !== 404) {
+                  console.log(`Permission check warning: ${permErr.message} — proceeding with spam check`);
+                }
+              }
+
+              const { data: openResult } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} type:pr is:open author:${author}`,
+                per_page: 1,
+              });
+              const openCount = openResult.total_count;
+              console.log(`@${author} has ${openCount} open PR(s) in this repo`);
+
+              if (openCount > 10) {
+                // Ensure the label exists (create it if missing)
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: 'Close-and-review-later',
+                    color: 'e4e669',
+                    description: 'Closed automatically for later review',
+                  });
+                } catch (labelErr) {
+                  // 422 = label already exists, that's fine
+                  if (labelErr.status !== 422) console.log(`Label creation warning: ${labelErr.message}`);
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: ['Close-and-review-later'],
+                });
+
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  state: 'closed',
+                });
+
+                const warningComment = [
+                  `<div align="center">`,
+                  ``,
+                  `<img src="https://img.alicdn.com/imgextra/i2/O1CN01eSmIfy1hJImze8NN8_!!6000000004256-2-tps-1858-1858.png" width="80" height="80" />`,
+                  ``,
+                  `</div>`,
+                  ``,
+                  `Hi @${author},`,
+                  ``,
+                  `This pull request has been **automatically closed** because you currently have more than **10 open pull requests** in this repository.`,
+                  ``,
+                  `> **Why this happened**`,
+                  `> Our [contribution policy](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333) asks contributors to maintain a manageable number of active pull requests to ensure fair use of maintainer resources. A high volume of simultaneous open PRs — especially those that are AI-generated and submitted without personal verification — places a significant burden on maintainers.`,
+                  ``,
+                  `**What you can do:**`,
+                  `1. Review your open pull requests and close any that are no longer relevant, are duplicated, or have not been personally verified.`,
+                  `2. Once you have fewer than 10 open pull requests, you are welcome to reopen this PR or submit a new one.`,
+                  `3. Please ensure every PR you submit has been **personally tested**, addresses a verified issue, and follows our [pull request guidelines](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333).`,
+                  ``,
+                  `This pull request has been labeled \`Close-and-review-later\` and may be revisited by a maintainer.`,
+                  ``,
+                  `Thank you for your understanding. 🐾`,
+                  ``,
+                  `---`,
+                  ``,
+                  `你好 @${author}，`,
+                  ``,
+                  `由于你目前在本仓库有超过 **10 个处于 open 状态的 PR**，此 pull request 已被**自动关闭**。`,
+                  ``,
+                  `> **原因说明**`,
+                  `> 根据我们的[贡献规范](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333)，为保障维护者资源的合理使用，我们要求贡献者控制活跃 PR 的数量。大量未经人工验证的 open PR（尤其是 AI 生成内容）会给维护者带来沉重负担。`,
+                  ``,
+                  `**你可以采取以下措施：**`,
+                  `1. 检查并关闭不再相关、重复或未经本人验证的 open PR。`,
+                  `2. 当你的 open PR 数量少于 10 个时，欢迎重新开启此 PR 或提交新的 PR。`,
+                  `3. 请确保每个 PR 均经过**本人亲自测试**，针对已验证的问题，并遵循我们的 [PR 提交规范](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/4333)。`,
+                  ``,
+                  `此 PR 已被标记为 \`Close-and-review-later\`，维护者可能会在后续进行审核。`,
+                  ``,
+                  `感谢你的理解与配合。🐾`,
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: warningComment,
+                });
+
+                console.log(`Closed PR #${prNumber} for @${author} — open PR limit exceeded (${openCount} open)`);
+                return;
+              }
+            } catch (spamErr) {
+              if (spamErr.message !== '__bypass__') {
+                // Fail open: if the check itself errors, don't block legitimate contributors.
+                console.log(`Spam gate check failed: ${spamErr.message} — continuing with normal welcome`);
+              }
+            }
+            // ---------------------------------------------------------------
 
             // Check if Chinese characters exist in title
             const hasChinese = /[\u4e00-\u9fff]/.test(prTitle);

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,18 @@ name: Pre-commit Checks
 on: [push, pull_request]
 
 jobs:
+  spam-gate:
+    name: PR Spam Gate
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-spam-gate.yml
+    with:
+      author: ${{ github.event.pull_request.user.login }}
+
   run:
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,8 +24,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  spam-gate:
+    name: PR Spam Gate
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-spam-gate.yml
+    with:
+      author: ${{ github.event.pull_request.user.login }}
+
   unit-tests:
     name: Unit Tests - py${{ matrix.python-version }}
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -68,6 +79,10 @@ jobs:
 
   coverage:
     name: Coverage Report
+    needs: [spam-gate]
+    if: |
+      always() &&
+      (needs.spam-gate.result == 'skipped' || needs.spam-gate.outputs.blocked != 'true')
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:


### PR DESCRIPTION
## Description

Add an automated spam gate to the CI/CD pipeline to address the growing volume of unverified, AI-generated issues and pull requests that consume maintainer review time and exhaust CI runner resources.

When a user opens a new issue or PR, the bot now checks how many open issues / PRs they already have in this repo. If the count exceeds **10**, the item is automatically closed, labeled `Close-and-review-later`, and a bilingual (English + Chinese) explanation is posted — pointing the contributor to the [contribution policy](https://github.com/agentscope-ai/QwenPaw/issues/4333). Repo **admins and maintainers are bypassed** unconditionally.

In parallel, a new reusable gate workflow (`pr-spam-gate.yml`) is wired into every test workflow so that no CI runner time is spent on a spam PR that will immediately be closed.

**Related Issue:** Relates to #4333

**Security Considerations:** All permission checks use `GITHUB_TOKEN` scoped to the repository. The spam gate fails open (allows through) on any API error to avoid accidentally blocking legitimate contributors.

## Type of Change

- [x] New feature
- [x] CI/CD

## Component(s) Affected

- [x] CI/CD

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

**Spam path (issue):**
1. Open a new issue with an account that already has >10 open issues in the repo.
2. Expected: issue is immediately closed, labeled `Close-and-review-later`, and a warning comment is posted. No welcome message is sent.

**Spam path (PR):**
1. Open a new PR with an account that already has >10 open PRs in the repo.
2. Expected: PR is immediately closed, labeled `Close-and-review-later`, and a warning comment is posted. All test workflows (`unit-tests`, `pre-commit`, `frontend-tests`, `channel-tests`, `npm-format`) skip their jobs.

**Normal path:**
1. Open an issue or PR with an account that has ≤10 open items.
2. Expected: existing welcome flow runs unchanged; all test workflows execute normally.

**Admin bypass:**
1. Open an issue or PR with a repo admin or maintainer account that has >10 open items.
2. Expected: spam gate is bypassed; normal welcome + tests proceed.

**Push event (not a PR):**
- All test workflows continue to run normally; the `spam-gate` job is skipped by its `if: github.event_name == 'pull_request'` condition, and downstream jobs see `result == 'skipped'` which is treated as non-blocking.

## Local Verification Evidence

```bash
pre-commit run --all-files
# check yaml...Passed  trim trailing whitespace...Passed  detect private key...Passed
```

## Additional Notes

### Implementation details

| File | Change |
|------|--------|
| `.github/workflows/pr-spam-gate.yml` | **New** reusable workflow (`workflow_call`). Accepts `author` input, returns `blocked` output. Uses Search API with `per_page=1` to read `total_count` directly — no pagination required, minimal API quota usage. |
| `issue-welcome.yml` | Inline spam check at script start. Checks open issue count; if >10 closes, labels, warns, and returns early. Admin/maintain bypass via `getCollaboratorPermissionLevel`. |
| `pr-welcome.yml` | Same pattern for PRs. Added `issues: write` permission (needed for label API). |
| `unit-tests.yml` | New `spam-gate` job → `unit-tests` and `coverage` jobs gain `needs: [spam-gate]` with conditional skip. |
| `pre-commit.yml` | Same gate pattern. |
| `frontend-tests.yml` | Same gate pattern. |
| `channel-tests.yml` | Gate added before `detect-changes` (Phase 1); all subsequent phases cascade from there. |
| `npm-format.yml` | Gate added; both `website` and `console` jobs gated. |

### Why not `workflow_run`?

`workflow_run` introduces significant latency (the downstream workflow starts only after the upstream one completes) and makes it harder to surface status checks on the PR. The `workflow_call` + `needs` approach is synchronous within each workflow and shows clear per-job status in the PR check list.

### Why `tests.yml` is not gated

`tests.yml` already requires explicit maintainer approval via an environment gate (`maintainer-approved`). Any spam PR will be blocked there regardless.
