### PR TITLE
style(console): update plugin page in console

### DIFF
--- a/console/src/api/modules/plugin.ts
+++ b/console/src/api/modules/plugin.ts
@@ -51,6 +51,8 @@ export interface OfficialPluginCatalogEntry {
   plugin_id: string;
   name: string;
   description: string;
+  /** Locale-keyed descriptions, e.g. { "zh-CN": "...", "en-US": "..." } */
+  description_i18n?: Record<string, string>;
   version: string;
   author: string;
   kind: string;

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2241,6 +2241,10 @@
     "catalogUpgrade": "Upgrade available",
     "catalogUpgradeBtn": "Upgrade",
     "catalogInstalled": "Installed",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "Bundle",
+    "kindTool": "Tool",
+    "filterByName": "Filter by name",
+    "filterByKind": "Filter by kind"
   }
 }

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -634,7 +634,11 @@
     "catalogUpgrade": "Pembaruan tersedia",
     "catalogUpgradeBtn": "Perbarui",
     "catalogInstalled": "Terinstal",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "Bundel",
+    "kindTool": "Alat",
+    "filterByName": "Filter berdasarkan nama",
+    "filterByKind": "Filter berdasarkan jenis"
   },
   "debug": {
     "title": "Debug",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2061,7 +2061,11 @@
     "catalogUpgrade": "アップグレード可能",
     "catalogUpgradeBtn": "アップグレード",
     "catalogInstalled": "インストール済み",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "バンドル",
+    "kindTool": "ツール",
+    "filterByName": "名前で絞り込み",
+    "filterByKind": "タグで絞り込み"
   },
   "plan": {
     "title": "プラン",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2096,7 +2096,11 @@
     "catalogUpgrade": "Atualização disponível",
     "catalogUpgradeBtn": "Atualizar",
     "catalogInstalled": "Instalado",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "Pacote",
+    "kindTool": "Ferramenta",
+    "filterByName": "Filtrar por nome",
+    "filterByKind": "Filtrar por tipo"
   },
   "plan": {
     "title": "Plan",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2076,7 +2076,11 @@
     "catalogUpgrade": "Доступно обновление",
     "catalogUpgradeBtn": "Обновить",
     "catalogInstalled": "Установлен",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "Пакет",
+    "kindTool": "Инструмент",
+    "filterByName": "Фильтр по имени",
+    "filterByKind": "Фильтр по типу"
   },
   "plan": {
     "title": "План",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2249,6 +2249,10 @@
     "catalogUpgrade": "可升级",
     "catalogUpgradeBtn": "升级",
     "catalogInstalled": "已安装",
-    "catalogSha256": "SHA256"
+    "catalogSha256": "SHA256",
+    "kindBundle": "插件包",
+    "kindTool": "工具",
+    "filterByName": "按名称筛选",
+    "filterByKind": "按标签筛选"
   }
 }

--- a/console/src/pages/Settings/PluginManager/components/InstallPluginModal.module.less
+++ b/console/src/pages/Settings/PluginManager/components/InstallPluginModal.module.less
@@ -1,0 +1,68 @@
+.dropZone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 36px 24px;
+  border: 1.5px dashed var(--ant-color-border);
+  border-radius: 10px;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+  user-select: none;
+
+  &:hover {
+    border-color: var(--ant-color-primary);
+    background: var(--ant-color-primary-bg);
+
+    .dropIcon {
+      color: var(--ant-color-primary);
+    }
+  }
+}
+
+.dropZoneActive {
+  border-color: var(--ant-color-primary);
+  background: var(--ant-color-primary-bg);
+
+  .dropIcon {
+    color: var(--ant-color-primary);
+  }
+}
+
+.dropIcon {
+  color: var(--ant-color-text-quaternary);
+  transition: color 0.2s ease;
+  margin-bottom: 4px;
+}
+
+.dropPrimary {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ant-color-text);
+}
+
+.dropSecondary {
+  font-size: 12px;
+}
+
+.selectionCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--ant-color-border);
+  border-radius: 8px;
+  background: var(--ant-color-fill-quaternary);
+  color: var(--ant-color-text);
+}
+
+.selectionName {
+  flex: 1;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/console/src/pages/Settings/PluginManager/components/InstallPluginModal.tsx
+++ b/console/src/pages/Settings/PluginManager/components/InstallPluginModal.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Button, Modal, Input, Form, Divider, Typography, Space } from "antd";
 import { Package, Link, FolderOpen, FileArchive, X } from "lucide-react";
 import type { useInstallModal } from "../hooks/useInstallModal";
