### PR TITLE
Cache context token estimates from model usage

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -495,7 +495,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
                         if len(loaded_messages) >= MAX_LOAD_HISTORY_COUNT:
                             break
 
-            # Clear existing memory
+            # Clear existing memory without persisting it into dialog history.
             self.memory.content.clear()
             self.memory.clear_compressed_summary()
 

--- a/src/qwenpaw/agents/context/agent_context.py
+++ b/src/qwenpaw/agents/context/agent_context.py
@@ -6,6 +6,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 import aiofiles
 import aiofiles.os
@@ -27,6 +28,7 @@ class AgentContext(InMemoryMemory):
         self,
         token_counter: EstimatedTokenCounter,
         dialog_path: str | Path | None = None,
+        on_context_rewritten: Callable[[], None] | None = None,
     ):
         """Initialize the AgentContext.
 
@@ -35,6 +37,8 @@ class AgentContext(InMemoryMemory):
             dialog_path: Path to the dialog storage directory.
                 If provided, messages will be persisted to jsonl
                 files when cleared or compressed.
+            on_context_rewritten: Callback invoked when existing context is
+                rewritten rather than appended to.
         """
         super().__init__()
         self._token_counter: EstimatedTokenCounter = token_counter
@@ -42,6 +46,20 @@ class AgentContext(InMemoryMemory):
         self._dialog_path: Path | None = (
             Path(dialog_path) if dialog_path else None
         )
+        self._on_context_rewritten = on_context_rewritten
+
+    def _notify_context_rewritten(self) -> None:
+        """Notify owner that cached context-derived state is stale."""
+        if self._on_context_rewritten is None:
+            return
+        try:
+            self._on_context_rewritten()
+        except Exception:
+            logger.debug("Failed to notify context rewrite", exc_info=True)
+
+    def notify_context_rewritten(self) -> None:
+        """Public hook for callers that rewrite stored message objects."""
+        self._notify_context_rewritten()
 
     async def _append_messages_to_dialog(self, messages: list[Msg]) -> int:
         """Append messages to dialog storage file.
@@ -206,6 +224,11 @@ class AgentContext(InMemoryMemory):
 
         self._compressed_summary = state_dict.get("_compressed_summary", "")
 
+    async def update_compressed_summary(self, summary: str) -> None:
+        """Update compressed summary and invalidate context-derived caches."""
+        await super().update_compressed_summary(summary)
+        self._notify_context_rewritten()
+
     async def mark_messages_compressed(
         self,
         messages: list[Msg],
@@ -243,6 +266,8 @@ class AgentContext(InMemoryMemory):
             f"Marked {removed_count} messages as compressed "
             f"and removed from memory",
         )
+        if removed_count:
+            self._notify_context_rewritten()
         return removed_count
 
     def clear_compressed_summary(self):
@@ -250,6 +275,7 @@ class AgentContext(InMemoryMemory):
         self._compressed_summary = (
             ""  # pylint: disable=attribute-defined-outside-init
         )
+        self._notify_context_rewritten()
 
     async def clear_content(self):
         """Persist all messages to dialog storage and clear the content.
@@ -265,6 +291,7 @@ class AgentContext(InMemoryMemory):
 
         # Clear in-memory content
         self.content.clear()
+        self._notify_context_rewritten()
         logger.info("Cleared all messages from memory")
 
     async def estimate_tokens(self, max_input_length: int) -> dict:

--- a/src/qwenpaw/agents/context/as_msg_handler.py
+++ b/src/qwenpaw/agents/context/as_msg_handler.py
@@ -288,6 +288,7 @@ class AsMsgHandler:
         messages: list[Msg],
         context_compact_threshold: int,
         context_compact_reserve: int,
+        total_tokens_override: int | None = None,
     ) -> tuple[list[Msg], list[Msg], int, int]:
         """Check if context exceeds threshold and split messages.
 
@@ -297,8 +298,16 @@ class AsMsgHandler:
         if not messages:
             return [], [], 0, 0
 
+        if total_tokens_override is not None:
+            total_tokens = max(0, total_tokens_override)
+            if total_tokens < context_compact_threshold:
+                return [], messages, total_tokens, total_tokens
+        else:
+            total_tokens = None
+
         msg_stats = [await self.stat_message(msg) for msg in messages]
-        total_tokens = sum(stat.total_tokens for stat in msg_stats)
+        if total_tokens is None:
+            total_tokens = sum(stat.total_tokens for stat in msg_stats)
 
         if total_tokens < context_compact_threshold:
             return [], messages, total_tokens, total_tokens

--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -2,10 +2,12 @@
 # pylint: disable=too-many-nested-blocks,too-many-branches
 # pylint: disable=too-many-return-statements,too-many-statements
 """Context manager for agents with compaction support."""
+
 import logging
 import os
 import sys
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Set
@@ -39,9 +41,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_current_session_id() -> str:
+    """Return the current session id without creating import cycles."""
+    from ...app.agent_context import get_current_session_id
+
+    return get_current_session_id() or ""
+
+
 def _fmt_tokens(n: int) -> str:
     """Format token count as e.g. '82.3k' or '450'."""
     return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+
+
+@dataclass
+class _TokenEstimateSnapshot:
+    """Message boundary for applying the next provider usage reading."""
+
+    message_count: int
+    usage_sequence_floor: int
 
 
 @context_registry.register("light")
@@ -65,8 +82,12 @@ class LightContextManager(BaseContextManager):
             agent_id: Agent ID for config loading.
         """
         super().__init__(working_dir=working_dir, agent_id=agent_id)
