### PR TITLE
feat(context): add file block processing in message handler

### DIFF
--- a/src/qwenpaw/agents/context/as_msg_handler.py
+++ b/src/qwenpaw/agents/context/as_msg_handler.py
@@ -145,6 +145,20 @@ class AsMsgHandler:
                     ),
                 )
 
+            elif block_type == "file":
+                file_path = block.get("path", "") or block.get("url", "")
+                file_name = block.get("name", file_path)
+                text = f"[file] {file_name}: {file_path}"
+                token_count = await self.count_str_token(file_path)
+                blocks.append(
+                    AsBlockStat(
+                        block_type=block_type,
+                        text=text,
+                        token_count=token_count,
+                        media_url=file_path,
+                    ),
+                )
+
             elif block_type == "tool_use":
                 tool_name = block.get("name", "")
                 tool_input = block.get("input", "")

--- a/src/qwenpaw/agents/context/as_msg_handler.py
+++ b/src/qwenpaw/agents/context/as_msg_handler.py
@@ -51,7 +51,7 @@ class AsMsgHandler:
                         textual_parts[-1],
                     )
 
-                elif block_type in ["image", "audio", "video"]:
+                elif block_type in ["image", "audio", "video", "file"]:
                     source = block.get("source", {})
                     if source.get("type") == "base64":
                         data = source.get("data", "")
@@ -62,12 +62,6 @@ class AsMsgHandler:
                             await self.count_str_token(url) if url else 10
                         )
                         textual_parts.append(f"[{block_type}] {url}")
-
-                elif block_type == "file":
-                    file_path = block.get("path", "") or block.get("url", "")
-                    file_name = block.get("name", file_path)
-                    textual_parts.append(f"[file] {file_name}: {file_path}")
-                    total_token_count += await self.count_str_token(file_path)
 
                 else:
                     logger.warning(
@@ -126,7 +120,7 @@ class AsMsgHandler:
                     ),
                 )
 
-            elif block_type in ("image", "audio", "video"):
+            elif block_type in ("image", "audio", "video", "file"):
                 source = block.get("source", {})
                 url = source.get("url", "")
                 if source.get("type") == "base64":
@@ -142,20 +136,6 @@ class AsMsgHandler:
                         text="",
                         token_count=token_count,
                         media_url=url,
-                    ),
-                )
-
-            elif block_type == "file":
-                file_path = block.get("path", "") or block.get("url", "")
-                file_name = block.get("name", file_path)
-                text = f"[file] {file_name}: {file_path}"
-                token_count = await self.count_str_token(file_path)
-                blocks.append(
-                    AsBlockStat(
-                        block_type=block_type,
-                        text=text,
-                        token_count=token_count,
-                        media_url=file_path,
                     ),
                 )
 

--- a/src/qwenpaw/agents/context/as_msg_stat.py
+++ b/src/qwenpaw/agents/context/as_msg_stat.py
@@ -75,7 +75,7 @@ class AsBlockStat(BaseModel):
             if not include_thinking or not self.text:
                 return ""
             return f"[think]: {self._truncate(self.text, max_length)}"
-        if self.block_type in ("image", "audio", "video"):
+        if self.block_type in ["image", "audio", "video", "file"]:
             content = self.media_url if self.media_url else ""
             return f"[{self.block_type}]: {content}"
         if self.block_type == "tool_use":


### PR DESCRIPTION
- Implemented file block type handling with path and name extraction
- Added token counting for file paths using count_str_token method
- Created AsBlockStat instances for file blocks with proper formatting
- Included media_url field with file path for file block types
- Added formatted text display showing [file] label with name and path

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
