### PR TITLE
feat(console): （会话草稿持久化）persist chat input draft across page navigation

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -718,10 +718,10 @@ export default function ChatPage() {
   useEffect(() => {
     const KEY = "qwenpaw_chat_draft";
     let ta: HTMLTextAreaElement | null = null;
-    let restoring = false, done = false;
-    const el = () => document.querySelector<HTMLTextAreaElement>(
-      '[class*="sender"] textarea',
-    );
+    let restoring = false,
+      done = false;
+    const el = () =>
+      document.querySelector<HTMLTextAreaElement>('[class*="sender"] textarea');
 
     // Restore: poll until textarea appears (async render)
     const iv = setInterval(() => {
@@ -729,15 +729,30 @@ export default function ChatPage() {
       ta = el();
       if (!ta) return;
       const raw = localStorage.getItem(KEY);
-      if (!raw) { done = true; clearInterval(iv); return; }
-      let v = "", s = 0, e = 0;
-      try { const d = JSON.parse(raw); v = d.v ?? ""; s = d.s ?? 0; e = d.e ?? 0; } catch {}
+      if (!raw) {
+        done = true;
+        clearInterval(iv);
+        return;
+      }
+      let v = "",
+        s = 0,
+        e = 0;
+      try {
+        const d = JSON.parse(raw);
+        v = d.v ?? "";
+        s = d.s ?? 0;
+        e = d.e ?? 0;
+      } catch {}
       restoring = true;
       setTextareaValue(ta, v);
       requestAnimationFrame(() => {
-        ta!.selectionStart = s; ta!.selectionEnd = e; ta!.focus(); restoring = false;
+        ta!.selectionStart = s;
+        ta!.selectionEnd = e;
+        ta!.focus();
+        restoring = false;
       });
-      done = true; clearInterval(iv);
+      done = true;
+      clearInterval(iv);
     }, 150);
 
     const onInput = (e: Event) => {
@@ -745,9 +760,14 @@ export default function ChatPage() {
       const t = e.target as HTMLTextAreaElement;
       if (t?.tagName === "TEXTAREA" && t.closest('[class*="sender"]')) {
         ta = t;
-        localStorage.setItem(KEY, JSON.stringify({
-          v: t.value.trim(), s: t.selectionStart, e: t.selectionEnd,
-        }));
+        localStorage.setItem(
+          KEY,
+          JSON.stringify({
+            v: t.value.trim(),
+            s: t.selectionStart,
+            e: t.selectionEnd,
+          }),
+        );
       }
     };
     document.addEventListener("input", onInput);
@@ -756,9 +776,14 @@ export default function ChatPage() {
       document.removeEventListener("input", onInput);
       const el_ = ta || el();
       if (el_?.value?.trim()) {
-        localStorage.setItem(KEY, JSON.stringify({
-          v: el_.value.trim(), s: el_.selectionStart, e: el_.selectionEnd,
-        }));
+        localStorage.setItem(
+          KEY,
+          JSON.stringify({
+            v: el_.value.trim(),
+            s: el_.selectionStart,
+            e: el_.selectionEnd,
+          }),
+        );
       } else {
         localStorage.removeItem(KEY);
       }

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -714,6 +714,57 @@ export default function ChatPage() {
 
   useMessageHistoryNavigation(chatRef, isChatActive, isComposingRef);
 
+  // Persist input draft across tab navigation (e.g. chat → models → chat)
+  useEffect(() => {
+    const KEY = "qwenpaw_chat_draft";
+    let ta: HTMLTextAreaElement | null = null;
+    let restoring = false, done = false;
+    const el = () => document.querySelector<HTMLTextAreaElement>(
+      '[class*="sender"] textarea',
+    );
+
+    // Restore: poll until textarea appears (async render)
+    const iv = setInterval(() => {
+      if (done) return clearInterval(iv);
+      ta = el();
+      if (!ta) return;
+      const raw = localStorage.getItem(KEY);
+      if (!raw) { done = true; clearInterval(iv); return; }
+      let v = "", s = 0, e = 0;
+      try { const d = JSON.parse(raw); v = d.v ?? ""; s = d.s ?? 0; e = d.e ?? 0; } catch {}
+      restoring = true;
+      setTextareaValue(ta, v);
+      requestAnimationFrame(() => {
+        ta!.selectionStart = s; ta!.selectionEnd = e; ta!.focus(); restoring = false;
+      });
+      done = true; clearInterval(iv);
+    }, 150);
+
+    const onInput = (e: Event) => {
+      if (restoring) return;
+      const t = e.target as HTMLTextAreaElement;
+      if (t?.tagName === "TEXTAREA" && t.closest('[class*="sender"]')) {
+        ta = t;
+        localStorage.setItem(KEY, JSON.stringify({
+          v: t.value.trim(), s: t.selectionStart, e: t.selectionEnd,
+        }));
+      }
+    };
+    document.addEventListener("input", onInput);
+    return () => {
+      clearInterval(iv);
+      document.removeEventListener("input", onInput);
+      const el_ = ta || el();
+      if (el_?.value?.trim()) {
+        localStorage.setItem(KEY, JSON.stringify({
+          v: el_.value.trim(), s: el_.selectionStart, e: el_.selectionEnd,
+        }));
+      } else {
+        localStorage.removeItem(KEY);
+      }
+    };
+  }, []);
+
   // Shortcut key for voice recording (Ctrl+Shift+M or Cmd+Shift+M on Mac)
   useEffect(() => {
     const handleShortcut = (e: KeyboardEvent) => {


### PR DESCRIPTION
## 问题描述

在聊天页面输入内容后，切换到其他页面（如模型、技能等），再切回聊天页面时，输入框中的内容会丢失。

## 改动说明

`console/src/pages/Chat/index.tsx`（+51, 0）

新增一个 `useEffect`，实现输入框草稿的持久化：

- **保存**：通过全局 `input` 事件监听，每次输入时实时写入 `localStorage`
- **恢复**：组件挂载后轮询等待 textarea 渲染完成，从 `localStorage` 读取并回填
- **清理**：组件卸载时做最终保存，确保切换页面不丢失内容
- 同时保存光标位置（`selectionStart` / `selectionEnd`），恢复后光标位置不变

## 测试

- [x] 输入内容 → 切换到其他页面 → 切回，内容恢复
- [x] 光标位置在恢复后保持不变
- [x] 清空输入框后切回，不会恢复旧内容
- [x] 刷新页面后内容仍然保留