### PR TITLE
Introduce QWENPAW_AUTO_INITIALIZATION in deploy/entrypoint.sh to allow disabling auto-init 

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -3,64 +3,18 @@
 # Default port 8088; override at runtime with -e QWENPAW_PORT=3000.
 set -e
 
-wait_for_csi_mount() {
-  mount_dir="$1"
-  timeout="${QWENPAW_CSI_WAIT_TIMEOUT:-0}"
-  waited=0
-
-  mkdir -p "$mount_dir"
-  echo "Waiting for CSI mount at ${mount_dir}..."
-
-  while true; do
-    link_target="$(readlink "$mount_dir" 2>/dev/null || true)"
-
-    if [ -n "$link_target" ] && echo "$link_target" | grep -q '^/run/csi/mount-root/'; then
-      echo "CSI mount detected: ${mount_dir} -> ${link_target}"
-      return 0
-    fi
-
-    if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$mount_dir"; then
-      echo "Mount detected at ${mount_dir}"
-      return 0
-    fi
-
-    if [ "$timeout" != "0" ] && [ "$waited" -ge "$timeout" ]; then
-      echo "ERROR: timed out waiting for CSI mount at ${mount_dir}" >&2
-      exit 1
-    fi
-
-    sleep 2
-    waited=$((waited + 2))
-  done
-}
-
-bootstrap_and_start() {
-  mkdir -p "$QWENPAW_WORKING_DIR" "$QWENPAW_SECRET_DIR" "$QWENPAW_BACKUP_DIR"
-
-  # Auto-initialize if config.json is missing.
+# Auto-initialize if config.json is missing (bind mount with empty directory).
+# Set QWENPAW_REQUIRED_INITIALIZATION=0 to skip (e.g. during image warm-up).
+if [ "${QWENPAW_REQUIRED_INITIALIZATION:-1}" = "1" ]; then
   if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
-    echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
-    echo "📦 Running initialization..."
     qwenpaw init --defaults --accept-security
-    echo "✅ Initialization complete!"
-  else
-    echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
   fi
-
-  export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
-  envsubst '${QWENPAW_PORT}' \
-    < /etc/supervisor/conf.d/supervisord.conf.template \
-    > /etc/supervisor/conf.d/supervisord.conf
-  exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
-}
-
-export QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR:-/app/working}"
-export QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR:-/app/working.secret}"
-export QWENPAW_BACKUP_DIR="${QWENPAW_BACKUP_DIR:-/app/working.backups}"
-
-if [ "${QWENPAW_WAIT_FOR_CSI:-0}" = "1" ]; then
-  wait_for_csi_mount "${QWENPAW_CSI_MOUNT_DIR:-$QWENPAW_WORKING_DIR}"
-  bootstrap_and_start
 else
-  bootstrap_and_start
+  echo "Skipping initialization."
 fi
+
+export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
+envsubst '${QWENPAW_PORT}' \
+  < /etc/supervisor/conf.d/supervisord.conf.template \
+  > /etc/supervisor/conf.d/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -4,8 +4,10 @@
 set -e
 
 # Auto-initialize if config.json is missing (bind mount with empty directory).
-# Set QWENPAW_REQUIRED_INITIALIZATION=0 to skip (e.g. during image warm-up).
-if [ "${QWENPAW_REQUIRED_INITIALIZATION:-1}" = "1" ]; then
+# Set QWENPAW_AUTO_INITIALIZATION=0 to skip (e.g. during image warm-up).
+if [ "${QWENPAW_AUTO_INITIALIZATION:-1}" = "0" ]; then
+  echo "Skipping initialization."
+else
   if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
     echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
     echo "📦 Running initialization..."
@@ -14,8 +16,6 @@ if [ "${QWENPAW_REQUIRED_INITIALIZATION:-1}" = "1" ]; then
   else
     echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
   fi
-else
-  echo "Skipping initialization."
 fi
 
 export QWENPAW_PORT="${QWENPAW_PORT:-8088}"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -3,18 +3,64 @@
 # Default port 8088; override at runtime with -e QWENPAW_PORT=3000.
 set -e
 
-# Auto-initialize if config.json is missing (bind mount with empty directory).
-if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
-  echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
-  echo "📦 Running initialization..."
-  qwenpaw init --defaults --accept-security
-  echo "✅ Initialization complete!"
-else
-  echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
-fi
+wait_for_csi_mount() {
+  mount_dir="$1"
+  timeout="${QWENPAW_CSI_WAIT_TIMEOUT:-0}"
+  waited=0
 
-export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
-envsubst '${QWENPAW_PORT}' \
-  < /etc/supervisor/conf.d/supervisord.conf.template \
-  > /etc/supervisor/conf.d/supervisord.conf
-exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+  mkdir -p "$mount_dir"
+  echo "Waiting for CSI mount at ${mount_dir}..."
+
+  while true; do
+    link_target="$(readlink "$mount_dir" 2>/dev/null || true)"
+
+    if [ -n "$link_target" ] && echo "$link_target" | grep -q '^/run/csi/mount-root/'; then
+      echo "CSI mount detected: ${mount_dir} -> ${link_target}"
+      return 0
+    fi
+
+    if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$mount_dir"; then
+      echo "Mount detected at ${mount_dir}"
+      return 0
+    fi
+
+    if [ "$timeout" != "0" ] && [ "$waited" -ge "$timeout" ]; then
+      echo "ERROR: timed out waiting for CSI mount at ${mount_dir}" >&2
+      exit 1
+    fi
+
+    sleep 2
+    waited=$((waited + 2))
+  done
+}
+
+bootstrap_and_start() {
+  mkdir -p "$QWENPAW_WORKING_DIR" "$QWENPAW_SECRET_DIR" "$QWENPAW_BACKUP_DIR"
+
+  # Auto-initialize if config.json is missing.
+  if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
+    echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
+    echo "📦 Running initialization..."
+    qwenpaw init --defaults --accept-security
+    echo "✅ Initialization complete!"
+  else
+    echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
+  fi
+
+  export QWENPAW_PORT="${QWENPAW_PORT:-8088}"
+  envsubst '${QWENPAW_PORT}' \
+    < /etc/supervisor/conf.d/supervisord.conf.template \
+    > /etc/supervisor/conf.d/supervisord.conf
+  exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+}
+
+export QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR:-/app/working}"
+export QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR:-/app/working.secret}"
+export QWENPAW_BACKUP_DIR="${QWENPAW_BACKUP_DIR:-/app/working.backups}"
+
+if [ "${QWENPAW_WAIT_FOR_CSI:-0}" = "1" ]; then
+  wait_for_csi_mount "${QWENPAW_CSI_MOUNT_DIR:-$QWENPAW_WORKING_DIR}"
+  bootstrap_and_start
+else
+  bootstrap_and_start
+fi

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -7,7 +7,12 @@ set -e
 # Set QWENPAW_REQUIRED_INITIALIZATION=0 to skip (e.g. during image warm-up).
 if [ "${QWENPAW_REQUIRED_INITIALIZATION:-1}" = "1" ]; then
   if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
+    echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
+    echo "📦 Running initialization..."
     qwenpaw init --defaults --accept-security
+    echo "✅ Initialization complete!"
+  else
+    echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
   fi
 else
   echo "Skipping initialization."


### PR DESCRIPTION
## Description

Introduce QWENPAW_AUTO_INITIALIZATION in deploy/entrypoint.sh.
Only =0 disables auto-initialization and prints Skipping initialization.

Setting QWENPAW_AUTO_INITIALIZATION= 0, allows disabling auto-init during image warm-up so the entrypoint does not write into a mounted working directory before the real instance starts.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
