### PR TITLE
fix(auth): resolve real client IP from proxy headers in auth bypass check

### DIFF
--- a/src/qwenpaw/app/auth.py
+++ b/src/qwenpaw/app/auth.py
@@ -567,6 +567,17 @@ def revoke_all_tokens() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_client_ip(request: Request) -> str:
+    """Return the real client IP, respecting reverse-proxy headers."""
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    real_ip = request.headers.get("x-real-ip", "")
+    if real_ip:
+        return real_ip.strip()
+    return request.client.host if request.client else ""
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Middleware that checks Bearer token on protected routes."""
 
@@ -623,7 +634,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # Check if client host is in allow_no_auth_hosts whitelist
         from ..config import load_config
 
-        client_host = request.client.host if request.client else ""
+        client_host = _resolve_client_ip(request)
         config = load_config()
         allowed_hosts = config.security.allow_no_auth_hosts
         return client_host in allowed_hosts


### PR DESCRIPTION
## Description

Use `X-Forwarded-For / X-Real-IP` to determine the real client IP when checking the `allow_no_auth_hosts` whitelist, so that reverse-proxied requests are not misidentified as localhost.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
