### PR TITLE
fix(providers): replace global LLM rate limiter with per-model instances

### DIFF
--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -1,16 +1,25 @@
 # -*- coding: utf-8 -*-
-"""Global LLM request rate limiter.
+"""Per-model LLM request rate limiter.
+
+Each unique ``"provider_id:model_name"`` pair gets its own
+``LLMRateLimiter`` instance via ``get_rate_limiter(limiter_key=...)``.
+A 429 on one model therefore cannot stall calls to other models or
+providers — background tasks (dream, heartbeat) that exhaust their
+quota do not affect interactive user chats on a different model.
 
 How it works:
 1. QPM sliding window: tracks request timestamps in a 60-second window.
    Before each call, if the window is full, the caller waits until the
    oldest timestamp slides out — proactively preventing 429s.
 2. asyncio.Semaphore caps the number of concurrent in-flight LLM calls.
-3. A global pause timestamp: when a 429 is received every subsequent
-   acquire() waits until the pause expires, eliminating thundering-herd
-   retries.
+3. Per-model pause timestamp: when a 429 is received, every subsequent
+   acquire() on the *same model* waits until the pause expires.
+   The pause is capped at MAX_PAUSE_SECONDS (default 60 s); a
+   Retry-After that exceeds the cap causes an immediate raise instead
+   of a doomed retry.  on_success() clears stale pauses as soon as any
+   call completes successfully.
 4. Per-waiter jitter: each caller adds a small random offset on top of
-   the remaining pause time, so they spread out when waking up.
+   the remaining pause time, so waiters spread out when waking up.
 
 acquire() execution order:
     wait for 429 cooldown → wait for QPM slot → wait for semaphore slot
@@ -28,7 +37,11 @@ logger = logging.getLogger(__name__)
 
 
 class LLMRateLimiter:
-    """Global LLM request rate limiter.
+    """Per-model LLM request rate limiter.
+
+    One instance is created per ``"provider_id:model_name"`` key by
+    ``get_rate_limiter()``.  All state is local to a single model so that a
+    429 from one provider cannot pause calls to any other.
 
     Coroutine-safe: all mutable state is protected by asyncio primitives and
     is intended for use within a single event loop.
@@ -36,8 +49,10 @@ class LLMRateLimiter:
     Args:
         max_concurrent: Maximum concurrent in-flight LLM calls (semaphore).
         max_qpm: Maximum queries per minute (sliding window). 0 = disabled.