+        self._token_estimate_snapshots: dict[
+            str,
+            _TokenEstimateSnapshot,
+        ] = {}
         logger.info(
-            f"LightContextManager init: "
+            "LightContextManager init: "
             f"agent_id={agent_id}, working_dir={working_dir}",
         )
 
@@ -203,7 +224,7 @@ class LightContextManager(BaseContextManager):
         output: str | list[dict],
         max_bytes: int,
         encoding: str = "utf-8",
-    ) -> str | list[dict]:
+    ) -> tuple[str | list[dict], bool]:
         """Prune output by truncating to max_bytes.
 
         Args:
@@ -212,19 +233,26 @@ class LightContextManager(BaseContextManager):
             encoding: Character encoding.
 
         Returns:
-            Pruned output.
+            Tuple of (pruned output, whether output changed).
         """
         if isinstance(output, str):
-            return self._truncate_tool_result(output, max_bytes, encoding)
+            pruned = self._truncate_tool_result(output, max_bytes, encoding)
+            return pruned, pruned != output
         if isinstance(output, list):
+            changed = False
             for block in output:
                 if isinstance(block, dict) and block.get("type") == "text":
-                    block["text"] = self._truncate_tool_result(
-                        block.get("text", ""),
+                    original_text = block.get("text", "")
+                    pruned_text = self._truncate_tool_result(
+                        original_text,
                         max_bytes,
                         encoding,
                     )
-        return output
+                    if pruned_text != original_text:
+                        block["text"] = pruned_text
+                        changed = True
+            return output, changed
+        return output, False
 
     async def _prune_tool_result(
         self,
@@ -233,7 +261,7 @@ class LightContextManager(BaseContextManager):
         old_max_bytes: int = 3000,
         recent_max_bytes: int = DEFAULT_MAX_BYTES,
         **_kwargs,
-    ) -> list[Msg]:
+    ) -> bool:
         """Process all messages, truncating large tool results.
 
         Args:
@@ -245,10 +273,12 @@ class LightContextManager(BaseContextManager):
                 (unused here, set in init).
 
         Returns:
-            Processed messages list.
+            True if any tool result was changed.
         """
         if not messages:
-            return messages
+            return False
+
+        changed = False
 
         # Count recent tool_result messages from the end
         recent_count = 0
@@ -327,12 +357,15 @@ class LightContextManager(BaseContextManager):
                         if tool_id in exempt_tool_ids
                         else max_bytes
                     )
