### PR TITLE
feat(browser): add url and title to tabs action response

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -713,6 +713,47 @@ def _get_page(state: dict, page_id: str):
     return state["pages"].get(page_id)
 
 
+async def _get_tab_info_list(state: dict) -> list[dict[str, str]]:
+    """Return a list of dicts with page_id, url, and title for all pages.
+    Safely handles closed or detached pages without raising exceptions.
+    """
+    pages = state.get("pages", {})
+    tab_list = []
+    for pid, p in list(pages.items()):
+        try:
+            # Basic sanity check: if the page object is gone or explicitly closed
+            if p is None:
+                continue
+
+            # Playwright pages might be closed but still in our dict
+            # We use a try-except block to catch 'Target closed' errors during property access
+            if _USE_SYNC_PLAYWRIGHT:
+                is_closed = await _run_sync(p.is_closed)
+                if is_closed:
+                    continue
+                url = p.url
+                title = await _run_sync(p.title)
+            else:
+                if p.is_closed():
+                    continue
+                url = p.url
+                title = await p.title()
+
+            tab_list.append(
+                {
+                    "page_id": pid,
+                    "url": url or "about:blank",
+                    "title": title or "Untitled",
+                },
+            )
+        except Exception:
+            # If any error occurs (e.g. page detached, browser crashed),
+            # we skip this tab or provide a fallback if we know it exists.
+            logger.debug("Failed to get info for tab %s, skipping", pid)
+            continue
+    return tab_list
+
+
 def _get_context(state: dict):
     """Return the active browser context regardless of sync/async mode."""
     return state["context"] or state.get("_sync_context")
@@ -3299,7 +3340,12 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
     if tab_action == "list":
         return _tool_response(
             json.dumps(
-                {"ok": True, "tabs": page_ids, "count": len(page_ids)},
+                {
+                    "ok": True,
+                    "tabs": page_ids,
+                    "tab_list": await _get_tab_info_list(state),
+                    "count": len(page_ids),
+                },
                 ensure_ascii=False,
                 indent=2,
             ),
@@ -3350,6 +3396,7 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                         "ok": True,
                         "page_id": new_id,
                         "tabs": list(state["pages"].keys()),
+                        "tab_list": await _get_tab_info_list(state),
                     },
                     ensure_ascii=False,
                     indent=2,


### PR DESCRIPTION
✦ Description

  Enhance the browser_use tool (specifically the tabs action) to return detailed information for each open tab, including its URL
  and title.

  Key changes:
   - Added _get_tab_info_list helper to fetch real-time tab metadata (URL and Title) across both sync and async Playwright modes.
   - Updated _action_tabs to include a new tab_list field in the response for list and new actions.
   - Maintained strict backward compatibility by keeping the original tabs (list of page_id strings) field unchanged.
   - Hardened the implementation to gracefully handle "Target closed" or detached tab scenarios by checking is_closed() and
     implementing robust error handling, ensuring the tool never throws an error even if tabs are manually closed.

  Related Issue: Relates to # (if applicable)

  Security Considerations: N/A

  Type of Change

   - [ ] Bug fix
   - [x] New feature
   - [ ] Breaking change
   - [ ] Documentation
   - [ ] Refactoring

  Component(s) Affected

   - [x] Core / Backend (app, agents, config, providers, utils, local_models)
   - [ ] Console (frontend web UI)
   - [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
   - [ ] Skills
   - [ ] CLI
   - [ ] Documentation (website)
   - [ ] Tests
   - [ ] CI/CD
   - [ ] Scripts / Deploy

  Checklist

   - [x] I ran pre-commit run --all-files locally and it passes
   - [x] If pre-commit auto-fixed files, I committed those changes and reran checks
   - [ ] I ran tests locally (pytest or as relevant) and they pass
   - [ ] Documentation updated (if needed)
   - [x] Ready for review

  Testing

   - Start a browser session using browser_use(action='start').
   - Open multiple pages using browser_use(action='open', url='...').
   - Invoke the tabs list action: browser_use(action='tabs', tab_action='list').
   - Verify that the JSON response contains both the original tabs array (list of IDs) and the new tab_list array (list of objects
     with page_id, url, and title).
   - Manually close a tab in the browser and re-run the list action to verify that no error is thrown and the closed tab is safely
     skipped.

  Local Verification Evidence

   1 pre-commit run --all-files
   2 # Output summary:
   3 # check python ast.........................................................Passed
   4 # ...
   5 # pylint...................................................................Passed
   6 # prettier.................................................................Passed

  Additional Notes

  The tab_list is fetched dynamically in real-time, ensuring that manual navigations or title changes performed by the user are
  accurately reflected in the next tool call.