-import styles from "../index.module.less";
+import styles from "./InstallPluginModal.module.less";
 
 const { Text } = Typography;
 

--- a/console/src/pages/Settings/PluginManager/components/OfficialPluginList.module.less
+++ b/console/src/pages/Settings/PluginManager/components/OfficialPluginList.module.less
@@ -1,0 +1,96 @@
+.catalogSection {
+  margin-bottom: 8px;
+}
+
+.catalogToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.catalogFilters {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.catalogList {
+  display: flex;
+  flex-direction: column;
+}
+
+.catalogRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--color-border-secondary, #eae8e7);
+  transition: background 0.2s ease;
+  border-bottom: none;
+
+  &:first-child {
+    border-radius: 8px 8px 0 0;
+  }
+
+  &:last-child {
+    border-bottom: 1px solid var(--color-border-secondary, #eae8e7);
+    border-radius: 0 0 8px 8px;
+  }
+
+  &:only-child {
+    border-radius: 8px;
+    border-bottom: 1px solid var(--color-border-secondary, #eae8e7);
+  }
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.02);
+  }
+}
+
+.catalogIcon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--ant-color-fill-tertiary);
+  color: var(--ant-color-text-secondary);
+}
+
+.catalogInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.catalogNameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.catalogDescription {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.catalogMeta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--ant-color-text-quaternary);
+}
+
+.catalogActions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
@@ -1,90 +1,110 @@
-import { useCallback, useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Space, Spin, Typography, Alert, Tag } from "antd";
-import { Download, RefreshCw } from "lucide-react";
-import { useAppMessage } from "@/hooks/useAppMessage";
-import {
-  fetchPluginCatalog,
-  installPlugin,
-  type OfficialPluginCatalogEntry,
-} from "@/api/modules/plugin";
-import styles from "../index.module.less";
+import { Button, Input, Select, Spin, Typography, Alert, Tag } from "antd";
+import { Download, RefreshCw, Package } from "lucide-react";
+import type { OfficialPluginCatalogEntry } from "@/api/modules/plugin";
+import { useOfficialPlugins } from "../hooks/useOfficialPlugins";
+import styles from "./OfficialPluginList.module.less";
 
 const { Text } = Typography;
+
+/**
+ * Resolve the best-matching description from `description_i18n` based on
+ * the current i18n language. Falls back to the default `description` field.
+ *
+ * Matching strategy:
+ *   1. Exact match (e.g. "zh" → "zh", "zh-CN" → "zh-CN")
+ *   2. Prefix match (e.g. "zh" → "zh-CN", "en" → "en-US")
+ *   3. Fallback to `description`
+ */
+function pickLocalizedDescription(
+  entry: OfficialPluginCatalogEntry,
+  language: string,
+): string {
+  const i18nMap = entry.description_i18n;
+  if (!i18nMap || Object.keys(i18nMap).length === 0) {
+    return entry.description || "";
+  }
+
+  // Exact match
+  if (i18nMap[language]) {
+    return i18nMap[language];
+  }
+
+  // Prefix match: "zh" matches "zh-CN", "en" matches "en-US"
+  const prefix = language.split("-")[0].toLowerCase();
+  for (const key of Object.keys(i18nMap)) {
+    if (key.toLowerCase().startsWith(prefix)) {
+      return i18nMap[key];
+    }
+  }
+
+  return entry.description || "";
+}
 
 interface OfficialPluginListProps {
   onInstalled: () => void;
 }
 
 export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