-                    block["output"] = self._prune_output(
+                    pruned_output, output_changed = self._prune_output(
                         output,
                         effective_max_bytes,
                     )
+                    if output_changed:
+                        block["output"] = pruned_output
+                        changed = True
 
-        return messages
+        return changed
 
     @staticmethod
     async def _check_context(
@@ -340,6 +373,7 @@ class LightContextManager(BaseContextManager):
         context_compact_threshold: int,
         context_compact_reserve: int,
         as_token_counter: EstimatedTokenCounter,
+        total_tokens_override: int | None = None,
     ) -> tuple[list[Msg], list[Msg], int, int]:
         """Check context size and determine if compaction is needed.
 
@@ -365,7 +399,92 @@ class LightContextManager(BaseContextManager):
             messages=messages,
             context_compact_threshold=context_compact_threshold,
             context_compact_reserve=context_compact_reserve,
+            total_tokens_override=total_tokens_override,
         )
+
+    def _clear_token_estimate_snapshot(
+        self,
+        session_id: str | None = None,
+    ) -> None:
+        """Invalidate request-level token cache after context mutation."""
+        if session_id:
+            self._token_estimate_snapshots.pop(session_id, None)
+            return
+        self._token_estimate_snapshots.clear()
+
+    @staticmethod
+    def _peek_latest_prompt_usage(
+        session_id: str,
+    ) -> tuple[int, int]:
+        """Return latest recorded prompt tokens and its monotonic sequence."""
+        if not session_id:
+            return 0, 0
+        try:
+            from ...token_usage.model_wrapper import (
+                TokenRecordingModelWrapper,
+            )
+
+            usage = TokenRecordingModelWrapper.peek_usage_for_session(
+                session_id,
+            )
+        except Exception:
+            logger.debug("Failed to peek latest token usage", exc_info=True)
+            return 0, 0
+        if not usage:
+            return 0, 0
+        try:
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            sequence = int(usage.get("sequence", 0) or 0)
+        except (TypeError, ValueError):
+            logger.debug("Ignoring malformed token usage: %s", usage)
+            return 0, 0
+        return max(prompt_tokens, 0), max(sequence, 0)
+
+    async def _resolve_context_total_override(
+        self,
+        *,
+        session_id: str,
+        messages: list[Msg],
+        msg_handler: AsMsgHandler,
+    ) -> int | None:
+        """Use provider prompt tokens for the previous snapshot if it matches.
+
+        The provider usage describes the full prompt from the previous
+        pre-reasoning snapshot. If the current context still has at least as
+        many messages, only the appended messages are estimated locally.
+        """
+        prompt_tokens, usage_sequence = self._peek_latest_prompt_usage(
+            session_id,
+        )
+        override: int | None = None
+        snapshot = self._token_estimate_snapshots.get(session_id)
+
+        if (
+            prompt_tokens > 0
+            and snapshot is not None
+            and usage_sequence > snapshot.usage_sequence_floor
+            and len(messages) >= snapshot.message_count
+        ):
+            delta_tokens = 0
+            for msg in messages[snapshot.message_count :]:
+                delta_tokens += (
+                    await msg_handler.stat_message(msg)
+                ).total_tokens
+            override = max(0, prompt_tokens + delta_tokens)
+            logger.debug(
+                "Applied provider prompt usage to context estimate: "
+                "prompt_tokens=%s delta_tokens=%s ctx_override=%s session=%s",
+                prompt_tokens,
+                delta_tokens,
+                override,
+                session_id,
+            )
+
+        self._token_estimate_snapshots[session_id] = _TokenEstimateSnapshot(
+            message_count=len(messages),
+            usage_sequence_floor=usage_sequence,
+        )
+        return override
 
     @staticmethod
     def _is_valid_summary(content: str) -> bool:
@@ -748,7 +867,20 @@ class LightContextManager(BaseContextManager):
                 context_compact_threshold - str_token_count
             )
 
-            if left_compact_threshold <= 0:
+            messages = await memory.get_memory(prepend_summary=False)
+            msg_handler = AsMsgHandler(token_counter)
+            ctx_total_tokens_override = (
+                await self._resolve_context_total_override(
+                    session_id=_get_current_session_id(),
+                    messages=messages,
+                    msg_handler=msg_handler,
+                )
+            )
+
+            if (
+                ctx_total_tokens_override is None
+                and left_compact_threshold <= 0
+            ):
                 logger.warning(
                     "The context_compact_threshold is set too low; "
                     "the combined token length of system_prompt and "
@@ -759,7 +891,16 @@ class LightContextManager(BaseContextManager):
                 )
                 return None
 
-            messages = await memory.get_memory(prepend_summary=False)
+            check_context_threshold = (
+                context_compact_threshold
+                if ctx_total_tokens_override is not None
+                else left_compact_threshold
+            )
+            fallback_context_reserve = (
+                context_compact_threshold
+                if ctx_total_tokens_override is not None
+                else left_compact_threshold
+            )
 
             (
                 messages_to_compact,
@@ -768,9 +909,10 @@ class LightContextManager(BaseContextManager):
                 ctx_keep_tokens,
             ) = await self._check_context(
                 messages=messages,
-                context_compact_threshold=left_compact_threshold,
+                context_compact_threshold=check_context_threshold,
                 context_compact_reserve=context_compact_reserve,
                 as_token_counter=token_counter,
+                total_tokens_override=ctx_total_tokens_override,
             )
 
             if not messages_to_compact:
@@ -782,7 +924,11 @@ class LightContextManager(BaseContextManager):
             compact_count = len(messages_to_compact)
             keep_count = len(messages_to_keep)
 
-            total_tokens = str_token_count + ctx_total_tokens
+            total_tokens = (
+                ctx_total_tokens
+                if ctx_total_tokens_override is not None
+                else str_token_count + ctx_total_tokens
+            )
             keep_tokens = ctx_keep_tokens
 
             pct = total_tokens / max_len * 100 if max_len > 0 else 0
@@ -829,16 +975,21 @@ class LightContextManager(BaseContextManager):
                         ctx_keep_tokens,
                     ) = await self._check_context(
                         messages=messages,
-                        context_compact_threshold=left_compact_threshold,
-                        context_compact_reserve=left_compact_threshold,
+                        context_compact_threshold=check_context_threshold,
+                        context_compact_reserve=fallback_context_reserve,
                         as_token_counter=token_counter,
+                        total_tokens_override=ctx_total_tokens_override,
                     )
                     messages_to_compact = fallback_to_compact
                     messages_to_keep = fallback_to_keep
                     compact_content = memory.get_compressed_summary() or ""
                     keep_count = len(messages_to_keep)
                     compact_count = len(messages_to_compact)
-                    total_tokens = str_token_count + ctx_total_tokens
+                    total_tokens = (
+                        ctx_total_tokens
+                        if ctx_total_tokens_override is not None
+                        else str_token_count + ctx_total_tokens
+                    )
                     pct = total_tokens / max_len * 100 if max_len > 0 else 0
                     token_line = (
                         f"📝 {_fmt_tokens(total_tokens)} / "
@@ -846,8 +997,8 @@ class LightContextManager(BaseContextManager):
                     )
                     if compact_count > 0:
                         msg_line = (
-                            f"💬 Fallback: keep({keep_count})"
-                            f" + drop({compact_count})"
+                            f"💬 Fallback: keep({keep_count}) + "
+                            f"drop({compact_count})"
                         )
                     else:
                         msg_line = f"💬 Fallback: keep({keep_count}) msgs"
@@ -887,16 +1038,21 @@ class LightContextManager(BaseContextManager):
                     ctx_keep_tokens,
                 ) = await self._check_context(
                     messages=messages,
-                    context_compact_threshold=left_compact_threshold,
-                    context_compact_reserve=left_compact_threshold,
+                    context_compact_threshold=check_context_threshold,
+                    context_compact_reserve=fallback_context_reserve,
                     as_token_counter=token_counter,
+                    total_tokens_override=ctx_total_tokens_override,
                 )
                 messages_to_compact = fallback_to_compact
                 messages_to_keep = fallback_to_keep
                 compact_content = memory.get_compressed_summary() or ""
                 keep_count = len(messages_to_keep)
                 compact_count = len(messages_to_compact)
-                total_tokens = str_token_count + ctx_total_tokens
+                total_tokens = (
+                    ctx_total_tokens
+                    if ctx_total_tokens_override is not None
+                    else str_token_count + ctx_total_tokens
+                )
                 pct = total_tokens / max_len * 100 if max_len > 0 else 0
                 token_line = (
                     f"📝 {_fmt_tokens(total_tokens)} / "
@@ -904,8 +1060,8 @@ class LightContextManager(BaseContextManager):
                 )
                 if compact_count > 0:
                     msg_line = (
-                        f"💬 Fallback: keep({keep_count})"
-                        f" + drop({compact_count})"
+                        f"💬 Fallback: keep({keep_count}) + "
+                        f"drop({compact_count})"
                     )
                 else:
                     msg_line = f"💬 Fallback: keep({keep_count}) msgs"
@@ -952,13 +1108,17 @@ class LightContextManager(BaseContextManager):
 
             memory = agent.memory
             messages = await memory.get_memory(prepend_summary=False)
-            await self._prune_tool_result(
+            tool_result_changed = await self._prune_tool_result(
                 messages=messages,
                 recent_n=trc.pruning_recent_n,
                 old_max_bytes=trc.pruning_old_msg_max_bytes,
                 recent_max_bytes=trc.pruning_recent_msg_max_bytes,
                 retention_days=trc.offload_retention_days,
             )
+            if tool_result_changed:
+                self._clear_token_estimate_snapshot(
+                    _get_current_session_id(),
+                )
         except Exception as e:
             logger.exception(
                 "Failed to prune tool results in post_acting hook: %s",
@@ -1006,4 +1166,7 @@ class LightContextManager(BaseContextManager):
         return AgentContext(
             token_counter=get_token_counter(agent_config),
             dialog_path=dialog_path,
+            on_context_rewritten=lambda: self._clear_token_estimate_snapshot(
+                _get_current_session_id(),
+            ),
         )

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -1360,6 +1360,11 @@ class QwenPawAgent(ToolGuardMixin, ReActAgent):
 
             msg.content = new_content
 
+        if total_stripped > 0:
+            notify = getattr(self.memory, "notify_context_rewritten", None)
+            if callable(notify):
+                notify()
+
         return total_stripped
 
     # pylint: disable=protected-access

--- a/src/qwenpaw/app/runner/command_dispatch.py
+++ b/src/qwenpaw/app/runner/command_dispatch.py
@@ -106,6 +106,13 @@ async def run_command_path(  # pylint: disable=too-many-statements,too-many-bran
     session_id = getattr(request, "session_id", "") or ""
     user_id = getattr(request, "user_id", "") or ""
     channel_name = getattr(request, "channel", "") or ""
+    from ..agent_context import (
+        set_current_agent_id,
+        set_current_session_id,
+    )
+
+    set_current_agent_id(runner.agent_id)
+    set_current_session_id(session_id)
 
     # Daemon path
     parsed = parse_daemon_query(query)

--- a/src/qwenpaw/token_usage/model_wrapper.py
+++ b/src/qwenpaw/token_usage/model_wrapper.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Model wrapper that records token usage from LLM responses."""
 
+from collections.abc import Mapping
 from datetime import date, datetime, timezone
 from typing import Any, AsyncGenerator, Literal, Type
 
@@ -16,7 +17,13 @@ from .manager import get_token_usage_manager
 class TokenRecordingModelWrapper(ChatModelBase):
     """Wraps a ChatModelBase to record token usage on each call."""
 
+    # Pending usage events for channel/UI reporting. `pop_usage_for_session`
+    # intentionally consumes these so the same usage is emitted once.
     _usage_by_session: dict[str, dict[str, Any]] = {}
+    # Retained latest usage for non-destructive consumers such as context
+    # estimation. This survives UI pops and is keyed by session.
+    _latest_usage_by_session: dict[str, dict[str, Any]] = {}
+    _usage_sequence: int = 0
 
     def __init__(self, provider_id: str, model: ChatModelBase) -> None:
         super().__init__(
@@ -26,12 +33,42 @@ class TokenRecordingModelWrapper(ChatModelBase):
         self._model = model
         self._provider_id = provider_id
 
-    def _record_usage(self, usage: ChatUsage | None) -> None:
+    @staticmethod
+    def _read_token_count(usage: Any, *keys: str) -> int:
+        """Read a non-negative token count from attr- or dict-style usage."""
+        for key in keys:
+            value = (
+                usage.get(key)
+                if isinstance(usage, Mapping)
+                else getattr(usage, key, None)
+            )
+            if value is None:
+                continue
+            try:
+                return max(int(value), 0)
+            except (TypeError, ValueError):
+                continue
+        return 0
+
+    def _record_usage(
+        self,
+        usage: ChatUsage | Mapping[str, Any] | None,
+    ) -> None:
         """Enqueue a usage event synchronously — never blocks the caller."""
         if usage is None:
             return
-        pt = getattr(usage, "input_tokens", 0) or 0
-        ct = getattr(usage, "output_tokens", 0) or 0
+        pt = self._read_token_count(
+            usage,
+            "input_tokens",
+            "prompt_tokens",
+            "prompt_eval_count",
+        )
+        ct = self._read_token_count(
+            usage,
+            "output_tokens",
+            "completion_tokens",
+            "eval_count",
+        )
         if pt <= 0 and ct <= 0:
             return
 
@@ -61,12 +98,27 @@ class TokenRecordingModelWrapper(ChatModelBase):
     def pop_usage_for_session(cls, session_id: str) -> dict[str, Any] | None:
         return cls._usage_by_session.pop(session_id, None)
 
+    @classmethod
+    def peek_usage_for_session(cls, session_id: str) -> dict[str, Any] | None:
+        usage = cls._latest_usage_by_session.get(session_id)
+        return dict(usage) if usage else None
+
     def _store_usage(self, usage: dict[str, Any] | None) -> None:
         from ..app.agent_context import get_current_session_id
 
         session_id = get_current_session_id()
         if session_id and usage:
-            TokenRecordingModelWrapper._usage_by_session[session_id] = usage
+            TokenRecordingModelWrapper._usage_sequence += 1
+            usage_with_sequence = {
+                **usage,
+                "sequence": TokenRecordingModelWrapper._usage_sequence,
+            }
+            TokenRecordingModelWrapper._usage_by_session[
+                session_id
+            ] = usage_with_sequence
+            TokenRecordingModelWrapper._latest_usage_by_session[
+                session_id
+            ] = usage_with_sequence
 
     async def __call__(
         self,

--- a/tests/unit/agents/context/test_agent_context.py
+++ b/tests/unit/agents/context/test_agent_context.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import pytest
+from agentscope.message import Msg
+
+from qwenpaw.agents.context.agent_context import AgentContext
+from qwenpaw.agents.utils.estimate_token_counter import EstimatedTokenCounter
+
+
+def _make_context(events: list[str]) -> AgentContext:
+    return AgentContext(
+        token_counter=EstimatedTokenCounter(),
+        on_context_rewritten=lambda: events.append("rewritten"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_content_notifies_context_rewritten() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+    await memory.add(Msg(name="user", content="hello", role="user"))
+
+    await memory.clear_content()
+
+    assert events == ["rewritten"]
+
+
+def test_clear_compressed_summary_notifies_context_rewritten() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+
+    memory.clear_compressed_summary()
+
+    assert events == ["rewritten"]
+
+
+@pytest.mark.asyncio
+async def test_update_compressed_summary_notifies_context_rewritten() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+
+    await memory.update_compressed_summary("summary")
+
+    assert events == ["rewritten"]
+
+
+@pytest.mark.asyncio
+async def test_mark_messages_compressed_notifies_on_remove() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+    msg = Msg(name="user", content="hello", role="user")
+    await memory.add(msg)
+
+    removed = await memory.mark_messages_compressed([msg])
+
+    assert removed == 1
+    assert events == ["rewritten"]
+
+
+def test_load_state_dict_does_not_notify_context_rewritten() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+
+    memory.load_state_dict({"content": [], "_compressed_summary": ""})
+
+    assert not events
+
+
+def test_notify_context_rewritten_public_hook() -> None:
+    events: list[str] = []
+    memory = _make_context(events)
+
+    memory.notify_context_rewritten()
+
+    assert events == ["rewritten"]

--- a/tests/unit/agents/context/test_as_msg_handler.py
+++ b/tests/unit/agents/context/test_as_msg_handler.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa: E501
-# pylint: disable=line-too-long,unused-argument,unused-variable,redefined-outer-name
+# pylint: disable=line-too-long,unused-argument,unused-variable
+# pylint: disable=redefined-outer-name,protected-access
 """Unit tests for AsMsgHandler context_check with tool_use/tool_result alignment."""
 
 import pytest
 from agentscope.message import Msg
 
 from qwenpaw.agents.context.as_msg_handler import AsMsgHandler
+from qwenpaw.agents.context.light_context_manager import LightContextManager
 from qwenpaw.agents.utils.estimate_token_counter import EstimatedTokenCounter
+from qwenpaw.token_usage.model_wrapper import TokenRecordingModelWrapper
 
 
 class MockTokenCounter(EstimatedTokenCounter):
@@ -16,9 +19,11 @@ class MockTokenCounter(EstimatedTokenCounter):
     def __init__(self, token_map: dict[str, int] | None = None):
         super().__init__()
         self.token_map = token_map or {}
+        self.count_calls = 0
 
     async def count(self, text: str = "", messages: list | None = None) -> int:
         """Count tokens based on text length or predefined mapping."""
+        self.count_calls += 1
         if text in self.token_map:
             return self.token_map[text]
         # Simple estimation: roughly 4 chars per token for Chinese
@@ -467,3 +472,304 @@ class TestAsMsgHandlerToolAlignment:
         assert (
             tool_use_ids_in_keep == tool_result_ids_in_keep
         ), f"tool_use ids: {tool_use_ids_in_keep}, tool_result ids: {tool_result_ids_in_keep}"
+
+
+class TestAsMsgHandlerTokenOverride:
+    """Test request-level token overrides."""
+
+    @pytest.mark.asyncio
+    async def test_context_check_uses_total_tokens_override(self):
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+            Msg(
+                name="assistant",
+                role="assistant",
+                content="efgh",
+                metadata={},
+            ),
+        ]
+
+        result = await handler.context_check(
+            messages=messages,
+            context_compact_threshold=10,
+            context_compact_reserve=1,
+            total_tokens_override=20,
+        )
+
+        msgs_to_compact, msgs_to_keep, total_tokens, keep_tokens = result
+        assert total_tokens == 20
+        assert msgs_to_compact == messages[:1]
+        assert msgs_to_keep == messages[1:]
+        assert keep_tokens == 1
+
+    @pytest.mark.asyncio
+    async def test_context_check_override_under_threshold_skips_full_count(
+        self,
+    ):
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+            Msg(
+                name="assistant",
+                role="assistant",
+                content="efgh",
+                metadata={},
+            ),
+        ]
+
+        result = await handler.context_check(
+            messages=messages,
+            context_compact_threshold=10,
+            context_compact_reserve=1,
+            total_tokens_override=2,
+        )
+
+        msgs_to_compact, msgs_to_keep, total_tokens, keep_tokens = result
+        assert msgs_to_compact == []
+        assert msgs_to_keep == messages
+        assert total_tokens == 2
+        assert keep_tokens == 2
+        assert token_counter.count_calls == 0
+
+
+class TestLightContextManagerTokenSnapshot:
+    """Test request-level prompt usage reuse."""
+
+    @pytest.mark.asyncio
+    async def test_uses_latest_prompt_usage_for_matching_snapshot(
+        self,
+        tmp_path,
+    ):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_id = "session-1"
+        first_messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+        ]
+
+        first = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=first_messages,
+            msg_handler=handler,
+        )
+        assert first is None
+
+        TokenRecordingModelWrapper._latest_usage_by_session[session_id] = {
+            "prompt_tokens": 10,
+            "sequence": 1,
+        }
+        current_messages = [
+            *first_messages,
+            Msg(
+                name="assistant",
+                role="assistant",
+                content="efgh",
+                metadata={},
+            ),
+        ]
+
+        override = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=current_messages,
+            msg_handler=handler,
+        )
+
+        assert override == 11
+        assert token_counter.count_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_snapshots_are_kept_per_session(self, tmp_path):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_a = "session-a"
+        session_b = "session-b"
+        messages_a = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+        ]
+        messages_b = [
+            Msg(name="user", role="user", content="ijkl", metadata={}),
+        ]
+
+        await manager._resolve_context_total_override(
+            session_id=session_a,
+            messages=messages_a,
+            msg_handler=handler,
+        )
+        await manager._resolve_context_total_override(
+            session_id=session_b,
+            messages=messages_b,
+            msg_handler=handler,
+        )
+
+        TokenRecordingModelWrapper._latest_usage_by_session[session_a] = {
+            "prompt_tokens": 10,
+            "sequence": 1,
+        }
+        override = await manager._resolve_context_total_override(
+            session_id=session_a,
+            messages=[
+                *messages_a,
+                Msg(
+                    name="assistant",
+                    role="assistant",
+                    content="efgh",
+                    metadata={},
+                ),
+            ],
+            msg_handler=handler,
+        )
+
+        assert override == 11
+
+    @pytest.mark.asyncio
+    async def test_latest_usage_without_snapshot_is_not_used(self, tmp_path):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_id = "session-1"
+        TokenRecordingModelWrapper._latest_usage_by_session[session_id] = {
+            "prompt_tokens": 10,
+            "sequence": 1,
+        }
+
+        override = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=[
+                Msg(name="user", role="user", content="abcd", metadata={}),
+            ],
+            msg_handler=handler,
+        )
+
+        assert override is None
+        assert token_counter.count_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_prompt_usage_falls_back_to_full_estimate(
+        self,
+        tmp_path,
+    ):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_id = "session-1"
+        messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+        ]
+
+        await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=messages,
+            msg_handler=handler,
+        )
+        TokenRecordingModelWrapper._latest_usage_by_session[session_id] = {
+            "prompt_tokens": 0,
+            "sequence": 1,
+        }
+
+        override = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=[
+                *messages,
+                Msg(
+                    name="assistant",
+                    role="assistant",
+                    content="efgh",
+                    metadata={},
+                ),
+            ],
+            msg_handler=handler,
+        )
+
+        assert override is None
+        assert token_counter.count_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_malformed_prompt_usage_falls_back_to_full_estimate(
+        self,
+        tmp_path,
+    ):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_id = "session-1"
+        messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+        ]
+
+        await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=messages,
+            msg_handler=handler,
+        )
+        TokenRecordingModelWrapper._latest_usage_by_session[session_id] = {
+            "prompt_tokens": "bad",
+            "sequence": 1,
+        }
+
+        override = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=[
+                *messages,
+                Msg(
+                    name="assistant",
+                    role="assistant",
+                    content="efgh",
+                    metadata={},
+                ),
+            ],
+            msg_handler=handler,
+        )
+
+        assert override is None
+        assert token_counter.count_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_prompt_usage_override_ignores_static_estimate(
+        self,
+        tmp_path,
+    ):
+        TokenRecordingModelWrapper._latest_usage_by_session.clear()
+        manager = LightContextManager(str(tmp_path), "default")
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+        session_id = "session-1"
+        messages = [
+            Msg(name="user", role="user", content="abcd", metadata={}),
+        ]
+
+        await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=messages,
+            msg_handler=handler,
+        )
+        TokenRecordingModelWrapper._latest_usage_by_session[session_id] = {
+            "prompt_tokens": 10,
+            "sequence": 1,
+        }
+
+        override = await manager._resolve_context_total_override(
+            session_id=session_id,
+            messages=[
+                *messages,
+                Msg(
+                    name="assistant",
+                    role="assistant",
+                    content="efgh",
+                    metadata={},
+                ),
+            ],
+            msg_handler=handler,
+        )
+
+        assert override == 11
+        assert token_counter.count_calls == 1

