### PR TITLE
test(integration): refactor and expand integration test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ sessions_mount_dir/
 coverage.xml
 htmlcov/
 htmlcov.zip
+htmlcov-integration/
+.integration_coverage/
 
 # cookbook
 cookbook/_build
@@ -112,5 +114,11 @@ src/.hypothesis/
 # Qoder IDE
 .qoder/
 
+# Cursor IDE
+.cursor/
+
 # Worktrees
 .worktrees/
+
+# Local File
+/localfile/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "p0: critical user flows (messaging, CRUD, global config, security); PR smoke gate",
+    "p1: supported features (settings, scoped overrides, helpers); nightly regression",
+    "p2: error paths, 404 handling, validation, contracts, metadata",
     "unit: marks tests as unit tests",
     "contract: marks tests as contract tests",
     "integration: marks tests as integration tests",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,221 @@
+# Integration Tests
+
+[简体中文](README_zh.md)
+
+HTTP smoke tests that exercise the QwenPaw FastAPI app end-to-end via a
+real subprocess. Each test file owns its own QwenPaw app subprocess on a
+random port, with isolated workspace directories — no real API keys or
+external services required.
+
+---
+
+## Running
+
+```bash
+# Full suite (~3 minutes)
+make test-integration
+# or directly:
+pytest tests/integration/ --no-cov
+
+# By priority (PR / nightly / broad)
+pytest tests/integration/ -m p0 --no-cov   # ~2 min, PR smoke gate
+pytest tests/integration/ -m p1 --no-cov   # nightly / merge regression
+pytest tests/integration/ -m p2 --no-cov   # error paths and contracts
+
+# Single file
+pytest tests/integration/test_agents.py -v --no-cov
+
+# Single test
+pytest tests/integration/test_agents.py::test_api_agents_list_create_get_delete -v --no-cov
+```
+
+Tests run sequentially (not validated under `pytest-xdist`). Use `--no-cov`
+to skip parent-process coverage; see [Coverage](#coverage-optional) for
+subprocess coverage.
+
+---
+
+## Priority markers
+
+Tests are tagged by **user-facing impact**, not technical complexity. When
+adding a test, ask:
+
+> *"If this fails, can users still send a message and get a reply?"*
+> Yes → `p1` or `p2`. No → `p0`.
+
+### `p0` — Critical (PR smoke gate)
+
+Failure means the product is essentially unusable. Every PR must pass
+these. Covers:
+
+- **Messaging main path** — `/api/messages/send` core flow, default-agent
+  routing
+- **Agent / Chat / Skills core CRUD** — list/create/get/delete, toggle
+  enabled, system prompt files
+- **Global config** — channels, heartbeat, MCP CRUD, workspace running
+  config
+- **Security guards (global)** — file guard, tool guard, skill scanner
+- **Tools toggle** — affects agent capabilities at runtime
+- **API version** — base health check
+
+Run: `pytest -m p0` (~22 tests, ~2 min).
+
+### `p1` — Supported (nightly / merge regression)
+
+Failure causes degradation but defaults still let users get by. Covers:
+
+- **Settings & scoped overrides** — language, audio mode, timezone,
+  transcription provider, scoped versions of channel/heartbeat/guards
+- **Workspace files** — working/memory file CRUD, zip up/down, scoped
+  consistency
+- **ACP / LLM routing** — developer-facing features
+- **Plan / Cron** — assistive features
+- **Statistics** — token usage, plugins/backups list, agent stats, auth
+  status
+- **Helper APIs** — files preview, agent ordering, batch operations
+
+Run: `pytest -m p1` (~53 tests).
+
+### `p2` — Contracts (broad coverage)
+
+Boundary behavior with no main-flow impact. Covers:
+
+- **Validation rejection** — `*_rejected` tests (duplicate names, invalid
+  payload, non-zip uploads)
+- **404 handling** — `*_returns_404`, `missing_*` tests
+- **Partial-success branches** — batch operations with some failures
+- **Isolation boundaries** — `*_isolated_*`, cross-agent edge cases
+- **HEAD requests & contracts** — `*_minimal_contract`, file-preview HEAD
+- **Version metadata** — package version, PEP 440 compliance
+
+Run: `pytest -m p2` (~30 tests).
+
+---
+
+## Layout
+
+| File | Coverage |
+|---|---|
+| `test_agents.py` | Agent CRUD, ordering, toggle |
+| `test_chats_global.py` | Global `/api/chats` (CRUD, batch, isolation) |
+| `test_chats_agent_scoped.py` | Agent-scoped chats |
+| `test_workspace_files.py` | Working/memory files, zip up/down |
+| `test_workspace_running_config.py` | Running config (global + scoped) |
+| `test_workspace_agent_settings.py` | Agent-scoped workspace settings (language, audio, prompt, transcription, memory) |
+| `test_heartbeat.py` | Heartbeat config (global + scoped) |
+| `test_channels_config.py` | Channels config + health/restart |
+| `test_security_config.py` | File guard, tool guard, skill scanner |
+| `test_agent_routing_config.py` | ACP, LLM routing, allow-no-auth, timezone |
+| `test_skills_global.py` | Global skills (CRUD, batch, validation) |
+| `test_skills_agent_scoped.py` | Agent-scoped skills |
+| `test_mcp.py` | MCP clients lifecycle |
+| `test_messages_files.py` | Send messages + file preview |
+| `test_plan.py` | Plan config |
+| `test_cron.py` | Agent-scoped cron jobs |
+| `test_console.py` | Console-specific endpoints (chat stop, upload) |
+| `test_console_metadata.py` | Plugins / backups / token-usage / auth / agent-stats list |
+| `test_settings_envs.py` | Settings + persisted env vars |
+| `test_tools.py` | Tools toggle and async execution |
+| `test_app_startup.py` | App readiness, console entry/fallback |
+| `test_version.py` | Package version metadata (no app subprocess) |
+
+---
+
+## How `app_server` works
+
+`tests/integration/conftest.py::app_server` is **module-scoped**: each
+test file gets its own QwenPaw app subprocess on a random port, sharing
+the subprocess across all tests within the file. Cross-module isolation
+is achieved by re-launching with a fresh tmp dir.
+
+**Tests must use unique resource ids within the module** (e.g.
+`agent_id = "integ_<scope>_01"`) to avoid collisions inside the shared
+subprocess. The existing convention already does this.
+
+The fixture:
+
+- Sanitizes 11 sensitive environment variables (`OPENAI_API_KEY`,
+  `DASHSCOPE_API_KEY`, IM tokens, etc.) before launching
+- Forces `QWENPAW_AUTH_ENABLED=false` and `NO_PROXY=*`
+- Allocates a random free port via `socket.bind(0)`
+- Polls `/api/version` for up to 60s as the readiness signal
+- Uses **SIGINT** at teardown so uvicorn's atexit hooks flush state and
+  subprocess coverage data writes correctly (SIGTERM often skips this)
+- Uses a **15s HTTP timeout** to absorb cold-start delays (e.g. ACP
+  getter on first hit takes 4-5s)
+
+---
+
+## Coverage (optional)
+
+The default `pytest --cov` only sees the test process, which has near-zero
+coverage of the actual app. To collect coverage from the **app
+subprocess**:
+
+```bash
+QWENPAW_INTEGRATION_COVERAGE=1 pytest tests/integration/ --no-cov
+```
+
+This:
+
+1. Writes a coverage rcfile under `.integration_coverage/` with absolute
+   `source=…/src/qwenpaw`
+2. Runs each subprocess with `COVERAGE_PROCESS_START` and `COVERAGE_FILE`
+3. After the session, combines parallel data files and writes
+   `htmlcov-integration/index.html`
+
+> ⚠️ Always pass `--no-cov` when using this mode — `pytest-cov` on the
+> parent process would otherwise enforce `fail_under=30` on near-zero
+> host-process coverage and fail the run.
+
+This flow is **not validated under `pytest-xdist`**.
+
+---
+
+## Adding a new test
+
+1. **Pick the right file** by business subdomain (see [Layout](#layout))
+   or create a new `test_<subdomain>.py`.
+2. **Tag priority** with `@pytest.mark.integration` plus one of
+   `@pytest.mark.p0` / `p1` / `p2` (see [Priority markers](#priority-markers)).
+3. **Use unique resource ids** within the module (e.g.
+   `integ_<feature>_<seq>`).
+4. **Document the case** at the top of the function — purpose, flow,
+   API endpoints touched. Use existing tests as template:
+
+   ```python
+   @pytest.mark.integration
+   @pytest.mark.p1
+   def test_my_feature_put_get_roundtrip(app_server) -> None:
+       """Test purpose:
+       - Verify ...
+
+       Test flow:
+       1. ...
+
+       API endpoints:
+       - PUT ...
+       - GET ...
+       """
+   ```
+
+5. **Always pass `app_server.logs_tail()`** to assertion messages so
+   failures show backend logs:
+
+   ```python
+   assert resp.status_code == 200, app_server.logs_tail()
+   ```
+
+---
+
+## Known constraints
+
+- **Sequential only**: not validated under `pytest-xdist`.
+- **Cold-start cost**: each module re-launches the app subprocess
+  (~4s setup). Full suite ~3 min; P0 set ~2 min.
+- **No real LLM calls**: messaging tests use the `console` channel and do
+  not exercise model providers.
+- **No real channel I/O**: only configuration-layer tests for channels;
+  IM webhook/long-poll paths are not covered here.
+- **Coverage mode is single-worker**: `QWENPAW_INTEGRATION_COVERAGE=1`
+  cannot be combined with `pytest-xdist`.

--- a/tests/integration/README_zh.md
+++ b/tests/integration/README_zh.md
@@ -1,0 +1,207 @@
+# 集成测试
+
+[English](README.md)
+
+通过真实子进程对 QwenPaw FastAPI 应用做端到端的 HTTP 冒烟测试。每个测试
+文件拥有自己的 QwenPaw app 子进程,绑定随机端口,工作目录隔离 —— 不需要
+任何真实的 API key 或外部服务。
+
+---
+
+## 运行
+
+```bash
+# 全量(~3 分钟)
+make test-integration
+# 或直接:
+pytest tests/integration/ --no-cov
+
+# 按优先级(PR 必跑 / 每夜回归 / 全面契约)
+pytest tests/integration/ -m p0 --no-cov   # ~2 分钟,PR 必跑冒烟
+pytest tests/integration/ -m p1 --no-cov   # 每夜 / 合入回归
+pytest tests/integration/ -m p2 --no-cov   # 异常路径与契约
+
+# 单文件
+pytest tests/integration/test_agents.py -v --no-cov
+
+# 单用例
+pytest tests/integration/test_agents.py::test_api_agents_list_create_get_delete -v --no-cov
+```
+
+测试串行执行(未在 `pytest-xdist` 下验证)。`--no-cov` 跳过父进程覆盖率;
+子进程覆盖率见 [覆盖率](#覆盖率可选)。
+
+---
+
+## 优先级 marker
+
+测试按 **用户视角的影响** 标记,而非技术复杂度。新增用例时先问自己:
+
+> *"如果它挂了,用户还能正常发消息并收到回复吗?"*
+> 能 → `p1` 或 `p2`;不能 → `p0`。
+
+### `p0` — 命脉(PR 必跑冒烟)
+
+挂了产品基本不可用,每个 PR 必须通过。覆盖:
+
+- **消息收发主链路** — `/api/messages/send` 核心流程、默认 agent 路由
+- **Agent / Chat / Skills 核心 CRUD** — 列表、增、查、删、启停、system
+  prompt 文件
+- **全局配置** — 通道、心跳、MCP CRUD、workspace 运行时配置
+- **全局安全 Guard** — file guard、tool guard、skill scanner
+- **Tools 启停** — 直接影响 agent 运行时能力
+- **API version** — 基础健康检查
+
+运行:`pytest -m p0`(约 22 个用例,~2 分钟)。
+
+### `p1` — 降级但能用(每夜 / 合入回归)
+
+挂了体验降级,但默认值能让用户继续使用。覆盖:
+
+- **设置项与 scoped 覆盖** — 语言、音频模式、时区、转录服务,以及通道/
+  心跳/Guard 的 agent-scoped 版本
+- **Workspace 文件** — 工作/记忆目录文件 CRUD,zip 导入导出,scoped 一致性
+- **ACP / LLM 路由** — 开发者向特性
+- **Plan / Cron** — 辅助功能
+- **统计接口** — token 用量、插件/备份列表、agent 统计、auth 状态
+- **辅助 API** — 文件预览、agent 排序、批量操作
+
+运行:`pytest -m p1`(约 53 个用例)。
+
+### `p2` — 契约(全面覆盖)
+
+边界行为,不影响主流程。覆盖:
+
+- **校验拒绝** — `*_rejected` 系列(重名、非法 payload、非 zip 上传)
+- **404 处理** — `*_returns_404`、`missing_*` 系列
+- **批量部分成功** — 批量操作中部分成功的分支
+- **隔离边界** — `*_isolated_*`、跨 agent 边界用例
+- **HEAD 请求与契约** — `*_minimal_contract`、文件预览 HEAD
+- **版本元数据** — 包版本、PEP 440 合规
+
+运行:`pytest -m p2`(约 30 个用例)。
+
+---
+
+## 文件分布
+
+| 文件 | 覆盖范围 |
+|---|---|
+| `test_agents.py` | Agent CRUD、排序、启停 |
+| `test_chats_global.py` | 全局 `/api/chats`(CRUD、批量、隔离) |
+| `test_chats_agent_scoped.py` | Agent-scoped chats |
+| `test_workspace_files.py` | 工作/记忆目录文件、zip 导入导出 |
+| `test_workspace_running_config.py` | 运行时配置(全局 + scoped) |
+| `test_workspace_agent_settings.py` | Agent-scoped workspace 设置(语言、音频、prompt、转录、记忆) |
+| `test_heartbeat.py` | 心跳配置(全局 + scoped) |
+| `test_channels_config.py` | 通道配置 + 健康/重启 |
+| `test_security_config.py` | File guard、tool guard、skill scanner |
+| `test_agent_routing_config.py` | ACP、LLM 路由、白名单、时区 |
+| `test_skills_global.py` | 全局 skills(CRUD、批量、校验) |
+| `test_skills_agent_scoped.py` | Agent-scoped skills |
+| `test_mcp.py` | MCP 客户端生命周期 |
+| `test_messages_files.py` | 发送消息 + 文件预览 |
+| `test_plan.py` | Plan 配置 |
+| `test_cron.py` | Agent-scoped cron 任务 |
+| `test_console.py` | Console 专属接口(chat stop、upload) |
+| `test_console_metadata.py` | 插件/备份/token 用量/auth/agent 统计列表 |
+| `test_settings_envs.py` | Settings + 持久化环境变量 |
+| `test_tools.py` | Tools 启停与异步执行 |
+| `test_app_startup.py` | App 就绪、console 入口/fallback |
+| `test_version.py` | 包版本元数据(不拉 app 子进程) |
+
+---
+
+## `app_server` 工作原理
+
+`tests/integration/conftest.py::app_server` 是 **module-scoped** fixture:
+每个测试文件得到自己的 QwenPaw app 子进程(随机端口),同一文件内的所有
+用例共享该子进程。跨文件隔离通过重新拉起子进程 + 全新 tmp 目录实现。
+
+**用例必须在文件内使用唯一的资源 id**(例如
+`agent_id = "integ_<scope>_01"`)以避免共享子进程内的命名冲突 —— 当前
+约定已经这样做了。
+
+Fixture 行为:
+
+- 启动前清理 11 个敏感环境变量(`OPENAI_API_KEY`、`DASHSCOPE_API_KEY`、
+  各 IM token 等)
+- 强制 `QWENPAW_AUTH_ENABLED=false` 与 `NO_PROXY=*`
+- 通过 `socket.bind(0)` 分配空闲端口
+- 轮询 `/api/version` 最长 60 秒作为就绪信号
+- 关停时使用 **SIGINT**(不是 SIGTERM),让 uvicorn 的 atexit 钩子能正常
+  flush(子进程覆盖率数据依赖这一点;SIGTERM 经常会跳过)
+- HTTP 超时 **15 秒**,吸收冷启动延迟(例如 ACP getter 首次访问需要 4-5
+  秒)
+
+---
+
+## 覆盖率(可选)
+
+默认 `pytest --cov` 只看到测试进程本身,对真实 app 几乎零覆盖。要采集
+**app 子进程**的覆盖率:
+
+```bash
+QWENPAW_INTEGRATION_COVERAGE=1 pytest tests/integration/ --no-cov
+```
+
+执行流程:
+
+1. 在 `.integration_coverage/` 写入 coverage rcfile,使用 **绝对路径**
+   `source=…/src/qwenpaw`
+2. 每个子进程通过 `COVERAGE_PROCESS_START` 与 `COVERAGE_FILE` 注入
+3. 会话结束后合并并行数据文件,生成
+   `htmlcov-integration/index.html`
+
+> ⚠️ 此模式必须传 `--no-cov` —— 否则 `pytest-cov` 会因为父进程接近零
+> 覆盖率而触发 `fail_under=30` 阈值,直接 fail 整轮。
+
+此流程**未在 `pytest-xdist` 下验证**。
+
+---
+
+## 添加新用例
+
+1. **按业务子域选文件**(参考 [文件分布](#文件分布))或新建
+   `test_<subdomain>.py`。
+2. **标记优先级** 用 `@pytest.mark.integration` + `p0` / `p1` / `p2`
+   之一(参考 [优先级 marker](#优先级-marker))。
+3. **使用唯一资源 id**(例如 `integ_<feature>_<seq>`)。
+4. **文档化用例**,在函数顶部说明 purpose / flow / API endpoints。参考
+   现有用例模板:
+
+   ```python
+   @pytest.mark.integration
+   @pytest.mark.p1
+   def test_my_feature_put_get_roundtrip(app_server) -> None:
+       """Test purpose:
+       - Verify ...
+
+       Test flow:
+       1. ...
+
+       API endpoints:
+       - PUT ...
+       - GET ...
+       """
+   ```
+
+5. **断言失败信息总是带 `app_server.logs_tail()`**,这样失败时能看到后端
+   日志:
+
+   ```python
+   assert resp.status_code == 200, app_server.logs_tail()
+   ```
+
+---
+
+## 已知约束
+
+- **仅支持串行**:未在 `pytest-xdist` 下验证。
+- **冷启动开销**:每个文件重新拉起 app 子进程(~4 秒 setup)。全量约 3
+  分钟,P0 子集约 2 分钟。
+- **不调真实 LLM**:消息测试走 `console` 通道,不触发模型 provider。
+- **不打通真实通道 I/O**:只覆盖通道的配置层,IM webhook / long-poll
+  路径不在范围内。
+- **覆盖率模式仅单 worker**:`QWENPAW_INTEGRATION_COVERAGE=1` 不能与
+  `pytest-xdist` 并用。

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -280,7 +280,7 @@ class AppServer:
 
 
 @pytest.fixture(scope="module")
-def app_server(  # pylint: disable=too-many-statements
+def app_server(  # pylint: disable=too-many-statements,too-many-branches
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Iterator[AppServer]:
     """Start one isolated qwenpaw app process per test module.
@@ -397,11 +397,19 @@ def app_server(  # pylint: disable=too-many-statements
         finally:
             client.close()
             if process.poll() is None:
-                # SIGINT lets uvicorn shut down cleanly so subprocess
-                # coverage data flushes (SIGTERM often skips atexit
-                # / data-file write).
+                # On POSIX, SIGINT lets uvicorn shut down cleanly so
+                # subprocess coverage data flushes (SIGTERM often skips
+                # atexit / data-file write). On Windows, SIGINT is not
+                # delivered reliably to subprocesses (CTRL_C_EVENT only
+                # works for console process groups created with
+                # CREATE_NEW_PROCESS_GROUP), so use terminate directly.
+                # Windows CI does not enable subprocess coverage, so the
+                # graceful-shutdown nicety isn't needed there.
                 try:
-                    process.send_signal(signal.SIGINT)
+                    if sys.platform == "win32":
+                        process.terminate()
+                    else:
+                        process.send_signal(signal.SIGINT)
                     process.wait(timeout=15)
                 except subprocess.TimeoutExpired:
                     process.terminate()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,11 +3,29 @@
 
 These fixtures start a real QwenPaw app subprocess with isolated workspace
 directories and a sanitized environment to avoid touching local secrets.
+
+Subprocess coverage (optional):
+
+    QWENPAW_INTEGRATION_COVERAGE=1 pytest tests/integration/
+
+When set, ``pytest_sessionstart`` writes a coverage rcfile under
+``.integration_coverage/`` with an **absolute** ``source=`` path
+(``…/src/qwenpaw``); the app subprocess runs with
+``COVERAGE_PROCESS_START`` / ``COVERAGE_FILE`` so the child traces
+that tree. The fixture stops the app with **SIGINT** first so coverage
+can flush (SIGTERM often yields empty data). After the session, files
+under ``.integration_coverage/`` are combined and HTML is written to
+``htmlcov-integration/``. Run integration tests without ``--cov`` from
+pytest-cov (or use ``--no-cov``) so the parent process does not enforce
+``fail_under`` on near-zero host-process coverage. This flow is not
+validated under ``pytest-xdist``.
 """
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -20,6 +38,133 @@ from typing import Any
 
 import httpx
 import pytest
+
+_INTEGRATION_COVERAGE_DIR: Path | None = None
+_COVERAGE_SUBPROC_BASENAME = "integration_subproc"
+_COVERAGE_RCFILE_NAME = "coverage_subprocess.ini"
+
+
+def _write_integration_subprocess_rc(root: Path, dest_ini: Path) -> None:
+    """Write a coverage rcfile with absolute ``source`` for the app subprocess.
+
+    Relative ``source=`` paths in a checked-in rcfile are not resolved reliably
+    when the file is loaded via ``COVERAGE_PROCESS_START``, which produced
+    empty traces (0 files) even though the app ran.
+    """
+    src_qwenpaw = (root / "src" / "qwenpaw").resolve()
+    text = (
+        "[run]\n"
+        "parallel = true\n"
+        "branch = false\n"
+        f"source = {src_qwenpaw}\n"
+        "omit =\n"
+        "    */tests/*\n"
+        "    */test_*\n"
+        "    */__pycache__/*\n"
+    )
+    dest_ini.write_text(text, encoding="utf-8")
+
+
+def _integration_coverage_requested() -> bool:
+    return os.environ.get(
+        "QWENPAW_INTEGRATION_COVERAGE",
+        "",
+    ).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Prepare directory and config for subprocess coverage when requested."""
+    global _INTEGRATION_COVERAGE_DIR
+    if not _integration_coverage_requested():
+        return
+    root = Path(session.config.rootpath).resolve()
+    _INTEGRATION_COVERAGE_DIR = root / ".integration_coverage"
+    _INTEGRATION_COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
+    for p in _INTEGRATION_COVERAGE_DIR.glob(f"{_COVERAGE_SUBPROC_BASENAME}*"):
+        p.unlink(missing_ok=True)
+    _write_integration_subprocess_rc(
+        root,
+        _INTEGRATION_COVERAGE_DIR / _COVERAGE_RCFILE_NAME,
+    )
+
+
+def pytest_sessionfinish(  # pylint: disable=unused-argument
+    session: pytest.Session,
+    exitstatus: int,
+) -> None:
+    """Merge parallel coverage files from app subprocesses and write HTML."""
+    if (
+        not _integration_coverage_requested()
+        or _INTEGRATION_COVERAGE_DIR is None
+    ):
+        return
+    wd = _INTEGRATION_COVERAGE_DIR
+    if not any(wd.glob(f"{_COVERAGE_SUBPROC_BASENAME}*")):
+        print(
+            "[integration coverage] No data files under "
+            f"{wd} (no app_server tests ran?).",
+            flush=True,
+        )
+        return
+
+    combine = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "combine",
+            "--data-file",
+            _COVERAGE_SUBPROC_BASENAME,
+        ],
+        cwd=wd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if combine.returncode != 0:
+        print(
+            "[integration coverage] coverage combine failed:\n"
+            f"{combine.stdout}\n{combine.stderr}",
+            flush=True,
+        )
+        return
+
+    root = Path(session.config.rootpath).resolve()
+    html_dir = root / "htmlcov-integration"
+    if html_dir.is_dir():
+        shutil.rmtree(html_dir)
+    html = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "html",
+            "--data-file",
+            _COVERAGE_SUBPROC_BASENAME,
+            "-d",
+            str(html_dir),
+        ],
+        cwd=wd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if html.returncode != 0:
+        print(
+            "[integration coverage] coverage html failed:\n"
+            f"{html.stdout}\n{html.stderr}",
+            flush=True,
+        )
+        return
+
+    print(
+        f"[integration coverage] HTML report: {html_dir / 'index.html'}",
+        flush=True,
+    )
 
 
 _SENSITIVE_ENV_VARS = (
@@ -46,11 +191,17 @@ def _find_free_port(host: str = "127.0.0.1") -> int:
 
 
 def _tee_stream(stream, buffer: list[str]) -> None:
-    """Read subprocess output, print it live, and keep a copy."""
+    """Read subprocess output, tag and print live, keep a raw copy."""
+    prefix = "[app server] "
     try:
         for line in iter(stream.readline, ""):
             buffer.append(line)
-            print(line, end="", flush=True)
+            try:
+                print(f"{prefix}{line}", end="", flush=True)
+            except (OSError, ValueError):
+                # pytest may close captured stdout before this daemon thread
+                # finishes draining; keep the raw copy in `buffer` regardless.
+                pass
     finally:
         stream.close()
 
@@ -74,8 +225,12 @@ class AppServer:
         return "".join(self.logs)[-chars:]
 
     @staticmethod
-    def _compact(value: Any, max_len: int = 240) -> str:
-        """Render values as a compact single-line summary."""
+    def _compact(value: Any, max_len: int | None = None) -> str:
+        """Render params/body/response for logs (single line, escaped).
+
+        ``max_len`` is only applied when set; by default the full string
+        is kept so integration logs are usable for debugging.
+        """
         if value is None:
             return "-"
         if isinstance(value, str):
@@ -86,7 +241,9 @@ class AppServer:
             except TypeError:
                 text = repr(value)
         text = text.replace("\n", "\\n")
-        return f"{text[: max_len - 3]}..." if len(text) > max_len else text
+        if max_len is not None and len(text) > max_len:
+            return f"{text[: max_len - 3]}..."
+        return text
 
     def api_request(
         self,
@@ -94,7 +251,7 @@ class AppServer:
         path: str,
         **kwargs: Any,
     ) -> httpx.Response:
-        """Send an HTTP request and always print request/response summary."""
+        """Send a request and print the full request/response to stdout."""
         url = f"{self.base_url}{path}" if path.startswith("/") else path
         request_payload = kwargs.get("json")
         if request_payload is None:
@@ -107,8 +264,6 @@ class AppServer:
             **kwargs,
         )
         response_text = response.text
-        if len(response_text) > 240:
-            response_text = f"{response_text[:237]}..."
 
         level = "PASS" if 200 <= response.status_code < 400 else "FAIL"
         print(
@@ -124,9 +279,18 @@ class AppServer:
         return response
 
 
-@pytest.fixture
-def app_server(tmp_path: Path) -> Iterator[AppServer]:
-    """Start one isolated qwenpaw app process for a test."""
+@pytest.fixture(scope="module")
+def app_server(  # pylint: disable=too-many-statements
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[AppServer]:
+    """Start one isolated qwenpaw app process per test module.
+
+    Module-scoped: cases in the same file share one subprocess. Cross-module
+    isolation is preserved by re-launching with a fresh tmp dir. Cases must
+    use unique resource ids (agent_id, chat_id, ...) to stay isolated within
+    a module — current convention (e.g. ``integ_ws_01``) already supports this.
+    """
+    tmp_path = tmp_path_factory.mktemp("app_server")
     host = "127.0.0.1"
     port = _find_free_port(host)
 
@@ -147,6 +311,19 @@ def app_server(tmp_path: Path) -> Iterator[AppServer]:
     env["QWENPAW_AUTH_ENABLED"] = "false"
     env["NO_PROXY"] = "*"
     env["PYTHONUNBUFFERED"] = "1"
+
+    if _integration_coverage_requested():
+        if _INTEGRATION_COVERAGE_DIR is None:
+            raise AssertionError(
+                "QWENPAW_INTEGRATION_COVERAGE is set but coverage dir was not "
+                "initialised (pytest_sessionstart should create "
+                ".integration_coverage/).",
+            )
+        rcfile = _INTEGRATION_COVERAGE_DIR / _COVERAGE_RCFILE_NAME
+        env["COVERAGE_PROCESS_START"] = str(rcfile.resolve())
+        env["COVERAGE_FILE"] = str(
+            _INTEGRATION_COVERAGE_DIR / _COVERAGE_SUBPROC_BASENAME,
+        )
 
     logs: list[str] = []
     with subprocess.Popen(
@@ -177,7 +354,11 @@ def app_server(tmp_path: Path) -> Iterator[AppServer]:
         )
         log_thread.start()
 
-        client = httpx.Client(timeout=5.0, trust_env=False)
+        # 15s default lets cold-start endpoints (ACP getter, heartbeat)
+        # finish without hiding real deadlocks; 30s in coverage mode
+        # for tracer overhead.
+        http_timeout = 30.0 if _integration_coverage_requested() else 15.0
+        client = httpx.Client(timeout=http_timeout, trust_env=False)
 
         try:
             max_wait_seconds = 60
@@ -216,10 +397,17 @@ def app_server(tmp_path: Path) -> Iterator[AppServer]:
         finally:
             client.close()
             if process.poll() is None:
-                process.terminate()
+                # SIGINT lets uvicorn shut down cleanly so subprocess
+                # coverage data flushes (SIGTERM often skips atexit
+                # / data-file write).
                 try:
-                    process.wait(timeout=5)
+                    process.send_signal(signal.SIGINT)
+                    process.wait(timeout=15)
                 except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=5)
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
             log_thread.join(timeout=2)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -311,6 +311,11 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     env["QWENPAW_AUTH_ENABLED"] = "false"
     env["NO_PROXY"] = "*"
     env["PYTHONUNBUFFERED"] = "1"
+    # Force UTF-8 stdio in the subprocess so non-ASCII log lines (e.g.
+    # 中文/emoji from skills, agentscope, etc.) don't crash the parent's
+    # _tee_stream reader on Windows where the default console encoding
+    # is cp1252.
+    env["PYTHONIOENCODING"] = "utf-8"
 
     if _integration_coverage_requested():
         if _INTEGRATION_COVERAGE_DIR is None:
@@ -343,6 +348,11 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        # Decode subprocess output as UTF-8 in the parent. Without this,
+        # Popen falls back to locale.getpreferredencoding(False) which
+        # is cp1252 on Windows CI runners and crashes _tee_stream.
+        encoding="utf-8",
+        errors="replace",
         env=env,
     ) as process:
         assert process.stdout is not None

--- a/tests/integration/test_agent_routing_config.py
+++ b/tests/integration/test_agent_routing_config.py
@@ -1,0 +1,431 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for ACP, LLM routing, allow-no-auth, timezone."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_acp_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped ACP config endpoint supports full payload update and
+      readback.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped ACP config as baseline.
+    3. PUT scoped ACP config with one agent's enabled flag toggled.
+    4. GET scoped ACP config and verify the update is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/acp
+    - PUT /api/agents/{agentId}/config/acp
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_acp_01"
+    endpoint = f"/api/agents/{agent_id}/config/acp"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Scoped ACP agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    changed_agent = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        agents = baseline.get("agents")
+        assert isinstance(agents, dict) and agents
+        changed_agent = next(iter(agents.keys()))
+
+        updated = {"agents": {}}
+        for name, cfg in agents.items():
+            cfg_dict = dict(cfg)
+            if name == changed_agent:
+                cfg_dict["enabled"] = not bool(cfg_dict.get("enabled", False))
+            updated["agents"][name] = cfg_dict
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(
+            put_resp.json()
+            .get("agents", {})
+            .get(changed_agent, {})
+            .get("enabled", False),
+        ) == bool(updated["agents"][changed_agent]["enabled"])
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(
+            get_after.json()
+            .get("agents", {})
+            .get(changed_agent, {})
+            .get("enabled", False),
+        ) == bool(updated["agents"][changed_agent]["enabled"])
+    finally:
+        if isinstance(baseline, dict):
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_acp_single_agent_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped ACP single-agent endpoint supports update and
+      readback for one ACP agent entry.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped ACP and pick one existing ACP agent key.
+    3. GET scoped ACP single-agent config as baseline.
+    4. PUT scoped single-agent config with toggled enabled value.
+    5. GET again and verify update persisted.
+    6. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/acp
+    - GET /api/agents/{agentId}/config/acp/{agent_name}
+    - PUT /api/agents/{agentId}/config/acp/{agent_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_acp_agent_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped ACP single agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    acp_agent_name = None
+    baseline = None
+    try:
+        get_acp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/config/acp",
+        )
+        assert get_acp.status_code == 200, app_server.logs_tail()
+        agents = get_acp.json().get("agents")
+        assert isinstance(agents, dict) and agents
+        acp_agent_name = next(iter(agents.keys()))
+
+        endpoint = f"/api/agents/{agent_id}/config/acp/{acp_agent_name}"
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "enabled" in baseline
+        assert "tool_parse_mode" in baseline
+
+        updated = dict(baseline)
+        updated["enabled"] = not bool(baseline.get("enabled", False))
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+    finally:
+        if acp_agent_name and isinstance(baseline, dict):
+            endpoint = f"/api/agents/{agent_id}/config/acp/{acp_agent_name}"
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_llm_routing_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped llm-routing endpoint supports update and readback.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped llm-routing config as baseline.
+    3. PUT scoped llm-routing with toggled ``enabled`` value.
+    4. GET scoped llm-routing and verify updated value persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/agents/llm-routing
+    - PUT /api/agents/{agentId}/config/agents/llm-routing
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_llm_routing_01"
+    endpoint = f"/api/agents/{agent_id}/config/agents/llm-routing"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped llm routing agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "enabled" in baseline
+        assert "mode" in baseline
+        assert "local" in baseline
+
+        updated = dict(baseline)
+        updated["enabled"] = not bool(baseline.get("enabled", False))
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+    finally:
+        if isinstance(baseline, dict):
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_global_allow_no_auth_hosts_normalization_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify allow-no-auth-hosts update path normalizes (trim/dedup) valid IPs
+      and supports readback.
+
+    Test flow:
+    1. GET current allow-no-auth-hosts list.
+    2. PUT a list with duplicates and whitespace around valid IPs.
+    3. Assert response is normalized and deduplicated.
+    4. GET again and assert persisted hosts match normalized result.
+    5. Restore original hosts.
+
+    API endpoints:
+    - GET /api/config/security/allow-no-auth-hosts
+    - PUT /api/config/security/allow-no-auth-hosts
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/config/security/allow-no-auth-hosts",
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before_hosts = get_before.json().get("hosts")
+    assert isinstance(before_hosts, list)
+
+    update_body = {"hosts": [" 127.0.0.1 ", "::1", "127.0.0.1", "  ::1  "]}
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/security/allow-no-auth-hosts",
+            json=update_body,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        put_hosts = put_resp.json().get("hosts")
+        assert put_hosts == ["127.0.0.1", "::1"]
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/config/security/allow-no-auth-hosts",
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("hosts") == ["127.0.0.1", "::1"]
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/config/security/allow-no-auth-hosts",
+            json={"hosts": before_hosts},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_global_allow_no_auth_hosts_reject_invalid_ip(app_server) -> None:
+    """Test purpose:
+    - Verify allow-no-auth-hosts rejects invalid IP literals with 400.
+
+    Test flow:
+    1. PUT hosts payload containing an invalid IP token.
+    2. Assert 400 status and error detail mentions invalid IP.
+
+    API endpoints:
+    - PUT /api/config/security/allow-no-auth-hosts
+    """
+    bad_resp = app_server.api_request(
+        "PUT",
+        "/api/config/security/allow-no-auth-hosts",
+        json={"hosts": ["127.0.0.1", "bad-ip-value"]},
+    )
+    assert bad_resp.status_code == 400, app_server.logs_tail()
+    detail = bad_resp.json().get("detail", "")
+    assert "Invalid IP address" in detail
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_allow_no_auth_hosts_put_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped allow-no-auth-hosts endpoint supports update and
+      readback with normalized values.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped allow-no-auth-hosts as baseline.
+    3. PUT scoped hosts payload with duplicates and whitespace.
+    4. GET again and verify normalized hosts persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/security/allow-no-auth-hosts
+    - PUT /api/agents/{agentId}/config/security/allow-no-auth-hosts
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_allow_no_auth_01"
+    endpoint = f"/api/agents/{agent_id}/config/security/allow-no-auth-hosts"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped allow-no-auth agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    before_hosts = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        before_hosts = get_before.json().get("hosts")
+        assert isinstance(before_hosts, list)
+
+        put_resp = app_server.api_request(
+            "PUT",
+            endpoint,
+            json={"hosts": [" 127.0.0.1 ", " ::1 ", "127.0.0.1"]},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("hosts") == ["127.0.0.1", "::1"]
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("hosts") == ["127.0.0.1", "::1"]
+    finally:
+        if isinstance(before_hosts, list):
+            restore = app_server.api_request(
+                "PUT",
+                endpoint,
+                json={"hosts": before_hosts},
+            )
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_user_timezone_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped user-timezone GET/PUT roundtrip and that the value
+      is reflected on the global config endpoint (scoped routes share root
+      ``user_timezone``).
+
+    Test flow:
+    1. Record global user timezone as baseline.
+    2. Create a dedicated test agent.
+    3. PUT scoped user-timezone with a different valid IANA id.
+    4. GET scoped and global endpoints; assert normalized timezone matches.
+    5. Restore baseline via global PUT and delete the test agent.
+
+    API endpoints:
+    - GET /api/config/user-timezone
+    - PUT /api/config/user-timezone
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/user-timezone
+    - PUT /api/agents/{agentId}/config/user-timezone
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_user_tz_01"
+    global_tz = "/api/config/user-timezone"
+    scoped_tz = f"/api/agents/{agent_id}/config/user-timezone"
+
+    get_baseline = app_server.api_request("GET", global_tz)
+    assert get_baseline.status_code == 200, app_server.logs_tail()
+    baseline = get_baseline.json().get("timezone")
+    assert isinstance(baseline, str) and baseline
+
+    alternate = "UTC" if baseline != "UTC" else "Asia/Shanghai"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped user timezone agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            scoped_tz,
+            json={"timezone": alternate},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        resolved = put_resp.json().get("timezone")
+        assert isinstance(resolved, str) and resolved
+
+        get_scoped = app_server.api_request("GET", scoped_tz)
+        assert get_scoped.status_code == 200, app_server.logs_tail()
+        assert get_scoped.json().get("timezone") == resolved
+
+        get_global_after = app_server.api_request("GET", global_tz)
+        assert get_global_after.status_code == 200, app_server.logs_tail()
+        assert get_global_after.json().get("timezone") == resolved
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            global_tz,
+            json={"timezone": baseline},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_agents.py
+++ b/tests/integration/test_agents.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for agents lifecycle (list/create/update/order/toggle)."""
+from __future__ import annotations
+
+
+import pytest
+
+from qwenpaw.constant import BUILTIN_QA_AGENT_ID
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_agents_list_create_get_delete(app_server) -> None:
+    """Test purpose:
+    - Verify the primary Agents management flow works end-to-end: list system
+      agents, create one, read details, delete it, and confirm removal.
+    - Verify a newly created agent includes required top-level config groups.
+
+    Test flow:
+    1. GET /api/agents; confirm list contains ``default`` and builtin QA.
+    2. POST /api/agents to create a test agent.
+    3. GET /api/agents/{agentId} and validate name plus key config groups.
+    4. DELETE /api/agents/{agentId}.
+    5. GET /api/agents/{agentId} again and assert 404.
+
+    API endpoints:
+    - GET /api/agents
+    - POST /api/agents
+    - GET /api/agents/{agentId}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_agents_01"
+
+    list_resp = app_server.api_request("GET", "/api/agents")
+    assert list_resp.status_code == 200, app_server.logs_tail()
+    agents_payload = list_resp.json()
+    assert "agents" in agents_payload
+    assert isinstance(agents_payload["agents"], list)
+    listed_ids = {a["id"] for a in agents_payload["agents"]}
+    assert "default" in listed_ids, f"missing default agent in {listed_ids}"
+    assert (
+        BUILTIN_QA_AGENT_ID in listed_ids
+    ), f"missing builtin QA agent in {listed_ids}"
+
+    create_resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Integration smoke agent",
+            "description": "",
+        },
+    )
+    assert create_resp.status_code == 201, app_server.logs_tail()
+    created = create_resp.json()
+    assert created["id"] == agent_id
+    assert created.get("enabled") is True
+    assert isinstance(created.get("workspace_dir"), str)
+    assert created["workspace_dir"].strip()
+
+    try:
+        get_resp = app_server.api_request("GET", f"/api/agents/{agent_id}")
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        profile = get_resp.json()
+        assert profile["id"] == agent_id
+        assert profile["name"] == "Integration smoke agent"
+        missing_keys = [
+            k for k in _AGENT_PROFILE_TOP_LEVEL_KEYS if k not in profile
+        ]
+        assert not missing_keys, (
+            f"agent profile missing top-level keys {missing_keys}; "
+            f"have {sorted(profile.keys())}"
+        )
+    finally:
+        del_resp = app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("success") is True
+
+    missing = app_server.api_request("GET", f"/api/agents/{agent_id}")
+    assert missing.status_code == 404, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_agents_update_and_readback(app_server) -> None:
+    """Test purpose:
+    - Verify full agent updates (PUT) take effect and can be read back via GET.
+
+    Test flow:
+    1. POST /api/agents to create a test agent.
+    2. GET /api/agents/{agentId} to obtain a complete profile payload.
+    3. Update name/description/system_prompt_files and PUT it back.
+    4. GET /api/agents/{agentId} again and verify updated fields.
+    5. DELETE /api/agents/{agentId} for cleanup.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}
+    - PUT /api/agents/{agentId}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_agents_upd_01"
+    updated_name = "Integration smoke agent updated"
+    updated_desc = "updated by integration test"
+    updated_prompt_files = ["AGENTS.md", "PROFILE.md", "SOUL.md"]
+
+    create_resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Integration smoke agent",
+            "description": "",
+        },
+    )
+    assert create_resp.status_code == 201, app_server.logs_tail()
+
+    try:
+        get_before = app_server.api_request("GET", f"/api/agents/{agent_id}")
+        assert get_before.status_code == 200, app_server.logs_tail()
+        profile = get_before.json()
+
+        profile["name"] = updated_name
+        profile["description"] = updated_desc
+        profile["system_prompt_files"] = updated_prompt_files
+
+        put_resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}",
+            json=profile,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        put_payload = put_resp.json()
+        assert put_payload["id"] == agent_id
+        assert put_payload["name"] == updated_name
+        assert put_payload["description"] == updated_desc
+        assert put_payload["system_prompt_files"] == updated_prompt_files
+
+        get_after = app_server.api_request("GET", f"/api/agents/{agent_id}")
+        assert get_after.status_code == 200, app_server.logs_tail()
+        after_payload = get_after.json()
+        assert after_payload["name"] == updated_name
+        assert after_payload["description"] == updated_desc
+        assert after_payload["system_prompt_files"] == updated_prompt_files
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_agents_order_put_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify /api/agents/order persists a full agent order update.
+
+    Test flow:
+    1. GET /api/agents to capture a stable baseline order.
+    2. PUT /api/agents/order with a reordered full agent ID list.
+    3. GET /api/agents and verify returned order matches the updated order.
+    4. PUT baseline order back for cleanup.
+
+    API endpoints:
+    - GET /api/agents
+    - PUT /api/agents/order
+    """
+    list_before = app_server.api_request("GET", "/api/agents")
+    assert list_before.status_code == 200, app_server.logs_tail()
+    agents_before = list_before.json().get("agents", [])
+    assert isinstance(agents_before, list)
+    assert len(agents_before) >= 2, "need at least two agents for reorder test"
+
+    baseline_ids = [item["id"] for item in agents_before]
+    reordered_ids = [baseline_ids[-1], *baseline_ids[:-1]]
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/agents/order",
+            json={"agent_ids": reordered_ids},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("success") is True
+        assert put_resp.json().get("agent_ids") == reordered_ids
+
+        list_after = app_server.api_request("GET", "/api/agents")
+        assert list_after.status_code == 200, app_server.logs_tail()
+        after_ids = [
+            item["id"] for item in list_after.json().get("agents", [])
+        ]
+        assert after_ids == reordered_ids
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/agents/order",
+            json={"agent_ids": baseline_ids},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_agent_patch_toggle_enabled_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify PATCH /api/agents/{agentId}/toggle updates persisted ``enabled``
+      and can be read back from the agent profile.
+
+    Test flow:
+    1. POST a dedicated test agent (starts enabled).
+    2. PATCH toggle with ``enabled`` false and GET /api/agents list to verify
+       the summary row for that agent shows ``enabled`` false.
+    3. PATCH toggle with ``enabled`` true and verify via list again.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - PATCH /api/agents/{agentId}/toggle
+    - GET /api/agents
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_agent_toggle_01"
+
+    def _enabled_from_list() -> bool | None:
+        list_resp = app_server.api_request("GET", "/api/agents")
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        for row in list_resp.json().get("agents", []):
+            if row.get("id") == agent_id:
+                return bool(row.get("enabled", True))
+        return None
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Toggle agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        off = app_server.api_request(
+            "PATCH",
+            f"/api/agents/{agent_id}/toggle",
+            json={"enabled": False},
+        )
+        assert off.status_code == 200, app_server.logs_tail()
+        assert off.json().get("enabled") is False
+        assert _enabled_from_list() is False
+
+        on = app_server.api_request(
+            "PATCH",
+            f"/api/agents/{agent_id}/toggle",
+            json={"enabled": True},
+        )
+        assert on.status_code == 200, app_server.logs_tail()
+        assert on.json().get("enabled") is True
+        assert _enabled_from_list() is True
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_app_startup.py
+++ b/tests/integration/test_app_startup.py
@@ -2,9 +2,24 @@
 """Integration smoke tests for app startup and console."""
 from __future__ import annotations
 
+import pytest
 
+
+@pytest.mark.integration
+@pytest.mark.p0
 def test_api_version_ok(app_server) -> None:
-    """App should expose /api/version after startup."""
+    """Test purpose:
+    - Verify the basic version endpoint is available after startup, as the
+      minimum readiness signal for integration tests.
+
+    Test flow:
+    1. Request the version endpoint.
+    2. Assert status code is 200.
+    3. Assert the response contains a non-empty string version.
+
+    API endpoints:
+    - GET /api/version
+    """
     response = app_server.api_request("GET", "/api/version")
     assert response.status_code == 200, app_server.logs_tail()
     payload = response.json()
@@ -13,8 +28,22 @@ def test_api_version_ok(app_server) -> None:
     assert payload["version"].strip()
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_console_entry_or_fallback_ok(app_server) -> None:
-    """Console path should return HTML or explicit unavailable fallback."""
+    """Test purpose:
+    - Verify the console entry returns predictable behavior across build
+      variants (either a working HTML page or an explicit fallback).
+
+    Test flow:
+    1. Request /console/.
+    2. If status is 200, assert HTML content-type and HTML body markers.
+    3. If status is 404, request / and assert a clear JSON fallback message.
+
+    API endpoints:
+    - GET /console/
+    - GET /
+    """
     response = app_server.api_request("GET", "/console/")
     if response.status_code == 200:
         content_type = response.headers.get("content-type", "").lower()

--- a/tests/integration/test_channels_config.py
+++ b/tests/integration/test_channels_config.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for channels config (global/scoped + health/restart)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_channels_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped /config/channels supports full payload update and
+      readback for the selected channel switch.
+
+    Test flow:
+    1. Create a dedicated test agent and read full profile channels payload.
+    2. PUT /api/agents/{agentId}/config/channels with toggled console enabled.
+    3. GET /api/agents/{agentId}/config/channels and assert value changed.
+    4. Restore baseline payload and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}
+    - PUT /api/agents/{agentId}/config/channels
+    - GET /api/agents/{agentId}/config/channels
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_channels_01"
+    channels_endpoint = f"/api/agents/{agent_id}/config/channels"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped channels agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    original_channels = None
+    try:
+        get_agent = app_server.api_request("GET", f"/api/agents/{agent_id}")
+        assert get_agent.status_code == 200, app_server.logs_tail()
+        original_channels = get_agent.json().get("channels")
+        assert isinstance(original_channels, dict), app_server.logs_tail()
+        assert "console" in original_channels, app_server.logs_tail()
+
+        updated_channels = dict(original_channels)
+        updated_console = dict(updated_channels.get("console") or {})
+        updated_console["enabled"] = not bool(
+            updated_console.get("enabled", False),
+        )
+        updated_channels["console"] = updated_console
+
+        put_resp = app_server.api_request(
+            "PUT",
+            channels_endpoint,
+            json=updated_channels,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(
+            put_resp.json().get("console", {}).get("enabled", False),
+        ) == bool(
+            updated_console["enabled"],
+        )
+
+        get_after = app_server.api_request("GET", channels_endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(
+            get_after.json().get("console", {}).get("enabled", False),
+        ) == bool(
+            updated_console["enabled"],
+        )
+    finally:
+        if isinstance(original_channels, dict):
+            restore = app_server.api_request(
+                "PUT",
+                channels_endpoint,
+                json=original_channels,
+            )
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_single_channel_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped /config/channels/{channel_name} update path supports
+      deterministic readback for one channel.
+
+    Test flow:
+    1. Create a dedicated test agent and choose one available channel type.
+    2. GET scoped single-channel config as baseline.
+    3. PUT scoped single-channel config with toggled enabled value.
+    4. GET again and assert value changed.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/channels/types
+    - GET /api/agents/{agentId}/config/channels/{channel_name}
+    - PUT /api/agents/{agentId}/config/channels/{channel_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_single_channel_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped single channel agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    channel_name = None
+    baseline = None
+    try:
+        types_resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/config/channels/types",
+        )
+        assert types_resp.status_code == 200, app_server.logs_tail()
+        channel_types = types_resp.json()
+        assert isinstance(channel_types, list) and channel_types
+        channel_name = (
+            "console" if "console" in channel_types else str(channel_types[0])
+        )
+
+        endpoint = f"/api/agents/{agent_id}/config/channels/{channel_name}"
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "enabled" in baseline
+
+        updated = dict(baseline)
+        updated["enabled"] = not bool(baseline.get("enabled", False))
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled", False)) == bool(
+            updated["enabled"],
+        )
+    finally:
+        if channel_name and isinstance(baseline, dict):
+            endpoint = f"/api/agents/{agent_id}/config/channels/{channel_name}"
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_global_channels_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify the global channels endpoint accepts a full channels payload and
+      the updated value can be observed from list/get APIs.
+
+    Test flow:
+    1. GET /api/agents/default and extract ``channels`` as a valid PUT payload.
+    2. GET /api/config/channels and keep current state for later comparison.
+    3. Flip ``console.enabled`` in the payload and PUT /api/config/channels.
+    4. GET /api/config/channels and GET /api/config/channels/console to verify
+       the changed value is reflected.
+    5. PUT original channels payload back, then verify restoration.
+
+    API endpoints:
+    - GET /api/agents/default
+    - GET /api/config/channels
+    - PUT /api/config/channels
+    - GET /api/config/channels/console
+    """
+    get_agent = app_server.api_request("GET", "/api/agents/default")
+    assert get_agent.status_code == 200, app_server.logs_tail()
+    original_channels = get_agent.json().get("channels")
+    assert isinstance(original_channels, dict), app_server.logs_tail()
+
+    list_before = app_server.api_request("GET", "/api/config/channels")
+    assert list_before.status_code == 200, app_server.logs_tail()
+    before = list_before.json()
+    assert isinstance(before, dict)
+    assert "console" in before
+    assert isinstance(before["console"], dict)
+    assert "enabled" in before["console"]
+
+    updated_channels = dict(original_channels)
+    console_cfg = dict(updated_channels.get("console") or {})
+    console_cfg["enabled"] = not bool(console_cfg.get("enabled", False))
+    updated_channels["console"] = console_cfg
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/channels",
+            json=updated_channels,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert isinstance(put_resp.json(), dict)
+
+        list_after = app_server.api_request("GET", "/api/config/channels")
+        assert list_after.status_code == 200, app_server.logs_tail()
+        after_console_enabled = bool(
+            list_after.json().get("console", {}).get("enabled", False),
+        )
+        assert after_console_enabled == console_cfg["enabled"]
+
+        console_after = app_server.api_request(
+            "GET",
+            "/api/config/channels/console",
+        )
+        assert console_after.status_code == 200, app_server.logs_tail()
+        assert (
+            bool(console_after.json().get("enabled", False))
+            == console_cfg["enabled"]
+        )
+    finally:
+        restore_resp = app_server.api_request(
+            "PUT",
+            "/api/config/channels",
+            json=original_channels,
+        )
+        assert restore_resp.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_global_channel_health_minimal_contract(app_server) -> None:
+    """Test purpose:
+    - Verify channel health endpoint keeps a stable minimal contract for an
+      available channel type.
+
+    Test flow:
+    1. GET /api/config/channels/types and select one available channel.
+    2. GET /api/config/channels/{channel}/health for that channel.
+    3. Accept either 200 (health payload) or 404 (channel not running), and
+       validate response structure accordingly.
+
+    API endpoints:
+    - GET /api/config/channels/types
+    - GET /api/config/channels/{channel}/health
+    """
+    types_resp = app_server.api_request("GET", "/api/config/channels/types")
+    assert types_resp.status_code == 200, app_server.logs_tail()
+    channel_types = types_resp.json()
+    assert isinstance(channel_types, list)
+    assert (
+        channel_types
+    ), "channels/types should return at least one channel type"
+
+    channel_name = str(channel_types[0])
+    health_resp = app_server.api_request(
+        "GET",
+        f"/api/config/channels/{channel_name}/health",
+    )
+
+    assert health_resp.status_code in (200, 404), app_server.logs_tail()
+    payload = health_resp.json()
+    assert isinstance(payload, dict)
+    assert "detail" in payload
+
+    if health_resp.status_code == 200:
+        assert payload.get("channel") == channel_name
+        assert payload.get("status") in {"healthy", "unhealthy", "disabled"}
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_channel_restart_when_healthy(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/config/channels/{name}/restart succeeds
+      when the channel reports ``healthy`` on the scoped health endpoint.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped channel types and iterate channel names.
+    3. For the first channel whose scoped health is 200 / ``healthy``,
+       POST scoped restart and assert ``ChannelRestartResponse`` shape.
+    4. Delete the test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/channels/types
+    - GET /api/agents/{agentId}/config/channels/{channel_name}/health
+    - POST /api/agents/{agentId}/config/channels/{channel_name}/restart
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_channel_restart_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped channel restart agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        types_resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/config/channels/types",
+        )
+        assert types_resp.status_code == 200, app_server.logs_tail()
+        channel_types = types_resp.json()
+        assert isinstance(channel_types, list)
+        assert channel_types, app_server.logs_tail()
+
+        restarted = False
+        for raw_name in channel_types:
+            channel_name = str(raw_name)
+            health_resp = app_server.api_request(
+                "GET",
+                f"/api/agents/{agent_id}/config/channels/"
+                f"{channel_name}/health",
+            )
+            if health_resp.status_code != 200:
+                continue
+            health_payload = health_resp.json()
+            if health_payload.get("status") != "healthy":
+                continue
+
+            restart_resp = app_server.api_request(
+                "POST",
+                f"/api/agents/{agent_id}/config/channels/"
+                f"{channel_name}/restart",
+            )
+            assert restart_resp.status_code == 200, app_server.logs_tail()
+            body = restart_resp.json()
+            assert body.get("status") == "restarted"
+            assert body.get("channel") == channel_name
+            restarted = True
+            break
+
+        assert restarted, (
+            "expected at least one channel with scoped health status=healthy "
+            f"for agent {agent_id!r}; types={channel_types!r}"
+        )
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_chats_agent_scoped.py
+++ b/tests/integration/test_chats_agent_scoped.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for agent-scoped chats endpoints."""
+from __future__ import annotations
+
+
+import pytest
+
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_agent_scoped_chats_create_list_batch_delete(app_server) -> None:
+    """Test purpose:
+    - Verify chats can be created, listed, and batch-deleted using only
+      agent-scoped paths (no ``X-Agent-Id`` header).
+
+    Test flow:
+    1. POST /api/agents to create a test agent.
+    2. POST /api/agents/{agentId}/chats twice to create two chats.
+    3. GET /api/agents/{agentId}/chats and assert both IDs are listed.
+    4. POST /api/agents/{agentId}/chats/batch-delete with both IDs.
+    5. GET the scoped list again and assert both IDs are gone.
+    6. Defensive per-chat DELETE and DELETE agent in finally.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/chats
+    - GET /api/agents/{agentId}/chats
+    - POST /api/agents/{agentId}/chats/batch-delete
+    - DELETE /api/agents/{agentId}/chats/{chatId}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_chats_batch_01"
+    base = f"/api/agents/{agent_id}"
+    chat_ids: list[str] = []
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped chats batch agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        for idx in (1, 2):
+            resp = app_server.api_request(
+                "POST",
+                f"{base}/chats",
+                json={
+                    "name": f"Scoped batch chat {idx}",
+                    "session_id": f"console:integ-scoped-batch-{idx}",
+                    "user_id": f"integ-scoped-batch-user-{idx}",
+                    "channel": "console",
+                    "meta": {},
+                },
+            )
+            assert resp.status_code == 200, app_server.logs_tail()
+            chat_ids.append(resp.json()["id"])
+
+        list_before = app_server.api_request("GET", f"{base}/chats")
+        assert list_before.status_code == 200, app_server.logs_tail()
+        before_ids = {item["id"] for item in list_before.json()}
+        for chat_id in chat_ids:
+            assert chat_id in before_ids
+
+        batch_delete = app_server.api_request(
+            "POST",
+            f"{base}/chats/batch-delete",
+            json=chat_ids,
+        )
+        assert batch_delete.status_code == 200, app_server.logs_tail()
+        assert batch_delete.json().get("deleted") is True
+
+        list_after = app_server.api_request("GET", f"{base}/chats")
+        assert list_after.status_code == 200, app_server.logs_tail()
+        after_ids = {item["id"] for item in list_after.json()}
+        for chat_id in chat_ids:
+            assert chat_id not in after_ids
+    finally:
+        for chat_id in chat_ids:
+            cleanup = app_server.api_request(
+                "DELETE",
+                f"{base}/chats/{chat_id}",
+            )
+            assert cleanup.status_code in (200, 404), app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_agent_scoped_chat_put_get_delete(app_server) -> None:
+    """Test purpose:
+    - Verify a single chat can be updated, read back, and deleted via
+      agent-scoped chat routes.
+
+    Test flow:
+    1. POST /api/agents then POST /api/agents/{agentId}/chats to create a chat.
+    2. PUT /api/agents/{agentId}/chats/{chatId} to rename it.
+    3. GET /api/agents/{agentId}/chats/{chatId}; assert history + name
+       consistency on a follow-up list read.
+    4. DELETE /api/agents/{agentId}/chats/{chatId}; 404 on repeat delete.
+    5. DELETE the test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/chats
+    - PUT /api/agents/{agentId}/chats/{chatId}
+    - GET /api/agents/{agentId}/chats/{chatId}
+    - DELETE /api/agents/{agentId}/chats/{chatId}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_chat_crud_01"
+    base = f"/api/agents/{agent_id}"
+    chat_id: str | None = None
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped single chat agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        post_chat = app_server.api_request(
+            "POST",
+            f"{base}/chats",
+            json={
+                "name": "Scoped chat original",
+                "session_id": "console:integ-scoped-crud",
+                "user_id": "integ-scoped-crud-user",
+                "channel": "console",
+                "meta": {},
+            },
+        )
+        assert post_chat.status_code == 200, app_server.logs_tail()
+        chat_id = post_chat.json()["id"]
+        assert isinstance(chat_id, str) and chat_id
+
+        put_chat = app_server.api_request(
+            "PUT",
+            f"{base}/chats/{chat_id}",
+            json={"name": "Scoped chat renamed"},
+        )
+        assert put_chat.status_code == 200, app_server.logs_tail()
+        assert put_chat.json()["name"] == "Scoped chat renamed"
+
+        get_hist = app_server.api_request("GET", f"{base}/chats/{chat_id}")
+        assert get_hist.status_code == 200, app_server.logs_tail()
+        history = get_hist.json()
+        assert "messages" in history and isinstance(history["messages"], list)
+        assert "status" in history and isinstance(history["status"], str)
+
+        list_chats = app_server.api_request("GET", f"{base}/chats")
+        assert list_chats.status_code == 200, app_server.logs_tail()
+        names_by_id = {c["id"]: c.get("name") for c in list_chats.json()}
+        assert names_by_id.get(chat_id) == "Scoped chat renamed"
+
+        del_first = app_server.api_request("DELETE", f"{base}/chats/{chat_id}")
+        assert del_first.status_code == 200, app_server.logs_tail()
+        assert del_first.json().get("deleted") is True
+
+        del_second = app_server.api_request(
+            "DELETE",
+            f"{base}/chats/{chat_id}",
+        )
+        assert del_second.status_code == 404, app_server.logs_tail()
+        chat_id = None
+    finally:
+        if chat_id is not None:
+            app_server.api_request("DELETE", f"{base}/chats/{chat_id}")
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_chats_global.py
+++ b/tests/integration/test_chats_global.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for global /api/chats (CRUD, batch, isolation)."""
+from __future__ import annotations
+
+
+import pytest
+
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_chats_crud_and_agent_scoped_list(app_server) -> None:
+    """Test purpose:
+    - Verify core chat CRUD works correctly under a specific agent context.
+    - Verify agent-scoped route (/api/agents/{agentId}/...) + header
+      context target the same agent data.
+
+    Test flow:
+    1. POST /api/agents to create a test agent.
+    2. POST /api/chats with X-Agent-Id to create a chat.
+    3. GET /api/agents/{agentId}/chats and confirm the chat is visible.
+    4. GET /api/chats/{chatId} to read history.
+    5. PUT /api/chats/{chatId} to update the name.
+    6. DELETE chat and test agent for cleanup.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/chats
+    - GET /api/agents/{agentId}/chats
+    - GET /api/chats/{chatId}
+    - PUT /api/chats/{chatId}
+    - DELETE /api/chats/{chatId}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_chats_01"
+    headers = {"X-Agent-Id": agent_id}
+    chat_id: str | None = None
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Chats smoke agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        post_chat = app_server.api_request(
+            "POST",
+            "/api/chats",
+            headers=headers,
+            json={
+                "name": "Integration smoke chat",
+                "session_id": "console:integ-user-1",
+                "user_id": "integ-user-1",
+                "channel": "console",
+                "meta": {},
+            },
+        )
+        assert post_chat.status_code == 200, app_server.logs_tail()
+        spec = post_chat.json()
+        chat_id = spec["id"]
+        assert isinstance(chat_id, str) and chat_id
+        assert spec["name"] == "Integration smoke chat"
+        assert spec["session_id"] == "console:integ-user-1"
+        assert spec["user_id"] == "integ-user-1"
+        assert spec["channel"] == "console"
+
+        scoped_list = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/chats",
+        )
+        assert scoped_list.status_code == 200, app_server.logs_tail()
+        chats = scoped_list.json()
+        assert isinstance(chats, list)
+        ids = {c["id"] for c in chats}
+        assert chat_id in ids
+
+        get_hist = app_server.api_request(
+            "GET",
+            f"/api/chats/{chat_id}",
+            headers=headers,
+        )
+        assert get_hist.status_code == 200, app_server.logs_tail()
+        history = get_hist.json()
+        assert "messages" in history and isinstance(history["messages"], list)
+        assert "status" in history and isinstance(history["status"], str)
+
+        put_chat = app_server.api_request(
+            "PUT",
+            f"/api/chats/{chat_id}",
+            headers=headers,
+            json={"name": "Integration smoke chat renamed"},
+        )
+        assert put_chat.status_code == 200, app_server.logs_tail()
+        assert put_chat.json()["name"] == "Integration smoke chat renamed"
+    finally:
+        if chat_id is not None:
+            app_server.api_request(
+                "DELETE",
+                f"/api/chats/{chat_id}",
+                headers=headers,
+            )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_chats_batch_delete(app_server) -> None:
+    """Test purpose:
+    - Verify batch-delete removes multiple chats in one request and
+      they no longer appear in list results.
+
+    Test flow:
+    1. POST /api/agents to create a test agent.
+    2. POST /api/chats twice (with X-Agent-Id) to create two chats.
+    3. GET /api/chats and assert both chat IDs exist.
+    4. POST /api/chats/batch-delete with both IDs.
+    5. GET /api/chats again and assert both IDs are gone.
+    6. Cleanup: delete test agent (chat IDs defensively in finally).
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/chats
+    - GET /api/chats
+    - POST /api/chats/batch-delete
+    - DELETE /api/chats/{chatId} (defensive cleanup in finally)
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_chats_batch_01"
+    headers = {"X-Agent-Id": agent_id}
+    chat_ids: list[str] = []
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Chats batch smoke agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        for idx in (1, 2):
+            resp = app_server.api_request(
+                "POST",
+                "/api/chats",
+                headers=headers,
+                json={
+                    "name": f"Batch chat {idx}",
+                    "session_id": f"console:integ-batch-user-{idx}",
+                    "user_id": f"integ-batch-user-{idx}",
+                    "channel": "console",
+                    "meta": {},
+                },
+            )
+            assert resp.status_code == 200, app_server.logs_tail()
+            chat_ids.append(resp.json()["id"])
+
+        list_before = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers,
+        )
+        assert list_before.status_code == 200, app_server.logs_tail()
+        before_ids = {item["id"] for item in list_before.json()}
+        for chat_id in chat_ids:
+            assert chat_id in before_ids
+
+        batch_delete = app_server.api_request(
+            "POST",
+            "/api/chats/batch-delete",
+            headers=headers,
+            json=chat_ids,
+        )
+        assert batch_delete.status_code == 200, app_server.logs_tail()
+        assert batch_delete.json().get("deleted") is True
+
+        list_after = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers,
+        )
+        assert list_after.status_code == 200, app_server.logs_tail()
+        after_ids = {item["id"] for item in list_after.json()}
+        for chat_id in chat_ids:
+            assert chat_id not in after_ids
+    finally:
+        for chat_id in chat_ids:
+            cleanup_resp = app_server.api_request(
+                "DELETE",
+                f"/api/chats/{chat_id}",
+                headers=headers,
+            )
+            assert cleanup_resp.status_code in (
+                200,
+                404,
+            ), app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_api_chats_isolated_between_agents(app_server) -> None:
+    """Test purpose:
+    - Verify chat data is isolated per agent and does not leak across agents.
+    - Verify both header-based and scoped chat listing honor agent boundaries.
+
+    Test flow:
+    1. Create two test agents (A/B).
+    2. Create one chat under each agent with the same user filter key.
+    3. List chats for each agent with ``user_id`` filter and verify only local
+       chat IDs are present.
+    4. Repeat listing via scoped routes to verify the same isolation behavior.
+    5. Cleanup chats (defensive) and both agents.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/chats
+    - GET /api/chats
+    - GET /api/agents/{agentId}/chats
+    - DELETE /api/chats/{chatId} (defensive cleanup in finally)
+    - DELETE /api/agents/{agentId}
+    """
+    agent_a = "integ_iso_agent_a"
+    agent_b = "integ_iso_agent_b"
+    headers_a = {"X-Agent-Id": agent_a}
+    headers_b = {"X-Agent-Id": agent_b}
+    shared_user = "integ-isolation-user"
+    chat_a_id: str | None = None
+    chat_b_id: str | None = None
+
+    create_a = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_a, "name": "Isolation agent A", "description": ""},
+    )
+    assert create_a.status_code == 201, app_server.logs_tail()
+    create_b = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_b, "name": "Isolation agent B", "description": ""},
+    )
+    assert create_b.status_code == 201, app_server.logs_tail()
+
+    try:
+        chat_a = app_server.api_request(
+            "POST",
+            "/api/chats",
+            headers=headers_a,
+            json={
+                "name": "Isolation chat A",
+                "session_id": "console:iso-a",
+                "user_id": shared_user,
+                "channel": "console",
+                "meta": {},
+            },
+        )
+        assert chat_a.status_code == 200, app_server.logs_tail()
+        chat_a_id = chat_a.json()["id"]
+
+        chat_b = app_server.api_request(
+            "POST",
+            "/api/chats",
+            headers=headers_b,
+            json={
+                "name": "Isolation chat B",
+                "session_id": "console:iso-b",
+                "user_id": shared_user,
+                "channel": "console",
+                "meta": {},
+            },
+        )
+        assert chat_b.status_code == 200, app_server.logs_tail()
+        chat_b_id = chat_b.json()["id"]
+
+        list_a = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers_a,
+            params={"user_id": shared_user},
+        )
+        assert list_a.status_code == 200, app_server.logs_tail()
+        list_a_ids = {item["id"] for item in list_a.json()}
+        assert chat_a_id in list_a_ids
+        assert chat_b_id not in list_a_ids
+
+        list_b = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers_b,
+            params={"user_id": shared_user},
+        )
+        assert list_b.status_code == 200, app_server.logs_tail()
+        list_b_ids = {item["id"] for item in list_b.json()}
+        assert chat_b_id in list_b_ids
+        assert chat_a_id not in list_b_ids
+
+        scoped_a = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_a}/chats",
+            params={"user_id": shared_user},
+        )
+        assert scoped_a.status_code == 200, app_server.logs_tail()
+        scoped_a_ids = {item["id"] for item in scoped_a.json()}
+        assert chat_a_id in scoped_a_ids
+        assert chat_b_id not in scoped_a_ids
+
+        scoped_b = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_b}/chats",
+            params={"user_id": shared_user},
+        )
+        assert scoped_b.status_code == 200, app_server.logs_tail()
+        scoped_b_ids = {item["id"] for item in scoped_b.json()}
+        assert chat_b_id in scoped_b_ids
+        assert chat_a_id not in scoped_b_ids
+    finally:
+        if chat_a_id is not None:
+            app_server.api_request(
+                "DELETE",
+                f"/api/chats/{chat_a_id}",
+                headers=headers_a,
+            )
+        if chat_b_id is not None:
+            app_server.api_request(
+                "DELETE",
+                f"/api/chats/{chat_b_id}",
+                headers=headers_b,
+            )
+        app_server.api_request("DELETE", f"/api/agents/{agent_a}")
+        app_server.api_request("DELETE", f"/api/agents/{agent_b}")

