### PR TITLE
refactor(console): Model performance optimization

### DIFF
--- a/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/LocalProviderCard.tsx
@@ -1,22 +1,20 @@
-import React, { useState } from "react";
+import React from "react";
 import { Card, Button } from "@agentscope-ai/design";
 import type { ProviderInfo } from "../../../../../api/types";
-import { ModelManageModal } from "../modals/ModelManageModal";
 import { useTranslation } from "react-i18next";
 import styles from "../../index.module.less";
 import { ProviderIcon } from "../ProviderIconComponent";
 
 interface LocalProviderCardProps {
   provider: ProviderInfo;
-  onSaved: () => void;
+  onOpenModels: (provider: ProviderInfo) => void;
 }
 
 export const LocalProviderCard = React.memo(function LocalProviderCard({
   provider,
-  onSaved,
+  onOpenModels,
 }: LocalProviderCardProps) {
   const { t } = useTranslation();
-  const [modelManageOpen, setModelManageOpen] = useState(false);
 
   const totalCount = provider.models.length + provider.extra_models.length;
   const statusReady = totalCount > 0;
@@ -77,20 +75,13 @@ export const LocalProviderCard = React.memo(function LocalProviderCard({
           size="small"
           onClick={(e) => {
             e.stopPropagation();
-            setModelManageOpen(true);
+            onOpenModels(provider);
           }}
           className={styles.actionBtn}
         >
           {t("models.models")}
         </Button>
       </div>
-
-      <ModelManageModal
-        provider={provider}
-        open={modelManageOpen}
-        onClose={() => setModelManageOpen(false)}
-        onSaved={onSaved}
-      />
     </Card>
   );
 });

--- a/console/src/pages/Settings/Models/components/cards/ProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/ProviderCard.tsx
@@ -7,22 +7,28 @@ interface ProviderCardProps {
   provider: ProviderInfo;
   activeModels: ActiveModelsInfo | null;
   onSaved: () => void;
+  onOpenConfig: (provider: ProviderInfo) => void;
+  onOpenModels: (provider: ProviderInfo) => void;
 }
 
 export const ProviderCard = React.memo(function ProviderCard({
   provider,
-  activeModels,
   onSaved,
+  onOpenConfig,
+  onOpenModels,
 }: ProviderCardProps) {
   if (provider.id === "qwenpaw-local") {
-    return <LocalProviderCard provider={provider} onSaved={onSaved} />;
+    return (
+      <LocalProviderCard provider={provider} onOpenModels={onOpenModels} />
+    );
   }
 
   return (
     <RemoteProviderCard
       provider={provider}
-      activeModels={activeModels}
       onSaved={onSaved}
+      onOpenConfig={onOpenConfig}
+      onOpenModels={onOpenModels}
     />
   );
 });

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -1,29 +1,28 @@
-import React, { useState } from "react";
+import React from "react";
 import { Card, Button, Modal } from "@agentscope-ai/design";
-import type { ProviderInfo, ActiveModelsInfo } from "../../../../../api/types";
-import { ProviderConfigModal } from "../modals/ProviderConfigModal";
-import { ModelManageModal } from "../modals/ModelManageModal";
+import type { ProviderInfo } from "../../../../../api/types";
 import api from "../../../../../api";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../../../../../hooks/useAppMessage";
+import { getIsConfigured } from "../../utils";
 import styles from "../../index.module.less";
 import { ProviderIcon } from "../ProviderIconComponent";
 
 interface RemoteProviderCardProps {
   provider: ProviderInfo;
-  activeModels: ActiveModelsInfo | null;
   onSaved: () => void;
+  onOpenConfig: (provider: ProviderInfo) => void;
+  onOpenModels: (provider: ProviderInfo) => void;
 }
 
 export const RemoteProviderCard = React.memo(function RemoteProviderCard({
   provider,
-  activeModels,
   onSaved,
+  onOpenConfig,
+  onOpenModels,
 }: RemoteProviderCardProps) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
-  const [modalOpen, setModalOpen] = useState(false);
-  const [modelManageOpen, setModelManageOpen] = useState(false);
 
   const handleDeleteProvider = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -50,19 +49,7 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
   };
 
   const totalCount = provider.models.length + provider.extra_models.length;
-
-  let isConfigured = false;
-
-  if (provider.id === "qwenpaw-local") {
-    isConfigured = true;
-  } else if (provider.is_custom && provider.base_url) {
-    isConfigured = true;
-  } else if (provider.require_api_key === false) {
-    isConfigured = true;
-  } else if (provider.require_api_key && provider.api_key) {
-    isConfigured = true;
-  }
-
+  const isConfigured = getIsConfigured(provider);
   const hasModels = totalCount > 0;
   const isAvailable = isConfigured && hasModels;
 
@@ -162,7 +149,7 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
           size="small"
           onClick={(e) => {
             e.stopPropagation();
-            setModelManageOpen(true);
+            onOpenModels(provider);
           }}
           className={styles.actionBtn}
         >
@@ -173,7 +160,7 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
           size="small"
           onClick={(e) => {
             e.stopPropagation();
-            setModalOpen(true);
+            onOpenConfig(provider);
           }}
           className={styles.actionBtn}
         >
@@ -191,20 +178,6 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
           </Button>
         )}
       </div>