--- a/tests/unit/agents/test_react_agent_context_cache.py
+++ b/tests/unit/agents/test_react_agent_context_cache.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from types import SimpleNamespace
+
+from agentscope.message import Msg
+
+from qwenpaw.agents.context.agent_context import AgentContext
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.agents.utils.estimate_token_counter import EstimatedTokenCounter
+
+
+def test_media_strip_notifies_context_rewritten() -> None:
+    events: list[str] = []
+    memory = AgentContext(
+        token_counter=EstimatedTokenCounter(),
+        on_context_rewritten=lambda: events.append("rewritten"),
+    )
+    memory.content.append(
+        (
+            Msg(
+                name="user",
+                role="user",
+                content=[
+                    {"type": "text", "text": "hello"},
+                    {"type": "image", "url": "file:///tmp/a.png"},
+                ],
+            ),
+            [],
+        ),
+    )
+    agent = SimpleNamespace(
+        memory=memory,
+        _MEDIA_BLOCK_TYPES={"image", "audio", "video"},
+    )
+
+    stripped = QwenPawAgent._strip_media_blocks_from_memory(agent)
+
+    assert stripped == 1
+    assert events == ["rewritten"]

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Unit tests for the token usage core module."""
+
 from __future__ import annotations
 
 import asyncio
@@ -23,6 +24,7 @@ from qwenpaw.token_usage.manager import (
 )
 from qwenpaw.token_usage.model_wrapper import TokenRecordingModelWrapper
 from qwenpaw.token_usage.storage import load_data, save_data_sync
+from qwenpaw.app.agent_context import set_current_session_id
 
 
 # =============================================================================
@@ -35,8 +37,16 @@ def _isolate_token_usage_manager():
     """Isolate token usage manager singleton for each test."""
     # pylint: disable=protected-access
     TokenUsageManager._instance = None
+    TokenRecordingModelWrapper._usage_by_session.clear()
+    TokenRecordingModelWrapper._latest_usage_by_session.clear()
+    TokenRecordingModelWrapper._usage_sequence = 0
+    set_current_session_id("")
     yield
     TokenUsageManager._instance = None
+    TokenRecordingModelWrapper._usage_by_session.clear()
+    TokenRecordingModelWrapper._latest_usage_by_session.clear()
+    TokenRecordingModelWrapper._usage_sequence = 0
+    set_current_session_id("")
 
 
 # =============================================================================
@@ -513,6 +523,88 @@ class TestTokenRecordingModelWrapper:
 
         wrapper._record_usage(mock_usage)
 
+    def test_record_usage_ignores_missing_usage(self, tmp_path, monkeypatch):
+        """Missing provider usage should not update context estimate cache."""
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.WORKING_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.TOKEN_USAGE_FILE",
+            "test_token_usage.json",
+        )
+        set_current_session_id("test-session")
+
+        mock_model = MagicMock()
+        mock_model.model_name = "gpt-4"
+        wrapper = TokenRecordingModelWrapper(
+            provider_id="openai",
+            model=mock_model,
+        )
+
+        wrapper._record_usage(None)
+
+        assert (
+            TokenRecordingModelWrapper.peek_usage_for_session("test-session")
+            is None
+        )
+
+    def test_record_usage_accepts_dict_usage(self, tmp_path, monkeypatch):
+        """Dict-style provider usage should update context estimate cache."""
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.WORKING_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.TOKEN_USAGE_FILE",
+            "test_token_usage.json",
+        )
+        set_current_session_id("test-session")
+
+        mock_model = MagicMock()
+        mock_model.model_name = "gpt-4"
+        wrapper = TokenRecordingModelWrapper(
+            provider_id="openai",
+            model=mock_model,
+        )
+
+        wrapper._record_usage(
+            {"prompt_tokens": "123", "completion_tokens": "45"},
+        )
+
+        usage = TokenRecordingModelWrapper.peek_usage_for_session(
+            "test-session",
+        )
+        assert usage is not None
+        assert usage["prompt_tokens"] == 123
+        assert usage["completion_tokens"] == 45
+
+    def test_record_usage_ignores_malformed_usage(self, tmp_path, monkeypatch):
+        """Malformed provider usage should fall back by not updating cache."""
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.WORKING_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.TOKEN_USAGE_FILE",
+            "test_token_usage.json",
+        )
+        set_current_session_id("test-session")
+
+        mock_model = MagicMock()
+        mock_model.model_name = "gpt-4"
+        wrapper = TokenRecordingModelWrapper(
+            provider_id="openai",
+            model=mock_model,
+        )
+
+        wrapper._record_usage({"prompt_tokens": "bad"})
+
+        assert (
+            TokenRecordingModelWrapper.peek_usage_for_session("test-session")
+            is None
+        )
+
     def test_pop_usage_for_session(self, monkeypatch):
         """Should pop usage for session."""
         monkeypatch.setattr(
@@ -543,3 +635,44 @@ class TestTokenRecordingModelWrapper:
             TokenRecordingModelWrapper.pop_usage_for_session("test-session")
             is None
         )
+
+    def test_peek_usage_survives_pop_for_context_estimates(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Latest usage should remain available after channel pop."""
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.WORKING_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.TOKEN_USAGE_FILE",
+            "test_token_usage.json",
+        )
+        set_current_session_id("test-session")
+
+        mock_model = MagicMock()
+        mock_model.model_name = "gpt-4"
+        wrapper = TokenRecordingModelWrapper(
+            provider_id="openai",
+            model=mock_model,
+        )
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 123
+        mock_usage.output_tokens = 45
+
+        wrapper._record_usage(mock_usage)
+
+        popped = TokenRecordingModelWrapper.pop_usage_for_session(
+            "test-session",
+        )
+        peeked = TokenRecordingModelWrapper.peek_usage_for_session(
+            "test-session",
+        )
+
+        assert popped is not None
+        assert popped["prompt_tokens"] == 123
+        assert peeked is not None
+        assert peeked["prompt_tokens"] == 123
+        assert peeked["sequence"] == popped["sequence"]


