### PR TITLE
fix(runner): persist /mission and /skill info responses to session me…

### DIFF
--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -301,6 +301,56 @@ class AgentRunner(Runner):
         elif isinstance(content, str):
             last.content = new_text
 
+    async def _persist_exchange_to_session(
+        self,
+        session_id: str,
+        user_id: str,
+        channel: str,
+        msgs: list,
+        response_msg: "Msg",
+    ) -> None:
+        """Persist a user-message + response to session memory.
+
+        Used by early-exit paths (/mission info, /skill info) that bypass
+        the full agent pipeline and would otherwise leave session memory
+        unsaved — causing the response to vanish when the frontend
+        reloads the session from the backend.
+        """
+        if not session_id or not user_id:
+            return
+        try:
+            context_manager = self.context_manager
+            if context_manager is None:
+                return
+            memory = context_manager.get_agent_context()
+            if memory is None:
+                return
+            state = await self.session.get_session_state_dict(
+                session_id,
+                user_id,
+                channel,
+                allow_not_exist=True,
+            )
+            memory_state = (state or {}).get("agent", {}).get("memory", {})
+            memory.load_state_dict(memory_state, strict=False)
+            if msgs:
+                await memory.add(msgs[-1])
+            await memory.add(response_msg)
+            await self.session.update_session_state(
+                session_id=session_id,
+                key="agent.memory",
+                value=memory.state_dict(),
+                user_id=user_id,
+                channel=channel,
+            )
+            preview = session_id[:12] if len(session_id) >= 12 else session_id
+            logger.debug("Persisted exchange to session %s", preview)
+        except Exception:
+            logger.debug(
+                "Failed to persist exchange to session",
+                exc_info=True,
+            )
+
     async def query_handler(
         self,
         msgs,
@@ -454,6 +504,13 @@ class AgentRunner(Runner):
                 agent_name=self.agent_name,
             )
             if isinstance(mission_result, Msg):
+                await self._persist_exchange_to_session(
+                    session_id,
+                    user_id,
+                    channel,
+                    msgs,
+                    mission_result,
+                )
                 yield mission_result, True
                 return
             if isinstance(mission_result, dict):
@@ -651,6 +708,13 @@ class AgentRunner(Runner):
                     agent.toolkit.skills,
                 )
                 if skill_response is not None:
+                    await self._persist_exchange_to_session(
+                        session_id,
+                        user_id,
+                        channel,
+                        msgs,
+                        skill_response,
+                    )
                     yield skill_response, True
                     return
 


### PR DESCRIPTION
## Description

Fixes a bug where `/mission` info responses and bare `/<skill>` display responses flash briefly in the frontend chat UI and then disappear after the session is reloaded from the backend.

**Root Cause:** Both paths use an "early-exit" pattern — they yield a response `Msg` and return immediately, bypassing the full agent pipeline. This means the agent's `InMemoryMemory` is never updated, and `save_session_state` is never called. When the frontend later reloads the session via `GET /chats/{id}` (which reconstructs message history from `InMemoryMemory` in session state), the response is absent, so the message vanishes.

**Affected flows:**

| Command | Behavior before fix |
|---|---|
| `/mission <query with meta keywords>` (e.g. "你会做什么") | Response flashes and disappears |
| `/mission` (empty / < 5 chars) | Response flashes and disappears |
| `/mission status` / `/mission list` | Response flashes and disappears |
| `/<skill>` (bare, no input) | Response flashes and disappears |
| `/mission <real task ≥ 5 chars>` | ✅ Already working (full agent path) |
| `/<skill> <input>` | ✅ Already working (full agent path) |

**Related Issue:** N/A

**Security Considerations:** None — this change only adds persistence of existing public chat responses to session memory. No new data is exposed and no auth paths are modified.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Changes

Single file changed: `src/qwenpaw/app/runner/runner.py`

**New helper method `AgentRunner._persist_exchange_to_session`:**

```python
async def _persist_exchange_to_session(
    self,
    session_id: str,
    user_id: str,
    channel: str,
    msgs: list,
    response_msg: Msg,
) -> None:
    """Persist a user-message + response to session memory.

    Used by early-exit paths (/mission info, /skill info) that bypass
    the full agent pipeline and would otherwise leave session memory
    unsaved — causing the response to vanish when the frontend
    reloads the session from the backend.
    """
```

The helper:
1. Loads existing session memory from state (using `allow_not_exist=True` to handle new sessions)
2. Appends the user message (`msgs[-1]`) and the response `Msg` to memory
3. Saves the updated memory state back via `update_session_state`
4. Wrapped in `try/except` — a persistence failure is logged at DEBUG level and never blocks response delivery

This matches the pattern used by `run_command_path` for conversation commands (`/clear`, `/compact`, etc.).

**Two early-exit paths updated:**

```python
# /mission info path (before agent creation)
if isinstance(mission_result, Msg):
    await self._persist_exchange_to_session(          # ← new
        session_id, user_id, channel, msgs, mission_result
    )
    yield mission_result, True
    return

# /skill display path (after agent creation, before session load)
if skill_response is not None:
    await self._persist_exchange_to_session(          # ← new
        session_id, user_id, channel, msgs, skill_response
    )
    yield skill_response, True
    return
```

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start QwenPaw backend + frontend
2. In the chat UI, send `/mission 你会做什么`
   - **Before:** Response text flashes and disappears after ~1s
   - **After:** Response persists; refreshing the page also shows the exchange in history
3. Send `/mission 123` (< 5 chars)
   - **After:** Help text persists in chat history
4. Send `/mission status`
   - **After:** Status text persists in chat history
5. If a skill is installed, send `/<skill_name>` without arguments
   - **After:** Skill info card persists in chat history
6. Verify normal flows are unaffected:
   - `/mission 实现用户认证系统包含JWT` (real task) → still enters Phase 1 normally
   - `/<skill> <input>` → still executes the skill normally

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast...Passed
# Add trailing commas...Passed
# mypy...Passed
# black...Passed
# flake8...Passed
# pylint...Passed
```

Backend log after fix (session persisted successfully):
```
INFO  session.py | Updated session state key 'agent.memory' in .../default_1779179921564.json successfully.
DEBUG runner.py  | Persisted exchange to session 177917992156
```

## Additional Notes

The "flash and disappear" symptom was first observed with the title generation background task: when `generate_and_update_title` completes, the frontend refreshes the session list and then calls `getSession`, which fetches `GET /chats/{id}`. This endpoint reads from `InMemoryMemory` in session state — if that state is empty (early-exit path), the returned message list is empty and the local frontend messages are replaced with `[]`.

The fix is minimal (64 lines added, 0 removed) and does not affect any other command paths.
