### PR TITLE
perf(trace): batch append inbox trace events to reduce file I/O

### DIFF
--- a/src/qwenpaw/app/inbox_trace_store.py
+++ b/src/qwenpaw/app/inbox_trace_store.py
@@ -78,22 +78,33 @@ async def create_trace(
         _write_trace(run_id, payload)
 
 
-async def append_trace_event(
+async def append_trace_events(
     run_id: str,
-    event: Any,
-    *,
-    at: float | None = None,
+    events: list[dict[str, Any]],
 ) -> None:
-    async with _LOCK:
-        payload = _read_trace(run_id)
-        events = payload.get("events", [])
-        events.append(
+    if not events:
+        return
+
+    normalized_events: list[dict[str, Any]] = []
+    for item in events:
+        if not isinstance(item, dict):
+            continue
+        normalized_events.append(
             {
-                "at": at if at is not None else time.time(),
-                "event": _to_jsonable(event),
+                "at": item.get("at")
+                if item.get("at") is not None
+                else time.time(),
+                "event": _to_jsonable(item.get("event")),
             },
         )
-        payload["events"] = events
+    if not normalized_events:
+        return
+
+    async with _LOCK:
+        payload = _read_trace(run_id)
+        existing_events = payload.get("events", [])
+        existing_events.extend(normalized_events)
+        payload["events"] = existing_events
         _write_trace(run_id, payload)
 
 
@@ -164,9 +175,16 @@ async def append_trace_from_session_delta(
     )
     baseline_count = max(baseline_count, 0)
     delta = messages[baseline_count:]
-    for msg in delta:
-        at = parse_session_timestamp(msg.get("timestamp"))
-        await append_trace_event(run_id, msg, at=at)
+    await append_trace_events(
+        run_id,
+        [
+            {
+                "at": parse_session_timestamp(msg.get("timestamp")),
+                "event": msg,
+            }
+            for msg in delta
+        ],
+    )
     return delta
 
 


### PR DESCRIPTION
## Description

Refactor inbox trace persistence to write session deltas in batch instead of per-message appends. 

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