### PR DESCRIPTION
## Description

This PR improves QwenPaw's context token estimation without replacing the existing lightweight fixed-coefficient estimator.

The current fallback estimates context length with `len(utf-8 bytes) / divisor`. That matches the simple hot-path tradeoff used by OpenClaw, Codex, and Hermes: cheap fixed-coefficient estimation, no per-model/provider calibration table, and no bundled tokenizer matrix. The drawback is that QwenPaw often has Chinese conversations plus large tool/skill schemas, and the fixed estimate does not include provider-side prompt formatting or tool schema overhead. In real Qwen/DashScope validation, a simple first-turn request estimated at roughly 2.4k tokens locally while the provider reported about 12.3k `prompt_tokens`.

This PR keeps that estimator as the fallback and delta counter, then layers provider usage reuse on top:

- records the latest model-reported prompt usage per session without consuming the existing token-usage display cache
- stores a per-session token estimate snapshot describing the message boundary that a usage reading applies to
- uses `latest prompt_tokens + estimated appended-message delta` when the current history extends the cached boundary
- falls back to the existing full estimate when usage is missing, malformed, stale, or the history boundary cannot be matched
- invalidates the snapshot when existing context is rewritten, including compaction, `/clear`, `/compact`, compressed summary updates, tool-result pruning, and media fallback rewrites

