### PR TITLE
fix(console): ChatSessionInitializer

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -8,6 +8,10 @@ import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
  * Only reacts to URL or session list changes. currentSessionId is read via ref
  * to avoid triggering the effect when the context changes from the other direction
  * (context → URL via onSessionSelected), which would cause circular re-loads.
+ *
+ * IMPORTANT: sessions array reference changes (e.g. from polling in pinned drawer)
+ * must NOT re-trigger setCurrentSessionId when the chatId hasn't changed, otherwise
+ * it causes an infinite loop of getSession calls bouncing between two chat IDs.
  */
 const ChatSessionInitializer: React.FC = () => {
   const location = useLocation();
@@ -22,11 +26,28 @@ const ChatSessionInitializer: React.FC = () => {
   const currentSessionIdRef = useRef(currentSessionId);
   currentSessionIdRef.current = currentSessionId;
 
+  /** Track the last chatId for which we called setCurrentSessionId, so that
+   *  subsequent sessions array reference changes (from polling in pinned drawer)
+   *  don't re-trigger setCurrentSessionId and cause infinite getSession loops. */
+  const lastAppliedChatIdRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
     if (!chatId || !sessions.length) return;
+
+    // If we already applied this exact chatId and the context is in sync, skip.
+    // This prevents the polling-triggered sessions refresh (pinned drawer)
+    // from re-calling setCurrentSessionId and causing circular getSession loops.
+    if (chatId === lastAppliedChatIdRef.current) {
+      return;
+    }
+
     const matching = sessions.find((s) => s.id === chatId);
     if (matching && currentSessionIdRef.current !== matching.id) {
+      lastAppliedChatIdRef.current = chatId;
       setCurrentSessionId(matching.id);
+    } else if (matching) {
+      // Already in sync, just record that we've handled this chatId
+      lastAppliedChatIdRef.current = chatId;
     }
     // Intentionally exclude currentSessionId from deps: only react to URL / session list changes.
     // currentSessionId is read via ref to avoid circular triggers.


### PR DESCRIPTION
## Description

The `ChatSessionInitializer` component handles the one-way synchronization of URL and context. Its `useEffect` dependency includes `[chatId, sessions, setCurrentSessionId]`. When a drawer is pinned, it internally polls every 3 seconds, continuously calling `setSessions(list)` to refresh the list, generating a new `sessions` array reference each time.

This causes the effect to repeatedly re-execute even when the `chatId` remains unchanged. Each execution may trigger `setCurrentSessionId` again due to asynchronous timing differences, leading to `sessionApi.getSession` being called, `onSessionSelected` being triggered to update the URL, and the effect being triggered again, creating an infinite loop where the two chat IDs alternate.

## Solution


Add `lastAppliedChatIdRef` to `ChatSessionInitializer` to record the last successfully applied `chatId`. When the sessions reference changes but the `chatId` remains the same (i.e., when the pinned drawer polls for a refresh), skip the `setCurrentSessionId` call to break the loop.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
