### PR TITLE
add when QWENPAW_AUTO_INITIALIZATION=0 to skip init and app startup

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -4,18 +4,19 @@
 set -e
 
 # Auto-initialize if config.json is missing (bind mount with empty directory).
-# Set QWENPAW_AUTO_INITIALIZATION=0 to skip (e.g. during image warm-up).
+# Set QWENPAW_AUTO_INITIALIZATION=0 to skip init and app startup (e.g. image warm-up).
 if [ "${QWENPAW_AUTO_INITIALIZATION:-1}" = "0" ]; then
-  echo "Skipping initialization."
+  echo "Skipping initialization and qwenpaw app startup."
+  exit 0
+fi
+
+if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
+  echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
+  echo "📦 Running initialization..."
+  qwenpaw init --defaults --accept-security
+  echo "✅ Initialization complete!"
 else
-  if [ ! -f "${QWENPAW_WORKING_DIR}/config.json" ]; then
-    echo "⚠️  No config.json found in ${QWENPAW_WORKING_DIR}"
-    echo "📦 Running initialization..."
-    qwenpaw init --defaults --accept-security
-    echo "✅ Initialization complete!"
-  else
-    echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
-  fi
+  echo "✓ Config found in ${QWENPAW_WORKING_DIR}, skipping initialization."
 fi
 
 export QWENPAW_PORT="${QWENPAW_PORT:-8088}"


### PR DESCRIPTION
## Description

add when QWENPAW_AUTO_INITIALIZATION=0 to skip init and app startup in entry point

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