**Related Issue:** Fixes #4463

**Security Considerations:** No new auth, secret, or external API paths. The PR reuses in-process token usage data already collected from model responses and stores only per-session token counts/sequence metadata.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Automated coverage includes:

- context checks using a total token override below and above compaction thresholds
- session-scoped token estimate snapshots and appended-message delta estimation
- missing, malformed, stale, and non-matching usage fallback to the original full estimate path
- snapshot invalidation on `AgentContext` context rewrites: clear content, compressed summary updates, manual summary clear, and message compaction
- snapshot invalidation after tool-result pruning actually changes stored tool output
- media fallback rewrite notification when persisted media blocks are stripped
- non-destructive latest-usage reads from `TokenRecordingModelWrapper`
- provider usage parsing for attr-style, dict-style, missing, and malformed usage payloads

Manual live validation was also run through `qwenpaw app` and the console HTTP SSE endpoint against the configured real Qwen/DashScope model:

- consecutive real chat turns returned and reused session usage (`prompt_tokens` updated across turns)
- `/clear`, `/new`, `/compact`, and `/load_history` executed through the HTTP stream path
- automatic compaction was triggered with a temporary low `max_input_length` and then restored
- real `execute_shell_command` tool output was generated and later pruned after another tool call
- media input was tested through HTTP; the active Qwen model did not naturally hit the persisted-history rewrite fallback, so the rewrite notification path is covered by unit tests

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed
# Note: an earlier run reformatted files with black/add-trailing-comma;
# those changes were committed and pre-commit was rerun successfully.

PYTHONPATH=src pytest tests/unit/agents/context/test_agent_context.py tests/unit/agents/context/test_as_msg_handler.py tests/unit/agents/test_react_agent_context_cache.py tests/unit/token_usage/test_token_usage.py tests/unit/agents/test_command_handler.py
# 52 passed in 6.50s

ruff check src/qwenpaw/agents/context/agent_context.py src/qwenpaw/agents/context/as_msg_handler.py src/qwenpaw/agents/context/light_context_manager.py src/qwenpaw/agents/command_handler.py src/qwenpaw/agents/react_agent.py src/qwenpaw/app/runner/command_dispatch.py src/qwenpaw/token_usage/model_wrapper.py tests/unit/agents/context/test_agent_context.py tests/unit/agents/context/test_as_msg_handler.py tests/unit/agents/test_command_handler.py tests/unit/agents/test_react_agent_context_cache.py tests/unit/token_usage/test_token_usage.py
# All checks passed!

git diff --check
# no output
```

## Additional Notes

This intentionally avoids tokenizer integration, remote token-counting APIs, content-type-specific coefficients, and per-provider calibration tables. Those can be revisited later, but this PR keeps the hot path close to the current fixed-estimate design while correcting the largest undercount once a provider usage report is available.
