### PR TITLE
feat(feishu): add CardKit streaming card output

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -40,6 +40,7 @@ export interface FeishuConfig extends BaseChannelConfig {
   verification_token: string;
   media_dir: string;
   domain?: "feishu" | "lark";
+  streaming_enabled?: boolean;
 }
 
 export interface QQConfig extends BaseChannelConfig {

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -986,6 +986,7 @@
     "filterThinkingTooltip": "Show model thinking/reasoning content to users (turn off to hide)",
     "streamingEnabled": "Streaming Output",
     "streamingEnabledDingtalkHint": "Only effective when message type is Card",
+    "streamingEnabledFeishuHint": "Requires enabling cardkit:card:write permission in the Feishu Open Platform permission management page",
     "ackMessage": "Acknowledgment Message",
     "ackMessageTooltip": "Send an instant reply when a message is received, before agent processing begins. Leave empty to disable.",
     "ackMessagePlaceholder": "⏳ Processing...",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -695,6 +695,7 @@
     "filterThinkingTooltip": "モデルの思考・推論内容をユーザーに表示します（オフにすると非表示）",
     "streamingEnabled": "ストリーミング出力",
     "streamingEnabledDingtalkHint": "メッセージタイプがCardの場合のみ有効",
+    "streamingEnabledFeishuHint": "Feishuオープンプラットフォームの権限管理ページでcardkit:card:write権限を有効にする必要があります",
     "ackMessage": "即時確認メッセージ",
     "ackMessageTooltip": "メッセージ受信時にエージェント処理の前に即時返信を送信します。空欄で無効化。",
     "ackMessagePlaceholder": "⏳ 処理中...",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -898,6 +898,7 @@
     "filterThinkingTooltip": "Show model thinking/reasoning content to users (turn off to hide)",
     "streamingEnabled": "Saída em Streaming",
     "streamingEnabledDingtalkHint": "Apenas efetivo quando o tipo de mensagem é Card",
+    "streamingEnabledFeishuHint": "Requer habilitar a permissão cardkit:card:write na página de gerenciamento de permissões da Plataforma Aberta Feishu",
     "ackMessage": "Acknowledgment Message",
     "ackMessageTooltip": "Send an instant reply when a message is received, before agent processing begins. Leave empty to disable.",
     "ackMessagePlaceholder": "⏳ Processing...",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -695,6 +695,7 @@
     "filterThinkingTooltip": "Показывать пользователям рассуждения модели (выключите, чтобы скрыть)",
     "streamingEnabled": "Потоковый вывод",
     "streamingEnabledDingtalkHint": "Действует только при типе сообщения Card",
+    "streamingEnabledFeishuHint": "Необходимо включить разрешение cardkit:card:write на странице управления разрешениями открытой платформы Feishu",
     "ackMessage": "Сообщение подтверждения",
     "ackMessageTooltip": "Отправить мгновенный ответ при получении сообщения до начала обработки агентом. Оставьте пустым для отключения.",
     "ackMessagePlaceholder": "⏳ Обработка...",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -825,6 +825,7 @@
     "filterThinkingTooltip": "向用户显示模型的思考/推理内容（关闭则隐藏）",
     "streamingEnabled": "流式输出",
     "streamingEnabledDingtalkHint": "仅在消息类型为 Card 时生效",
+    "streamingEnabledFeishuHint": "需要在飞书开放平台权限管理界面开通 cardkit:card:write 权限",
     "ackMessage": "即时确认消息",
     "ackMessageTooltip": "收到消息后立即发送一条确认回复，在 Agent 处理之前。留空则禁用。",
     "ackMessagePlaceholder": "⏳ 正在处理中...",

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1361,8 +1361,8 @@ export function ChannelDrawer({
                 activeKey === "dingtalk"
                   ? t("channels.streamingEnabledDingtalkHint")
                   : activeKey === "feishu"
-                    ? t("channels.streamingEnabledFeishuHint")
-                    : undefined
+                  ? t("channels.streamingEnabledFeishuHint")
+                  : undefined
               }
             >
               <Switch />

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1351,7 +1351,8 @@ export function ChannelDrawer({
 
           {(activeKey === "wecom" ||
             activeKey === "telegram" ||
-            activeKey === "dingtalk") && (
+            activeKey === "dingtalk" ||
+            activeKey === "feishu") && (
             <Form.Item
               name="streaming_enabled"
               label={t("channels.streamingEnabled")}
@@ -1359,7 +1360,9 @@ export function ChannelDrawer({
               tooltip={
                 activeKey === "dingtalk"
                   ? t("channels.streamingEnabledDingtalkHint")
-                  : undefined
+                  : activeKey === "feishu"
+                    ? t("channels.streamingEnabledFeishuHint")
+                    : undefined
               }
             >
               <Switch />

--- a/src/qwenpaw/app/channels/feishu/card_handler.py
+++ b/src/qwenpaw/app/channels/feishu/card_handler.py
@@ -42,6 +42,7 @@ from typing import (
 from .card_templates import (
     TOOL_GUARD_ACTION_TYPE,
     build_tool_guard_approval_card,
+    build_tool_guard_compact_card,
     build_tool_guard_resolved_card,
     build_tool_guard_toast,
     parse_tool_guard_action_value,
@@ -66,13 +67,10 @@ logger = logging.getLogger(__name__)
 # Registry record
 # ---------------------------------------------------------------------
 
-# Outbound: given (to_handle, event, send_meta, meta) build + send the
-# card. Returns True if the card was sent so the caller can skip the
-# default text rendering.
-RenderFn = Callable[
-    [str, Any, Dict[str, Any], Dict[str, Any]],
-    Awaitable[bool],
-]
+# Outbound: given (to_handle, event, send_meta, meta, **kwargs) build +
+# send the card. Returns True if sent so the caller can skip default
+# rendering.  Uses ``...`` to allow keyword arguments like ``compact``.
+RenderFn = Callable[..., Awaitable[bool]]
 
 # Inbound: given (event, action_value) produce the synchronous card
 # response for lark_oapi.
@@ -156,11 +154,17 @@ class FeishuCardHandler:
         to_handle: str,
         event: Any,
         send_meta: Dict[str, Any],
+        *,
+        compact: bool = False,
     ) -> bool:
         """Render ``event`` as an interactive card if any kind matches.
 
         Returns ``True`` when a card was sent (the caller should then
         skip the default text/post rendering), ``False`` otherwise.
+
+        When ``compact=True`` (streaming mode), the render function
+        receives ``compact=True`` so it can produce a minimal card
+        (e.g. buttons only, no body text).
         """
         meta = self._extract_meta(event)
         if meta is None:
@@ -169,7 +173,13 @@ class FeishuCardHandler:
         if kind is None:
             return False
         try:
-            return await kind.render(to_handle, event, send_meta, meta)
+            return await kind.render(
+                to_handle,
+                event,
+                send_meta,
+                meta,
+                compact=compact,
+            )
         except Exception:  # pragma: no cover - defensive
             logger.exception(
                 "feishu card render failed: kind=%s",
@@ -223,7 +233,15 @@ class FeishuCardHandler:
         event: Any,
         send_meta: Dict[str, Any],
         meta: Dict[str, Any],
+        *,
+        compact: bool = False,
     ) -> bool:
+        """Send a tool-guard approval interactive card.
+
+        When ``compact=True`` (streaming mode), send a minimal card with
+        only the header and approve/deny buttons — the full approval
+        body has already been rendered in the streaming card.
+        """
         if not meta.get("approval_request_id"):
             return False
         ch = self._channel
@@ -244,7 +262,12 @@ class FeishuCardHandler:
             receive_id=receive_id,
             receive_id_type=receive_id_type,
         )
-        content = build_tool_guard_approval_card(
+        builder = (
+            build_tool_guard_compact_card
+            if compact
+            else build_tool_guard_approval_card
+        )
+        content = builder(
             request_id=str(meta.get("approval_request_id") or ""),
             tool_name=str(meta.get("tool_name") or "tool"),
             severity=str(meta.get("severity") or "medium"),

--- a/src/qwenpaw/app/channels/feishu/card_templates.py
+++ b/src/qwenpaw/app/channels/feishu/card_templates.py
@@ -137,6 +137,84 @@ def build_tool_guard_approval_card(
     return json.dumps(card, ensure_ascii=False)
 
 
+def build_tool_guard_compact_card(
+    *,
+    request_id: str,
+    tool_name: str,
+    severity: str,
+    body_text: str,
+    session_ctx: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Build a compact tool-guard card with only header and buttons.
+
+    Used in streaming mode where the full approval body has already been
+    rendered in the streaming card; this card only provides the
+    interactive approve/deny buttons.
+    """
+    body_snapshot = _truncate(body_text or "", 1500)
+    ctx_snapshot = dict(session_ctx or {})
+    approve_value = {
+        "type": TOOL_GUARD_ACTION_TYPE,
+        "action": "approve",
+        "request_id": request_id,
+        "tool_name": tool_name,
+        "severity": severity or "medium",
+        "body": body_snapshot,
+        "session_ctx": ctx_snapshot,
+    }
+    deny_value = {**approve_value, "action": "deny"}
+
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "template": _tool_guard_severity_template(severity),
+            "title": {
+                "tag": "plain_text",
+                "content": "🛡️ Tool Approval Required",
+            },
+        },
+        "elements": [
+            {
+                "tag": "markdown",
+                "content": f"**Tool**: `{tool_name}`",
+            },
+            {
+                "tag": "markdown",
+                "content": (
+                    "ⓘ <font color='orange'>**"
+                    "[Buttons not working?  Click here]"
+                    f"({_FEISHU_CALLBACK_CONFIG_DOC_URL})"
+                    "**</font>"
+                ),
+            },
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {
+                            "tag": "plain_text",
+                            "content": "✅ Approve",
+                        },
+                        "type": "primary",
+                        "value": approve_value,
+                    },
+                    {
+                        "tag": "button",
+                        "text": {
+                            "tag": "plain_text",
+                            "content": "❌ Deny",
+                        },
+                        "type": "danger",
+                        "value": deny_value,
+                    },
+                ],
+            },
+        ],
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
 def build_tool_guard_resolved_card(
     *,
     tool_name: str,

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -20,6 +20,7 @@ import re
 import sys
 import threading
 import time
+import uuid as _uuid
 from email.utils import parsedate_to_datetime
 import types
 from collections import OrderedDict
@@ -51,6 +52,8 @@ from .constants import (
     FEISHU_NICKNAME_CACHE_MAX,
     FEISHU_PROCESSED_IDS_MAX,
     FEISHU_STALE_MSG_THRESHOLD_MS,
+    FEISHU_STREAM_ELEMENT_ID,
+    FEISHU_STREAM_MIN_INTERVAL_S,
     FEISHU_WS_BACKOFF_FACTOR,
     FEISHU_WS_INITIAL_RETRY_DELAY,
     FEISHU_WS_MAX_RETRY_DELAY,
@@ -203,6 +206,7 @@ class FeishuChannel(BaseChannel):
         deny_message: str = "",
         require_mention: bool = False,
         domain: str = "feishu",
+        streaming_enabled: bool = False,
     ):
         super().__init__(
             process,
@@ -215,6 +219,7 @@ class FeishuChannel(BaseChannel):
             allow_from=allow_from,
             deny_message=deny_message,
             require_mention=require_mention,
+            streaming_enabled=streaming_enabled,
         )
         self.enabled = enabled
         self.app_id = app_id
@@ -294,6 +299,9 @@ class FeishuChannel(BaseChannel):
             deny_message=os.getenv("FEISHU_DENY_MESSAGE", ""),
             require_mention=os.getenv("FEISHU_REQUIRE_MENTION", "0") == "1",
             domain=os.getenv("FEISHU_DOMAIN", "feishu"),
+            streaming_enabled=(
+                os.getenv("FEISHU_STREAMING_ENABLED", "0") == "1"
+            ),
         )
 
     @classmethod
@@ -327,6 +335,9 @@ class FeishuChannel(BaseChannel):
             deny_message=config.deny_message or "",
             require_mention=config.require_mention,
             domain=config.domain or "feishu",
+            streaming_enabled=bool(
+                getattr(config, "streaming_enabled", False),
+            ),
         )
 
     def resolve_session_id(
@@ -1927,6 +1938,398 @@ class FeishuChannel(BaseChannel):
             meta["_last_sent_message_id"] = last_message_id
         return last_message_id
 
+    # ------------------------------------------------------------------
+    # CardKit streaming card helpers
+    # ------------------------------------------------------------------
+
+    def _get_feishu_stream_state(
+        self,
+        send_meta: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Get or create per-request streaming state in send_meta."""
+        state = send_meta.get("_fs_stream")
+        if state is None:
+            state = {"cards": {}}
+            send_meta["_fs_stream"] = state
+        return state
+
+    async def _create_streaming_card(
+        self,
+        receive_id_type: str,
+        receive_id: str,
+        initial_text: str = "...",
+    ) -> Optional[Dict[str, str]]:
+        """Create a CardKit streaming card and send it as a message.
+
+        Returns ``{"card_id": ..., "message_id": ...}`` or ``None``.
+        """
+        if not self._client:
+            return None
+
+        from lark_oapi.api.cardkit.v1 import (
+            CreateCardRequest,
+            CreateCardRequestBody,
+        )
+
+        element_id = FEISHU_STREAM_ELEMENT_ID
+        card_json = {
+            "schema": "2.0",
+            "config": {"streaming_mode": True},
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": initial_text,
+                        "element_id": element_id,
+                    },
+                ],
+            },
+        }
+
+        try:
+            create_req = (
+                CreateCardRequest.builder()
+                .request_body(
+                    CreateCardRequestBody.builder()
+                    .type("card_json")
+                    .data(json.dumps(card_json, ensure_ascii=False))
+                    .build(),
+                )
+                .build()
+            )
+            create_resp = await self._client.cardkit.v1.card.acreate(
+                create_req,
+            )
+            if not create_resp.success():
+                logger.warning(
+                    "feishu create streaming card failed: code=%s msg=%s",
+                    create_resp.code,
+                    create_resp.msg,
+                )
+                return None
+            card_id = (
+                getattr(create_resp.data, "card_id", None)
+                if create_resp.data
+                else None
+            )
+            if not card_id:
+                logger.warning("feishu create streaming card: no card_id")
+                return None
+        except Exception:
+            logger.exception("feishu create streaming card failed")
+            return None
+
+        # Send the card as an interactive message referencing card_id
+        try:
+            msg_content = json.dumps(
+                {"type": "card", "data": {"card_id": card_id}},
+                ensure_ascii=False,
+            )
+            message_id = await self._send_message(
+                receive_id_type,
+                receive_id,
+                "interactive",
+                msg_content,
+            )
+            if not message_id:
+                logger.warning(
+                    "feishu streaming card: send failed card_id=%s",
+                    card_id[:20],
+                )
+                return None
+            return {"card_id": card_id, "message_id": message_id}
+        except Exception:
+            logger.warning(
+                "feishu streaming card: send exception",
+                exc_info=True,
+            )
+            return None
+
+    async def _update_streaming_text(
+        self,
+        card_id: str,
+        text: str,
+        sequence: Optional[int] = None,
+    ) -> bool:
+        """Stream-update the markdown element via CardKit content API."""
+        if not self._client or not card_id:
+            return False
+
+        from lark_oapi.api.cardkit.v1 import (
+            ContentCardElementRequest,
+            ContentCardElementRequestBody,
+        )
+
+        try:
+            body_builder = (
+                ContentCardElementRequestBody.builder()
+                .content(text)
+                .uuid(str(_uuid.uuid4()))
+            )
+            if sequence is not None:
+                body_builder = body_builder.sequence(sequence)
+
+            req = (
+                ContentCardElementRequest.builder()
+                .card_id(card_id)
+                .element_id(FEISHU_STREAM_ELEMENT_ID)
+                .request_body(body_builder.build())
+                .build()
+            )
+            resp = await self._client.cardkit.v1.card_element.acontent(req)
+            if not resp.success():
+                logger.debug(
+                    "feishu stream update text failed: code=%s msg=%s",
+                    resp.code,
+                    resp.msg,
+                )
+                return False
+            return True
+        except Exception:
+            logger.debug("feishu stream update text exception", exc_info=True)
+            return False
+
+    async def _finalize_streaming_card(
+        self,
+        card_id: str,
+        summary_text: str = "",
+        sequence: int = 0,
+    ) -> bool:
+        """Close streaming mode and set summary via settings API.
+
+        ``SettingsCardRequestBody.settings`` accepts a JSON string.
+        ``sequence`` must exceed the last update sequence.
+        """
+        if not self._client or not card_id:
+            return False
+
+        from lark_oapi.api.cardkit.v1 import (
+            SettingsCardRequest,
+            SettingsCardRequestBody,
+        )
+
+        # Truncate summary for chat list preview
+        preview = (summary_text or "").strip()
+        if len(preview) > 80:
+            preview = preview[:77] + "..."
+        if not preview:
+            preview = "✅"
+
+        settings_json = json.dumps(
+            {
+                "config": {
+                    "streaming_mode": False,
+                    "summary": {"content": preview},
+                },
+            },
+            ensure_ascii=False,
+        )
+
+        try:
+            req = (
+                SettingsCardRequest.builder()
+                .card_id(card_id)
+                .request_body(
+                    SettingsCardRequestBody.builder()
+                    .settings(settings_json)
+                    .sequence(sequence)
+                    .uuid(str(_uuid.uuid4()))
+                    .build(),
+                )
+                .build()
+            )
+            resp = await self._client.cardkit.v1.card.asettings(req)
+            if not resp.success():
+                logger.warning(
+                    "feishu finalize card failed: code=%s msg=%s",
+                    resp.code,
+                    resp.msg,
+                )
+                return False
+            return True
+        except Exception:
+            logger.warning(
+                "feishu finalize streaming card exception",
+                exc_info=True,
+            )
+            return False
+
+    def _is_card_event(self, event: Any) -> bool:
+        """Check if the event matches a registered interactive card kind."""
+        meta = self._card_handler._extract_meta(event)
+        if meta is None:
+            return False
+        message_type = str(meta.get("message_type") or "")
+        return message_type in self._card_handler._by_message_type
+
+    # ------------------------------------------------------------------
+    # Streaming hooks (CardKit card mode)
+    # ------------------------------------------------------------------
+
+    def _build_stream_display_text(
+        self,
+        stream_type: str,
+        text: str,
+        send_meta: Dict[str, Any],
+    ) -> str:
+        """Build display text with bot_prefix for streaming cards."""
+        prefix = send_meta.get("bot_prefix") or self.bot_prefix or ""
+        if stream_type == "reasoning" and text:
+            if prefix:
+                return f"{prefix}  💭 {text}"
+            return f"💭 {text}"
+        if prefix and text:
+            return f"{prefix}  {text}"
+        return text
+
+    async def on_streaming_start(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Create a new streaming card for this stream segment."""
+        if not self.streaming_enabled:
+            return
+        recv = await self._get_receive_for_send(to_handle, send_meta)
+        if not recv:
+            return
+
+        receive_id_type, receive_id = recv
+        state = self._get_feishu_stream_state(send_meta)
+
+        # Reuse pre-created card for the first arriving segment.
+        card_info = getattr(request, "_precreated_card", None)
+        if card_info:
+            setattr(request, "_precreated_card", None)
+        else:
+            initial = self._build_stream_display_text(
+                stream_type,
+                "...",
+                send_meta,
+            )
+            card_info = await self._create_streaming_card(
+                receive_id_type,
+                receive_id,
+                initial_text=initial,
+            )
+
+        if card_info:
+            state["cards"][stream_type] = {
+                "card_id": card_info["card_id"],
+                "message_id": card_info["message_id"],
+                "last_update_ts": time.monotonic(),
+                "sequence": 0,
+            }
+
+    async def on_streaming_delta(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Stream-update the card with incremental text (throttled)."""
+        state = send_meta.get("_fs_stream")
+        if not state:
+            return
+        card_state = state["cards"].get(stream_type)
+        if not card_state:
+            return
+
+        now = time.monotonic()
+        if now - card_state["last_update_ts"] < FEISHU_STREAM_MIN_INTERVAL_S:
+            return
+
+        display_text = self._build_stream_display_text(
+            stream_type,
+            accumulated_text,
+            send_meta,
+        )
+
+        card_state["sequence"] += 1
+        success = await self._update_streaming_text(
+            card_state["card_id"],
+            display_text,
+            sequence=card_state["sequence"],
+        )
+        if success:
+            card_state["last_update_ts"] = now
+
+    async def on_streaming_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Finalize the streaming card; fallback to plain text on failure."""
+        state = send_meta.get("_fs_stream")
+        card_state = state["cards"].pop(stream_type, None) if state else None
+
+        final_text = self._build_stream_display_text(
+            stream_type,
+            accumulated_text,
+            send_meta,
+        )
+
+        # Fallback: card creation failed — send as plain text
+        if not card_state:
+            if accumulated_text.strip():
+                await self.send_content_parts(
+                    to_handle,
+                    [TextContent(text=final_text)],
+                    send_meta,
+                )
+            return
+
+        card_id = card_state["card_id"]
+
+        # Apply Feishu markdown normalization for the final render
+        final_text = normalize_feishu_md(final_text)
+
+        # Final text update
+        card_state["sequence"] += 1
+        await self._update_streaming_text(
+            card_id,
+            final_text,
+            sequence=card_state["sequence"],
+        )
+
+        # Close streaming mode and set summary to replace [生成中...]
+        card_state["sequence"] += 1
+        await self._finalize_streaming_card(
+            card_id,
+            summary_text=accumulated_text,
+            sequence=card_state["sequence"],
+        )
+
+        # Track last sent message_id for DONE reaction
+        message_id = card_state.get("message_id")
+        if message_id:
+            send_meta["_last_sent_message_id"] = message_id
+
+        # Card events (e.g. tool_guard) consumed by streaming need a
+        # compact interactive card sent after the streaming card.
+        if stream_type == "message" and self._is_card_event(event):
+            await self._card_handler.try_send_card_for_event(
+                to_handle,
+                event,
+                send_meta,
+                compact=True,
+            )
+
+    # ------------------------------------------------------------------
+    # Process lifecycle hooks
+    # ------------------------------------------------------------------
+
     async def _on_process_completed(
         self,
         request: Any,
@@ -2009,7 +2412,7 @@ class FeishuChannel(BaseChannel):
         )
 
     async def _before_consume_process(self, request: Any) -> None:
-        """Save receive_id from webhook meta for later send."""
+        """Save receive_id and pre-create streaming card if enabled."""
         meta = getattr(request, "channel_meta", None) or {}
         receive_id = meta.get("feishu_receive_id")
         receive_id_type = meta.get("feishu_receive_id_type", "open_id")
@@ -2019,6 +2422,27 @@ class FeishuChannel(BaseChannel):
                 receive_id,
                 receive_id_type,
             )
+
+        # Pre-create streaming card for immediate feedback.
+        # Skip card-action requests (e.g. /approval from buttons).
+        if (
+            self.streaming_enabled
+            and receive_id
+            and not meta.get("from_card_action")
+        ):
+            try:
+                card_info = await self._create_streaming_card(
+                    receive_id_type,
+                    receive_id,
+                    initial_text="...",
+                )
+                if card_info:
+                    setattr(request, "_precreated_card", card_info)
+            except Exception:
+                logger.debug(
+                    "feishu streaming card pre-creation failed",
+                    exc_info=True,
+                )
 
     def _run_ws_forever(self) -> None:
         """Run WebSocket with exponential-backoff reconnection."""

--- a/src/qwenpaw/app/channels/feishu/constants.py
+++ b/src/qwenpaw/app/channels/feishu/constants.py
@@ -30,3 +30,12 @@ FEISHU_WS_BACKOFF_FACTOR = 2
 # If no data (including pong) received for this many seconds, force reconnect.
 # SDK pings every ~120s, so 240s ≈ 2 missed cycles.
 FEISHU_WS_RECV_TIMEOUT = 240
+
+# ---- CardKit streaming card constants ----
+
+# Minimum interval (seconds) between streaming update API calls.
+# CardKit allows 10 QPS per card entity; we use a conservative interval.
+FEISHU_STREAM_MIN_INTERVAL_S = 0.15
+
+# Element ID for the markdown component inside the streaming card.
+FEISHU_STREAM_ELEMENT_ID = "streaming_content"

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -236,6 +236,8 @@ class FeishuConfig(BaseChannelConfig):
     """Feishu/Lark channel: app_id, app_secret; optional encrypt_key,
     verification_token for event handler. media_dir for received media.
     domain: 'feishu' for China, 'lark' for international.
+    streaming_enabled: enable CardKit streaming card updates for real-time
+    typewriter-style text output.
     """
 
     app_id: str = ""
@@ -244,6 +246,7 @@ class FeishuConfig(BaseChannelConfig):
     verification_token: str = ""
     media_dir: Optional[str] = None
     domain: Literal["feishu", "lark"] = "feishu"
+    streaming_enabled: bool = False
 
 
 class QQConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

Add real-time streaming output for the Feishu channel using CardKit v1 streaming card API.

- Implement streaming card lifecycle: create → throttled text updates (150ms) → finalize with streaming_mode=false and summary.content
- Pre-create streaming card in _before_consume_process; skip card-action requests via from_card_action meta flag
- Handle tool_guard events in streaming path: send compact approval card (fixed title + tool name in body + buttons) after streaming finishes
- Add build_tool_guard_compact_card template and compact flag through card handler
- Fallback to plain text when card creation fails
- Add streaming_enabled config, env var FEISHU_STREAMING_ENABLED, frontend toggle
- Add i18n cardkit:card:write permission hint for 5 locales

Requires cardkit:card:write permission in Feishu Open Platform (free, no approval needed).

**Related Issue:** Fixes #3001 
**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
