### PR TITLE
perf(security): prevent path traversal in AgentMdManager file operations

### DIFF
--- a/src/qwenpaw/agents/memory/agent_md_manager.py
+++ b/src/qwenpaw/agents/memory/agent_md_manager.py
@@ -37,6 +37,55 @@ class AgentMdManager:
         self.memory_dir: Path = self.working_dir / memory_dir_name
         self.memory_dir.mkdir(parents=True, exist_ok=True)
 
+    # ------------------------------------------------------------------
+    # Path safety helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sanitize_md_name(md_name: str) -> str:
+        """Normalize *md_name* to a plain filename (no path components).
+
+        Rejects names that contain path separators or ``..`` traversal
+        sequences so that callers cannot escape the intended directory.
+
+        Raises:
+            ValueError: If the name contains illegal path components.
+        """
+        # Normalise Windows-style backslashes before any other check
+        normalized = md_name.replace("\\", "/")
+
+        # Reject any component that looks like directory traversal
+        parts = normalized.split("/")
+        for part in parts:
+            if part == "..":
+                raise ValueError(
+                    f"Invalid md_name '{md_name}':"
+                    " path traversal is not allowed",
+                )
+
+        # Keep only the final component so that any remaining "/" is stripped
+        filename = parts[-1]
+
+        if not filename:
+            raise ValueError(f"Invalid md_name '{md_name}': filename is empty")
+
+        return filename
+
+    @staticmethod
+    def _assert_within_dir(file_path: Path, base_dir: Path) -> None:
+        """Raise *ValueError* if *file_path* resolves outside *base_dir*.
+
+        Uses :meth:`Path.resolve` so that symlinks are followed before the
+        comparison, which closes any remaining bypass vectors.
+        """
+        try:
+            file_path.resolve().relative_to(base_dir.resolve())
+        except ValueError:
+            raise ValueError(
+                f"Resolved path '{file_path}' escapes"
+                f" the allowed directory '{base_dir}'",
+            ) from None
+
     def list_working_mds(self) -> list[dict]:
         """List all markdown files with metadata in the working dir.
 
@@ -78,10 +127,11 @@ class AgentMdManager:
         Returns:
             str: The file content as string
         """
-        # Auto-append .md extension if not present
+        md_name = self._sanitize_md_name(md_name)
         if not md_name.endswith(".md"):
             md_name += ".md"
         file_path = self.working_dir / md_name
+        self._assert_within_dir(file_path, self.working_dir)
         if not file_path.exists():
             raise FileNotFoundError(f"Working md file not found: {md_name}")
 
@@ -89,10 +139,11 @@ class AgentMdManager:
 
     def write_working_md(self, md_name: str, content: str):
         """Write markdown content to a file in the working directory."""
-        # Auto-append .md extension if not present
+        md_name = self._sanitize_md_name(md_name)
         if not md_name.endswith(".md"):
             md_name += ".md"
         file_path = self.working_dir / md_name
+        self._assert_within_dir(file_path, self.working_dir)
         file_path.write_text(content, encoding="utf-8")
 
     def list_memory_mds(self) -> list[dict]:
@@ -136,10 +187,11 @@ class AgentMdManager:
         Returns:
             str: The file content as string
         """
-        # Auto-append .md extension if not present
+        md_name = self._sanitize_md_name(md_name)
         if not md_name.endswith(".md"):
             md_name += ".md"
         file_path = self.memory_dir / md_name
+        self._assert_within_dir(file_path, self.memory_dir)
         if not file_path.exists():
             raise FileNotFoundError(f"Memory md file not found: {md_name}")
 
@@ -147,8 +199,9 @@ class AgentMdManager:
 
     def write_memory_md(self, md_name: str, content: str):
         """Write markdown content to a file in the memory directory."""
-        # Auto-append .md extension if not present
+        md_name = self._sanitize_md_name(md_name)
         if not md_name.endswith(".md"):
             md_name += ".md"
         file_path = self.memory_dir / md_name
+        self._assert_within_dir(file_path, self.memory_dir)
         file_path.write_text(content, encoding="utf-8")


### PR DESCRIPTION
## Description

Fix a path traversal vulnerability in `AgentMdManager` where externally
supplied filenames were concatenated directly with the workspace path
without any boundary validation.

An attacker (or a malicious agent instruction) could supply a crafted
`md_name` such as `../../etc/passwd` or, on Windows, `..\..\\secret` to
read or overwrite arbitrary files outside the intended working/memory
directory.  The `.md` auto-append only changed the extension; it did
**not** prevent traversal.

**Vulnerable pattern (before):**

```python
if not md_name.endswith(".md"):
    md_name += ".md"
file_path = self.working_dir / md_name   # no boundary check
file_path.write_text(content, encoding="utf-8")
```

Two static safety helpers are added and called at the entry of every
read/write method:

| Helper | What it does |
|---|---|
| `_sanitize_md_name` | Normalises Windows `\` → `/`, rejects any `..` path component, strips leading directory prefixes, ensures a non-empty bare filename |
| `_assert_within_dir` | Calls `Path.resolve()` (follows symlinks) then asserts the resolved path is still inside the intended base directory – defence-in-depth backstop |

**Related Issue:** Relates to path-traversal class of vulnerabilities in
agent workspace file APIs.

**Security Considerations:** This change hardens the Agent Markdown
file read/write endpoints (`GET/PUT /workspace/files/{md_name}` and
`GET/PUT /workspace/memory/{md_name}`) against path traversal.  Both
Unix (`../`) and Windows (`..\\`) separators are covered.  Symlink
bypass is also mitigated via `Path.resolve()`.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

---

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

---

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

---

## Testing

Manual verification against the affected methods:

```python
from qwenpaw.agents.memory.agent_md_manager import AgentMdManager

mgr = AgentMdManager("/tmp/workspace_test")

# --- should raise ValueError ---
mgr.write_working_md("../../etc/passwd", "evil")
# ValueError: Invalid md_name '../../etc/passwd': path traversal is not allowed

mgr.write_working_md("..\\..\\secret", "evil")
# ValueError: Invalid md_name '..\\..\secret': path traversal is not allowed

# --- should succeed ---
mgr.write_working_md("notes", "hello")          # writes /tmp/workspace_test/notes.md
mgr.write_working_md("notes.md", "hello again") # same file, explicit extension
```

---

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast...........Passed
# mypy.......................Passed
# black......................Passed
# flake8.....................Passed
# pylint.....................Passed
# → All hooks passed.
```

---

## Additional Notes

- The fix is entirely backward-compatible: well-formed filenames (no
  path separators, no `..`) continue to work exactly as before.
- `_assert_within_dir` is intentionally kept as a second independent
  check so that any future code path that skips `_sanitize_md_name`
  still cannot escape the sandbox.
- All four methods (`read_working_md`, `write_working_md`,
  `read_memory_md`, `write_memory_md`) are patched uniformly.