-  const { t } = useTranslation();
-  const { message } = useAppMessage();
-  const [loading, setLoading] = useState(true);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [plugins, setPlugins] = useState<OfficialPluginCatalogEntry[]>([]);
-  const [installingId, setInstallingId] = useState<string | null>(null);
+  const { t, i18n } = useTranslation();
+  const [nameFilter, setNameFilter] = useState("");
+  const [kindFilter, setKindFilter] = useState<string | undefined>(undefined);
 
-  const loadCatalog = useCallback(async () => {
-    setLoading(true);
-    setCatalogError(null);
-    try {
-      const data = await fetchPluginCatalog();
-      if (data.error) {
-        setCatalogError(data.error);
-        setPlugins([]);
-      } else {
-        setPlugins(data.plugins ?? []);
-      }
-    } catch (err) {
-      const msg =
-        err instanceof Error
-          ? err.message
-          : t("pluginManager.catalogLoadFailed");
-      setCatalogError(msg);
-      setPlugins([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [t]);
+  const {
+    loading,
+    catalogError,
+    plugins,
+    installingId,
+    loadCatalog,
+    handleInstall,
+  } = useOfficialPlugins({ onInstalled });
 
-  useEffect(() => {
-    void loadCatalog();
-  }, [loadCatalog]);
+  const filteredPlugins = useMemo(() => {
+    return plugins.filter((entry) => {
+      const matchesName =
+        !nameFilter ||
+        entry.name.toLowerCase().includes(nameFilter.toLowerCase());
+      const matchesKind =
+        !kindFilter || entry.kind?.toLowerCase() === kindFilter;
+      return matchesName && matchesKind;
+    });
+  }, [plugins, nameFilter, kindFilter]);
 
-  const handleInstall = useCallback(
-    async (entry: OfficialPluginCatalogEntry) => {
-      setInstallingId(entry.id);
-      try {
-        const result = await installPlugin(entry.install_url, {
-          force: entry.installed || entry.upgrade_available,
-        });
-        message.success(`${t("pluginManager.installSuccess")}: ${result.name}`);
-        onInstalled();
-        await loadCatalog();
-      } catch (err) {
-        const msg =
-          err instanceof Error ? err.message : t("pluginManager.installFailed");
-        message.error(msg);
-      } finally {
-        setInstallingId(null);
-      }
-    },
-    [loadCatalog, message, onInstalled, t],
-  );
+  const kindOptions = useMemo(() => {
+    const kinds = [...new Set(plugins.map((p) => p.kind).filter(Boolean))];
+    return kinds.map((kind) => ({
+      value: kind!.toLowerCase(),
+      label: t(
+        `pluginManager.kind${kind!.charAt(0).toUpperCase()}${kind!
+          .slice(1)
+          .toLowerCase()}`,
+      ),
+    }));
+  }, [plugins, t]);
 
   return (
     <div className={styles.catalogSection}>
-      <div className={styles.catalogHeader}>
-        <div>
-          <Text strong>{t("pluginManager.officialTitle")}</Text>
-          <div>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {t("pluginManager.officialDesc")}
-            </Text>
-          </div>
+      <div className={styles.catalogToolbar}>
+        <div className={styles.catalogFilters}>
+          <Input
+            placeholder={t("pluginManager.filterByName")}
+            allowClear
+            value={nameFilter}
+            onChange={(e) => setNameFilter(e.target.value)}
+            style={{ width: 220 }}
+          />
+          <Select
+            placeholder={t("pluginManager.filterByKind")}
+            allowClear
+            value={kindFilter}
+            onChange={(val) => setKindFilter(val)}
+            options={kindOptions}
+            style={{ width: 150 }}
+          />
         </div>
         <Button
-          type="text"
+          type="default"
           size="small"
           icon={<RefreshCw size={14} />}
           onClick={() => void loadCatalog()}
@@ -104,76 +124,76 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
       )}
 
       <Spin spinning={loading}>
-        {!loading && plugins.length === 0 && !catalogError && (
+        {!loading && filteredPlugins.length === 0 && !catalogError && (
           <Text type="secondary">{t("pluginManager.catalogEmpty")}</Text>
         )}
         <div className={styles.catalogList}>
-          {plugins.map((entry) => (
+          {filteredPlugins.map((entry) => (
             <div className={styles.catalogRow} key={entry.id}>
+              <div className={styles.catalogIcon}>
+                <Package size={18} />
+              </div>
               <div className={styles.catalogInfo}>
-                <Space size={8} wrap>
+                <div className={styles.catalogNameRow}>
                   <Text strong>{entry.name}</Text>
                   {entry.kind && (
-                    <Tag style={{ margin: 0, textTransform: "uppercase" }}>
-                      {entry.kind}
+                    <Tag
+                      color={
+                        entry.kind.toLowerCase() === "bundle"
+                          ? "purple"
+                          : "blue"
+                      }
+                      style={{ margin: 0, fontSize: 11 }}
+                    >
+                      {t(
+                        `pluginManager.kind${entry.kind
+                          .charAt(0)
+                          .toUpperCase()}${entry.kind.slice(1).toLowerCase()}`,
+                      )}
                     </Tag>
                   )}
                   {entry.installed && !entry.upgrade_available && (
-                    <Tag color="success" style={{ margin: 0 }}>
+                    <Tag color="success" style={{ margin: 0, fontSize: 11 }}>
                       {t("pluginManager.catalogInstalled")}
                     </Tag>
                   )}
                   {entry.upgrade_available && (
-                    <Tag color="processing" style={{ margin: 0 }}>
+                    <Tag color="processing" style={{ margin: 0, fontSize: 11 }}>
                       {t("pluginManager.catalogUpgrade")}
                     </Tag>
                   )}
-                </Space>
-                {entry.description && (
-                  <Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: "block" }}
-                  >
-                    {entry.description}
-                  </Text>
+                </div>
+                {(entry.description || entry.description_i18n) && (
+                  <div className={styles.catalogDescription}>
+                    {pickLocalizedDescription(entry, i18n.language)}
+                  </div>
                 )}
-                <Text type="secondary" style={{ fontSize: 12 }}>
+                <div className={styles.catalogMeta}>
                   v{entry.version}
                   {entry.size ? ` · ${entry.size}` : ""}
                   {entry.author ? ` · ${entry.author}` : ""}
-                </Text>
-                {entry.sha256 && (
-                  <div className={styles.catalogSha256}>
-                    <Text type="secondary" style={{ fontSize: 12 }}>
-                      {t("pluginManager.catalogSha256")}
-                    </Text>
-                    <Typography.Text
-                      copyable
-                      className={styles.catalogSha256Value}
-                    >
-                      {entry.sha256}
-                    </Typography.Text>
-                  </div>
-                )}
+                </div>
               </div>
-              <Button
-                type={
-                  entry.installed && !entry.upgrade_available
-                    ? "default"
-                    : "primary"
-                }
-                size="small"
-                icon={<Download size={14} />}
-                loading={installingId === entry.id}
-                disabled={installingId !== null && installingId !== entry.id}
-                onClick={() => void handleInstall(entry)}
-              >
-                {entry.upgrade_available
-                  ? t("pluginManager.catalogUpgradeBtn")
-                  : entry.installed
-                  ? t("pluginManager.catalogReinstall")
-                  : t("pluginManager.catalogInstall")}
-              </Button>
+              <div className={styles.catalogActions}>
+                <Button
+                  type={
+                    entry.installed && !entry.upgrade_available
+                      ? "default"
+                      : "primary"
+                  }
+                  size="small"
+                  icon={<Download size={14} />}
+                  loading={installingId === entry.id}
+                  disabled={installingId !== null && installingId !== entry.id}
+                  onClick={() => void handleInstall(entry)}
+                >
+                  {entry.upgrade_available
+                    ? t("pluginManager.catalogUpgradeBtn")
+                    : entry.installed
+                    ? t("pluginManager.catalogReinstall")
+                    : t("pluginManager.catalogInstall")}
+                </Button>
+              </div>
             </div>
           ))}
         </div>

--- a/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
@@ -79,6 +79,7 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
         `pluginManager.kind${kind!.charAt(0).toUpperCase()}${kind!
           .slice(1)
           .toLowerCase()}`,
+        { defaultValue: kind },
       ),
     }));
   }, [plugins, t]);
@@ -149,6 +150,7 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
                         `pluginManager.kind${entry.kind
                           .charAt(0)
                           .toUpperCase()}${entry.kind.slice(1).toLowerCase()}`,
+                        { defaultValue: entry.kind },
                       )}
                     </Tag>
                   )}

