### PR TITLE
test(provider): add fixture to isolate provider data during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from qwenpaw.providers import provider_manager as _provider_manager_module
+
 # =============================================================================
 # Third-Party Library Mocks
 # =============================================================================
@@ -428,3 +430,27 @@ def pytest_collection_modifyitems(
         #   - s_module: ["utils/tokenizer", "security/tool_guard"]
         #   - c_module: ["channels/dingtalk", "channels/feishu"]
         # This allows module classification to evolve without code changes.
+
+
+# =============================================================================
+# Provider Isolation
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def isolated_secret_dir(monkeypatch, tmp_path):
+    """Isolate all tests from real disk provider data.
+
+    ProviderManager._init_from_storage reads persisted configs and mutates
+    global provider singletons (e.g. base_url when freeze_url=False).
+    This fixture ensures every test uses a clean temporary directory and
+    a fresh ProviderManager singleton.
+    """
+    secret_dir = tmp_path / ".qwenpaw.secret"
+    monkeypatch.setattr(_provider_manager_module, "SECRET_DIR", secret_dir)
+    monkeypatch.setattr(
+        _provider_manager_module.ProviderManager,
+        "_instance",
+        None,
+    )
+    return secret_dir


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
