### PR TITLE
fix(QQ): Fix QQ Channel high-frequency reconnect on IP whitelist rejection

### DIFF
--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -1660,6 +1660,29 @@ class QQChannel(BaseChannel):
             min(state.reconnect_attempts, len(RECONNECT_DELAYS) - 1)
         ]
 
+    def _wait_and_check_reconnect(self, state: _WSState) -> bool:
+        """Apply backoff delay for connection-setup failures.
+
+        Increments reconnect_attempts, respects max_reconnect_attempts,
+        and waits with exponential backoff.
+        Returns True to continue reconnecting, False to stop.
+        """
+        delay = RECONNECT_DELAYS[
+            min(state.reconnect_attempts, len(RECONNECT_DELAYS) - 1)
+        ]
+        state.reconnect_attempts += 1
+        max_attempts = self._max_reconnect_attempts
+        if max_attempts != -1 and state.reconnect_attempts >= max_attempts:
+            logger.error("qq max reconnect attempts reached")
+            return False
+        logger.info(
+            "qq reconnecting in %ss (attempt %s)",
+            delay,
+            state.reconnect_attempts,
+        )
+        self._stop_event.wait(timeout=delay)
+        return not self._stop_event.is_set()
+
     # ------------------------------------------------------------------
     # WebSocket: single connection attempt
     # ------------------------------------------------------------------
@@ -1683,13 +1706,13 @@ class QQChannel(BaseChannel):
             url = _get_channel_url_sync(token)
         except Exception as e:
             logger.warning("qq get token/gateway failed: %s", e)
-            return True
+            return self._wait_and_check_reconnect(state)
         logger.info("qq connecting to %s", url)
         try:
             ws = websocket.create_connection(url)
         except Exception as e:
             logger.warning("qq ws connect failed: %s", e)
-            return True
+            return self._wait_and_check_reconnect(state)
 
         self._ws = ws
         hb = _HeartbeatController(ws, self._stop_event, state)


### PR DESCRIPTION
## Description

When QQ gateway rejects connections due to IP not in whitelist (error 11298), _ws_connect_once previously returned True immediately without any backoff delay, causing rapid-fire reconnection attempts.

Extracted _wait_and_check_reconnect helper that applies exponential backoff (1s → 2s → 5s → 10s → 30s → 60s) for connection-setup failures (token/gateway fetch and WebSocket connect), respecting max_reconnect_attempts. This also resolves a pylint too-many-return-statements warning.

**Related Issue:** Fixes #4501 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