--- a/console/src/pages/Settings/PluginManager/hooks/useOfficialPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useOfficialPlugins.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppMessage } from "@/hooks/useAppMessage";
+import {
+  fetchPluginCatalog,
+  installPlugin,
+  type OfficialPluginCatalogEntry,
+} from "@/api/modules/plugin";
+
+interface UseOfficialPluginsOptions {
+  onInstalled: () => void;
+}
+
+export function useOfficialPlugins({ onInstalled }: UseOfficialPluginsOptions) {
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+  const [loading, setLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [plugins, setPlugins] = useState<OfficialPluginCatalogEntry[]>([]);
+  const [installingId, setInstallingId] = useState<string | null>(null);
+
+  const loadCatalog = useCallback(async () => {
+    setLoading(true);
+    setCatalogError(null);
+    try {
+      const data = await fetchPluginCatalog();
+      if (data.error) {
+        setCatalogError(data.error);
+        setPlugins([]);
+      } else {
+        setPlugins(data.plugins ?? []);
+      }
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : t("pluginManager.catalogLoadFailed");
+      setCatalogError(msg);
+      setPlugins([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    void loadCatalog();
+  }, [loadCatalog]);
+
+  const handleInstall = useCallback(
+    async (entry: OfficialPluginCatalogEntry) => {
+      setInstallingId(entry.id);
+      try {
+        const result = await installPlugin(entry.install_url, {
+          force: entry.installed || entry.upgrade_available,
+        });
+        message.success(`${t("pluginManager.installSuccess")}: ${result.name}`);
+        onInstalled();
+        await loadCatalog();
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : t("pluginManager.installFailed");
+        message.error(msg);
+      } finally {
+        setInstallingId(null);
+      }
+    },
+    [loadCatalog, message, onInstalled, t],
+  );
+
+  return {
+    loading,
+    catalogError,
+    plugins,
+    installingId,
+    loadCatalog,
+    handleInstall,
+  };
+}

--- a/console/src/pages/Settings/PluginManager/hooks/usePluginColumns.tsx
+++ b/console/src/pages/Settings/PluginManager/hooks/usePluginColumns.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from "react-i18next";
+import { Tag, Tooltip, Button, Space, Typography } from "antd";
+import { Package, Trash2, CheckCircle, XCircle } from "lucide-react";
+import type { PluginType, PluginInfo } from "@/api/modules/plugin";
+import { PluginTypeTag } from "../components/PluginTypeTag";
+
+const { Text } = Typography;
+
+interface UsePluginColumnsOptions {
+  uninstallingId: string | null;
+  onUninstall: (record: PluginInfo) => void;
+}
+
+export function usePluginColumns({
+  uninstallingId,
+  onUninstall,
+}: UsePluginColumnsOptions) {
+  const { t } = useTranslation();
+
+  return [
+    {
+      title: t("pluginManager.title"),
+      dataIndex: "name",
+      key: "name",
+      render: (name: string, record: PluginInfo) => (
+        <Space direction="vertical" size={2}>
+          <Space size={8}>
+            <Package size={16} style={{ flexShrink: 0 }} />
+            <Text strong>{name}</Text>
+          </Space>
+          {record.description && (
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {record.description}
+            </Text>
+          )}
+        </Space>
+      ),
+    },
+    {
+      title: t("pluginManager.type"),
+      dataIndex: "plugin_type",
+      key: "plugin_type",
+      width: 110,
+      render: (type: PluginType) => <PluginTypeTag type={type ?? "general"} />,
+    },
+    {
+      title: t("pluginManager.version"),
+      dataIndex: "version",
+      key: "version",
+      width: 100,
+      render: (version: string) => (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          {version}
+        </Text>
+      ),
+    },
+    {
+      title: t("pluginManager.author"),
+      dataIndex: "author",
+      key: "author",
+      width: 140,
+      render: (author: string) => (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          {author || t("pluginManager.unknown")}
+        </Text>
+      ),
+    },
+    {
+      title: "Status",
+      dataIndex: "loaded",
+      key: "loaded",
+      width: 110,
+      render: (loaded: boolean) =>
+        loaded ? (
+          <Tag
+            icon={<CheckCircle size={12} />}
+            color="success"
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            {t("pluginManager.statusLoaded")}
+          </Tag>
+        ) : (
+          <Tag
+            icon={<XCircle size={12} />}
+            color="default"
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            {t("pluginManager.statusUnloaded")}
+          </Tag>
+        ),
+    },
+    {
+      title: "",
+      key: "actions",
+      width: 100,
+      render: (_: unknown, record: PluginInfo) => (
+        <Tooltip title={t("pluginManager.uninstall")}>
+          <Button
+            type="text"
+            danger
+            size="small"
+            icon={<Trash2 size={14} />}
+            loading={uninstallingId === record.id}
+            onClick={() => onUninstall(record)}
+          />
+        </Tooltip>
+      ),
+    },
+  ];
+}

--- a/console/src/pages/Settings/PluginManager/index.module.less
+++ b/console/src/pages/Settings/PluginManager/index.module.less
@@ -8,6 +8,13 @@
 .content {
   flex: 1;
   overflow: auto;
+  padding: 0 24px;
+}
+
+.tabs {
+  :global(.ant-tabs-nav) {
+    margin-bottom: 16px;
+  }
 }
 
 .table {
@@ -35,125 +42,4 @@
   :global(.ant-table-tbody > tr:hover > td) {
     background: var(--ant-color-fill-quaternary);
   }
-}
-
-/* ── Official catalog ──────────────────────────────────────────────── */
-
-.catalogSection {
-  margin-bottom: 8px;
-}
-
-.catalogHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.catalogList {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.catalogRow {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 12px 14px;
-  border: 1px solid var(--ant-color-border-secondary);
-  border-radius: 8px;
-  background: var(--ant-color-fill-quaternary);
-}
-
-.catalogInfo {
-  flex: 1;
-  min-width: 0;
-}
-
-.catalogSha256 {
-  margin-top: 6px;
-}
-
-.catalogSha256Value {
-  display: block;
-  margin-top: 2px;
-  font-size: 11px;
-  line-height: 1.45;
-  word-break: break-all;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  color: var(--ant-color-text-secondary);
-}
-
-/* ── Install modal ─────────────────────────────────────────────────── */
-
-.dropZone {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 36px 24px;
-  border: 1.5px dashed var(--ant-color-border);
-  border-radius: 10px;
-  cursor: pointer;
-  transition:
-    border-color 0.2s ease,
-    background 0.2s ease;
-  user-select: none;
-
-  &:hover {
-    border-color: var(--ant-color-primary);
-    background: var(--ant-color-primary-bg);
-
-    .dropIcon {
-      color: var(--ant-color-primary);
-    }
-  }
-}
-
-.dropZoneActive {
-  border-color: var(--ant-color-primary);
-  background: var(--ant-color-primary-bg);
-
-  .dropIcon {
-    color: var(--ant-color-primary);
-  }
-}
-
-.dropIcon {
-  color: var(--ant-color-text-quaternary);
-  transition: color 0.2s ease;
-  margin-bottom: 4px;
-}
-
-.dropPrimary {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--ant-color-text);
-}
-
-.dropSecondary {
-  font-size: 12px;
-}
-
-.selectionCard {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 14px;
-  border: 1px solid var(--ant-color-border);
-  border-radius: 8px;
-  background: var(--ant-color-fill-quaternary);
-  color: var(--ant-color-text);
-}
-
-.selectionName {
-  flex: 1;
-  font-size: 14px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }

--- a/console/src/pages/Settings/PluginManager/index.tsx
+++ b/console/src/pages/Settings/PluginManager/index.tsx
@@ -1,25 +1,13 @@
 import { useTranslation } from "react-i18next";
-import {
-  Button,
-  Tag,
-  Tooltip,
-  Empty,
-  Spin,
-  Typography,
-  Space,
-  Table,
-} from "antd";
-import { Package, Plus, Trash2, CheckCircle, XCircle } from "lucide-react";
-import type { PluginType, PluginInfo } from "@/api/modules/plugin";
+import { Button, Empty, Spin, Table, Tabs } from "antd";
+import { Package, Plus } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { usePluginManager } from "./hooks/usePluginManager";
+import { usePluginColumns } from "./hooks/usePluginColumns";
 import { useInstallModal } from "./hooks/useInstallModal";
 import { InstallPluginModal } from "./components/InstallPluginModal";
 import { OfficialPluginList } from "./components/OfficialPluginList";
-import { PluginTypeTag } from "./components/PluginTypeTag";
 import styles from "./index.module.less";
-
-const { Text } = Typography;
 
 export default function PluginManagerPage() {
   const { t } = useTranslation();
@@ -29,94 +17,39 @@ export default function PluginManagerPage() {
 
   const installModal = useInstallModal(refresh);
 
-  const columns = [
+  const columns = usePluginColumns({
+    uninstallingId,
+    onUninstall: handleUninstall,
+  });
+
+  const tabItems = [
     {
-      title: t("pluginManager.title"),
-      dataIndex: "name",
-      key: "name",
-      render: (name: string, record: PluginInfo) => (
-        <Space direction="vertical" size={2}>
-          <Space size={8}>
-            <Package size={16} style={{ flexShrink: 0 }} />
-            <Text strong>{name}</Text>
-          </Space>
-          {record.description && (
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {record.description}
-            </Text>
+      key: "installed",
+      label: t("pluginManager.installed"),
+      children: (
+        <Spin spinning={loading}>
+          {!loading && (!plugins || plugins.length === 0) ? (
+            <Empty
+              image={<Package size={48} strokeWidth={1} />}
+              description={t("pluginManager.noPlugins")}
+              style={{ marginTop: 24 }}
+            />
+          ) : (
+            <Table
+              dataSource={plugins}
+              columns={columns}
+              rowKey="id"
+              pagination={false}
+              className={styles.table}
+            />
           )}
-        </Space>
+        </Spin>
       ),
     },
     {
-      title: t("pluginManager.type"),
-      dataIndex: "plugin_type",
-      key: "plugin_type",
-      width: 110,
-      render: (type: PluginType) => <PluginTypeTag type={type ?? "general"} />,
-    },
-    {
-      title: t("pluginManager.version"),
-      dataIndex: "version",
-      key: "version",
-      width: 100,
-      render: (v: string) => (
-        <Text type="secondary" style={{ fontSize: 12 }}>
-          {v}
-        </Text>
-      ),
-    },
-    {
-      title: t("pluginManager.author"),
-      dataIndex: "author",
-      key: "author",
-      width: 140,
-      render: (author: string) => (
-        <Text type="secondary" style={{ fontSize: 12 }}>
-          {author || t("pluginManager.unknown")}
-        </Text>
-      ),
-    },
-    {
-      title: "Status",
-      dataIndex: "loaded",
-      key: "loaded",
-      width: 110,
-      render: (loaded: boolean) =>
-        loaded ? (
-          <Tag
-            icon={<CheckCircle size={12} />}
-            color="success"
-            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
-          >
-            {t("pluginManager.statusLoaded")}
-          </Tag>
-        ) : (
-          <Tag
-            icon={<XCircle size={12} />}
-            color="default"
-            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
-          >
-            {t("pluginManager.statusUnloaded")}
-          </Tag>
-        ),
-    },
-    {
-      title: "",
-      key: "actions",
-      width: 100,
-      render: (_: unknown, record: PluginInfo) => (
-        <Tooltip title={t("pluginManager.uninstall")}>
-          <Button
-            type="text"
-            danger
-            size="small"
-            icon={<Trash2 size={14} />}
-            loading={uninstallingId === record.id}
-            onClick={() => handleUninstall(record)}
-          />
-        </Tooltip>
-      ),
+      key: "official",
+      label: t("pluginManager.officialTitle"),
+      children: <OfficialPluginList onInstalled={refresh} />,
     },
   ];
 
@@ -137,29 +70,7 @@ export default function PluginManagerPage() {
       />
 
       <div className={styles.content}>
-        <OfficialPluginList onInstalled={refresh} />
-
-        <Typography.Title level={5} style={{ margin: "24px 0 12px" }}>
-          {t("pluginManager.installed")}
-        </Typography.Title>
-
-        <Spin spinning={loading}>
-          {!loading && (!plugins || plugins.length === 0) ? (
-            <Empty
-              image={<Package size={48} strokeWidth={1} />}
-              description={t("pluginManager.noPlugins")}
-              style={{ marginTop: 24 }}
-            />
-          ) : (
-            <Table
-              dataSource={plugins}
-              columns={columns}
-              rowKey="id"
-              pagination={false}
-              className={styles.table}
-            />
-          )}
-        </Spin>
+        <Tabs items={tabItems} className={styles.tabs} />
       </div>
 
       <InstallPluginModal {...installModal} />

--- a/src/qwenpaw/plugins/download_catalog.py
+++ b/src/qwenpaw/plugins/download_catalog.py
@@ -155,12 +155,21 @@ def build_plugin_catalog() -> dict[str, Any]:
         plugin_id = _plugin_id_from_file_entry(entry)
         catalog_version = str(entry.get("version") or "")
         installed_version = installed.get(plugin_id)
+        # Build description_i18n dict from the raw entry
+        raw_desc = entry.get("description")
+        description_i18n: dict[str, str] = {}
+        if isinstance(raw_desc, dict):
+            description_i18n = {
+                k: str(v) for k, v in raw_desc.items() if v
+            }
+
         plugins.append(
             {
                 "id": str(entry.get("id") or _file_id),
                 "plugin_id": plugin_id,
                 "name": _pick_en(entry.get("name")),
                 "description": _pick_en(entry.get("description")),
+                "description_i18n": description_i18n,
                 "version": catalog_version,
                 "author": str(entry.get("author") or ""),
                 "kind": str(entry.get("platform") or ""),

--- a/src/qwenpaw/plugins/download_catalog.py
+++ b/src/qwenpaw/plugins/download_catalog.py
@@ -159,9 +159,7 @@ def build_plugin_catalog() -> dict[str, Any]:
         raw_desc = entry.get("description")
         description_i18n: dict[str, str] = {}
         if isinstance(raw_desc, dict):
-            description_i18n = {
-                k: str(v) for k, v in raw_desc.items() if v
-            }
+            description_i18n = {k: str(v) for k, v in raw_desc.items() if v}
 
         plugins.append(
             {


### PR DESCRIPTION
## Description

1. Page layout changed to Tab switching

2. Official plugin list style redesigned

3. Type tags internationalized + color differentiation

4. Added filter bars (by name + by tag)

5. Plugin descriptions support multilingual internationalization

## Images

<img width="1705" height="1228" alt="image" src="https://github.com/user-attachments/assets/cbb79a43-1933-4e67-bc41-42700000fa10" />
<img width="1700" height="1222" alt="image" src="https://github.com/user-attachments/assets/ad3c6bc8-b720-49c3-98a5-6dbfd313983c" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
