### PR TITLE
fix: keep runner package imports lightweight

### DIFF
--- a/src/qwenpaw/app/runner/__init__.py
+++ b/src/qwenpaw/app/runner/__init__.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
-"""Runner module with chat manager for coordinating repository."""
-from .runner import AgentRunner
-from .api import router
-from .manager import ChatManager
-from .models import (
-    ChatSpec,
-    ChatHistory,
-    ChatsFile,
-)
-from .repo import (
-    BaseChatRepository,
-    JsonChatRepository,
-)
+"""Runner package exports.
 
+Keep this package initializer lightweight. Importing a submodule such as
+``qwenpaw.app.runner.session`` should not eagerly import AgentRunner,
+QwenPawAgent, tools, or ACP runtime dependencies.
+"""
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .api import router
+    from .manager import ChatManager
+    from .models import ChatHistory, ChatSpec, ChatsFile
+    from .repo import BaseChatRepository, JsonChatRepository
+    from .runner import AgentRunner
 
 __all__ = [
     # Core classes
@@ -28,3 +28,35 @@ __all__ = [
     "BaseChatRepository",
     "JsonChatRepository",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose historical package-level exports."""
+    if name == "AgentRunner":
+        from .runner import AgentRunner
+
+        return AgentRunner
+    if name == "router":
+        from .api import router
+
+        return router
+    if name == "ChatManager":
+        from .manager import ChatManager
+
+        return ChatManager
+    if name in {"ChatSpec", "ChatHistory", "ChatsFile"}:
+        from .models import ChatHistory, ChatSpec, ChatsFile
+
+        return {
+            "ChatSpec": ChatSpec,
+            "ChatHistory": ChatHistory,
+            "ChatsFile": ChatsFile,
+        }[name]
+    if name in {"BaseChatRepository", "JsonChatRepository"}:
+        from .repo import BaseChatRepository, JsonChatRepository
+
+        return {
+            "BaseChatRepository": BaseChatRepository,
+            "JsonChatRepository": JsonChatRepository,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/runner/test_runner_import_boundary.py
+++ b/tests/unit/runner/test_runner_import_boundary.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_runner_submodule_import_is_lightweight():
+    """Importing lightweight runner submodules should not load agent tools."""
+    code = textwrap.dedent(
+        """
+        import importlib
+        import sys
+
+        importlib.import_module("qwenpaw.app.runner.session")
+        importlib.import_module("qwenpaw.app.runner.command_dispatch")
+
+        heavy_modules = [
+            "qwenpaw.agents.react_agent",
+            "qwenpaw.agents.acp",
+        ]
+        loaded = [name for name in heavy_modules if name in sys.modules]
+        if loaded:
+            raise SystemExit(f"heavy modules loaded: {loaded}")
+        """,
+    )
+
+    env = os.environ.copy()
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else src_path + os.pathsep + env["PYTHONPATH"]
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_runner_package_lazy_exports_remain_available():
+    """Package-level imports stay compatible via lazy __getattr__."""
+    code = textwrap.dedent(
+        """
+        from qwenpaw.app.runner import ChatManager
+
+        assert ChatManager.__name__ == "ChatManager"
+        """,
+    )
+
+    env = os.environ.copy()
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else src_path + os.pathsep + env["PYTHONPATH"]
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Description

Fixes the import boundary around `qwenpaw.app.runner` by making the package initializer lightweight. Package-level exports such as `AgentRunner`, `ChatManager`, `router`, runner models, and runner repositories remain available through lazy `__getattr__` imports, but importing lightweight submodules no longer eagerly imports the full runner/agent/tool/ACP stack.

This keeps existing public imports compatible while avoiding side effects for focused tests and helper modules that only need runner-adjacent utilities.

**Related Issue:** Fixes #4445

**Security Considerations:** No security-sensitive runtime behavior changes. This only changes import timing for existing runner package exports and adds import-boundary tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Covered scenarios:

- Importing lightweight runner submodules (`qwenpaw.app.runner.session`, `qwenpaw.app.runner.command_dispatch`) in a fresh Python process does not load `qwenpaw.agents.react_agent` or `qwenpaw.agents.acp`.
- Historical package-level import compatibility remains available through lazy exports (`from qwenpaw.app.runner import ChatManager`).
- Existing chat update tests still pass, including the current `from qwenpaw.app.runner import manager as chat_manager_module` usage.

## Local Verification Evidence

```bash
PYTHONPATH=src pytest tests/unit/runner/test_runner_import_boundary.py
# 2 passed in 2.82s

PYTHONPATH=src pytest tests/unit/runner/test_runner_import_boundary.py tests/unit/app/test_chat_updates.py
# 9 passed in 3.70s

pre-commit run pylint --all-files
# Passed

pre-commit run --all-files
# Passed: check-ast, yaml/toml/json/xml checks, encoding pragma, detect-private-key, trailing whitespace, add-trailing-comma, mypy, black, flake8, pylint, prettier
```

## Additional Notes

The fix intentionally does not move ACP/tool imports or change `AgentRunner` behavior. It only prevents the runner package initializer from importing heavy runtime dependencies before callers explicitly request heavy exports.
