### PR TITLE
feat(core): prefix MCP tool names with client key to avoid collision

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Type, TYPE_CHECKING
 
@@ -537,6 +538,9 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
     ) -> None:
         """Register MCP clients on this agent's toolkit after construction.
 
+        Each MCP tool is registered as ``<client_key>_<tool_name>`` so
+        multiple servers with identical tool names don't collide.
+
         Args:
             namesake_strategy: Strategy to handle namesake tool functions.
                 Options: "override", "skip", "raise", "rename"
@@ -544,11 +548,22 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
         """
         for i, client in enumerate(self._mcp_clients):
             client_name = getattr(client, "name", repr(client))
+            client_key = getattr(
+                client, "_qwenpaw_mcp_client_key", None
+            ) or getattr(client, "name", "mcp")
+            # Sanitize client key for use as a tool name prefix
+            slug = re.sub(
+                r"_+",
+                "_",
+                re.sub(r"[^a-z0-9_-]", "_", client_key.lower()),
+            ).strip("_")[:40]
+            if not slug or slug.isdigit():
+                slug = f"mcp{i}"
             try:
-                await self.toolkit.register_mcp_client(
+                await self._register_mcp_client_tools(
                     client,
+                    slug,
                     namesake_strategy=namesake_strategy,
-                    execution_timeout=client.read_timeout_seconds,
                 )
             except (ClosedResourceError, asyncio.CancelledError) as error:
                 if self._should_propagate_cancelled_error(error):
@@ -562,10 +577,10 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                 if recovered_client is not None:
                     self._mcp_clients[i] = recovered_client
                     try:
-                        await self.toolkit.register_mcp_client(
+                        await self._register_mcp_client_tools(
                             recovered_client,
+                            slug,
                             namesake_strategy=namesake_strategy,
-                            execution_timeout=client.read_timeout_seconds,
                         )
                         continue
                     except asyncio.CancelledError as recover_error:
@@ -597,6 +612,33 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
                     e,
                     exc_info=True,
                 )
+
+    async def _register_mcp_client_tools(
+        self,
+        client: Any,
+        slug: str,
+        namesake_strategy: NamesakeStrategy = "skip",
+    ) -> None:
+        """Register tools from an MCP client with a slug prefix.
+
+        Args:
+            client: MCP client instance.
+            slug: Prefix slug for tool names.
+            namesake_strategy: Strategy for namesake tool functions.
+        """
+        tools = await client.list_tools()
+        for mcp_tool in tools:
+            func_obj = await client.get_callable_function(
+                func_name=mcp_tool.name,
+                wrap_tool_result=True,
+                execution_timeout=client.read_timeout_seconds,
+            )
+            exposed = f"{slug}_{mcp_tool.name}"
+            self.toolkit.register_tool_function(
+                tool_func=func_obj,
+                func_name=exposed,
+                namesake_strategy=namesake_strategy,
+            )
 
     async def _recover_mcp_client(self, client: Any) -> Any | None:
         """Recover MCP client from broken session and return healthy client."""

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -106,7 +106,7 @@ class MCPClientManager:
         """
         # 1. Create and connect new client outside lock (may be slow)
         logger.debug(f"Connecting new MCP client: {key}")
-        new_client = self._build_client(client_config)
+        new_client = self._build_client(client_config, client_key=key)
 
         try:
             # Add timeout to prevent indefinite blocking
@@ -180,7 +180,7 @@ class MCPClientManager:
             client_config: Client configuration
             timeout: Connection timeout in seconds (default 60s)
         """
-        client = self._build_client(client_config)
+        client = self._build_client(client_config, client_key=key)
 
         try:
             await asyncio.wait_for(client.connect(), timeout=timeout)
@@ -243,7 +243,10 @@ class MCPClientManager:
         return result
 
     @staticmethod
-    def _build_client(client_config: "MCPClientConfig") -> Any:
+    def _build_client(
+        client_config: "MCPClientConfig",
+        client_key: str = "",
+    ) -> Any:
         """Build MCP client instance by configured transport."""
         rebuild_info = {
             "name": client_config.name,
@@ -265,6 +268,7 @@ class MCPClientManager:
                 cwd=client_config.cwd or None,
             )
             setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
+            setattr(client, "_qwenpaw_mcp_client_key", client_key or "")
             return client
 
         headers: dict = dict(client_config.headers or {})
@@ -283,4 +287,5 @@ class MCPClientManager:
             headers=headers or None,
         )
         setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
+        setattr(client, "_qwenpaw_mcp_client_key", client_key or "")
         return client


### PR DESCRIPTION
## Description

**问题：** 当配置多个同类型 MCP Server（如多个 MySQL MCP）时，每个 Server 暴露的工具名完全一样（如 `sql_query`、`get_database_info`）。由于工具名冲突，实际只有**其中一台** MCP Server 的工具有效注册到 Toolkit 中，其余的被静默丢弃。LLM 只能用到其中一台的数据。

官方提供的 `namesake_strategy` 四个选项都无法解决此问题：
- `skip`（默认）：只保留第一个注册的，其余丢弃
- `override`：只保留最后一个注册的，其余丢弃
- `raise`：直接抛异常
- `rename`：能全部注册，但生成随机后缀（如 `sql_query_Xk3pQ`），LLM 无法区分哪个工具对应哪个库

**解决方案：** 注册 MCP 工具时，使用 `{client_key}_{tool_name}` 作为工具名，从源头消除冲突。

**改动点：**
- `_build_client()` 在 MCP client 实例上设置 `_qwenpaw_mcp_client_key` 属性
- `register_mcp_clients()` 不再调用 `toolkit.register_mcp_client()` 批量注册，改为逐工具注册，以 `{client_key}_{tool_name}` 格式命名
- 保留原有的 session 中断恢复逻辑

**验证效果：** 配置 4 个同类型 MCP Server 后，工具名如下，LLM 可正确区分和调用所有库：

| MCP client key | 注册后的工具名 |
|---|---|
| `mysql-orders` | `mysql-orders_sql_query` |
| `mysql-inventory` | `mysql-inventory_sql_query` |
| `mysql-analytics` | `mysql-analytics_sql_query` |
| `prod-reader` | `prod-reader_sql_query` |

**Security Considerations:** The client key is derived from the MCP client identifier configured by the user in `agent.json`; no sensitive data is exposed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Configure two or more MCP servers of the same type (e.g., MySQL) in `agent.json` with different client keys
2. Start QwenPaw and check if all tools are available — they should appear as `{client_key}_sql_query`, `{client_key}_get_database_info`, etc.
3. Verify LLM can call each tool and correctly connect to its respective server

## Additional Notes

The client key is set on the MCP client instance via `_qwenpaw_mcp_client_key` attribute in `_build_client()` method, and then used in `register_mcp_clients()` to prefix each tool name during registration.