### PR TITLE
fix(cli): correct typo in tool_results directory reference

### DIFF
--- a/src/qwenpaw/cli/doctor_checks.py
+++ b/src/qwenpaw/cli/doctor_checks.py
@@ -680,7 +680,7 @@ def memory_embedding_notes(cfg: Config) -> list[str]:
 
 
 def workspace_hygiene_notes(cfg: Config) -> list[str]:
-    """Large prompt files, heavy tool_result/dialog dirs; memory tree size."""
+    """Large prompt files, heavy tool_results/dialog dirs; memory tree size."""
     notes: list[str] = []
     bootstrap_names = (
         "AGENTS.md",
@@ -706,7 +706,7 @@ def workspace_hygiene_notes(cfg: Config) -> list[str]:
                     "burn context; consider splitting or summarizing.",
                 )
         for sub, many, label in (
-            ("tool_result", _TOOL_RESULT_MANY, "tool_result"),
+            ("tool_results", _TOOL_RESULT_MANY, "tool_results"),
             ("dialog", _DIALOG_MANY, "dialog"),
         ):
             d = wd / sub


### PR DESCRIPTION
- Fixed typo from 'tool_result' to

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