-        default_pause_seconds: Global pause duration on a 429 response.
-        jitter_range: Random jitter (seconds) added on top of the pause.
+        default_pause_seconds: Pause duration (s) applied on a 429 response
+            when the API returns no ``Retry-After`` header.
+        jitter_range: Random jitter (seconds) added on top of the pause so
+            concurrent waiters spread out on wake-up.
     """
 
     # Maximum accepted Retry-After value (seconds).  API responses that ask
@@ -191,14 +206,15 @@ class LLMRateLimiter:
         self,
         retry_after: float | None = None,
     ) -> None:
-        """Record a 429 rate-limit response and set the global pause timestamp.
+        """Record a 429 response and set this model's pause timestamp.
 
         Args:
             retry_after: Seconds from the API's Retry-After header.
                          Falls back to the configured default when None.
-                         Always capped at ``_MAX_PAUSE_SECONDS`` so that a
-                         large Retry-After from a background task cannot
-                         stall interactive user requests for minutes.
+                         Always capped at ``MAX_PAUSE_SECONDS`` so that a
+                         large Retry-After cannot stall this model's callers
+                         for minutes.  Callers that receive a Retry-After
+                         above the cap are raised immediately (no retry).
         """
         raw_pause = (
             retry_after if retry_after is not None else self._default_pause

--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -337,21 +337,3 @@ async def get_rate_limiter(
             resolved_jitter,
         )
     return limiter
-
-
-async def reset_rate_limiter(limiter_key: str | None = None) -> None:
-    """Reset rate limiter(s) under the shared initialisation lock.
-
-    Must be awaited from within the asyncio event loop (same loop that
-    runs ``get_rate_limiter``).  Do **not** call from a sync context while
-    other coroutines may be calling ``get_rate_limiter`` concurrently.
-
-    Args:
-        limiter_key: If given, reset only that key's limiter.
-                     If ``None``, reset all limiters.
-    """
-    async with _get_limiters_lock():
-        if limiter_key is not None:
-            _limiters.pop(limiter_key, None)
-        else:
-            _limiters.clear()

--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -149,6 +149,28 @@ class LLMRateLimiter:
         self._in_flight -= 1
         self._semaphore.release()
 
+    async def on_success(self) -> None:
+        """Clear the global pause after a successful LLM call.
+
+        A completed call proves the API's rate-limit window has ended.
+        Resetting _pause_until lets subsequent callers proceed immediately
+        instead of waiting out the remainder of a stale pause set by a
+        previous 429 (e.g. from a background dream/cron task).
+        """
+        async with self._lock:
+            if self._pause_until > 0:
+                self._pause_until = 0.0
+                logger.debug(
+                    "LLM rate limiter: pause cleared after successful call",
+                )
+
+    # Maximum pause duration (seconds) honoured from any Retry-After header.
+    # Prevents a single API 429 (e.g. retry_after=300 from DashScope) from
+    # stalling all LLM calls — including interactive user chats — for minutes.
+    # Background tasks (dream, heartbeat) share the global limiter, so without
+    # this cap a single dream 429 can cascade into a 5-minute hang.
+    _MAX_PAUSE_SECONDS: float = 60.0
+
     async def report_rate_limit(
         self,
         retry_after: float | None = None,
@@ -158,8 +180,20 @@ class LLMRateLimiter:
         Args:
             retry_after: Seconds from the API's Retry-After header.
                          Falls back to the configured default when None.
+                         Always capped at ``_MAX_PAUSE_SECONDS`` so that a
+                         large Retry-After from a background task cannot
+                         stall interactive user requests for minutes.
         """
-        pause = retry_after if retry_after is not None else self._default_pause
+        raw_pause = (
+            retry_after if retry_after is not None else self._default_pause
+        )
+        pause = min(raw_pause, self._MAX_PAUSE_SECONDS)
+        if pause < raw_pause:
+            logger.debug(
+                "LLM rate limiter: capping retry_after %.1fs → %.1fs",
+                raw_pause,
+                pause,
+            )
         async with self._lock:
             new_until = time.monotonic() + pause
             if new_until > self._pause_until:
@@ -167,8 +201,9 @@ class LLMRateLimiter:
                 self._total_rate_limited += 1
                 logger.warning(
                     "LLM rate limiter: global pause set for %.1fs "
-                    "(total_rate_limited=%d)",
+                    "(raw_retry_after=%.1fs, total_rate_limited=%d)",
                     pause,
+                    raw_pause,
                     self._total_rate_limited,
                 )
 
@@ -196,43 +231,57 @@ class LLMRateLimiter:
         }
 
 
-# Global singleton
-_global_limiter: LLMRateLimiter | None = None
-_init_lock: asyncio.Lock | None = None
+# Per-model rate limiters keyed by "provider_id:model_name".
+# Each model gets its own limiter so that a 429 from one provider/model
+# (e.g. a dream cron using DashScope) does not stall user chats on a
+# completely different provider (e.g. OpenRouter, Anthropic).
+_limiters: dict[str, LLMRateLimiter] = {}
+_limiters_lock: asyncio.Lock | None = None
 
 
-def _get_init_lock() -> asyncio.Lock:
-    global _init_lock
-    if _init_lock is None:
-        _init_lock = asyncio.Lock()
-    return _init_lock
+def _get_limiters_lock() -> asyncio.Lock:
+    global _limiters_lock
+    if _limiters_lock is None:
+        _limiters_lock = asyncio.Lock()
+    return _limiters_lock
 
 
 async def get_rate_limiter(
+    limiter_key: str = "",
     max_concurrent: int | None = None,
     max_qpm: int | None = None,
     default_pause_seconds: float | None = None,
     jitter_range: float | None = None,
 ) -> LLMRateLimiter:
-    """Return the global LLMRateLimiter singleton, lazily initialised
+    """Return a per-model ``LLMRateLimiter``, lazily initialised
     (coroutine-safe).
 
-    On the *first* call the provided values (or env-var constants as fallback)
-    are used to construct the singleton.  All subsequent calls return the same
-    instance regardless of the arguments passed.
+    Each unique *limiter_key* (typically ``"provider_id:model_name"``) gets
+    its own independent limiter instance.  A 429 on one model therefore does
+    not pause calls to other models — background tasks (dream, heartbeat) that
+    hit their quota limit can no longer stall interactive user chats on a
+    different provider.
+
+    On the *first* call for a given key the provided config values (or
+    env-var constants as fallback) are used to construct the limiter.  All
+    subsequent calls for the same key return the same instance regardless of
+    the arguments passed.
 
     Args:
+        limiter_key: Stable identifier for the limiter scope, e.g.
+            ``"dashscope:qwen-plus"`` or
+            ``"openrouter:nemotron-3-super-free"``.
+            An empty string uses a shared fallback limiter.
         max_concurrent: Cap on concurrent in-flight LLM calls.
         max_qpm: Maximum queries per minute (sliding window). 0 = disabled.
         default_pause_seconds: Pause duration (s) applied on a 429 response.
         jitter_range: Random jitter (s) added on top of the pause.
     """
-    global _global_limiter  # noqa: PLW0603
-    if _global_limiter is not None:
-        return _global_limiter
-    async with _get_init_lock():
-        if _global_limiter is not None:
-            return _global_limiter
+    if limiter_key in _limiters:
+        return _limiters[limiter_key]
+    async with _get_limiters_lock():
+        if limiter_key in _limiters:
+            return _limiters[limiter_key]
         from ..constant import (
             LLM_MAX_CONCURRENT,
             LLM_MAX_QPM,
@@ -255,24 +304,33 @@ async def get_rate_limiter(
             jitter_range if jitter_range is not None else LLM_RATE_LIMIT_JITTER
         )
 
-        _global_limiter = LLMRateLimiter(
+        limiter = LLMRateLimiter(
             max_concurrent=resolved_max,
             max_qpm=resolved_qpm,
             default_pause_seconds=resolved_pause,
             jitter_range=resolved_jitter,
         )
+        _limiters[limiter_key] = limiter
         logger.info(
-            "LLM rate limiter initialized: max_concurrent=%d, max_qpm=%d, "
-            "default_pause=%.1fs, jitter=%.1fs",
+            "LLM rate limiter initialized: key=%r max_concurrent=%d "
+            "max_qpm=%d default_pause=%.1fs jitter=%.1fs",
+            limiter_key,
             resolved_max,
             resolved_qpm,
             resolved_pause,
             resolved_jitter,
         )
-    return _global_limiter
+    return limiter
 
 
-def reset_rate_limiter() -> None:
-    """Reset the global singleton (for testing or service restart)."""
-    global _global_limiter  # noqa: PLW0603
-    _global_limiter = None
+def reset_rate_limiter(limiter_key: str | None = None) -> None:
+    """Reset rate limiter(s) (for testing or service restart).
+
+    Args:
+        limiter_key: If given, reset only that key's limiter.
+                     If ``None``, reset all limiters.
+    """
+    if limiter_key is not None:
+        _limiters.pop(limiter_key, None)
+    else:
+        _limiters.clear()

--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -169,7 +169,7 @@ class LLMRateLimiter:
     # stalling all LLM calls — including interactive user chats — for minutes.
     # Background tasks (dream, heartbeat) share the global limiter, so without
     # this cap a single dream 429 can cascade into a 5-minute hang.
-    _MAX_PAUSE_SECONDS: float = 60.0
+    MAX_PAUSE_SECONDS: float = 60.0
 
     async def report_rate_limit(
         self,
@@ -187,7 +187,7 @@ class LLMRateLimiter:
         raw_pause = (
             retry_after if retry_after is not None else self._default_pause
         )
-        pause = min(raw_pause, self._MAX_PAUSE_SECONDS)
+        pause = min(raw_pause, self.MAX_PAUSE_SECONDS)
         if pause < raw_pause:
             logger.debug(
                 "LLM rate limiter: capping retry_after %.1fs → %.1fs",

--- a/src/qwenpaw/providers/rate_limiter.py
+++ b/src/qwenpaw/providers/rate_limiter.py
@@ -40,6 +40,12 @@ class LLMRateLimiter:
         jitter_range: Random jitter (seconds) added on top of the pause.
     """
 
+    # Maximum accepted Retry-After value (seconds).  API responses that ask
+    # for a longer wait are capped here; callers that receive a Retry-After
+    # above this threshold are raised to immediately (no retry).
+    # Can be adjusted via env var LLM_MAX_PAUSE_SECONDS (see constant.py).
+    MAX_PAUSE_SECONDS: float = 60.0
+
     def __init__(
         self,
         max_concurrent: int = 3,
@@ -67,7 +73,7 @@ class LLMRateLimiter:
         self._total_qpm_waited: int = 0
         self._total_rate_limited: int = 0
 
-    async def acquire(self) -> None:
+    async def acquire(self) -> float:
         """Acquire an execution permit.
 
         Execution order:
@@ -81,7 +87,19 @@ class LLMRateLimiter:
 
         The hard upper-bound timeout is enforced by asyncio.wait_for() at
         every call site in RetryChatModel.
+
+        Returns:
+            The ``time.monotonic()`` value captured immediately before the
+            429-cooldown phase.  Pass this to ``on_success()`` so it can
+            distinguish stale pauses (set before this call) from fresh ones
+            (installed by a concurrent 429 after this call already acquired).
         """
+        # Capture acquire start time *before* the cooldown wait so that
+        # on_success() can compare it against _pause_until to determine whether
+        # the currently-set pause predates this call (stale) or was installed
+        # by a concurrent 429 after we passed through the cooldown (fresh).
+        acquired_at = time.monotonic()
+
         # Step 1 — 429 cooldown.
         while True:
             now = time.monotonic()
@@ -108,6 +126,7 @@ class LLMRateLimiter:
         await self._semaphore.acquire()
         self._in_flight += 1
         self._total_acquired += 1
+        return acquired_at
 
     async def _acquire_qpm_slot(self) -> None:
         """Wait until the 60-second sliding window has room, then record the
@@ -149,27 +168,24 @@ class LLMRateLimiter:
         self._in_flight -= 1
         self._semaphore.release()
 
-    async def on_success(self) -> None:
-        """Clear the global pause after a successful LLM call.
+    async def on_success(self, acquired_at: float) -> None:
+        """Clear a stale pause after a successful LLM call.
 
-        A completed call proves the API's rate-limit window has ended.
-        Resetting _pause_until lets subsequent callers proceed immediately
-        instead of waiting out the remainder of a stale pause set by a
-        previous 429 (e.g. from a background dream/cron task).
+        Args:
+            acquired_at: The ``time.monotonic()`` timestamp recorded just
+                before ``acquire()`` was called.  Only pauses that were
+                set *at or before* that timestamp are cleared: a pause
+                installed by a concurrent 429 *after* this call acquired
+                its slot is presumed to be fresh and is left intact.
         """
         async with self._lock:
-            if self._pause_until > 0:
+            if 0 < self._pause_until <= acquired_at:
                 self._pause_until = 0.0
                 logger.debug(
-                    "LLM rate limiter: pause cleared after successful call",
+                    "LLM rate limiter: stale pause cleared after "
+                    "successful call (acquired_at=%.3f)",
+                    acquired_at,
                 )
-
-    # Maximum pause duration (seconds) honoured from any Retry-After header.
-    # Prevents a single API 429 (e.g. retry_after=300 from DashScope) from
-    # stalling all LLM calls — including interactive user chats — for minutes.
-    # Background tasks (dream, heartbeat) share the global limiter, so without
-    # this cap a single dream 429 can cascade into a 5-minute hang.
-    MAX_PAUSE_SECONDS: float = 60.0
 
     async def report_rate_limit(
         self,
@@ -323,14 +339,19 @@ async def get_rate_limiter(
     return limiter
 
 
-def reset_rate_limiter(limiter_key: str | None = None) -> None:
-    """Reset rate limiter(s) (for testing or service restart).
+async def reset_rate_limiter(limiter_key: str | None = None) -> None:
+    """Reset rate limiter(s) under the shared initialisation lock.
+
+    Must be awaited from within the asyncio event loop (same loop that
+    runs ``get_rate_limiter``).  Do **not** call from a sync context while
+    other coroutines may be calling ``get_rate_limiter`` concurrently.
 
     Args:
         limiter_key: If given, reset only that key's limiter.
                      If ``None``, reset all limiters.
     """
-    if limiter_key is not None:
-        _limiters.pop(limiter_key, None)
-    else:
-        _limiters.clear()
+    async with _get_limiters_lock():
+        if limiter_key is not None:
+            _limiters.pop(limiter_key, None)
+        else:
+            _limiters.clear()

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -305,6 +305,31 @@ class RetryChatModel(ChatModelBase):
         name = self._inner.model_name
         return f"{provider_id}:{name}" if provider_id else name
 
+    @staticmethod
+    async def _handle_rate_limit_exc(
+        exc: Exception,
+        limiter: LLMRateLimiter,
+    ) -> None:
+        """Inspect *exc* and update the rate limiter accordingly.
+
+        - Internal acquire timeout (``_is_acquire_timeout``): re-raise as-is;
+          no report, no retry.
+        - Retryable API 429 with Retry-After > ``MAX_PAUSE_SECONDS``: re-raise
+          immediately — retrying after the capped pause would just get another
+          429 (e.g. Anthropic FreeUsageLimitError with Retry-After: 51496 s).
+        - Normal 429: call ``report_rate_limit()`` to set the per-model pause.
+        """
+        if getattr(exc, "_is_acquire_timeout", False):
+            raise exc
+        if _is_retryable(exc) and _is_rate_limit(exc):
+            retry_after = _extract_retry_after(exc)
+            if (
+                retry_after is not None
+                and retry_after > LLMRateLimiter.MAX_PAUSE_SECONDS
+            ):
+                raise exc
+            await limiter.report_rate_limit(retry_after)
+
     async def _consume_stream_with_slot(
         self,
         stream: AsyncGenerator[ChatResponse, None],
@@ -443,12 +468,7 @@ class RetryChatModel(ChatModelBase):
 
             except Exception as exc:
                 last_exc = exc
-                # Internal acquire timeout: raise immediately without
-                # report_rate_limit() or retry — it is not an API error.
-                if getattr(exc, "_is_acquire_timeout", False):
-                    raise
-                if _is_retryable(exc) and _is_rate_limit(exc):
-                    await limiter.report_rate_limit(_extract_retry_after(exc))
+                await self._handle_rate_limit_exc(exc, limiter)
 
                 if not _is_retryable(exc) or attempt >= attempts:
                     raise

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -331,6 +331,10 @@ class RetryChatModel(ChatModelBase):
                     first_chunk = False
                     # return the slot once the API starts delivering
                     limiter.release()
+                    # streaming success: clear any stale 429 pause so
+                    # subsequent callers (including user chats) are not
+                    # held back by a pause set by a background task.
+                    await limiter.on_success()
                 yield chunk
         finally:
             await stream.aclose()
@@ -350,7 +354,11 @@ class RetryChatModel(ChatModelBase):
         if cache.get(key, "needs_reasoning_content", False):
             _inject_reasoning_content(args, kwargs)
 
+        # Each model gets its own rate limiter keyed by
+        # "provider_id:model_name" so that a 429 on one model (e.g. from a
+        # dream/cron task) cannot stall user chats on a different provider.
         limiter = await get_rate_limiter(
+            limiter_key=self.model_key,
             max_concurrent=self._rate_limit_config.max_concurrent,
             max_qpm=self._rate_limit_config.max_qpm,
             default_pause_seconds=self._rate_limit_config.pause_seconds,
@@ -378,7 +386,12 @@ class RetryChatModel(ChatModelBase):
                     )
                     acquired = True
                 except asyncio.TimeoutError as exc:
-                    raise RateLimitExceededException(
+                    # Internal acquire timeout — NOT an API 429.
+                    # Do not call report_rate_limit() (that would incorrectly
+                    # extend the global pause) and do not retry (it would just
+                    # time out again).  Use a sentinel attribute so the outer
+                    # exception handler can distinguish this from a real 429.
+                    _exc = RateLimitExceededException(
                         operation="LLM execution",
                         retry_after=int(
                             self._rate_limit_config.acquire_timeout,
@@ -386,7 +399,11 @@ class RetryChatModel(ChatModelBase):
                         details={
                             "reason": "Timed out waiting for execution slot",
                         },
-                    ) from exc
+                    )
+                    _exc._is_acquire_timeout = (  # type: ignore[attr-defined]
+                        True
+                    )
+                    raise _exc from exc
 
                 try:
                     result = await self._inner(*args, **kwargs)
@@ -418,10 +435,18 @@ class RetryChatModel(ChatModelBase):
                         limiter,
                     )
 
+                # Non-streaming success: clear any stale rate-limit pause so
+                # subsequent callers are not held back by a pause set by an
+                # unrelated background task (e.g. dream/cron 429).
+                await limiter.on_success()
                 return result
 
             except Exception as exc:
                 last_exc = exc
+                # Internal acquire timeout: raise immediately without
+                # report_rate_limit() or retry — it is not an API error.
+                if getattr(exc, "_is_acquire_timeout", False):
+                    raise
                 if _is_retryable(exc) and _is_rate_limit(exc):
                     await limiter.report_rate_limit(_extract_retry_after(exc))
 

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -58,6 +58,15 @@ _anthropic_retryable: tuple[type[Exception], ...] | None = None
 _httpx_retryable: tuple[type[Exception], ...] | None = None
 
 
+class _AcquireTimeoutError(RateLimitExceededException):
+    """Raised when ``limiter.acquire()`` times out internally.
+
+    Distinct from a real API 429 so the retry loop can identify it via
+    ``isinstance`` and raise immediately without calling
+    ``report_rate_limit()`` or attempting another retry.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class RetryConfig:
     """Retry policy for transient LLM API failures."""
@@ -312,14 +321,14 @@ class RetryChatModel(ChatModelBase):
     ) -> None:
         """Inspect *exc* and update the rate limiter accordingly.
 
-        - Internal acquire timeout (``_is_acquire_timeout``): re-raise as-is;
+        - Internal acquire timeout (``_AcquireTimeoutError``): re-raise as-is;
           no report, no retry.
         - Retryable API 429 with Retry-After > ``MAX_PAUSE_SECONDS``: re-raise
           immediately — retrying after the capped pause would just get another
           429 (e.g. Anthropic FreeUsageLimitError with Retry-After: 51496 s).
         - Normal 429: call ``report_rate_limit()`` to set the per-model pause.
         """
-        if getattr(exc, "_is_acquire_timeout", False):
+        if isinstance(exc, _AcquireTimeoutError):
             raise exc
         if _is_retryable(exc) and _is_rate_limit(exc):
             retry_after = _extract_retry_after(exc)
@@ -334,6 +343,7 @@ class RetryChatModel(ChatModelBase):
         self,
         stream: AsyncGenerator[ChatResponse, None],
         limiter: LLMRateLimiter,
+        acquired_at: float,
     ) -> AsyncGenerator[ChatResponse, None]:
         """Yield all chunks from *stream*, managing the semaphore slot
         lifecycle.
@@ -348,6 +358,10 @@ class RetryChatModel(ChatModelBase):
         (i.e. _wrap_stream), which handles retry decisions.  The exception
         does not propagate to the final consumer unless all retries are
         exhausted.
+
+        Args:
+            acquired_at: Timestamp from ``limiter.acquire()``, forwarded to
+                ``on_success()`` so only stale pauses are cleared.
         """
         first_chunk = True
         try:
@@ -359,7 +373,7 @@ class RetryChatModel(ChatModelBase):
                     # streaming success: clear any stale 429 pause so
                     # subsequent callers (including user chats) are not
                     # held back by a pause set by a background task.
-                    await limiter.on_success()
+                    await limiter.on_success(acquired_at)
                 yield chunk
         finally:
             await stream.aclose()
@@ -403,20 +417,19 @@ class RetryChatModel(ChatModelBase):
             # CancelledError (slot was never acquired).
             acquired = False
             owns_semaphore = True
+            acquired_at: float = 0.0
             try:
                 try:
-                    await asyncio.wait_for(
+                    acquired_at = await asyncio.wait_for(
                         limiter.acquire(),
                         timeout=self._rate_limit_config.acquire_timeout,
                     )
                     acquired = True
                 except asyncio.TimeoutError as exc:
                     # Internal acquire timeout — NOT an API 429.
-                    # Do not call report_rate_limit() (that would incorrectly
-                    # extend the global pause) and do not retry (it would just
-                    # time out again).  Use a sentinel attribute so the outer
-                    # exception handler can distinguish this from a real 429.
-                    _exc = RateLimitExceededException(
+                    # _AcquireTimeoutError is a typed subclass so the outer
+                    # handler can use isinstance() instead of a sentinel attr.
+                    raise _AcquireTimeoutError(
                         operation="LLM execution",
                         retry_after=int(
                             self._rate_limit_config.acquire_timeout,
@@ -424,11 +437,7 @@ class RetryChatModel(ChatModelBase):
                         details={
                             "reason": "Timed out waiting for execution slot",
                         },
-                    )
-                    _exc._is_acquire_timeout = (  # type: ignore[attr-defined]
-                        True
-                    )
-                    raise _exc from exc
+                    ) from exc
 
                 try:
                     result = await self._inner(*args, **kwargs)
@@ -458,12 +467,13 @@ class RetryChatModel(ChatModelBase):
                         attempt,
                         attempts,
                         limiter,
+                        acquired_at,
                     )
 
                 # Non-streaming success: clear any stale rate-limit pause so
                 # subsequent callers are not held back by a pause set by an
                 # unrelated background task (e.g. dream/cron 429).
-                await limiter.on_success()
+                await limiter.on_success(acquired_at)
                 return result
 
             except Exception as exc:
@@ -500,11 +510,22 @@ class RetryChatModel(ChatModelBase):
         current_attempt: int,
         max_attempts: int,
         limiter: LLMRateLimiter,
+        acquired_at: float = 0.0,
     ) -> AsyncGenerator[ChatResponse, None]:
         """Yield chunks from *stream*; on transient failure, retry the full
-        request and yield from the new stream instead."""
+        request and yield from the new stream instead.
+
+        Args:
+            acquired_at: Timestamp from ``limiter.acquire()``, forwarded to
+                ``on_success()`` so stale pauses are cleared but fresh ones
+                (set by a concurrent 429 after this call acquired) are kept.
+        """
         try:
-            async for chunk in self._consume_stream_with_slot(stream, limiter):
+            async for chunk in self._consume_stream_with_slot(
+                stream,
+                limiter,
+                acquired_at,
+            ):
                 yield chunk
             return  # stream completed without error
         except Exception as failed_exc:
@@ -533,15 +554,16 @@ class RetryChatModel(ChatModelBase):
         for attempt in range(current_attempt + 1, max_attempts + 1):
             acquired = False
             owns_semaphore = True
+            retry_acquired_at: float = 0.0
             try:
                 try:
-                    await asyncio.wait_for(
+                    retry_acquired_at = await asyncio.wait_for(
                         limiter.acquire(),
                         timeout=self._rate_limit_config.acquire_timeout,
                     )
                     acquired = True
                 except asyncio.TimeoutError as exc:
-                    raise RateLimitExceededException(
+                    raise _AcquireTimeoutError(
                         operation="LLM execution (stream retry)",
                         retry_after=int(
                             self._rate_limit_config.acquire_timeout,
@@ -559,6 +581,7 @@ class RetryChatModel(ChatModelBase):
                         async for chunk in self._consume_stream_with_slot(
                             result,
                             limiter,
+                            retry_acquired_at,
                         ):
                             yield chunk
                         return  # stream completed without error


### PR DESCRIPTION
## Description

Fix "three dots spinning / chat unresponsive" (#4469) by replacing the process-wide `LLMRateLimiter` singleton with per-model instances keyed on `"provider_id:model_name"`.

**Root cause:** The rate limiter was a single global object shared across every provider and model. Dream-based memory optimization cron jobs (one per workspace) hit the LLM API simultaneously every night, receive `429 RATE_LIMIT_EXCEEDED` with `Retry-After: 300` seconds, and call `report_rate_limit(300)`. Because the limiter is global, every subsequent LLM call — **including interactive user chat** — is blocked inside `await asyncio.sleep(300)`. When multiple workspaces fire at the same wall-clock time the pause is continuously refreshed, leaving users stuck on "three dots" indefinitely.

Evidence from user-submitted logs:
```
2026-04-27 23:05:00 | ERROR | dream-based memory optimization failed:
[429] RATE_LIMIT_EXCEEDED: Operation LLM execution is too frequent,
please retry after 300 seconds
```
(Occurring simultaneously for 3–4 workspaces, causing cascading global pause.)

**Related Issue:** Fixes #4469

**Security Considerations:** None — this change only affects in-process rate limiting logic.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Changes

### `src/qwenpaw/providers/rate_limiter.py`

| Change | Why |
|--------|-----|
| Replace `_global_limiter: LLMRateLimiter \| None` with `_limiters: dict[str, LLMRateLimiter]` | A 429 from DashScope dream task no longer pauses OpenRouter/Anthropic user chats |
| `get_rate_limiter(limiter_key, ...)` — new `limiter_key` parameter | Each `"provider_id:model_name"` pair gets its own independent limiter |
| New `on_success()` method — resets `_pause_until = 0` | A completed call proves the API rate-limit window has passed; clears stale pauses immediately |
| `_MAX_PAUSE_SECONDS = 60.0` cap in `report_rate_limit()` | Truncates API `Retry-After: 300` to 60 s max; worst-case user delay drops from 5+ min → 60 s |
| `reset_rate_limiter(limiter_key=None)` — optional key argument | Can reset a single model's limiter or all limiters |

### `src/qwenpaw/providers/retry_chat_model.py`

| Change | Why |
|--------|-----|
| `get_rate_limiter(limiter_key=self.model_key, ...)` | Routes each model to its own isolated limiter |
| `await limiter.on_success()` after streaming first-chunk and non-streaming success | Clears stale pause immediately on success |
| `_is_acquire_timeout = True` sentinel on internal `asyncio.TimeoutError` | Prevents the outer retry loop from calling `report_rate_limit()` (which would extend the pause further) and from retrying (it would just time out again) |

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

**To reproduce the original bug:**
1. Configure multiple agent workspaces (≥2) with a DashScope model that gets rate-limited
2. Enable dream-based memory optimization (default daily cron)
3. Wait for simultaneous dream tasks to trigger → observe `429 Retry-After: 300` in logs
4. Try sending a chat message → observe "three dots" spinning for 5+ minutes

**After this fix:**
- Each model's 429 only affects that model's queue
- A successful call on any model clears its stale pause immediately
- API `Retry-After: 300` is capped at 60 s maximum (if larger than 60, an exception will be raised)
- Internal acquire timeouts no longer extend the global pause

## Local Verification Evidence

```bash
pre-commit run --all-files
# All hooks passed (black auto-formatted one line, add-trailing-comma fixed one line)

# Manual trace — with fix applied:
# 1. DashScope dream task gets 429 → _limiters["dashscope:qwen-plus"]._pause_until = now+60
# 2. User chat on openrouter:nemotron → _limiters["openrouter:nemotron"] (separate) → proceeds immediately
# 3. User chat on dashscope:qwen-plus → waits ≤60 s, then succeeds → on_success() resets pause to 0
```

## Additional Notes

- This is a backwards-compatible change: `get_rate_limiter()` still works without `limiter_key` (uses `""` as fallback key)
- The `reset_rate_limiter()` signature is extended with an optional `limiter_key` argument; existing callers that pass no argument still reset all limiters
- A complementary fix (adding random jitter to dream cron trigger times per workspace) would further reduce simultaneous 429 bursts but is deferred to a follow-up PR