--- a/tests/integration/test_console.py
+++ b/tests/integration/test_console.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for console routes (no LLM / no external API keys)."""
+from __future__ import annotations
+
+import io
+import uuid
+
+import pytest
+
+_CONSOLE_HTTP_TIMEOUT = 30.0
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_console_chat_stop_no_running_task(app_server) -> None:
+    """Test purpose:
+    - Verify scoped console chat/stop returns a stable JSON contract when no
+      stream is attached for the given chat id (no model call).
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST /console/chat/stop with a random UUID chat_id.
+    3. Assert 200 and ``stopped`` is a boolean (typically False).
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/console/chat/stop
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_console_stop_01"
+    fake_chat_id = str(uuid.uuid4())
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Console stop agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        stop_url = (
+            f"{app_server.base_url}/api/agents/{agent_id}/console/chat/stop"
+            f"?chat_id={fake_chat_id}"
+        )
+        resp = app_server.client.post(stop_url, timeout=_CONSOLE_HTTP_TIMEOUT)
+        print(
+            (
+                f"[integration]"
+                f"[{'PASS' if resp.status_code == 200 else 'FAIL'}] "
+                f"POST /api/agents/{agent_id}/console/chat/stop | "
+                f"params=chat_id={fake_chat_id} | request=- | "
+                f"status={resp.status_code} | response={resp.text[:500]}"
+            ),
+            flush=True,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        body = resp.json()
+        assert isinstance(body.get("stopped"), bool)
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_console_upload_small_file(app_server) -> None:
+    """Test purpose:
+    - Verify scoped console upload accepts a small file and returns metadata
+      without calling external services.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST multipart upload to scoped console upload with tiny text content.
+    3. Assert JSON includes file_name and expected byte size.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/console/upload
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_console_upload_01"
+    payload = b"integration-console-upload\n"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Console upload agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        upload_url = (
+            f"{app_server.base_url}/api/agents/{agent_id}/console/upload"
+        )
+        files = {
+            "file": ("integ-upload.txt", io.BytesIO(payload), "text/plain"),
+        }
+        resp = app_server.client.post(
+            upload_url,
+            files=files,
+            timeout=_CONSOLE_HTTP_TIMEOUT,
+        )
+        print(
+            (
+                f"[integration]"
+                f"[{'PASS' if resp.status_code == 200 else 'FAIL'}] "
+                f"POST /api/agents/{agent_id}/console/upload | "
+                f"params=- | request=(multipart file) | "
+                f"status={resp.status_code} | response={resp.text[:800]}"
+            ),
+            flush=True,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        body = resp.json()
+        assert body.get("file_name") == "integ-upload.txt"
+        assert body.get("size") == len(payload)
+        assert "url" in body
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_console_metadata.py
+++ b/tests/integration/test_console_metadata.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""Integration smoke tests for console-adjacent read-only JSON APIs.
+
+No API keys, no LLM calls. Covers plugin list, backup list, token usage
+summary/details, auth status (disabled CI profile), and agent statistics
+with explicit ``X-Agent-Id``.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_plugins_list_contract(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/plugins returns a JSON array with stable per-item keys.
+
+    Test flow:
+    1. GET /api/plugins.
+    2. Assert 200 and list; for each entry assert id, name, enabled.
+
+    API endpoints:
+    - GET /api/plugins
+    """
+    resp = app_server.api_request("GET", "/api/plugins")
+    assert resp.status_code == 200, app_server.logs_tail()
+    data = resp.json()
+    assert isinstance(data, list)
+    for item in data:
+        assert isinstance(item, dict)
+        assert "id" in item and isinstance(item["id"], str)
+        assert "name" in item and isinstance(item["name"], str)
+        assert "enabled" in item and isinstance(item["enabled"], bool)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_backups_list_contract(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/backups returns a JSON list (empty allowed).
+
+    Test flow:
+    1. GET /api/backups.
+    2. Assert 200 and list type.
+
+    API endpoints:
+    - GET /api/backups
+    """
+    resp = app_server.api_request("GET", "/api/backups")
+    assert resp.status_code == 200, app_server.logs_tail()
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_token_usage_summary_and_details_contract(app_server) -> None:
+    """Test purpose:
+    - Verify token-usage summary and details endpoints return stable shapes
+      when there is no recorded usage.
+
+    Test flow:
+    1. GET /api/token-usage and assert TokenUsageSummary-like fields.
+    2. GET /api/token-usage/details and assert JSON array.
+
+    API endpoints:
+    - GET /api/token-usage
+    - GET /api/token-usage/details
+    """
+    summary = app_server.api_request("GET", "/api/token-usage")
+    assert summary.status_code == 200, app_server.logs_tail()
+    body = summary.json()
+    assert isinstance(body.get("total_prompt_tokens"), int)
+    assert isinstance(body.get("total_completion_tokens"), int)
+    assert isinstance(body.get("total_calls"), int)
+    assert body["total_prompt_tokens"] >= 0
+    assert body["total_completion_tokens"] >= 0
+    assert body["total_calls"] >= 0
+    assert isinstance(body.get("by_date"), dict)
+
+    details = app_server.api_request("GET", "/api/token-usage/details")
+    assert details.status_code == 200, app_server.logs_tail()
+    rows = details.json()
+    assert isinstance(rows, list)
+    for row in rows:
+        assert isinstance(row, dict)
+        assert "date" in row
+        assert isinstance(row.get("prompt_tokens"), int)
+        assert isinstance(row.get("completion_tokens"), int)
+        assert isinstance(row.get("call_count"), int)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_auth_status_disabled_contract(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/auth/status matches CI profile (auth disabled).
+
+    Test flow:
+    1. GET /api/auth/status.
+    2. Assert enabled is false and has_users is bool.
+
+    API endpoints:
+    - GET /api/auth/status
+    """
+    resp = app_server.api_request("GET", "/api/auth/status")
+    assert resp.status_code == 200, app_server.logs_tail()
+    body = resp.json()
+    assert body.get("enabled") is False
+    assert isinstance(body.get("has_users"), bool)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_agent_stats_summary_with_agent_header(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/agent-stats returns AgentStatsSummary-like JSON when
+      scoped via ``X-Agent-Id`` to a dedicated test agent.
+
+    Test flow:
+    1. Create a test agent.
+    2. GET /api/agent-stats with X-Agent-Id header.
+    3. Assert top-level counters and by_date / channel_stats list shapes.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agent-stats
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_agent_stats_meta_01"
+    headers = {"X-Agent-Id": agent_id}
+
+    create = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Agent stats meta", "description": ""},
+    )
+    assert create.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "GET",
+            "/api/agent-stats",
+            headers=headers,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        body = resp.json()
+        for key in (
+            "total_active_sessions",
+            "total_messages",
+            "total_user_messages",
+            "total_assistant_messages",
+            "total_prompt_tokens",
+            "total_completion_tokens",
+            "total_llm_calls",
+            "total_tool_calls",
+        ):
+            assert isinstance(body.get(key), int)
+            assert body[key] >= 0
+        assert isinstance(body.get("by_date"), list)
+        assert isinstance(body.get("channel_stats"), list)
+        assert isinstance(body.get("start_date"), str)
+        assert isinstance(body.get("end_date"), str)
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_cron.py
+++ b/tests/integration/test_cron.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for agent-scoped cron job APIs."""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+_CRON_HTTP_TIMEOUT = 30.0
+
+
+def _minimal_text_cron_spec(*, name: str) -> dict:
+    """Build a valid CronJobSpec with task_type=text (no agent request)."""
+    return {
+        "name": name,
+        "enabled": True,
+        "schedule": {"type": "cron", "cron": "0 0 * * *", "timezone": "UTC"},
+        "task_type": "text",
+        "text": "integration cron noop",
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {
+                "user_id": "integ-cron-user",
+                "session_id": "console:integ-cron-session",
+            },
+            "mode": "stream",
+            "meta": {},
+        },
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+# pylint: disable-next=too-many-statements
+def test_agent_scoped_cron_job_lifecycle(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify agent-scoped cron endpoints support create, list, detail, replace,
+      pause, resume, manual run trigger, runtime state read, and delete.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST a minimal text cron job and capture server-assigned ``id``.
+    3. GET job list and single job view; assert job is present.
+    4. PUT replace job (rename) and read back via GET view.
+    5. POST pause and resume; assert success flags.
+    6. POST run (fire-and-forget) and GET job state payload.
+    7. DELETE job and assert repeat DELETE returns 404.
+    8. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/cron/jobs
+    - GET /api/agents/{agentId}/cron/jobs
+    - GET /api/agents/{agentId}/cron/jobs/{job_id}
+    - PUT /api/agents/{agentId}/cron/jobs/{job_id}
+    - POST /api/agents/{agentId}/cron/jobs/{job_id}/pause
+    - POST /api/agents/{agentId}/cron/jobs/{job_id}/resume
+    - POST /api/agents/{agentId}/cron/jobs/{job_id}/run
+    - GET /api/agents/{agentId}/cron/jobs/{job_id}/state
+    - DELETE /api/agents/{agentId}/cron/jobs/{job_id}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_cron_lifecycle_01"
+    base = f"/api/agents/{agent_id}/cron"
+    job_id: str | None = None
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Cron lifecycle agent",
+            "description": "",
+        },
+        timeout=_CRON_HTTP_TIMEOUT,
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_job = app_server.api_request(
+            "POST",
+            f"{base}/jobs",
+            json=_minimal_text_cron_spec(name="integration cron job v1"),
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert create_job.status_code == 200, app_server.logs_tail()
+        created = create_job.json()
+        job_id = created.get("id")
+        assert isinstance(job_id, str) and job_id
+        assert created.get("name") == "integration cron job v1"
+
+        list_resp = app_server.api_request(
+            "GET",
+            f"{base}/jobs",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        listed_ids = {j.get("id") for j in list_resp.json()}
+        assert job_id in listed_ids
+
+        get_view = app_server.api_request(
+            "GET",
+            f"{base}/jobs/{job_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert get_view.status_code == 200, app_server.logs_tail()
+        view_payload = get_view.json()
+        assert view_payload.get("spec", {}).get("id") == job_id
+        assert "state" in view_payload
+
+        spec_for_put = copy.deepcopy(view_payload["spec"])
+        spec_for_put["name"] = "integration cron job v2"
+        put_replace = app_server.api_request(
+            "PUT",
+            f"{base}/jobs/{job_id}",
+            json=spec_for_put,
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert put_replace.status_code == 200, app_server.logs_tail()
+        assert put_replace.json().get("name") == "integration cron job v2"
+
+        get_after_put = app_server.api_request(
+            "GET",
+            f"{base}/jobs/{job_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert get_after_put.status_code == 200, app_server.logs_tail()
+        assert (
+            get_after_put.json()["spec"]["name"] == "integration cron job v2"
+        )
+
+        pause_resp = app_server.api_request(
+            "POST",
+            f"{base}/jobs/{job_id}/pause",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert pause_resp.status_code == 200, app_server.logs_tail()
+        assert pause_resp.json().get("paused") is True
+
+        resume_resp = app_server.api_request(
+            "POST",
+            f"{base}/jobs/{job_id}/resume",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert resume_resp.status_code == 200, app_server.logs_tail()
+        assert resume_resp.json().get("resumed") is True
+
+        run_resp = app_server.api_request(
+            "POST",
+            f"{base}/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200, app_server.logs_tail()
+        assert run_resp.json().get("started") is True
+
+        state_resp = app_server.api_request(
+            "GET",
+            f"{base}/jobs/{job_id}/state",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert state_resp.status_code == 200, app_server.logs_tail()
+        state_body = state_resp.json()
+        assert isinstance(state_body, dict)
+
+        del_ok = app_server.api_request(
+            "DELETE",
+            f"{base}/jobs/{job_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert del_ok.status_code == 200, app_server.logs_tail()
+        assert del_ok.json().get("deleted") is True
+
+        del_again = app_server.api_request(
+            "DELETE",
+            f"{base}/jobs/{job_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert del_again.status_code == 404, app_server.logs_tail()
+        job_id = None
+    finally:
+        if job_id is not None:
+            app_server.api_request(
+                "DELETE",
+                f"{base}/jobs/{job_id}",
+                timeout=_CRON_HTTP_TIMEOUT,
+            )
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )

--- a/tests/integration/test_heartbeat.py
+++ b/tests/integration/test_heartbeat.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for heartbeat config (global + agent-scoped)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_global_heartbeat_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify global heartbeat config can be updated and read back.
+
+    Test flow:
+    1. GET current /api/config/heartbeat payload.
+    2. Build an update payload by toggling ``enabled``.
+    3. PUT updated payload to /api/config/heartbeat.
+    4. GET /api/config/heartbeat and verify the updated ``enabled`` value.
+    5. PUT original payload back to avoid cross-step surprises.
+
+    API endpoints:
+    - GET /api/config/heartbeat
+    - PUT /api/config/heartbeat
+    """
+    get_before = app_server.api_request("GET", "/api/config/heartbeat")
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "enabled" in before
+    assert "every" in before
+    assert "target" in before
+
+    updated = dict(before)
+    updated["enabled"] = not bool(before.get("enabled", False))
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/heartbeat",
+            json=updated,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        put_payload = put_resp.json()
+        assert put_payload.get("enabled") == updated["enabled"]
+
+        get_after = app_server.api_request("GET", "/api/config/heartbeat")
+        assert get_after.status_code == 200, app_server.logs_tail()
+        after = get_after.json()
+        assert after.get("enabled") == updated["enabled"]
+    finally:
+        restore_resp = app_server.api_request(
+            "PUT",
+            "/api/config/heartbeat",
+            json=before,
+        )
+        assert restore_resp.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_agent_scoped_heartbeat_isolated_from_global(app_server) -> None:
+    """Test purpose:
+    - Verify updating heartbeat via agent-scoped config does not mutate the
+      global config heartbeat for other agents.
+
+    Test flow:
+    1. GET global heartbeat baseline from /api/config/heartbeat.
+    2. Create a dedicated test agent.
+    3. GET scoped heartbeat from /api/agents/{agentId}/config/heartbeat.
+    4. PUT scoped heartbeat with toggled ``enabled`` value.
+    5. GET scoped heartbeat again and verify update is applied.
+    6. GET global heartbeat again and verify baseline value is unchanged.
+    7. Delete test agent.
+
+    API endpoints:
+    - GET /api/config/heartbeat
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/heartbeat
+    - PUT /api/agents/{agentId}/config/heartbeat
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_hb_01"
+
+    global_before = app_server.api_request("GET", "/api/config/heartbeat")
+    assert global_before.status_code == 200, app_server.logs_tail()
+    global_before_payload = global_before.json()
+    assert isinstance(global_before_payload, dict)
+    assert "enabled" in global_before_payload
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped heartbeat agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        scoped_before = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/config/heartbeat",
+        )
+        assert scoped_before.status_code == 200, app_server.logs_tail()
+        scoped_before_payload = scoped_before.json()
+        assert isinstance(scoped_before_payload, dict)
+        assert "enabled" in scoped_before_payload
+        assert "every" in scoped_before_payload
+        assert "target" in scoped_before_payload
+
+        scoped_updated = dict(scoped_before_payload)
+        scoped_updated["enabled"] = not bool(
+            scoped_before_payload.get("enabled", False),
+        )
+
+        put_scoped = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/config/heartbeat",
+            json=scoped_updated,
+        )
+        assert put_scoped.status_code == 200, app_server.logs_tail()
+        assert put_scoped.json().get("enabled") == scoped_updated["enabled"]
+
+        scoped_after = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/config/heartbeat",
+        )
+        assert scoped_after.status_code == 200, app_server.logs_tail()
+        assert scoped_after.json().get("enabled") == scoped_updated["enabled"]
+
+        global_after = app_server.api_request("GET", "/api/config/heartbeat")
+        assert global_after.status_code == 200, app_server.logs_tail()
+        assert global_after.json().get("enabled") == global_before_payload.get(
+            "enabled",
+        )
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_heartbeat_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped heartbeat endpoint itself supports update and
+      readback in a stable roundtrip.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped heartbeat config as baseline.
+    3. PUT scoped heartbeat with toggled ``enabled`` value.
+    4. GET scoped heartbeat and verify the new value is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/heartbeat
+    - PUT /api/agents/{agentId}/config/heartbeat
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_hb_roundtrip_01"
+    endpoint = f"/api/agents/{agent_id}/config/heartbeat"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped heartbeat roundtrip agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "enabled" in baseline
+        assert "every" in baseline
+        assert "target" in baseline
+
+        updated = dict(baseline)
+        updated["enabled"] = not bool(baseline.get("enabled", False))
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("enabled") == updated["enabled"]
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("enabled") == updated["enabled"]
+    finally:
+        if isinstance(baseline, dict):
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -1,0 +1,623 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for MCP client APIs."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_mcp_create_get_list_delete(app_server) -> None:
+    """Test purpose:
+    - Verify MCP client basic lifecycle in one agent workspace.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/mcp to create one MCP client.
+    3. GET /api/mcp and GET /api/mcp/{client_key} to verify presence.
+    4. DELETE /api/mcp/{client_key}.
+    5. GET /api/mcp and verify client is removed.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - GET /api/mcp
+    - GET /api/mcp/{client_key}
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_crud_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_client_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "MCP CRUD agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "integration mcp client",
+                    "description": "created by integration tests",
+                    "enabled": True,
+                    "transport": "stdio",
+                    "command": "echo",
+                    "args": ["mcp"],
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+        created = create_client.json()
+        assert created.get("key") == client_key
+        assert created.get("name") == "integration mcp client"
+
+        list_clients = app_server.api_request(
+            "GET",
+            "/api/mcp",
+            headers=headers,
+        )
+        assert list_clients.status_code == 200, app_server.logs_tail()
+        keys = {item["key"] for item in list_clients.json()}
+        assert client_key in keys
+
+        get_client = app_server.api_request(
+            "GET",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        assert get_client.status_code == 200, app_server.logs_tail()
+        assert get_client.json().get("key") == client_key
+
+        delete_client = app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        assert delete_client.status_code == 200, app_server.logs_tail()
+
+        list_after_delete = app_server.api_request(
+            "GET",
+            "/api/mcp",
+            headers=headers,
+        )
+        assert list_after_delete.status_code == 200, app_server.logs_tail()
+        keys_after = {item["key"] for item in list_after_delete.json()}
+        assert client_key not in keys_after
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_mcp_toggle_enabled(app_server) -> None:
+    """Test purpose:
+    - Verify MCP toggle endpoint flips ``enabled`` state and persists.
+
+    Test flow:
+    1. Create a test agent and one MCP client with enabled=True.
+    2. PATCH /api/mcp/{client_key}/toggle and assert enabled=False.
+    3. GET /api/mcp/{client_key} and verify enabled=False persisted.
+    4. PATCH again and verify enabled=True.
+    5. Cleanup client and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - PATCH /api/mcp/{client_key}/toggle
+    - GET /api/mcp/{client_key}
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_toggle_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_toggle_client"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "MCP toggle agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "toggle mcp client",
+                    "enabled": True,
+                    "transport": "stdio",
+                    "command": "echo",
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+        assert create_client.json().get("enabled") is True
+
+        toggle_1 = app_server.api_request(
+            "PATCH",
+            f"/api/mcp/{client_key}/toggle",
+            headers=headers,
+        )
+        assert toggle_1.status_code == 200, app_server.logs_tail()
+        assert toggle_1.json().get("enabled") is False
+
+        get_after_toggle_1 = app_server.api_request(
+            "GET",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        assert get_after_toggle_1.status_code == 200, app_server.logs_tail()
+        assert get_after_toggle_1.json().get("enabled") is False
+
+        toggle_2 = app_server.api_request(
+            "PATCH",
+            f"/api/mcp/{client_key}/toggle",
+            headers=headers,
+        )
+        assert toggle_2.status_code == 200, app_server.logs_tail()
+        assert toggle_2.json().get("enabled") is True
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_mcp_tools_returns_empty_for_disabled_client(app_server) -> None:
+    """Test purpose:
+    - Verify /tools endpoint returns empty list when MCP client is disabled.
+
+    Test flow:
+    1. Create a test agent.
+    2. Create a disabled MCP client.
+    3. GET /api/mcp/{client_key}/tools and assert empty list.
+    4. Cleanup client and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - GET /api/mcp/{client_key}/tools
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_tools_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_disabled_tools_client"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "MCP tools agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "disabled mcp client",
+                    "enabled": False,
+                    "transport": "stdio",
+                    "command": "echo",
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+
+        tools_resp = app_server.api_request(
+            "GET",
+            f"/api/mcp/{client_key}/tools",
+            headers=headers,
+        )
+        assert tools_resp.status_code == 200, app_server.logs_tail()
+        assert tools_resp.json() == []
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_mcp_scoped_path_get_client(app_server) -> None:
+    """Test purpose:
+    - Verify MCP client can be fetched via ``/api/agents/{agentId}/mcp/...``
+      without ``X-Agent-Id`` header (path-derived agent context).
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/mcp with header to create a client (same as existing tests).
+    3. GET /api/agents/{agentId}/mcp/{client_key} without header.
+    4. Cleanup via header-based DELETE and agent delete.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - GET /api/agents/{agentId}/mcp/{client_key}
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_scoped_get_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_scoped_get_client"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "MCP scoped GET agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "scoped path get client",
+                    "enabled": True,
+                    "transport": "stdio",
+                    "command": "echo",
+                    "args": ["scoped"],
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+
+        scoped_get = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/mcp/{client_key}",
+        )
+        assert scoped_get.status_code == 200, app_server.logs_tail()
+        assert scoped_get.json().get("key") == client_key
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_mcp_create_duplicate_client_rejected(app_server) -> None:
+    """Test purpose:
+    - Verify creating an MCP client with duplicated ``client_key`` is rejected.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST /api/mcp once with a fixed client_key (expect 201).
+    3. POST /api/mcp again with the same client_key (expect 400).
+    4. Assert error detail includes guidance about existing client.
+    5. Cleanup client and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_duplicate_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_dup_client"
+    payload = {
+        "client_key": client_key,
+        "client": {
+            "name": "duplicate check client",
+            "enabled": True,
+            "transport": "stdio",
+            "command": "echo",
+            "args": ["dup"],
+        },
+    }
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "MCP duplicate agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        first = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json=payload,
+        )
+        assert first.status_code == 201, app_server.logs_tail()
+
+        second = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json=payload,
+        )
+        assert second.status_code == 400, app_server.logs_tail()
+        assert "already exists" in second.json().get("detail", "")
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_mcp_missing_client_paths_return_404(app_server) -> None:
+    """Test purpose:
+    - Verify MCP endpoints consistently return 404 for unknown ``client_key``.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. Call GET /api/mcp/{client_key}, PATCH /toggle, DELETE, and GET /tools
+       using a missing client_key.
+    3. Assert all responses are 404 with error details.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/mcp/{client_key}
+    - PATCH /api/mcp/{client_key}/toggle
+    - DELETE /api/mcp/{client_key}
+    - GET /api/mcp/{client_key}/tools
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_missing_01"
+    headers = {"X-Agent-Id": agent_id}
+    missing_key = "integ_mcp_missing_key"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "MCP missing agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        get_resp = app_server.api_request(
+            "GET",
+            f"/api/mcp/{missing_key}",
+            headers=headers,
+        )
+        assert get_resp.status_code == 404, app_server.logs_tail()
+        assert "detail" in get_resp.json()
+
+        toggle_resp = app_server.api_request(
+            "PATCH",
+            f"/api/mcp/{missing_key}/toggle",
+            headers=headers,
+        )
+        assert toggle_resp.status_code == 404, app_server.logs_tail()
+        assert "detail" in toggle_resp.json()
+
+        delete_resp = app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{missing_key}",
+            headers=headers,
+        )
+        assert delete_resp.status_code == 404, app_server.logs_tail()
+        assert "detail" in delete_resp.json()
+
+        tools_resp = app_server.api_request(
+            "GET",
+            f"/api/mcp/{missing_key}/tools",
+            headers=headers,
+        )
+        assert tools_resp.status_code == 404, app_server.logs_tail()
+        assert "detail" in tools_resp.json()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_mcp_update_client_put_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify MCP client update endpoint persists mutable fields and supports
+      deterministic readback.
+
+    Test flow:
+    1. Create a dedicated test agent and one MCP client.
+    2. PUT /api/mcp/{client_key} with updated name/description/enabled fields.
+    3. GET /api/mcp/{client_key} and verify updated fields.
+    4. Cleanup client and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/mcp
+    - PUT /api/mcp/{client_key}
+    - GET /api/mcp/{client_key}
+    - DELETE /api/mcp/{client_key}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mcp_update_01"
+    headers = {"X-Agent-Id": agent_id}
+    client_key = "integ_mcp_update_client"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "MCP update agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            "/api/mcp",
+            headers=headers,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "update before",
+                    "description": "before update",
+                    "enabled": True,
+                    "transport": "stdio",
+                    "command": "echo",
+                    "args": ["before"],
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+
+        update_resp = app_server.api_request(
+            "PUT",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+            json={
+                "name": "update after",
+                "description": "after update",
+                "enabled": False,
+                "args": ["after"],
+            },
+        )
+        assert update_resp.status_code == 200, app_server.logs_tail()
+        update_payload = update_resp.json()
+        assert update_payload.get("key") == client_key
+        assert update_payload.get("name") == "update after"
+        assert update_payload.get("description") == "after update"
+        assert update_payload.get("enabled") is False
+
+        get_after = app_server.api_request(
+            "GET",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        get_payload = get_after.json()
+        assert get_payload.get("name") == "update after"
+        assert get_payload.get("description") == "after update"
+        assert get_payload.get("enabled") is False
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/mcp/{client_key}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_mcp_agent_scoped_routes_update_toggle_delete(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped MCP routes support create/update/toggle/delete flow
+      under /api/agents/{agentId}/mcp.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST scoped MCP client.
+    3. PUT scoped client and verify updated fields.
+    4. PATCH scoped toggle and verify enabled flips.
+    5. DELETE scoped client and verify it is removed from scoped list.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/mcp
+    - PUT /api/agents/{agentId}/mcp/{client_key}
+    - PATCH /api/agents/{agentId}/mcp/{client_key}/toggle
+    - DELETE /api/agents/{agentId}/mcp/{client_key}
+    - GET /api/agents/{agentId}/mcp
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_mcp_01"
+    client_key = "integ_scoped_mcp_client_01"
+    scoped_base = f"/api/agents/{agent_id}/mcp"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Scoped MCP agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_client = app_server.api_request(
+            "POST",
+            scoped_base,
+            json={
+                "client_key": client_key,
+                "client": {
+                    "name": "scoped mcp before",
+                    "description": "before update",
+                    "enabled": True,
+                    "transport": "stdio",
+                    "command": "echo",
+                },
+            },
+        )
+        assert create_client.status_code == 201, app_server.logs_tail()
+        assert create_client.json().get("key") == client_key
+
+        update_client = app_server.api_request(
+            "PUT",
+            f"{scoped_base}/{client_key}",
+            json={
+                "name": "scoped mcp after",
+                "description": "after update",
+                "enabled": False,
+                "args": ["scoped"],
+            },
+        )
+        assert update_client.status_code == 200, app_server.logs_tail()
+        assert update_client.json().get("name") == "scoped mcp after"
+        assert update_client.json().get("enabled") is False
+
+        toggle_client = app_server.api_request(
+            "PATCH",
+            f"{scoped_base}/{client_key}/toggle",
+        )
+        assert toggle_client.status_code == 200, app_server.logs_tail()
+        assert toggle_client.json().get("enabled") is True
+
+        delete_client = app_server.api_request(
+            "DELETE",
+            f"{scoped_base}/{client_key}",
+        )
+        assert delete_client.status_code == 200, app_server.logs_tail()
+
+        list_after = app_server.api_request("GET", scoped_base)
+        assert list_after.status_code == 200, app_server.logs_tail()
+        keys_after = {item["key"] for item in list_after.json()}
+        assert client_key not in keys_after
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_messages_files.py
+++ b/tests/integration/test_messages_files.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for messages and files APIs."""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import pytest
+
+_MESSAGES_FILES_TIMEOUT = 20.0
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_messages_send_console(app_server) -> None:
+    """Test purpose:
+    - Verify messages/send endpoint can proactively dispatch a text message to
+      the console channel for the default agent.
+
+    Test flow:
+    1. POST /api/messages/send with channel=console and sample target IDs.
+    2. Assert 200 response and ``success=true``.
+    3. Assert response message indicates successful send.
+
+    API endpoints:
+    - POST /api/messages/send
+    """
+    resp = app_server.api_request(
+        "POST",
+        "/api/messages/send",
+        json={
+            "channel": "console",
+            "target_user": "integ-user",
+            "target_session": "integ-session",
+            "text": "integration hello",
+        },
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    payload = resp.json()
+    assert payload.get("success") is True
+    assert "Message sent successfully" in payload.get("message", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_messages_send_invalid_channel(app_server) -> None:
+    """Test purpose:
+    - Verify messages/send returns 404 when the requested channel does not
+      exist for the agent runtime.
+
+    Test flow:
+    1. POST /api/messages/send with a non-existent channel name.
+    2. Assert 404 response and error detail mentions channel not found.
+
+    API endpoints:
+    - POST /api/messages/send
+    """
+    resp = app_server.api_request(
+        "POST",
+        "/api/messages/send",
+        json={
+            "channel": "nonexistent_channel",
+            "target_user": "integ-user",
+            "target_session": "integ-session",
+            "text": "integration hello",
+        },
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    detail = resp.json().get("detail", "")
+    assert "Channel not found" in detail
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_messages_send_without_agent_header_uses_default_agent(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify messages/send works without X-Agent-Id and follows default-agent
+      routing behavior.
+
+    Test flow:
+    1. POST /api/messages/send without X-Agent-Id.
+    2. POST /api/messages/send with X-Agent-Id=default.
+    3. Assert both responses are 200 and ``success=true``.
+
+    API endpoints:
+    - POST /api/messages/send
+    """
+    payload = {
+        "channel": "console",
+        "target_user": "integ-user-default-route",
+        "target_session": "integ-session-default-route",
+        "text": "default route check",
+    }
+    no_header_resp = app_server.api_request(
+        "POST",
+        "/api/messages/send",
+        json=payload,
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert no_header_resp.status_code == 200, app_server.logs_tail()
+    assert no_header_resp.json().get("success") is True
+
+    explicit_default_resp = app_server.api_request(
+        "POST",
+        "/api/messages/send",
+        headers={"X-Agent-Id": "default"},
+        json=payload,
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert explicit_default_resp.status_code == 200, app_server.logs_tail()
+    assert explicit_default_resp.json().get("success") is True
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_messages_send_missing_agent_returns_404(app_server) -> None:
+    """Test purpose:
+    - Verify messages/send returns 404 when X-Agent-Id points to a missing
+      agent.
+
+    Test flow:
+    1. POST /api/messages/send with a non-existing X-Agent-Id.
+    2. Assert 404 status and ``Agent not found`` in detail.
+
+    API endpoints:
+    - POST /api/messages/send
+    """
+    resp = app_server.api_request(
+        "POST",
+        "/api/messages/send",
+        headers={"X-Agent-Id": "integ_missing_agent_for_messages"},
+        json={
+            "channel": "console",
+            "target_user": "integ-user",
+            "target_session": "integ-session",
+            "text": "missing agent check",
+        },
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    detail = resp.json().get("detail", "")
+    assert "Agent not found" in detail
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_messages_send_does_not_create_chat_record(app_server) -> None:
+    """Test purpose:
+    - Verify proactive channel message sending does not implicitly create chat
+      records under /api/chats.
+
+    Test flow:
+    1. Create a dedicated agent for isolation.
+    2. GET /api/chats and store existing chat IDs as baseline.
+    3. POST /api/messages/send with X-Agent-Id on the same agent.
+    4. GET /api/chats again and assert chat ID set is unchanged.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/chats
+    - POST /api/messages/send
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_messages_chat_boundary_01"
+    headers = {"X-Agent-Id": agent_id}
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Messages boundary agent",
+            "description": "",
+        },
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        chats_before = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers,
+            timeout=_MESSAGES_FILES_TIMEOUT,
+        )
+        assert chats_before.status_code == 200, app_server.logs_tail()
+        before_ids = {item.get("id") for item in chats_before.json()}
+
+        send_resp = app_server.api_request(
+            "POST",
+            "/api/messages/send",
+            headers=headers,
+            json={
+                "channel": "console",
+                "target_user": "integ-user",
+                "target_session": "integ-session",
+                "text": "boundary check",
+            },
+            timeout=_MESSAGES_FILES_TIMEOUT,
+        )
+        assert send_resp.status_code == 200, app_server.logs_tail()
+        assert send_resp.json().get("success") is True
+
+        chats_after = app_server.api_request(
+            "GET",
+            "/api/chats",
+            headers=headers,
+            timeout=_MESSAGES_FILES_TIMEOUT,
+        )
+        assert chats_after.status_code == 200, app_server.logs_tail()
+        after_ids = {item.get("id") for item in chats_after.json()}
+        assert after_ids == before_ids
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+            timeout=_MESSAGES_FILES_TIMEOUT,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_files_preview_existing_file(app_server, tmp_path) -> None:
+    """Test purpose:
+    - Verify files preview endpoint can stream an existing absolute-path file.
+
+    Test flow:
+    1. Create a temporary local text file.
+    2. URL-encode absolute path and request /api/files/preview/{filepath}.
+    3. Assert 200 response and body contains expected content bytes.
+
+    API endpoints:
+    - GET /api/files/preview/{filepath:path}
+    """
+    target_file = tmp_path / "preview_target.txt"
+    expected = "preview integration payload\n"
+    target_file.write_text(expected, encoding="utf-8")
+
+    encoded_path = quote(str(target_file), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_path}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    assert resp.content.decode("utf-8") == expected
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_files_preview_not_found(app_server, tmp_path) -> None:
+    """Test purpose:
+    - Verify files preview endpoint returns 404 for non-existing file paths.
+
+    Test flow:
+    1. Build a path to a missing file.
+    2. URL-encode and request /api/files/preview/{filepath}.
+    3. Assert 404 with ``detail=Not found``.
+
+    API endpoints:
+    - GET /api/files/preview/{filepath:path}
+    """
+    missing_file = tmp_path / "missing_file_404.txt"
+    encoded_path = quote(str(missing_file), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_path}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert resp.json().get("detail") == "Not found"
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_files_preview_head_existing_file_contract(
+    app_server,
+    tmp_path,
+) -> None:
+    """Test purpose:
+    - Verify HEAD /api/files/preview keeps a stable response contract for
+      existing files.
+
+    Test flow:
+    1. Create a temporary local file and URL-encode its absolute path.
+    2. Send HEAD /api/files/preview/{filepath}.
+    3. Assert 200 status, key headers exist, and response body is empty.
+
+    API endpoints:
+    - HEAD /api/files/preview/{filepath:path}
+    """
+    target_file = tmp_path / "preview_target_head.txt"
+    target_file.write_text("head contract payload\n", encoding="utf-8")
+
+    encoded_path = quote(str(target_file), safe="")
+    resp = app_server.client.head(
+        f"{app_server.base_url}/api/files/preview/{encoded_path}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "preview_target_head.txt" in content_disposition
+    assert resp.content == b""
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_files_preview_head_not_found(app_server, tmp_path) -> None:
+    """Test purpose:
+    - Verify HEAD /api/files/preview returns 404 for a missing file path.
+
+    Test flow:
+    1. Build a path to a non-existing file.
+    2. Send HEAD /api/files/preview/{filepath}.
+    3. Assert 404 status and empty response body for HEAD semantics.
+
+    API endpoints:
+    - HEAD /api/files/preview/{filepath:path}
+    """
+    missing_file = tmp_path / "missing_head_404.txt"
+    encoded_path = quote(str(missing_file), safe="")
+    resp = app_server.client.head(
+        f"{app_server.base_url}/api/files/preview/{encoded_path}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert resp.content == b""
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_files_preview_directory_path_returns_404(
+    app_server,
+    tmp_path,
+) -> None:
+    """Test purpose:
+    - Verify GET /api/files/preview rejects directory paths (non-file targets).
+
+    Test flow:
+    1. Create a temporary directory path.
+    2. URL-encode that directory path and call /api/files/preview/{filepath}.
+    3. Assert 404 status and ``detail=Not found``.
+
+    API endpoints:
+    - GET /api/files/preview/{filepath:path}
+    """
+    target_dir = tmp_path / "preview_dir_target"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    encoded_path = quote(str(target_dir), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_path}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert resp.json().get("detail") == "Not found"

--- a/tests/integration/test_messages_files.py
+++ b/tests/integration/test_messages_files.py
@@ -238,7 +238,9 @@ def test_files_preview_existing_file(app_server, tmp_path) -> None:
     """
     target_file = tmp_path / "preview_target.txt"
     expected = "preview integration payload\n"
-    target_file.write_text(expected, encoding="utf-8")
+    # Use write_bytes to avoid platform-specific newline translation
+    # (write_text in text mode converts \n -> \r\n on Windows).
+    target_file.write_bytes(expected.encode("utf-8"))
 
     encoded_path = quote(str(target_file), safe="")
     resp = app_server.client.get(

--- a/tests/integration/test_plan.py
+++ b/tests/integration/test_plan.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for plan APIs."""
+from __future__ import annotations
+
+import pytest
+
+_PLAN_HTTP_TIMEOUT = 20.0
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_plan_config_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped plan config supports update, readback, and restore
+      of the original payload.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped plan config and store baseline ``enabled``.
+    3. PUT scoped config with toggled ``enabled`` and GET to verify.
+    4. PUT scoped baseline payload back and GET to verify restoration.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/plan/config
+    - PUT /api/agents/{agentId}/plan/config
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_plan_scoped_roundtrip_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Plan scoped roundtrip agent",
+            "description": "",
+        },
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        get_before = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "enabled" in baseline
+
+        toggled = {"enabled": not bool(baseline.get("enabled", False))}
+        put_toggle = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/plan/config",
+            json=toggled,
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert put_toggle.status_code == 200, app_server.logs_tail()
+        assert put_toggle.json().get("enabled") == toggled["enabled"]
+
+        get_mid = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert get_mid.status_code == 200, app_server.logs_tail()
+        assert get_mid.json().get("enabled") == toggled["enabled"]
+
+        restore = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/plan/config",
+            json=baseline,
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+        assert restore.json().get("enabled") == baseline.get("enabled")
+
+        get_after = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("enabled") == baseline.get("enabled")
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_plan_config_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify global plan config supports update and readback.
+
+    Test flow:
+    1. GET /api/plan/config and store baseline ``enabled`` value.
+    2. PUT /api/plan/config with toggled ``enabled``.
+    3. GET /api/plan/config and verify updated value.
+    4. Restore baseline value in finally.
+
+    API endpoints:
+    - GET /api/plan/config
+    - PUT /api/plan/config
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/plan/config",
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "enabled" in before
+
+    updated = {"enabled": not bool(before.get("enabled", False))}
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/plan/config",
+            json=updated,
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("enabled") == updated["enabled"]
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("enabled") == updated["enabled"]
+    finally:
+        restore_resp = app_server.api_request(
+            "PUT",
+            "/api/plan/config",
+            json={"enabled": bool(before.get("enabled", False))},
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert restore_resp.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_plan_current_minimal_contract(app_server) -> None:
+    """Test purpose:
+    - Verify current-plan endpoint remains available with stable shape.
+
+    Test flow:
+    1. GET /api/plan/current without session_id.
+    2. Accept either ``null`` (no current plan) or an object payload.
+    3. If present, verify JSON object (schema is runtime-driven).
+
+    API endpoints:
+    - GET /api/plan/current
+    """
+    resp = app_server.api_request(
+        "GET",
+        "/api/plan/current",
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    payload = resp.json()
+    assert payload is None or isinstance(payload, dict)
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_plan_scoped_config_isolated_from_global(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped plan config updates do not mutate global plan config.
+
+    Test flow:
+    1. Read global baseline via /api/plan/config.
+    2. Create a dedicated test agent.
+    3. Read scoped config via /api/agents/{agentId}/plan/config.
+    4. Toggle scoped ``enabled`` via scoped PUT.
+    5. Verify scoped GET reflects update.
+    6. Verify global GET still matches baseline.
+    7. Delete test agent.
+
+    API endpoints:
+    - GET /api/plan/config
+    - POST /api/agents
+    - GET /api/agents/{agentId}/plan/config
+    - PUT /api/agents/{agentId}/plan/config
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_plan_scoped_01"
+
+    global_before = app_server.api_request(
+        "GET",
+        "/api/plan/config",
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert global_before.status_code == 200, app_server.logs_tail()
+    global_enabled = bool(global_before.json().get("enabled", False))
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Plan scoped agent", "description": ""},
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        scoped_before = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert scoped_before.status_code == 200, app_server.logs_tail()
+        scoped_enabled = bool(scoped_before.json().get("enabled", False))
+
+        scoped_put = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/plan/config",
+            json={"enabled": not scoped_enabled},
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert scoped_put.status_code == 200, app_server.logs_tail()
+        assert scoped_put.json().get("enabled") == (not scoped_enabled)
+
+        scoped_after = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert scoped_after.status_code == 200, app_server.logs_tail()
+        assert scoped_after.json().get("enabled") == (not scoped_enabled)
+
+        global_after = app_server.api_request(
+            "GET",
+            "/api/plan/config",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+        assert global_after.status_code == 200, app_server.logs_tail()
+        assert (
+            bool(global_after.json().get("enabled", False)) == global_enabled
+        )
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+            timeout=_PLAN_HTTP_TIMEOUT,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_plan_scoped_config_missing_agent_returns_404(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped plan config endpoints return 404 for unknown agents.
+
+    Test flow:
+    1. GET /api/agents/{agentId}/plan/config with a non-existing agent ID.
+    2. PUT /api/agents/{agentId}/plan/config with a non-existing agent ID.
+    3. Assert both responses are 404 and include error detail.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/plan/config
+    - PUT /api/agents/{agentId}/plan/config
+    """
+    missing_agent_id = "integ_plan_missing_agent_404"
+
+    get_resp = app_server.api_request(
+        "GET",
+        f"/api/agents/{missing_agent_id}/plan/config",
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert get_resp.status_code == 404, app_server.logs_tail()
+    assert "detail" in get_resp.json()
+
+    put_resp = app_server.api_request(
+        "PUT",
+        f"/api/agents/{missing_agent_id}/plan/config",
+        json={"enabled": True},
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert put_resp.status_code == 404, app_server.logs_tail()
+    assert "detail" in put_resp.json()
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_plan_config_rejects_invalid_payload(app_server) -> None:
+    """Test purpose:
+    - Verify global plan config update rejects invalid body schema.
+
+    Test flow:
+    1. PUT /api/plan/config with an invalid payload (``enabled`` is not bool).
+    2. Assert response is validation error and includes detail field.
+
+    API endpoints:
+    - PUT /api/plan/config
+    """
+    resp = app_server.api_request(
+        "PUT",
+        "/api/plan/config",
+        json={"enabled": "not_bool_value"},
+        timeout=_PLAN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 422, app_server.logs_tail()
+    assert "detail" in resp.json()

--- a/tests/integration/test_security_config.py
+++ b/tests/integration/test_security_config.py
@@ -1,0 +1,469 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for security guards (file/tool guard + skill scanner)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_global_file_guard_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify file-guard enabled flag supports update and readback.
+
+    Test flow:
+    1. GET current file-guard config.
+    2. PUT toggled ``enabled`` value.
+    3. GET file-guard and assert new value is visible.
+    4. Restore original value.
+
+    API endpoints:
+    - GET /api/config/security/file-guard
+    - PUT /api/config/security/file-guard
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/config/security/file-guard",
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "enabled" in before
+
+    updated_enabled = not bool(before.get("enabled", True))
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/security/file-guard",
+            json={"enabled": updated_enabled},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled")) == updated_enabled
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/config/security/file-guard",
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled")) == updated_enabled
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/config/security/file-guard",
+            json={"enabled": before.get("enabled", True)},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_global_tool_guard_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify tool-guard enabled flag supports update and readback.
+
+    Test flow:
+    1. GET current tool-guard config.
+    2. PUT same payload with toggled ``enabled``.
+    3. GET tool-guard and verify ``enabled`` changed.
+    4. Restore original payload.
+
+    API endpoints:
+    - GET /api/config/security/tool-guard
+    - PUT /api/config/security/tool-guard
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/config/security/tool-guard",
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "enabled" in before
+
+    updated = dict(before)
+    updated["enabled"] = not bool(before.get("enabled", True))
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/security/tool-guard",
+            json=updated,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled")) == updated["enabled"]
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/config/security/tool-guard",
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled")) == updated["enabled"]
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/config/security/tool-guard",
+            json=before,
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_global_skill_scanner_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify skill-scanner config accepts updates and readback remains
+      consistent.
+
+    Test flow:
+    1. GET /api/config/security/skill-scanner as baseline.
+    2. PUT same payload with toggled ``mode``.
+    3. GET /api/config/security/skill-scanner and verify changed value.
+    4. Restore baseline payload.
+
+    API endpoints:
+    - GET /api/config/security/skill-scanner
+    - PUT /api/config/security/skill-scanner
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/config/security/skill-scanner",
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "mode" in before
+
+    updated = dict(before)
+    updated["mode"] = "off" if before.get("mode") != "off" else "warn"
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/security/skill-scanner",
+            json=updated,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("mode") == updated["mode"]
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/config/security/skill-scanner",
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("mode") == updated["mode"]
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/config/security/skill-scanner",
+            json=before,
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skill_scanner_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped skill-scanner config supports update and readback
+      without using X-Agent-Id header.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET /api/agents/{agentId}/config/security/skill-scanner as baseline.
+    3. PUT the same endpoint with a changed ``mode`` value.
+    4. GET again and assert updated value is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/security/skill-scanner
+    - PUT /api/agents/{agentId}/config/security/skill-scanner
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skill_scanner_01"
+    endpoint = f"/api/agents/{agent_id}/config/security/skill-scanner"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped skill scanner agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "mode" in baseline
+
+        updated = dict(baseline)
+        updated["mode"] = (
+            "block" if baseline.get("mode") != "block" else "warn"
+        )
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("mode") == updated["mode"]
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("mode") == updated["mode"]
+    finally:
+        if isinstance(baseline, dict):
+            restore = app_server.api_request("PUT", endpoint, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skill_scanner_whitelist_add_delete(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped skill-scanner whitelist supports add and remove flow.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST whitelist endpoint with a unique skill name.
+    3. GET scoped skill-scanner config and assert whitelist contains the skill.
+    4. DELETE whitelist entry by skill name.
+    5. GET config again and assert whitelist no longer contains it.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/config/security/skill-scanner/whitelist
+    - GET /api/agents/{agentId}/config/security/skill-scanner
+    - DELETE .../skill-scanner/whitelist/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skill_white_01"
+    skill_name = "integ_whitelist_skill_01"
+    base = f"/api/agents/{agent_id}/config/security/skill-scanner"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped skill whitelist agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        add_resp = app_server.api_request(
+            "POST",
+            f"{base}/whitelist",
+            json={"skill_name": skill_name, "content_hash": "sha256:testhash"},
+        )
+        assert add_resp.status_code == 200, app_server.logs_tail()
+        assert add_resp.json().get("whitelisted") is True
+        assert add_resp.json().get("skill_name") == skill_name
+
+        get_after_add = app_server.api_request("GET", base)
+        assert get_after_add.status_code == 200, app_server.logs_tail()
+        whitelist_after_add = get_after_add.json().get("whitelist")
+        assert isinstance(whitelist_after_add, list)
+        skill_names_after_add = {
+            entry.get("skill_name") for entry in whitelist_after_add
+        }
+        assert skill_name in skill_names_after_add
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{base}/whitelist/{skill_name}",
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("removed") is True
+        assert del_resp.json().get("skill_name") == skill_name
+
+        get_after_del = app_server.api_request("GET", base)
+        assert get_after_del.status_code == 200, app_server.logs_tail()
+        whitelist_after_del = get_after_del.json().get("whitelist")
+        assert isinstance(whitelist_after_del, list)
+        skill_names_after_del = {
+            entry.get("skill_name") for entry in whitelist_after_del
+        }
+        assert skill_name not in skill_names_after_del
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skill_scanner_blocked_history_delete_paths(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify agent-scoped blocked-history delete paths keep stable contract for
+      clear-all and missing-index cases.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. DELETE blocked-history and assert clear result.
+    3. DELETE blocked-history/{index} for missing index; assert 404.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - DELETE .../skill-scanner/blocked-history
+    - DELETE .../skill-scanner/blocked-history/{index}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skill_hist_01"
+    base = (
+        f"/api/agents/{agent_id}/config/security/skill-scanner/blocked-history"
+    )
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped skill history agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        clear_resp = app_server.api_request("DELETE", base)
+        assert clear_resp.status_code == 200, app_server.logs_tail()
+        assert clear_resp.json().get("cleared") is True
+
+        remove_missing = app_server.api_request("DELETE", f"{base}/0")
+        assert remove_missing.status_code == 404, app_server.logs_tail()
+        assert "detail" in remove_missing.json()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_file_guard_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped file-guard endpoint supports update and readback.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped file-guard config as baseline.
+    3. PUT scoped file-guard with toggled ``enabled`` value.
+    4. GET again and verify updated value is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/security/file-guard
+    - PUT /api/agents/{agentId}/config/security/file-guard
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_file_guard_01"
+    endpoint = f"/api/agents/{agent_id}/config/security/file-guard"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped file guard agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    before = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        before = get_before.json()
+        assert isinstance(before, dict)
+        assert "enabled" in before
+
+        updated_enabled = not bool(before.get("enabled", True))
+
+        put_resp = app_server.api_request(
+            "PUT",
+            endpoint,
+            json={"enabled": updated_enabled},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled")) == updated_enabled
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled")) == updated_enabled
+    finally:
+        if isinstance(before, dict):
+            restore = app_server.api_request(
+                "PUT",
+                endpoint,
+                json={"enabled": before.get("enabled", True)},
+            )
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_tool_guard_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped tool-guard endpoint supports update and readback.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped tool-guard config as baseline.
+    3. PUT scoped tool-guard with toggled ``enabled`` value.
+    4. GET again and verify updated value is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/config/security/tool-guard
+    - PUT /api/agents/{agentId}/config/security/tool-guard
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_tool_guard_01"
+    endpoint = f"/api/agents/{agent_id}/config/security/tool-guard"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped tool guard agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    before = None
+    try:
+        get_before = app_server.api_request("GET", endpoint)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        before = get_before.json()
+        assert isinstance(before, dict)
+        assert "enabled" in before
+
+        updated = dict(before)
+        updated["enabled"] = not bool(before.get("enabled", True))
+
+        put_resp = app_server.api_request("PUT", endpoint, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled")) == updated["enabled"]
+
+        get_after = app_server.api_request("GET", endpoint)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled")) == updated["enabled"]
+    finally:
+        if isinstance(before, dict):
+            restore = app_server.api_request("PUT", endpoint, json=before)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_settings_envs.py
+++ b/tests/integration/test_settings_envs.py
@@ -2,16 +2,42 @@
 """Integration tests for settings and env management APIs."""
 from __future__ import annotations
 
+import pytest
 
+
+@pytest.mark.integration
+@pytest.mark.p1
 def test_settings_language_default_en(app_server) -> None:
-    """Language should default to English in a fresh workspace."""
+    """Test purpose:
+    - Verify the default language value in a fresh workspace.
+
+    Test flow:
+    1. Read language settings.
+    2. Assert status is 200 and value is ``en``.
+
+    API endpoints:
+    - GET /api/settings/language
+    """
     response = app_server.api_request("GET", "/api/settings/language")
     assert response.status_code == 200, app_server.logs_tail()
     assert response.json() == {"language": "en"}
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_settings_language_put_get_roundtrip(app_server) -> None:
-    """PUT language should persist and be visible in next GET."""
+    """Test purpose:
+    - Verify language updates persist and can be read back.
+
+    Test flow:
+    1. PUT language=zh.
+    2. Assert PUT returns 200 and ``{"language": "zh"}``.
+    3. GET again and verify value is still ``zh``.
+
+    API endpoints:
+    - PUT /api/settings/language
+    - GET /api/settings/language
+    """
     put_response = app_server.api_request(
         "PUT",
         "/api/settings/language",
@@ -25,8 +51,20 @@ def test_settings_language_put_get_roundtrip(app_server) -> None:
     assert get_response.json() == {"language": "zh"}
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_settings_language_reject_invalid(app_server) -> None:
-    """Invalid language should return 400 with meaningful message."""
+    """Test purpose:
+    - Verify invalid language values are rejected with a readable error.
+
+    Test flow:
+    1. PUT an invalid language value (xx).
+    2. Assert status is 400.
+    3. Assert ``detail`` contains ``Invalid language``.
+
+    API endpoints:
+    - PUT /api/settings/language
+    """
     response = app_server.api_request(
         "PUT",
         "/api/settings/language",
@@ -37,8 +75,21 @@ def test_settings_language_reject_invalid(app_server) -> None:
     assert "Invalid language" in detail
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_envs_put_get_roundtrip(app_server) -> None:
-    """Batch PUT should replace envs and GET should return saved entries."""
+    """Test purpose:
+    - Verify batch env writes can be fully read back.
+
+    Test flow:
+    1. PUT two env entries.
+    2. Assert PUT returns a list with expected count.
+    3. GET env list and verify key/value pairs match.
+
+    API endpoints:
+    - PUT /api/envs
+    - GET /api/envs
+    """
     put_response = app_server.api_request(
         "PUT",
         "/api/envs",
@@ -57,8 +108,21 @@ def test_envs_put_get_roundtrip(app_server) -> None:
     assert item_map["ANOTHER_KEY"] == "value_2"
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_envs_delete_key(app_server) -> None:
-    """Deleting an existing env key should remove it from stored envs."""
+    """Test purpose:
+    - Verify deleting one env key does not affect other keys.
+
+    Test flow:
+    1. Seed envs with DELETE_ME and KEEP_ME.
+    2. DELETE DELETE_ME.
+    3. Assert DELETE_ME is removed while KEEP_ME remains.
+
+    API endpoints:
+    - PUT /api/envs
+    - DELETE /api/envs/{key}
+    """
     seed_response = app_server.api_request(
         "PUT",
         "/api/envs",

--- a/tests/integration/test_skills_agent_scoped.py
+++ b/tests/integration/test_skills_agent_scoped.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for agent-scoped /api/agents/{id}/skills endpoints."""
+from __future__ import annotations
+
+import pytest
+
+
+def _skill_md(name: str, description: str) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        "# Integration Skill\n"
+        "This skill is created by integration tests.\n"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_create_list_batch_delete(app_server) -> None:
+    """Test purpose:
+    - Verify workspace skills can be created, listed, and batch-deleted using
+      only ``/api/agents/{agentId}/skills`` paths (no ``X-Agent-Id`` header).
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST two skills under the scoped skills prefix.
+    3. GET scoped skills list and assert both names appear.
+    4. POST scoped ``batch-delete`` with both names; per-skill success.
+    5. GET list again and assert both are gone.
+    6. Defensive per-skill DELETE and DELETE agent in finally.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/skills
+    - GET /api/agents/{agentId}/skills
+    - POST /api/agents/{agentId}/skills/batch-delete
+    - DELETE /api/agents/{agentId}/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skills_batch_01"
+    base = f"/api/agents/{agent_id}/skills"
+    skill_names = ["integ-scoped-skill-a", "integ-scoped-skill-b"]
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped skills agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        for skill_name in skill_names:
+            create_skill = app_server.api_request(
+                "POST",
+                base,
+                json={
+                    "name": skill_name,
+                    "content": _skill_md(skill_name, "scoped batch skill"),
+                    "enable": False,
+                },
+            )
+            assert create_skill.status_code == 200, app_server.logs_tail()
+
+        list_before = app_server.api_request("GET", base)
+        assert list_before.status_code == 200, app_server.logs_tail()
+        names_before = {item["name"] for item in list_before.json()}
+        for skill_name in skill_names:
+            assert skill_name in names_before
+
+        batch_delete = app_server.api_request(
+            "POST",
+            f"{base}/batch-delete",
+            json=skill_names,
+        )
+        assert batch_delete.status_code == 200, app_server.logs_tail()
+        results = batch_delete.json().get("results", {})
+        for skill_name in skill_names:
+            assert results.get(skill_name, {}).get("success") is True
+
+        list_after = app_server.api_request("GET", base)
+        assert list_after.status_code == 200, app_server.logs_tail()
+        names_after = {item["name"] for item in list_after.json()}
+        for skill_name in skill_names:
+            assert skill_name not in names_after
+    finally:
+        for skill_name in skill_names:
+            app_server.api_request("DELETE", f"{base}/{skill_name}")
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skills_batch_enable_disable(app_server) -> None:
+    """Test purpose:
+    - Verify scoped batch-enable and batch-disable update ``enabled`` flags.
+
+    Test flow:
+    1. Create a dedicated test agent and two disabled workspace skills.
+    2. POST scoped batch-enable and assert per-skill success plus list state.
+    3. POST scoped batch-disable and assert per-skill success plus list state.
+    4. POST scoped batch-delete for cleanup.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/skills
+    - POST /api/agents/{agentId}/skills/batch-enable
+    - POST /api/agents/{agentId}/skills/batch-disable
+    - POST /api/agents/{agentId}/skills/batch-delete
+    - GET /api/agents/{agentId}/skills
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skills_batch_enable_01"
+    base = f"/api/agents/{agent_id}/skills"
+    skill_names = ["integ-scoped-batch-en-a", "integ-scoped-batch-en-b"]
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped batch enable agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        for skill_name in skill_names:
+            create_skill = app_server.api_request(
+                "POST",
+                base,
+                json={
+                    "name": skill_name,
+                    "content": _skill_md(skill_name, "batch enable skill"),
+                    "enable": False,
+                },
+            )
+            assert create_skill.status_code == 200, app_server.logs_tail()
+
+        batch_en = app_server.api_request(
+            "POST",
+            f"{base}/batch-enable",
+            json=skill_names,
+        )
+        assert batch_en.status_code == 200, app_server.logs_tail()
+        en_results = batch_en.json().get("results", {})
+        for skill_name in skill_names:
+            assert en_results.get(skill_name, {}).get("success") is True
+
+        list_after_en = app_server.api_request("GET", base)
+        assert list_after_en.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_after_en.json()}
+        for skill_name in skill_names:
+            assert by_name[skill_name]["enabled"] is True
+
+        batch_dis = app_server.api_request(
+            "POST",
+            f"{base}/batch-disable",
+            json=skill_names,
+        )
+        assert batch_dis.status_code == 200, app_server.logs_tail()
+        dis_results = batch_dis.json().get("results", {})
+        for skill_name in skill_names:
+            assert dis_results.get(skill_name, {}).get("success") is True
+
+        list_after_dis = app_server.api_request("GET", base)
+        assert list_after_dis.status_code == 200, app_server.logs_tail()
+        by_name2 = {item["name"]: item for item in list_after_dis.json()}
+        for skill_name in skill_names:
+            assert by_name2[skill_name]["enabled"] is False
+
+        batch_del = app_server.api_request(
+            "POST",
+            f"{base}/batch-delete",
+            json=skill_names,
+        )
+        assert batch_del.status_code == 200, app_server.logs_tail()
+    finally:
+        for skill_name in skill_names:
+            app_server.api_request("DELETE", f"{base}/{skill_name}")
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skills_pool_refresh(app_server) -> None:
+    """Test purpose:
+    - Verify scoped POST skills/pool/refresh returns a list payload (local
+      reconcile only, no hub credentials).
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST scoped pool refresh.
+    3. Assert 200 and JSON array response.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/skills/pool/refresh
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skills_pool_refresh_01"
+    refresh_path = f"/api/agents/{agent_id}/skills/pool/refresh"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Pool refresh agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        refresh = app_server.api_request("POST", refresh_path)
+        assert refresh.status_code == 200, app_server.logs_tail()
+        payload = refresh.json()
+        assert isinstance(payload, list)
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_skills_refresh(app_server) -> None:
+    """Test purpose:
+    - Verify scoped POST /skills/refresh returns a workspace skill list.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. POST /api/agents/{agentId}/skills/refresh.
+    3. Assert 200 and JSON list (may be empty).
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/skills/refresh
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skills_refresh_01"
+    refresh_path = f"/api/agents/{agent_id}/skills/refresh"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills refresh agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        refresh = app_server.api_request("POST", refresh_path)
+        assert refresh.status_code == 200, app_server.logs_tail()
+        payload = refresh.json()
+        assert isinstance(payload, list)
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_disable_enable_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify per-skill POST disable/enable under scoped skills prefix.
+
+    Test flow:
+    1. Create agent and one enabled skill via scoped POST.
+    2. POST .../skills/{name}/disable and GET list -> enabled false.
+    3. POST .../skills/{name}/enable and GET list -> enabled true.
+    4. DELETE skill and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/agents/{agentId}/skills
+    - POST /api/agents/{agentId}/skills/{skill_name}/disable
+    - POST /api/agents/{agentId}/skills/{skill_name}/enable
+    - GET /api/agents/{agentId}/skills
+    - DELETE /api/agents/{agentId}/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_skills_toggle_01"
+    base = f"/api/agents/{agent_id}/skills"
+    skill_name = "integ-scoped-skill-toggle-01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped skill toggle agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_skill = app_server.api_request(
+            "POST",
+            base,
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "integration scoped toggle"),
+                "enable": True,
+            },
+        )
+        assert create_skill.status_code == 200, app_server.logs_tail()
+
+        disable = app_server.api_request(
+            "POST",
+            f"{base}/{skill_name}/disable",
+        )
+        assert disable.status_code == 200, app_server.logs_tail()
+        assert disable.json().get("disabled") is True
+
+        list_disabled = app_server.api_request("GET", base)
+        assert list_disabled.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_disabled.json()}
+        assert by_name[skill_name]["enabled"] is False
+
+        enable = app_server.api_request(
+            "POST",
+            f"{base}/{skill_name}/enable",
+        )
+        assert enable.status_code == 200, app_server.logs_tail()
+        assert enable.json().get("enabled") is True
+
+        list_enabled = app_server.api_request("GET", base)
+        assert list_enabled.status_code == 200, app_server.logs_tail()
+        by_name_2 = {item["name"]: item for item in list_enabled.json()}
+        assert by_name_2[skill_name]["enabled"] is True
+    finally:
+        app_server.api_request("DELETE", f"{base}/{skill_name}")
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_skills_global.py
+++ b/tests/integration/test_skills_global.py
@@ -1,0 +1,726 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for global /api/skills (CRUD, batch, validation)."""
+from __future__ import annotations
+
+import pytest
+
+
+def _skill_md(name: str, description: str) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        "# Integration Skill\n"
+        "This skill is created by integration tests.\n"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_skills_create_list_delete(app_server) -> None:
+    """Test purpose:
+    - Verify core workspace skill lifecycle: create, list, and delete.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/skills with valid SKILL.md frontmatter.
+    3. GET /api/skills and verify created skill appears.
+    4. DELETE /api/skills/{skill_name} and verify deletion succeeds.
+    5. GET /api/skills again and verify skill no longer appears.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - GET /api/skills
+    - DELETE /api/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_crud_01"
+    headers = {"X-Agent-Id": agent_id}
+    skill_name = "integ-skill-crud-01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Skills CRUD agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_skill = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "integration CRUD skill"),
+                "enable": True,
+            },
+        )
+        assert create_skill.status_code == 200, app_server.logs_tail()
+        create_payload = create_skill.json()
+        assert create_payload.get("created") is True
+        assert create_payload.get("name") == skill_name
+
+        list_after_create = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_after_create.status_code == 200, app_server.logs_tail()
+        names_after_create = {
+            item["name"] for item in list_after_create.json()
+        }
+        assert skill_name in names_after_create
+
+        delete_skill = app_server.api_request(
+            "DELETE",
+            f"/api/skills/{skill_name}",
+            headers=headers,
+        )
+        assert delete_skill.status_code == 200, app_server.logs_tail()
+        assert delete_skill.json().get("deleted") is True
+
+        list_after_delete = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_after_delete.status_code == 200, app_server.logs_tail()
+        names_after_delete = {
+            item["name"] for item in list_after_delete.json()
+        }
+        assert skill_name not in names_after_delete
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_skills_disable_enable(app_server) -> None:
+    """Test purpose:
+    - Verify single-skill disable/enable endpoints update enabled state.
+
+    Test flow:
+    1. Create a test agent and one enabled skill.
+    2. POST /api/skills/{skill}/disable and assert success.
+    3. GET /api/skills and assert skill ``enabled`` is False.
+    4. POST /api/skills/{skill}/enable and assert success.
+    5. GET /api/skills and assert skill ``enabled`` is True.
+    6. Cleanup skill and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - POST /api/skills/{skill_name}/disable
+    - POST /api/skills/{skill_name}/enable
+    - GET /api/skills
+    - DELETE /api/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_toggle_01"
+    headers = {"X-Agent-Id": agent_id}
+    skill_name = "integ-skill-toggle-01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills toggle agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_skill = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "integration toggle skill"),
+                "enable": True,
+            },
+        )
+        assert create_skill.status_code == 200, app_server.logs_tail()
+
+        disable_resp = app_server.api_request(
+            "POST",
+            f"/api/skills/{skill_name}/disable",
+            headers=headers,
+        )
+        assert disable_resp.status_code == 200, app_server.logs_tail()
+        assert disable_resp.json().get("disabled") is True
+
+        list_after_disable = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_after_disable.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_after_disable.json()}
+        assert by_name[skill_name]["enabled"] is False
+
+        enable_resp = app_server.api_request(
+            "POST",
+            f"/api/skills/{skill_name}/enable",
+            headers=headers,
+        )
+        assert enable_resp.status_code == 200, app_server.logs_tail()
+        assert enable_resp.json().get("enabled") is True
+
+        list_after_enable = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_after_enable.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_after_enable.json()}
+        assert by_name[skill_name]["enabled"] is True
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/skills/{skill_name}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_skills_batch_enable_disable_delete(app_server) -> None:
+    """Test purpose:
+    - Verify batch skill operations return per-skill results and update states.
+
+    Test flow:
+    1. Create a test agent and two disabled skills.
+    2. POST /api/skills/batch-enable and verify both succeed.
+    3. POST /api/skills/batch-disable and verify both succeed.
+    4. POST /api/skills/batch-delete and verify both succeed.
+    5. GET /api/skills and verify both are removed.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - POST /api/skills/batch-enable
+    - POST /api/skills/batch-disable
+    - POST /api/skills/batch-delete
+    - GET /api/skills
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_batch_01"
+    headers = {"X-Agent-Id": agent_id}
+    skill_names = ["integ-skill-batch-01", "integ-skill-batch-02"]
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Skills batch agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        for skill_name in skill_names:
+            create_skill = app_server.api_request(
+                "POST",
+                "/api/skills",
+                headers=headers,
+                json={
+                    "name": skill_name,
+                    "content": _skill_md(
+                        skill_name,
+                        "integration batch skill",
+                    ),
+                    "enable": False,
+                },
+            )
+            assert create_skill.status_code == 200, app_server.logs_tail()
+
+        batch_enable = app_server.api_request(
+            "POST",
+            "/api/skills/batch-enable",
+            headers=headers,
+            json=skill_names,
+        )
+        assert batch_enable.status_code == 200, app_server.logs_tail()
+        enable_results = batch_enable.json().get("results", {})
+        for skill_name in skill_names:
+            assert enable_results.get(skill_name, {}).get("success") is True
+
+        batch_disable = app_server.api_request(
+            "POST",
+            "/api/skills/batch-disable",
+            headers=headers,
+            json=skill_names,
+        )
+        assert batch_disable.status_code == 200, app_server.logs_tail()
+        disable_results = batch_disable.json().get("results", {})
+        for skill_name in skill_names:
+            assert disable_results.get(skill_name, {}).get("success") is True
+
+        batch_delete = app_server.api_request(
+            "POST",
+            "/api/skills/batch-delete",
+            headers=headers,
+            json=skill_names,
+        )
+        assert batch_delete.status_code == 200, app_server.logs_tail()
+        delete_results = batch_delete.json().get("results", {})
+        for skill_name in skill_names:
+            assert delete_results.get(skill_name, {}).get("success") is True
+
+        list_after_delete = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_after_delete.status_code == 200, app_server.logs_tail()
+        remaining_names = {item["name"] for item in list_after_delete.json()}
+        for skill_name in skill_names:
+            assert skill_name not in remaining_names
+    finally:
+        for skill_name in skill_names:
+            app_server.api_request(
+                "DELETE",
+                f"/api/skills/{skill_name}",
+                headers=headers,
+            )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_create_duplicate_name_rejected(app_server) -> None:
+    """Test purpose:
+    - Verify creating a workspace skill with duplicated name is rejected.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/skills once with a fixed skill name and assert success.
+    3. POST /api/skills again with the same name.
+    4. Assert status 409 and detail includes conflict reason metadata.
+    5. Cleanup skill and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - DELETE /api/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_dup_01"
+    headers = {"X-Agent-Id": agent_id}
+    skill_name = "integ-skill-dup-01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills duplicate agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        first_create = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": skill_name,
+                "content": _skill_md(
+                    skill_name,
+                    "integration duplicate skill",
+                ),
+                "enable": True,
+            },
+        )
+        assert first_create.status_code == 200, app_server.logs_tail()
+
+        second_create = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": skill_name,
+                "content": _skill_md(
+                    skill_name,
+                    "integration duplicate skill",
+                ),
+                "enable": True,
+            },
+        )
+        assert second_create.status_code == 409, app_server.logs_tail()
+        detail = second_create.json().get("detail", {})
+        assert detail.get("reason") == "conflict"
+        assert "suggested_name" in detail
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/skills/{skill_name}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_create_invalid_skill_md_rejected(app_server) -> None:
+    """Test purpose:
+    - Verify create skill rejects invalid SKILL.md frontmatter content.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/skills with invalid frontmatter (missing description).
+    3. Assert status 400 and detail mentions frontmatter requirement.
+    4. Assert the invalid skill does not appear in GET /api/skills.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - GET /api/skills
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_invalid_md_01"
+    headers = {"X-Agent-Id": agent_id}
+    skill_name = "integ-skill-invalid-md-01"
+    invalid_md = (
+        "---\n"
+        f"name: {skill_name}\n"
+        "---\n\n"
+        "# Invalid Skill\n"
+        "missing description in frontmatter\n"
+    )
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills invalid md agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_invalid = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": skill_name,
+                "content": invalid_md,
+                "enable": True,
+            },
+        )
+        assert create_invalid.status_code == 400, app_server.logs_tail()
+        detail = str(create_invalid.json().get("detail", ""))
+        assert "frontmatter" in detail
+
+        list_resp = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert skill_name not in names
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_batch_enable_partial_success(app_server) -> None:
+    """Test purpose:
+    - Verify batch-enable returns per-skill results and allows partial success
+      when some skill names do not exist.
+
+    Test flow:
+    1. Create a test agent and one disabled skill.
+    2. POST /api/skills/batch-enable with one existing and one missing skill.
+    3. Assert existing skill success=true and missing one success=false.
+    4. GET /api/skills and verify existing skill becomes enabled.
+    5. Cleanup skill and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - POST /api/skills/batch-enable
+    - GET /api/skills
+    - DELETE /api/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_batch_partial_01"
+    headers = {"X-Agent-Id": agent_id}
+    existing_skill = "integ-skill-batch-partial-existing"
+    missing_skill = "integ-skill-batch-partial-missing"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills batch partial agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_existing = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": existing_skill,
+                "content": _skill_md(
+                    existing_skill,
+                    "integration batch partial skill",
+                ),
+                "enable": False,
+            },
+        )
+        assert create_existing.status_code == 200, app_server.logs_tail()
+
+        batch_enable = app_server.api_request(
+            "POST",
+            "/api/skills/batch-enable",
+            headers=headers,
+            json=[existing_skill, missing_skill],
+        )
+        assert batch_enable.status_code == 200, app_server.logs_tail()
+        results = batch_enable.json().get("results", {})
+        assert results.get(existing_skill, {}).get("success") is True
+        assert results.get(missing_skill, {}).get("success") is False
+        assert results.get(missing_skill, {}).get("reason") == "not_found"
+
+        list_resp = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_resp.json()}
+        assert by_name[existing_skill]["enabled"] is True
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/skills/{existing_skill}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_enable_missing_skill_returns_404(app_server) -> None:
+    """Test purpose:
+    - Verify enabling a non-existing workspace skill returns 404.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/skills/{skill_name}/enable with a missing skill name.
+    3. Assert status is 404 and detail indicates skill not found.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills/{skill_name}/enable
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_enable_missing_01"
+    headers = {"X-Agent-Id": agent_id}
+    missing_skill = "integ-skill-enable-missing"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills enable missing agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        enable_resp = app_server.api_request(
+            "POST",
+            f"/api/skills/{missing_skill}/enable",
+            headers=headers,
+        )
+        assert enable_resp.status_code == 404, app_server.logs_tail()
+        detail = str(enable_resp.json().get("detail", ""))
+        assert detail in {"Skill not found", "not_found"}
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_batch_delete_partial_success(app_server) -> None:
+    """Test purpose:
+    - Verify batch-delete returns per-skill results and supports partial
+      success when some skill names do not exist.
+
+    Test flow:
+    1. Create a test agent and one disabled skill.
+    2. POST /api/skills/batch-delete with one existing and one missing skill.
+    3. Assert existing skill delete result is success=true.
+    4. Assert missing skill delete result is success=false with reason.
+    5. GET /api/skills and verify existing skill is removed.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - POST /api/skills/batch-delete
+    - GET /api/skills
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_batch_delete_partial_01"
+    headers = {"X-Agent-Id": agent_id}
+    existing_skill = "integ-skill-batch-delete-existing"
+    missing_skill = "integ-skill-batch-delete-missing"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills batch delete partial agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_existing = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": existing_skill,
+                "content": _skill_md(
+                    existing_skill,
+                    "integration batch delete partial",
+                ),
+                "enable": False,
+            },
+        )
+        assert create_existing.status_code == 200, app_server.logs_tail()
+
+        batch_delete = app_server.api_request(
+            "POST",
+            "/api/skills/batch-delete",
+            headers=headers,
+            json=[existing_skill, missing_skill],
+        )
+        assert batch_delete.status_code == 200, app_server.logs_tail()
+        results = batch_delete.json().get("results", {})
+        assert results.get(existing_skill, {}).get("success") is True
+        assert results.get(missing_skill, {}).get("success") is False
+        assert results.get(missing_skill, {}).get("reason") == "delete_failed"
+
+        list_resp = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert existing_skill not in names
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_skills_batch_disable_partial_success(app_server) -> None:
+    """Test purpose:
+    - Verify batch-disable returns per-skill results and supports partial
+      success when some skill names do not exist.
+
+    Test flow:
+    1. Create a test agent and one enabled skill.
+    2. POST /api/skills/batch-disable with one existing and one missing skill.
+    3. Assert existing skill disable result is success=true.
+    4. Assert missing skill disable result is success=false.
+    5. GET /api/skills and verify existing skill becomes disabled.
+    6. Cleanup skill and agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/skills
+    - POST /api/skills/batch-disable
+    - GET /api/skills
+    - DELETE /api/skills/{skill_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_skills_batch_disable_partial_01"
+    headers = {"X-Agent-Id": agent_id}
+    existing_skill = "integ-skill-batch-disable-existing"
+    missing_skill = "integ-skill-batch-disable-missing"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Skills batch disable partial agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_existing = app_server.api_request(
+            "POST",
+            "/api/skills",
+            headers=headers,
+            json={
+                "name": existing_skill,
+                "content": _skill_md(
+                    existing_skill,
+                    "integration batch disable partial",
+                ),
+                "enable": True,
+            },
+        )
+        assert create_existing.status_code == 200, app_server.logs_tail()
+
+        batch_disable = app_server.api_request(
+            "POST",
+            "/api/skills/batch-disable",
+            headers=headers,
+            json=[existing_skill, missing_skill],
+        )
+        assert batch_disable.status_code == 200, app_server.logs_tail()
+        results = batch_disable.json().get("results", {})
+        assert results.get(existing_skill, {}).get("success") is True
+        assert results.get(missing_skill, {}).get("success") is False
+
+        list_resp = app_server.api_request(
+            "GET",
+            "/api/skills",
+            headers=headers,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_resp.json()}
+        assert by_name[existing_skill]["enabled"] is False
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/skills/{existing_skill}",
+            headers=headers,
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for built-in tools API (scoped, no external keys)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_tools_toggle_and_async_execution_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify agent-scoped tool PATCH endpoints toggle ``enabled`` and update
+      ``async_execution`` with readback via GET list.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped tools list and pick the first built-in tool name.
+    3. Record baseline ``enabled`` and ``async_execution`` from that tool.
+    4. PATCH toggle twice (or once) to restore original ``enabled`` while
+       asserting each response matches the flipped value.
+    5. PATCH async_execution to the opposite value, GET list to confirm, then
+       restore baseline async_execution.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/tools
+    - PATCH /api/agents/{agentId}/tools/{tool_name}/toggle
+    - PATCH /api/agents/{agentId}/tools/{tool_name}/async-execution
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_tools_01"
+    base = f"/api/agents/{agent_id}/tools"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Scoped tools agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        list_resp = app_server.api_request("GET", base)
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        tools = list_resp.json()
+        assert isinstance(tools, list) and tools, app_server.logs_tail()
+        tool_name = str(tools[0]["name"])
+        baseline_enabled = bool(tools[0].get("enabled", True))
+        baseline_async = bool(tools[0].get("async_execution", False))
+
+        t1 = app_server.api_request(
+            "PATCH",
+            f"{base}/{tool_name}/toggle",
+        )
+        assert t1.status_code == 200, app_server.logs_tail()
+        assert bool(t1.json().get("enabled")) is (not baseline_enabled)
+
+        t2 = app_server.api_request(
+            "PATCH",
+            f"{base}/{tool_name}/toggle",
+        )
+        assert t2.status_code == 200, app_server.logs_tail()
+        assert bool(t2.json().get("enabled")) is baseline_enabled
+
+        target_async = not baseline_async
+        a1 = app_server.api_request(
+            "PATCH",
+            f"{base}/{tool_name}/async-execution",
+            json={"async_execution": target_async},
+        )
+        assert a1.status_code == 200, app_server.logs_tail()
+        assert bool(a1.json().get("async_execution")) is target_async
+
+        list_mid = app_server.api_request("GET", base)
+        assert list_mid.status_code == 200, app_server.logs_tail()
+        by_name = {item["name"]: item for item in list_mid.json()}
+        assert bool(by_name[tool_name].get("async_execution")) is target_async
+
+        a2 = app_server.api_request(
+            "PATCH",
+            f"{base}/{tool_name}/async-execution",
+            json={"async_execution": baseline_async},
+        )
+        assert a2.status_code == 200, app_server.logs_tail()
+        assert bool(a2.json().get("async_execution")) is baseline_async
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -9,8 +9,20 @@ import pytest
 from packaging.version import Version
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_version_import() -> None:
-    """Test that version can be imported without errors."""
+    """Test purpose:
+    - Verify the version module can be imported directly, preventing missing
+      version metadata in release artifacts.
+
+    Test flow:
+    1. Import ``__version__`` from ``qwenpaw.__version__``.
+    2. Assert it is a non-empty string.
+
+    API endpoints:
+    - None (Python module import only)
+    """
     from qwenpaw.__version__ import __version__
 
     assert __version__ is not None
@@ -18,8 +30,20 @@ def test_version_import() -> None:
     assert len(__version__) > 0
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_version_pep440_compliant() -> None:
-    """Test that version follows PEP 440 format."""
+    """Test purpose:
+    - Verify the project version string is PEP 440 compliant.
+
+    Test flow:
+    1. Import ``__version__``.
+    2. Parse it with ``packaging.version.Version``.
+    3. Assert parsed string equals the original.
+
+    API endpoints:
+    - None (Python version-format validation only)
+    """
     from qwenpaw.__version__ import __version__
 
     try:
@@ -29,8 +53,20 @@ def test_version_pep440_compliant() -> None:
         pytest.fail(f"Version '{__version__}' is not PEP 440 compliant: {e}")
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_version_via_subprocess() -> None:
-    """Test that version can be accessed via subprocess."""
+    """Test purpose:
+    - Verify version retrieval also works in an isolated Python subprocess.
+
+    Test flow:
+    1. Run a subprocess that imports and prints ``__version__``.
+    2. Assert return code is 0.
+    3. Assert output is non-empty and includes a version separator.
+
+    API endpoints:
+    - None (Python subprocess execution only)
+    """
     result = subprocess.run(
         [
             sys.executable,

--- a/tests/integration/test_workspace_agent_settings.py
+++ b/tests/integration/test_workspace_agent_settings.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8 -*-
+"""Smoke tests for agent-scoped workspace settings."""
+from __future__ import annotations
+
+
+import pytest
+
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_workspace_language_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify scoped workspace language GET/PUT roundtrip for a test agent.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped /workspace/language baseline.
+    3. PUT a different valid language (en <-> zh) and GET to verify.
+    4. Restore baseline and delete agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/workspace/language
+    - PUT /api/agents/{agentId}/workspace/language
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_ws_lang_01"
+    base = f"/api/agents/{agent_id}/workspace/language"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped language agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline_lang = None
+    try:
+        get_before = app_server.api_request("GET", base)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline_lang = get_before.json().get("language")
+        assert baseline_lang in ("en", "zh", "ru")
+
+        alt = "zh" if baseline_lang == "en" else "en"
+        put_resp = app_server.api_request("PUT", base, json={"language": alt})
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("language") == alt
+
+        get_after = app_server.api_request("GET", base)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("language") == alt
+    finally:
+        if baseline_lang is not None:
+            restore = app_server.api_request(
+                "PUT",
+                base,
+                json={"language": baseline_lang},
+            )
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_workspace_audio_mode_put_get_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify scoped workspace audio-mode roundtrip (auto/native).
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET scoped /workspace/audio-mode baseline.
+    3. PUT the alternate valid mode and GET to verify.
+    4. Restore baseline and delete agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/workspace/audio-mode
+    - PUT /api/agents/{agentId}/workspace/audio-mode
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_ws_audio_01"
+    base = f"/api/agents/{agent_id}/workspace/audio-mode"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped audio mode agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline_mode = None
+    try:
+        get_before = app_server.api_request("GET", base)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline_mode = get_before.json().get("audio_mode")
+        assert baseline_mode in ("auto", "native")
+
+        alt = "native" if baseline_mode == "auto" else "auto"
+        put_resp = app_server.api_request(
+            "PUT",
+            base,
+            json={"audio_mode": alt},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("audio_mode") == alt
+
+        get_after = app_server.api_request("GET", base)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("audio_mode") == alt
+    finally:
+        if baseline_mode is not None:
+            restore = app_server.api_request(
+                "PUT",
+                base,
+                json={"audio_mode": baseline_mode},
+            )
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_agent_scoped_agent_status_minimal_contract(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped agent-status endpoint returns a stable JSON contract.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET /api/agents/{agentId}/agent-status.
+    3. Assert status is one of idle/running/disabled and task count is int.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/agent-status
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_agent_status_01"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Agent status agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/agent-status",
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        body = resp.json()
+        assert body.get("status") in {"idle", "running", "disabled"}
+        assert isinstance(body.get("running_task_count"), int)
+        assert body["running_task_count"] >= 0
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_workspace_system_prompt_files_put_get_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify scoped system-prompt-files GET/PUT roundtrip for a test agent.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET baseline list of system prompt filenames.
+    3. PUT a reordered copy (when length >= 2) or the same list, then GET.
+    4. Restore original list and delete agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/workspace/system-prompt-files
+    - PUT /api/agents/{agentId}/workspace/system-prompt-files
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_sys_prompt_01"
+    base = f"/api/agents/{agent_id}/workspace/system-prompt-files"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "System prompt agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline: list[str] | None = None
+    try:
+        get_before = app_server.api_request("GET", base)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, list)
+
+        reordered = (
+            list(reversed(baseline)) if len(baseline) >= 2 else list(baseline)
+        )
+
+        put_resp = app_server.api_request("PUT", base, json=reordered)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json() == reordered
+
+        get_after = app_server.api_request("GET", base)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json() == reordered
+    finally:
+        if isinstance(baseline, list):
+            restore = app_server.api_request("PUT", base, json=baseline)
+            assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_workspace_transcription_provider_type_put_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify scoped transcription-provider-type PUT persists and can be read
+      back. The backing field is global; restore via global workspace path.
+
+    Test flow:
+    1. Record baseline from GET /api/workspace/transcription-provider-type.
+    2. Create a dedicated test agent.
+    3. PUT alternate valid type via scoped path and GET scoped path to verify.
+    4. Restore baseline via PUT /api/workspace/transcription-provider-type.
+    5. Delete test agent.
+
+    API endpoints:
+    - GET /api/workspace/transcription-provider-type
+    - PUT /api/workspace/transcription-provider-type
+    - POST /api/agents
+    - GET /api/agents/{agentId}/workspace/transcription-provider-type
+    - PUT /api/agents/{agentId}/workspace/transcription-provider-type
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_transcription_type_01"
+    global_path = "/api/workspace/transcription-provider-type"
+    scoped_base = (
+        f"/api/agents/{agent_id}/workspace/transcription-provider-type"
+    )
+
+    get_global_before = app_server.api_request("GET", global_path)
+    assert get_global_before.status_code == 200, app_server.logs_tail()
+    baseline = get_global_before.json().get("transcription_provider_type")
+    assert baseline in ("disabled", "whisper_api", "local_whisper")
+
+    alt = "whisper_api" if baseline == "disabled" else "disabled"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Transcription type agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        put_alt = app_server.api_request(
+            "PUT",
+            scoped_base,
+            json={"transcription_provider_type": alt},
+        )
+        assert put_alt.status_code == 200, app_server.logs_tail()
+        assert put_alt.json().get("transcription_provider_type") == alt
+
+        get_scoped = app_server.api_request("GET", scoped_base)
+        assert get_scoped.status_code == 200, app_server.logs_tail()
+        assert get_scoped.json().get("transcription_provider_type") == alt
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            global_path,
+            json={"transcription_provider_type": baseline},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_agent_scoped_workspace_memory_put_get_list(app_server) -> None:
+    """Test purpose:
+    - Verify agent-scoped memory file PUT/GET and list visibility.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. PUT scoped memory file with markdown content.
+    3. GET the same path and assert content roundtrip.
+    4. GET scoped memory list and assert filename stem appears.
+    5. Delete test agent (workspace cleanup).
+
+    API endpoints:
+    - POST /api/agents
+    - PUT /api/agents/{agentId}/workspace/memory/{md_name}
+    - GET /api/agents/{agentId}/workspace/memory/{md_name}
+    - GET /api/agents/{agentId}/workspace/memory
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_memory_01"
+    md_stem = "integ_scoped_memory_note"
+    base_mem = f"/api/agents/{agent_id}/workspace/memory"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped memory agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        body = "# Scoped memory\n\nintegration line.\n"
+        put_resp = app_server.api_request(
+            "PUT",
+            f"{base_mem}/{md_stem}",
+            json={"content": body},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+
+        get_one = app_server.api_request("GET", f"{base_mem}/{md_stem}")
+        assert get_one.status_code == 200, app_server.logs_tail()
+        # read_memory_md returns stripped file text
+        assert get_one.json().get("content") == body.strip()
+
+        list_resp = app_server.api_request("GET", base_mem)
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        filenames = {item.get("filename") for item in list_resp.json()}
+        assert f"{md_stem}.md" in filenames
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/integration/test_workspace_files.py
+++ b/tests/integration/test_workspace_files.py
@@ -1,0 +1,604 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for workspace file APIs (working/memory + zip up/down)."""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_working_file_list_put_get(app_server) -> None:
+    """Test purpose:
+    - Verify workspace working-file APIs are usable: builtin seed files exist,
+      new file writes succeed, reads match, and list results include new files.
+
+    Test flow:
+    1. POST /api/agents to create a test agent.
+    2. GET /api/workspace/files with X-Agent-Id; check seed files.
+    3. PUT /api/workspace/files/{md_name} to write a test markdown file.
+    4. GET /api/workspace/files/{md_name} and verify content roundtrip.
+    5. GET /api/workspace/files again and confirm the new file appears.
+    6. DELETE /api/agents/{agentId} for cleanup.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/workspace/files
+    - PUT /api/workspace/files/{md_name}
+    - GET /api/workspace/files/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_01"
+    headers = {"X-Agent-Id": agent_id}
+    md_stem = "integ_smoke_note"
+    expected_seed_files = {
+        "SOUL.md",
+        "PROFILE.md",
+        "MEMORY.md",
+        "HEARTBEAT.md",
+        "BOOTSTRAP.md",
+        "AGENTS.md",
+    }
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace smoke agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        list_before = app_server.api_request(
+            "GET",
+            "/api/workspace/files",
+            headers=headers,
+        )
+        assert list_before.status_code == 200, app_server.logs_tail()
+        list_before_payload = list_before.json()
+        assert isinstance(list_before_payload, list)
+        seed_names = {f["filename"] for f in list_before_payload}
+        missing_seed_files = sorted(expected_seed_files - seed_names)
+        assert not missing_seed_files, (
+            f"workspace seed files missing: {missing_seed_files}; "
+            f"have={sorted(seed_names)}"
+        )
+
+        content = "# integration\nline2\n"
+        put_resp = app_server.api_request(
+            "PUT",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+            json={"content": content},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json() == {"written": True}
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["content"] == content.strip()
+
+        list_after = app_server.api_request(
+            "GET",
+            "/api/workspace/files",
+            headers=headers,
+        )
+        assert list_after.status_code == 200, app_server.logs_tail()
+        names = {f["filename"] for f in list_after.json()}
+        assert f"{md_stem}.md" in names
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_memory_file_list_put_get(app_server) -> None:
+    """Test purpose:
+    - Verify workspace memory-file APIs support write/read/list roundtrip under
+      an explicit agent context.
+
+    Test flow:
+    1. Create a test agent.
+    2. GET /api/workspace/memory and assert list response shape.
+    3. PUT /api/workspace/memory/{md_name} with test content.
+    4. GET /api/workspace/memory/{md_name} and verify content matches.
+    5. GET /api/workspace/memory again and assert new file appears.
+    6. Delete test agent for cleanup.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/workspace/memory
+    - PUT /api/workspace/memory/{md_name}
+    - GET /api/workspace/memory/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_mem_01"
+    headers = {"X-Agent-Id": agent_id}
+    md_stem = "integ_memory_note"
+    content = "# memory integration\nfacts: 42\n"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={"id": agent_id, "name": "Memory smoke agent", "description": ""},
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        list_before = app_server.api_request(
+            "GET",
+            "/api/workspace/memory",
+            headers=headers,
+        )
+        assert list_before.status_code == 200, app_server.logs_tail()
+        assert isinstance(list_before.json(), list)
+
+        put_resp = app_server.api_request(
+            "PUT",
+            f"/api/workspace/memory/{md_stem}",
+            headers=headers,
+            json={"content": content},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json() == {"written": True}
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"/api/workspace/memory/{md_stem}",
+            headers=headers,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["content"] == content.strip()
+
+        list_after = app_server.api_request(
+            "GET",
+            "/api/workspace/memory",
+            headers=headers,
+        )
+        assert list_after.status_code == 200, app_server.logs_tail()
+        names = {f["filename"] for f in list_after.json()}
+        assert f"{md_stem}.md" in names
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_header_and_scoped_consistency(app_server) -> None:
+    """Test purpose:
+    - Verify workspace file APIs are consistent between header-based agent
+      context and explicit agent-scoped routes.
+
+    Test flow:
+    1. Create a test agent.
+    2. Write a working file via header route (X-Agent-Id).
+    3. Read the same file via scoped route and verify content matches.
+    4. Overwrite via scoped route and read back via header route.
+    5. Cleanup by deleting the test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - PUT /api/workspace/files/{md_name}
+    - GET /api/workspace/files/{md_name}
+    - PUT /api/agents/{agentId}/workspace/files/{md_name}
+    - GET /api/agents/{agentId}/workspace/files/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_scope_01"
+    headers = {"X-Agent-Id": agent_id}
+    md_stem = "scope_consistency_note"
+    v1 = "# scope consistency v1\n"
+    v2 = "# scope consistency v2\n"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace scoped agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        put_header = app_server.api_request(
+            "PUT",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+            json={"content": v1},
+        )
+        assert put_header.status_code == 200, app_server.logs_tail()
+        assert put_header.json() == {"written": True}
+
+        get_scoped = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/workspace/files/{md_stem}",
+        )
+        assert get_scoped.status_code == 200, app_server.logs_tail()
+        assert get_scoped.json()["content"] == v1.strip()
+
+        put_scoped = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/workspace/files/{md_stem}",
+            json={"content": v2},
+        )
+        assert put_scoped.status_code == 200, app_server.logs_tail()
+        assert put_scoped.json() == {"written": True}
+
+        get_header = app_server.api_request(
+            "GET",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+        )
+        assert get_header.status_code == 200, app_server.logs_tail()
+        assert get_header.json()["content"] == v2.strip()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_download_zip_contract(app_server) -> None:
+    """Test purpose:
+    - Verify workspace download returns a valid zip stream with expected HTTP
+      contract and readable archive entries.
+
+    Test flow:
+    1. Create a test agent.
+    2. Write a marker markdown file into workspace via API.
+    3. Download workspace zip through /api/workspace/download.
+    4. Validate status/content-type/content-disposition and zip signature.
+    5. Open zip in-memory and assert seed file plus marker file exist.
+    6. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - PUT /api/workspace/files/{md_name}
+    - GET /api/workspace/download
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_zip_01"
+    headers = {"X-Agent-Id": agent_id}
+    marker_stem = "zip_marker_note"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace zip agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        seed_file_resp = app_server.api_request(
+            "PUT",
+            f"/api/workspace/files/{marker_stem}",
+            headers=headers,
+            json={"content": "# zip marker\n"},
+        )
+        assert seed_file_resp.status_code == 200, app_server.logs_tail()
+
+        download_resp = app_server.client.get(
+            f"{app_server.base_url}/api/workspace/download",
+            headers=headers,
+        )
+        assert download_resp.status_code == 200, app_server.logs_tail()
+
+        content_type = download_resp.headers.get("content-type", "").lower()
+        assert "application/zip" in content_type
+        content_disposition = download_resp.headers.get(
+            "content-disposition",
+            "",
+        ).lower()
+        assert "attachment;" in content_disposition
+        assert "qwenpaw_workspace_" in content_disposition
+        assert agent_id.lower() in content_disposition
+
+        zip_bytes = download_resp.content
+        assert zip_bytes.startswith(
+            b"PK",
+        ), "zip stream must start with PK signature"
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+            names = set(zf.namelist())
+
+        assert "AGENTS.md" in names
+        assert f"{marker_stem}.md" in names
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_upload_zip_merge(app_server) -> None:
+    """Test purpose:
+    - Verify workspace upload accepts a zip archive and merges files into the
+      target agent workspace.
+
+    Test flow:
+    1. Create a test agent.
+    2. Build an in-memory zip with one markdown file.
+    3. POST /api/workspace/upload using multipart form-data.
+    4. GET /api/workspace/files/{md_name} and verify uploaded content exists.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/workspace/upload
+    - GET /api/workspace/files/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_upload_01"
+    headers = {"X-Agent-Id": agent_id}
+    uploaded_name = "uploaded_merge_note.md"
+    uploaded_content = "# uploaded by integration\n"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace upload agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(uploaded_name, uploaded_content)
+        buf.seek(0)
+
+        upload_resp = app_server.client.post(
+            f"{app_server.base_url}/api/workspace/upload",
+            headers=headers,
+            files={
+                "file": ("workspace.zip", buf.getvalue(), "application/zip"),
+            },
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        upload_payload = upload_resp.json()
+        assert upload_payload.get("success") is True
+
+        get_uploaded = app_server.api_request(
+            "GET",
+            f"/api/workspace/files/{uploaded_name}",
+            headers=headers,
+        )
+        assert get_uploaded.status_code == 200, app_server.logs_tail()
+        assert get_uploaded.json().get("content") == uploaded_content.strip()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_api_workspace_upload_reject_non_zip(app_server) -> None:
+    """Test purpose:
+    - Verify workspace upload rejects non-zip multipart content with 400.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST /api/workspace/upload with text/plain file.
+    3. Assert status is 400 and error mentions expected zip content-type.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - POST /api/workspace/upload
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_upload_bad_01"
+    headers = {"X-Agent-Id": agent_id}
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace bad upload agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        bad_upload = app_server.client.post(
+            f"{app_server.base_url}/api/workspace/upload",
+            headers=headers,
+            files={"file": ("not-zip.txt", b"plain text", "text/plain")},
+        )
+        assert bad_upload.status_code == 400, app_server.logs_tail()
+        detail = bad_upload.json().get("detail", "")
+        assert "Expected a zip file" in detail
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_workspace_upload_overwrite_existing_file(app_server) -> None:
+    """Test purpose:
+    - Verify workspace zip upload overwrites existing files with the same path.
+
+    Test flow:
+    1. Create a test agent.
+    2. Seed a working file via PUT with old content.
+    3. Upload a zip containing the same filename with new content.
+    4. Read the file and verify content is overwritten by uploaded payload.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - PUT /api/workspace/files/{md_name}
+    - POST /api/workspace/upload
+    - GET /api/workspace/files/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_upload_overwrite_01"
+    headers = {"X-Agent-Id": agent_id}
+    md_stem = "overwrite_target_note"
+    old_content = "# old content\n"
+    new_content = "# new content from zip\n"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace upload overwrite agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        seed_resp = app_server.api_request(
+            "PUT",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+            json={"content": old_content},
+        )
+        assert seed_resp.status_code == 200, app_server.logs_tail()
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"{md_stem}.md", new_content)
+        buf.seek(0)
+
+        upload_resp = app_server.client.post(
+            f"{app_server.base_url}/api/workspace/upload",
+            headers=headers,
+            files={
+                "file": ("workspace.zip", buf.getvalue(), "application/zip"),
+            },
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("success") is True
+
+        get_after = app_server.api_request(
+            "GET",
+            f"/api/workspace/files/{md_stem}",
+            headers=headers,
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("content") == new_content.strip()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_api_workspace_download_upload_cross_agent_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify a downloaded workspace zip can be uploaded into another agent
+      workspace and preserve user-authored files.
+
+    Test flow:
+    1. Create source and target test agents.
+    2. Write a marker file in source workspace.
+    3. Download source workspace zip.
+    4. Upload downloaded zip to target workspace.
+    5. Read marker file from target and verify content matches source.
+    6. Delete both agents.
+
+    API endpoints:
+    - POST /api/agents
+    - PUT /api/workspace/files/{md_name}
+    - GET /api/workspace/download
+    - POST /api/workspace/upload
+    - GET /api/workspace/files/{md_name}
+    - DELETE /api/agents/{agentId}
+    """
+    source_agent = "integ_ws_round_src_01"
+    target_agent = "integ_ws_round_tgt_01"
+    source_headers = {"X-Agent-Id": source_agent}
+    target_headers = {"X-Agent-Id": target_agent}
+    marker_stem = "roundtrip_marker"
+    marker_content = "# roundtrip marker\nfrom source agent\n"
+
+    create_source = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": source_agent,
+            "name": "Workspace roundtrip source",
+            "description": "",
+        },
+    )
+    assert create_source.status_code == 201, app_server.logs_tail()
+
+    create_target = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": target_agent,
+            "name": "Workspace roundtrip target",
+            "description": "",
+        },
+    )
+    assert create_target.status_code == 201, app_server.logs_tail()
+
+    try:
+        put_source = app_server.api_request(
+            "PUT",
+            f"/api/workspace/files/{marker_stem}",
+            headers=source_headers,
+            json={"content": marker_content},
+        )
+        assert put_source.status_code == 200, app_server.logs_tail()
+
+        download_source = app_server.client.get(
+            f"{app_server.base_url}/api/workspace/download",
+            headers=source_headers,
+        )
+        assert download_source.status_code == 200, app_server.logs_tail()
+        zip_blob = download_source.content
+        assert zip_blob.startswith(b"PK")
+
+        upload_target = app_server.client.post(
+            f"{app_server.base_url}/api/workspace/upload",
+            headers=target_headers,
+            files={"file": ("roundtrip.zip", zip_blob, "application/zip")},
+        )
+        assert upload_target.status_code == 200, app_server.logs_tail()
+        assert upload_target.json().get("success") is True
+
+        get_target = app_server.api_request(
+            "GET",
+            f"/api/workspace/files/{marker_stem}",
+            headers=target_headers,
+        )
+        assert get_target.status_code == 200, app_server.logs_tail()
+        assert get_target.json().get("content") == marker_content.strip()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{source_agent}")
+        app_server.api_request("DELETE", f"/api/agents/{target_agent}")

--- a/tests/integration/test_workspace_running_config.py
+++ b/tests/integration/test_workspace_running_config.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+"""HTTP smoke tests for workspace running_config (global + agent-scoped)."""
+from __future__ import annotations
+
+
+import pytest
+
+
+_AGENT_PROFILE_TOP_LEVEL_KEYS = (
+    "channels",
+    "mcp",
+    "heartbeat",
+    "running",
+    "llm_routing",
+    "system_prompt_files",
+    "tools",
+    "plan",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_api_workspace_running_config_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify workspace running-config supports update and readback for the
+      active agent context.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET /api/workspace/running-config as baseline.
+    3. PUT /api/workspace/running-config with a toggled max_iters value.
+    4. GET /api/workspace/running-config and verify update is persisted.
+    5. Restore baseline value and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/workspace/running-config
+    - PUT /api/workspace/running-config
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_ws_running_cfg_01"
+    headers = {"X-Agent-Id": agent_id}
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Workspace running config agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    try:
+        get_before = app_server.api_request(
+            "GET",
+            "/api/workspace/running-config",
+            headers=headers,
+        )
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "max_iters" in baseline
+
+        updated = dict(baseline)
+        old_max_iters = int(updated.get("max_iters", 100))
+        updated["max_iters"] = (
+            old_max_iters + 1 if old_max_iters < 1000 else old_max_iters - 1
+        )
+
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/workspace/running-config",
+            headers=headers,
+            json=updated,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("max_iters") == updated["max_iters"]
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/workspace/running-config",
+            headers=headers,
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("max_iters") == updated["max_iters"]
+    finally:
+        if isinstance(baseline, dict):
+            restore_resp = app_server.api_request(
+                "PUT",
+                "/api/workspace/running-config",
+                headers=headers,
+                json=baseline,
+            )
+            assert restore_resp.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_api_agent_scoped_workspace_running_config_put_get_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify agent-scoped workspace running-config endpoint supports update and
+      readback via /api/agents/{agentId}/workspace/running-config.
+
+    Test flow:
+    1. Create a dedicated test agent.
+    2. GET agent-scoped running-config as baseline.
+    3. PUT agent-scoped running-config with a changed max_iters value.
+    4. GET again and assert the value is persisted.
+    5. Restore baseline and delete test agent.
+
+    API endpoints:
+    - POST /api/agents
+    - GET /api/agents/{agentId}/workspace/running-config
+    - PUT /api/agents/{agentId}/workspace/running-config
+    - DELETE /api/agents/{agentId}
+    """
+    agent_id = "integ_scoped_ws_running_cfg_01"
+    base = f"/api/agents/{agent_id}/workspace/running-config"
+
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Scoped workspace running config agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    baseline = None
+    try:
+        get_before = app_server.api_request("GET", base)
+        assert get_before.status_code == 200, app_server.logs_tail()
+        baseline = get_before.json()
+        assert isinstance(baseline, dict)
+        assert "max_iters" in baseline
+
+        updated = dict(baseline)
+        old_max_iters = int(updated.get("max_iters", 100))
+        updated["max_iters"] = (
+            old_max_iters + 2 if old_max_iters < 999 else old_max_iters - 2
+        )
+
+        put_resp = app_server.api_request("PUT", base, json=updated)
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("max_iters") == updated["max_iters"]
+
+        get_after = app_server.api_request("GET", base)
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert get_after.json().get("max_iters") == updated["max_iters"]
+    finally:
+        if isinstance(baseline, dict):
+            restore_resp = app_server.api_request("PUT", base, json=baseline)
+            assert restore_resp.status_code == 200, app_server.logs_tail()
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")


### PR DESCRIPTION
## Description

Refactors and expands the integration test suite under `tests/integration/`, taking it from 4 files / ~10 cases to 23 files / **105 cases** organized by business subdomain. The fixture infrastructure is rewritten for performance (module-scoped) and reliability (15s timeout, platform-aware teardown, UTF-8 stdio, subprocess coverage support). Cases are tagged `p0`/`p1`/`p2` by user-facing impact for selective CI runs. Bilingual READMEs document running, decision rules, and how to add new tests.

**Related Issue:** N/A (broader test infrastructure work; happy to file a tracking issue if maintainers prefer that flow).

**Security Considerations:** \`conftest.py\` sanitizes 11 sensitive environment variables (\`OPENAI_API_KEY\`, \`DASHSCOPE_API_KEY\`, IM tokens, etc.) before launching the app subprocess and forces \`QWENPAW_AUTH_ENABLED=false\`. No real API keys or external services are exercised by the suite.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran \`pre-commit run --all-files\` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (\`pytest\` or as relevant) and they pass
- [x] Documentation updated (bilingual READMEs added under \`tests/integration/\`)
- [x] Verified across the full CI matrix in advance (Linux py3.10/py3.13, macOS py3.10, Windows py3.10) — see *Local Verification Evidence*
- [x] Ready for review

## Testing

\`\`\`bash
# Full integration suite
pytest tests/integration/ --no-cov

# By priority
pytest tests/integration/ -m p0 --no-cov   # ~2 min, PR smoke gate
pytest tests/integration/ -m p1 --no-cov   # nightly regression
pytest tests/integration/ -m p2 --no-cov   # error paths and contracts
\`\`\`

See \`tests/integration/README.md\` for the full guide (priority decision rule, layout, fixture details, subprocess coverage mode, adding new tests, known constraints).

## Local Verification Evidence

**pre-commit (local, macOS py3.13):**

\`\`\`
pre-commit run --all-files
... (15 hooks all Passed)
\`\`\`

**pytest (local, macOS py3.13):**

\`\`\`
pytest tests/integration/ --no-cov
============== 105 passed in 162.39s (0:02:42) ==============
\`\`\`

**Pre-flight CI matrix on fork (https://github.com/yutai78786/QwenPaw/pull/3) — all green:**

| Job                                          | Result | Duration |
| -------------------------------------------- | ------ | -------- |
| Integrated Tests — py3.10 — ubuntu-latest    | ✅      | 8m21s    |
| Integrated Tests — py3.13 — ubuntu-latest    | ✅      | 8m37s    |
| Integrated Tests — py3.10 — macos-latest     | ✅      | 8m24s    |
| Integrated Tests — py3.10 — windows-latest   | ✅      | 12m25s   |
| Unit Tests (4 jobs across same matrix)       | ✅      | —        |
| Coverage Report                              | ✅      | 10m26s   |
| Test Summary                                 | ✅      | —        |

## Additional Notes

**Why this PR is large (~7100 lines / 27 files):**
Unlike adding a single test, this PR delivers an integration-test infrastructure (fixture rewrite + priority markers + bilingual docs + 19 new test files spanning 16 business subdomains) as a coherent unit. Splitting into many small PRs would either share an unfinished \`conftest.py\` across PRs (causing churn) or land tests against an old fixture that doesn't yet support the new module-scope contract. A single bundled PR was deemed lower review cost overall, with commits structured by topic (markers / fixture / suite / docs / Windows fixes) so reviewers can navigate by commit.

**Windows compatibility issues discovered and fixed pre-flight (commits \`8d49cc15\` and \`fb3adc8a\`):**

These could not be caught by macOS local development; running the \`tests.yml\` matrix on a fork before opening this PR uncovered two distinct Windows-specific issues, both fixed:

1. **\`SIGINT\` is unreliable on Windows.** \`process.send_signal(SIGINT)\` raised an exception not caught by the \`subprocess.TimeoutExpired\` handler, which then triggered \`Popen.__exit__\`'s unbounded \`process.wait()\`, hanging the fixture indefinitely. Fixed by branching on \`sys.platform\` to use \`process.terminate()\` on Windows.
2. **\`UnicodeDecodeError\` in \`_tee_stream\` and \`\\r\\n\` vs \`\\n\` in file preview test.** \`Popen(text=True)\` defaulted to cp1252 on Windows, crashing the daemon stdout reader when uvicorn emitted non-cp1252 bytes. Separately, \`Path.write_text\` translated \`\\n\` to \`\\r\\n\` in text mode, breaking a byte-level assertion in one preview test. Fixed by pinning \`Popen\` to \`encoding=\"utf-8\", errors=\"replace\"\` plus \`PYTHONIOENCODING=utf-8\` for the subprocess, and switching the failing test to \`write_bytes\`.

**Out of scope (deliberately, follow-ups):**

- No changes to \`.github/workflows/tests.yml\`. The current matrix still runs the **full** suite per PR (not just \`p0\`). Selective per-priority runs (\`p0\` on every PR, \`p1\`+\`p2\` nightly) is a follow-up that needs maintainer alignment.
- No \`pytest-xdist\` parallel support. Subprocess coverage mode is single-worker by design.
- No real LLM call coverage (messaging tests use the \`console\` channel only).
- No real IM channel I/O coverage (channels are tested at the config layer only).
- No coverage for \`approval\` router, \`skills_stream\` SSE, real \`cron\` triggering, or the audio/voice flow. Tracked as known gaps to address incrementally.