### PR TITLE
feat(sec): add user deny info in tool response

### DIFF
--- a/src/qwenpaw/agents/tool_guard_mixin.py
+++ b/src/qwenpaw/agents/tool_guard_mixin.py
@@ -391,6 +391,7 @@ class ToolGuardMixin:
             f"- {tg('tool')}: `{tool_name}`\n"
             f"- {tg('severity')}: `{severity}`\n"
             f"- {tg('findings')}: `{count}`\n\n"
+            f"⚠️ **System instruction**: {tg('instruction_no_retry')}\n\n"
             f"{findings_text}\n\n"
             f"{tg('blocked_footer')}"
         )
@@ -708,6 +709,7 @@ class ToolGuardMixin:
             f"🚫 **{tg('tool_blocked')}**\n\n"
             f"- {tg('tool')}: `{tool_name}`\n"
             f"- {tg('reason')}: {tg('reason_denied')}\n\n"
+            f"⚠️ **System instruction**: {tg('instruction_no_retry')}\n\n"
             f"{findings_text}"
         )
 

--- a/src/qwenpaw/security/tool_guard/i18n.py
+++ b/src/qwenpaw/security/tool_guard/i18n.py
@@ -17,6 +17,10 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "parameters": "Parameters",
         "reason": "Reason",
         "reason_denied": "User denied execution",
+        "instruction_no_retry": (
+            "This specific tool call has been denied. Do not retry this "
+            "call or attempt alternative methods to complete it."
+        ),
         "reason_timeout": "Approval timeout after {timeout}s, auto-denied",
         "approve_hint": (
             "Type `/approve` to approve, or send any message to deny."
@@ -60,6 +64,7 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "parameters": "参数",
         "reason": "原因",
         "reason_denied": "用户拒绝执行",
+        "instruction_no_retry": ("此次工具调用已被拒绝。请不要重试该调用，也不要尝试其他方法来完" "成这一次调用。"),
         "reason_timeout": "审批超时（{timeout}秒），自动拒绝",
         "approve_hint": "输入 `/approve` 批准执行，或发送任意消息拒绝。",
         "blocked_footer": "该工具已被禁止，无法批准执行。",
@@ -94,6 +99,11 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "parameters": "Параметры",
         "reason": "Причина",
         "reason_denied": "Пользователь отклонил выполнение",
+        "instruction_no_retry": (
+            "Этот вызов инструмента отклонен. Не повторяйте его и не "
+            "пытайтесь завершить именно этот вызов альтернативными "
+            "способами."
+        ),
         "reason_timeout": (
             "Время подтверждения истекло ({timeout}с), "
             "автоматически отклонено"
@@ -142,6 +152,11 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "parameters": "パラメータ",
         "reason": "理由",
         "reason_denied": "ユーザーが実行を拒否しました",
+        "instruction_no_retry": (
+            "このツール呼び出しは拒否されました。この呼び出しを再試行した"
+            "り、代替手段でこの呼び出しを完了しようとしたりしないでくださ"
+            "い。"
+        ),
         "reason_timeout": "承認がタイムアウトしました（{timeout}秒）、自動拒否",
         "approve_hint": ("`/approve` と入力して承認するか、" "拒否するには任意のメッセージを送信してください。"),
         "blocked_footer": ("このツールはブロックされており、承認できません。"),

--- a/src/qwenpaw/security/tool_guard/i18n.py
+++ b/src/qwenpaw/security/tool_guard/i18n.py
@@ -18,7 +18,7 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "reason": "Reason",
         "reason_denied": "User denied execution",
         "instruction_no_retry": (
-            "This specific tool call has been denied. Do not retry this "
+            "This specific tool call has been denied by the user. Do not retry this "
             "call or attempt alternative methods to complete it."
         ),
         "reason_timeout": "Approval timeout after {timeout}s, auto-denied",
@@ -64,7 +64,7 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "parameters": "参数",
         "reason": "原因",
         "reason_denied": "用户拒绝执行",
-        "instruction_no_retry": ("此次工具调用已被拒绝。请不要重试该调用，也不要尝试其他方法来完" "成这一次调用。"),
+        "instruction_no_retry": ("用户已拒绝此次工具调用。请不要重试该调用，也不要尝试其他方法来完成这一次调用。"),
         "reason_timeout": "审批超时（{timeout}秒），自动拒绝",
         "approve_hint": "输入 `/approve` 批准执行，或发送任意消息拒绝。",
         "blocked_footer": "该工具已被禁止，无法批准执行。",
@@ -100,8 +100,8 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "reason": "Причина",
         "reason_denied": "Пользователь отклонил выполнение",
         "instruction_no_retry": (
-            "Этот вызов инструмента отклонен. Не повторяйте его и не "
-            "пытайтесь завершить именно этот вызов альтернативными "
+            "Пользователь отклонил этот вызов инструмента. Не повторяйте его "
+            "и не пытайтесь завершить именно этот вызов альтернативными "
             "способами."
         ),
         "reason_timeout": (
@@ -153,9 +153,9 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "reason": "理由",
         "reason_denied": "ユーザーが実行を拒否しました",
         "instruction_no_retry": (
-            "このツール呼び出しは拒否されました。この呼び出しを再試行した"
-            "り、代替手段でこの呼び出しを完了しようとしたりしないでくださ"
-            "い。"
+            "ユーザーがこのツール呼び出しを拒否しました。この呼び出しを再試行"
+            "したり、代替手段でこの呼び出しを完了しようとしたりしないでく"
+            "ださい。"
         ),
         "reason_timeout": "承認がタイムアウトしました（{timeout}秒）、自動拒否",
         "approve_hint": ("`/approve` と入力して承認するか、" "拒否するには任意のメッセージを送信してください。"),

--- a/src/qwenpaw/security/tool_guard/i18n.py
+++ b/src/qwenpaw/security/tool_guard/i18n.py
@@ -18,8 +18,9 @@ _TOOL_GUARD_I18N: dict[str, dict[str, str]] = {
         "reason": "Reason",
         "reason_denied": "User denied execution",
         "instruction_no_retry": (
-            "This specific tool call has been denied by the user. Do not retry this "
-            "call or attempt alternative methods to complete it."
+            "This specific tool call has been denied by the user. "
+            "Do not retry this call or attempt alternative methods "
+            "to complete it."
         ),
         "reason_timeout": "Approval timeout after {timeout}s, auto-denied",
         "approve_hint": (


### PR DESCRIPTION
## Description

When a tool call is blocked (auto-deny or user `/approval deny`), the `tool_result` written to memory now includes a **System instruction**: the denied call must not be retried as-is and must not be completed via alternate means for that same invocation—reducing repeated attempts after rejection.

**Related Issue:** Relates to #(issue_number)

**Security Considerations:** Copy-only guidance text and i18n; no auth, secrets, or new external surfaces. Enforcement remains the existing tool guard / approval flow.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] N/A — no channel changes

## Testing

1. **User deny:** Trigger an approval-required tool → `/approval deny` → confirm the corresponding `tool_result` includes the System instruction (verify locale via agent language).
2. **Auto-deny:** Trigger auto-deny (deny list / guard rules) → confirm the same instruction appears on the blocked `tool_result`.

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result