-
-      <ProviderConfigModal
-        provider={provider}
-        activeModels={activeModels}
-        open={modalOpen}
-        onClose={() => setModalOpen(false)}
-        onSaved={onSaved}
-      />
-      <ModelManageModal
-        provider={provider}
-        open={modelManageOpen}
-        onClose={() => setModelManageOpen(false)}
-        onSaved={onSaved}
-      />
     </Card>
   );
 });

--- a/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
+++ b/console/src/pages/Settings/Models/components/sections/ModelsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { SaveOutlined } from "@ant-design/icons";
 import { Select, Button, Card } from "@agentscope-ai/design";
 import type { ModelSlotRequest } from "../../../../../api/types";
@@ -29,7 +29,7 @@ interface ModelsSectionProps {
   onSaved: () => void;
 }
 
-export function ModelsSection({
+export const ModelsSection = React.memo(function ModelsSection({
   providers,
   activeModels,
   onSaved,
@@ -189,4 +189,4 @@ export function ModelsSection({
       <p className={styles.slotDescription}>{t("models.llmDescription")}</p>
     </Card>
   );
-}
+});

--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import { Button, Input } from "@agentscope-ai/design";
 import { PlusOutlined, SearchOutlined, SyncOutlined } from "@ant-design/icons";
 import { useProviders } from "./useProviders";
@@ -7,10 +7,13 @@ import {
   ProviderCard,
   CustomProviderModal,
   ModelsSection,
+  ProviderConfigModal,
+  ModelManageModal,
 } from "./components";
 import { PageHeader } from "@/components/PageHeader";
 import { useTranslation } from "react-i18next";
 import type { ProviderInfo } from "../../../api/types/provider";
+import { getIsConfigured } from "./utils";
 import styles from "./index.module.less";
 
 /* ------------------------------------------------------------------ */
@@ -23,9 +26,26 @@ function ModelsPage() {
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
+  // Shared Modal state — only one instance each instead of N per card
+  const [configModalProvider, setConfigModalProvider] =
+    useState<ProviderInfo | null>(null);
+  const [modelsModalProvider, setModelsModalProvider] =
+    useState<ProviderInfo | null>(null);
+
   const refreshProvidersSilently = useCallback(() => {
     void fetchAll(false);
   }, [fetchAll]);
+
+  const handleOpenConfig = useCallback((provider: ProviderInfo) => {
+    setConfigModalProvider(provider);
+  }, []);
+
+  const handleOpenModels = useCallback((provider: ProviderInfo) => {
+    setModelsModalProvider(provider);
+  }, []);
+
+  // P1: Defer search filtering to avoid blocking input responsiveness
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   const { regularProviders, localProviders } = useMemo(() => {
     const regular: ProviderInfo[] = [];
@@ -36,26 +56,12 @@ function ModelsPage() {
     }
 
     // Sort providers: custom/available first, then configured, then the rest.
-    // This mirrors the isConfigured logic in RemoteProviderCard.
     const sortPriority = (provider: ProviderInfo): number => {
-      let isConfigured = false;
-      if (provider.id === "qwenpaw-local") {
-        isConfigured = true;
-      } else if (provider.is_custom && provider.base_url) {
-        isConfigured = true;
-      } else if (provider.require_api_key === false) {
-        isConfigured = true;
-      } else if (provider.require_api_key && provider.api_key) {
-        isConfigured = true;
-      }
-
+      const isConfigured = getIsConfigured(provider);
       const hasModels =
         provider.models.length + provider.extra_models.length > 0;
       const isAvailable = isConfigured && hasModels;
 
-      // Lower number = higher priority (shown first)
-      // Available providers (configured + has models) always come first,
-      // then custom providers, then configured-only, then unconfigured.
       if (isAvailable && provider.is_custom) return 0;
       if (isAvailable) return 1;
       if (provider.is_custom) return 2;
@@ -66,7 +72,7 @@ function ModelsPage() {
     regular.sort((a, b) => sortPriority(a) - sortPriority(b));
 
     // Fuzzy search filter: match provider name (case-insensitive)
-    const query = searchQuery.trim().toLowerCase();
+    const query = deferredSearchQuery.trim().toLowerCase();
     if (!query) {
       return { regularProviders: regular, localProviders: local };
     }
@@ -76,7 +82,7 @@ function ModelsPage() {
       ),
       localProviders: local.filter((p) => p.name.toLowerCase().includes(query)),
     };
-  }, [providers, searchQuery]);
+  }, [providers, deferredSearchQuery]);
 
   const renderProviderCards = (list: ProviderInfo[]) =>
     list.map((provider) => (
@@ -85,6 +91,8 @@ function ModelsPage() {
         provider={provider}
         activeModels={activeModels}
         onSaved={refreshProvidersSilently}
+        onOpenConfig={handleOpenConfig}
+        onOpenModels={handleOpenModels}
       />
     ));
 
@@ -169,6 +177,25 @@ function ModelsPage() {
               onClose={() => setAddProviderOpen(false)}
               onSaved={fetchAll}
             />
+
+            {/* Shared Modal instances — one each for the entire page */}
+            {configModalProvider && (
+              <ProviderConfigModal
+                provider={configModalProvider}
+                activeModels={activeModels}
+                open={!!configModalProvider}
+                onClose={() => setConfigModalProvider(null)}
+                onSaved={refreshProvidersSilently}
+              />
+            )}
+            {modelsModalProvider && (
+              <ModelManageModal
+                provider={modelsModalProvider}
+                open={!!modelsModalProvider}
+                onClose={() => setModelsModalProvider(null)}
+                onSaved={refreshProvidersSilently}
+              />
+            )}
           </div>
         </>
       )}

--- a/console/src/pages/Settings/Models/useProviders.ts
+++ b/console/src/pages/Settings/Models/useProviders.ts
@@ -41,6 +41,9 @@ export function useProviders() {
     }
   }, []);
 
+  // Re-fetch when agent changes to ensure UI stays in sync even though
+  // this page uses scope:"global". If future requirements add agent-scoped
+  // models, this dependency will be needed.
   useEffect(() => {
     fetchAll();
   }, [fetchAll, selectedAgent]);

--- a/console/src/pages/Settings/Models/utils.ts
+++ b/console/src/pages/Settings/Models/utils.ts
@@ -1,0 +1,10 @@
+import type { ProviderInfo } from "../../../api/types/provider";
+
+/** Determine if a provider has valid credentials configured. */
+export function getIsConfigured(provider: ProviderInfo): boolean {
+  if (provider.id === "qwenpaw-local") return true;
+  if (provider.is_custom && provider.base_url) return true;
+  if (provider.require_api_key === false) return true;
+  if (provider.require_api_key && provider.api_key) return true;
+  return false;
+}


### PR DESCRIPTION
## Description

Redundant Modal component mounting: Each Provider card internally mounts its own ProviderConfigModal and ModelManageModal. N providers generate 2N Modal instances persistent in the component tree, causing significant memory overhead and initial rendering time.

No debouncing for search input: Each keystroke immediately triggers sorting, filtering, and a complete re-rendering of the entire card tree, resulting in a choppy input experience.

ModelsSection not memoized: When the parent element's state changes unrelated to search, ModelsSection unnecessarily re-renders.

Repeated isConfigured check logic: The same configuration state check is implemented once in both the index.tsx sorting logic and the RemoteProviderCard rendering logic.

## Solution

Modal Instance Redundancy: Modals are promoted from within each card to the parent `index.tsx`, ensuring only one `ProviderConfigModal` and one `ModelManageModal` instance are shared across the entire page. The provider for the current operation is controlled by state.

Search Without Debouncing: React 18's `useDeferredValue` is used for delayed search filtering calculations, ensuring input responses do not block the UI.

ModelsSection Without Memo: `ModelsSection` is wrapped with `React.memo` to prevent re-rendering caused by updates unrelated to the parent.

`isConfigured` Logic Redundancy: The `getIsConfigured()` utility function is extracted and reused in separate `utils.ts`, `index.tsx`, and `RemoteProviderCard`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
