### PR TITLE
fix(console): chatSession

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -62,8 +62,19 @@ vi.mock("@/api/modules/chat", () => ({
 }));
 
 vi.mock("../../sessionApi", () => ({
-  default: { getSessionList: mockGetSessionList },
+  default: {
+    getSessionList: mockGetSessionList,
+    isSessionSwitching: false,
+    preloadSession: vi.fn().mockResolvedValue({ session: {}, realId: null }),
+    finishSessionSwitch: vi.fn(),
+    lastNavigatedChatId: null,
+  },
 }));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => vi.fn() };
+});
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (k: string) => k }),

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useNavigate } from "react-router-dom";
 import { Drawer, Spin, Tooltip } from "antd";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { IconButton } from "@agentscope-ai/design";
@@ -38,6 +39,8 @@ const ITEM_HEIGHT = 77;
 interface SessionRowData {
   sortedSessions: ExtendedChatSession[];
   currentSessionId: string | undefined;
+  /** When non-null, a session switch is in progress and other items are disabled */
+  switchingSessionId: string | null;
   editingSessionId: string | null;
   editValue: string;
   t: ReturnType<typeof useTranslation>["t"];
@@ -64,6 +67,9 @@ const SessionRow = React.memo(function SessionRow({
     : undefined;
   const isEditing = data.editingSessionId === session.id;
 
+  const isDisabled =
+    !!data.switchingSessionId && session.id !== data.switchingSessionId;
+
   return (
     <div style={style}>
       <ChatSessionItem
@@ -76,6 +82,7 @@ const SessionRow = React.memo(function SessionRow({
         generating={session.generating}
         pinned={session.pinned}
         active={session.id === data.currentSessionId}
+        disabled={isDisabled}
         editing={isEditing}
         editValue={isEditing ? data.editValue : undefined}
         onClick={data.handleSessionClick}
@@ -138,6 +145,7 @@ const getBackendId = (session: ExtendedChatSession): string | null => {
 
 const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { sessions, currentSessionId, setCurrentSessionId, setSessions } =
     useChatAnywhereSessionsState();
 
@@ -263,11 +271,54 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     };
   }, [props.open, setSessions]);
 
+  /** Whether a session switch is in progress (issue #4557) */
+  const [switchingSessionId, setSwitchingSessionId] = useState<string | null>(
+    null,
+  );
+
   const handleSessionClick = useCallback(
     (sessionId: string) => {
-      setCurrentSessionId(sessionId);
+      // Block clicks while a switch is in progress.
+      if (sessionApi.isSessionSwitching) return;
+      if (sessionId === currentSessionId) return;
+
+      // Lock immediately (synchronous) before any async work.
+      sessionApi.isSessionSwitching = true;
+      setSwitchingSessionId(sessionId);
+
+      // 1) Pre-load session data (network request happens here).
+      // 2) Navigate to the correct URL (using realId if available).
+      // 3) Only THEN set currentSessionId so the library's useAsyncEffect
+      //    hits the result cache instead of making another request.
+      // 4) Keep lock held until the next React render cycle completes.
+      sessionApi
+        .preloadSession(sessionId)
+        .then(({ realId }) => {
+          const targetUrl = `/chat/${realId || sessionId}`;
+          sessionApi.lastNavigatedChatId = realId || sessionId;
+          navigate(targetUrl, { replace: true });
+          // Now set currentSessionId — the library's getSession will hit cache.
+          setCurrentSessionId(sessionId);
+        })
+        .catch(() => {
+          // On error, still try to switch normally.
+          setCurrentSessionId(sessionId);
+        })
+        .then(() => {
+          // Wait two animation frames so React commits + runs effects,
+          // ensuring ChatSessionInitializer's effect has been skipped.
+          return new Promise<void>((resolve) => {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => resolve());
+            });
+          });
+        })
+        .finally(() => {
+          sessionApi.finishSessionSwitch();
+          setSwitchingSessionId(null);
+        });
     },
-    [setCurrentSessionId],
+    [currentSessionId, setCurrentSessionId, navigate],
   );
 
   /** Delete a session: call deleteChat API then refresh the list */
@@ -413,6 +464,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     () => ({
       sortedSessions: sortedSessions as ExtendedChatSession[],
       currentSessionId,
+      switchingSessionId,
       editingSessionId,
       editValue,
       t,
@@ -428,6 +480,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     [
       sortedSessions,
       currentSessionId,
+      switchingSessionId,
       editingSessionId,
       editValue,
       t,
@@ -504,7 +557,11 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       </div>
 
       {/* Session list */}
-      <div className={styles.listWrapper} ref={listWrapperRef}>
+      <div
+        className={styles.listWrapper}
+        ref={listWrapperRef}
+        style={switchingSessionId ? { pointerEvents: "none" } : undefined}
+      >
         <div className={styles.topGradient} />
         {listLoading ? (
           <div

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
+import sessionApi from "../../sessionApi";
 
 /**
  * URL chatId → context currentSessionId (one direction of bidirectional sync).
@@ -33,6 +34,22 @@ const ChatSessionInitializer: React.FC = () => {
 
   useEffect(() => {
     if (!chatId || !sessions.length) return;
+
+    // Issue #4557: Do NOT trigger setCurrentSessionId while a user-initiated
+    // session switch is in progress. This breaks the infinite loop where
+    // onSessionSelected → navigate → this effect → setCurrentSessionId →
+    // library getSession → onSessionSelected → …
+    if (sessionApi.isSessionSwitching) return;
+
+    // If onSessionSelected already navigated to this chatId, skip.
+    // This prevents the displayId→realId URL change from triggering
+    // an unnecessary setCurrentSessionId(realId) that would cause
+    // a redundant getSession call (issue #4557).
+    if (sessionApi.lastNavigatedChatId === chatId) {
+      lastAppliedChatIdRef.current = chatId;
+      sessionApi.lastNavigatedChatId = null;
+      return;
+    }
 
     // If we already applied this exact chatId and the context is in sync, skip.
     // This prevents the polling-triggered sessions refresh (pinned drawer)

--- a/console/src/pages/Chat/components/ChatSessionItem/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionItem/index.module.less
@@ -57,6 +57,12 @@
     background: var(--color-fill-tertiary, rgba(43, 18, 0, 0.03));
   }
 
+  &.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
   // Reserve right-side padding for the edit input in editing mode
   &.editing {
     .content {

--- a/console/src/pages/Chat/components/ChatSessionItem/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionItem/index.tsx
@@ -27,6 +27,8 @@ interface ChatSessionItemProps {
   generating?: boolean;
   /** Whether this is the currently selected session */
   active?: boolean;
+  /** Whether clicks are disabled (e.g. during session switch) */
+  disabled?: boolean;
   /** Whether the item is in inline-edit mode */
   editing?: boolean;
   /** Current value of the edit input */
@@ -65,8 +67,9 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
     : t("chat.statusIdle");
 
   const handleClick = useCallback(() => {
+    if (props.disabled) return;
     props.onClick?.(props.sessionId);
-  }, [props.onClick, props.sessionId]);
+  }, [props.onClick, props.sessionId, props.disabled]);
 
   const handleEdit = useCallback(
     (event: React.MouseEvent) => {
@@ -102,6 +105,7 @@ const ChatSessionItem: React.FC<ChatSessionItemProps> = (props) => {
   const className = [
     styles.chatSessionItem,
     props.active ? styles.active : "",
+    props.disabled ? styles.disabled : "",
     props.editing ? styles.editing : "",
     props.pinned ? styles.pinned : "",
     props.className || "",

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -211,7 +211,7 @@ function useIMEComposition(isChatActive: () => boolean) {
 function useMultimodalCapabilities(
   refreshKey: number,
   locationPathname: string,
-  isChatActive: () => boolean,
+  _isChatActive: () => boolean,
   selectedAgent: string,
 ) {
   const [multimodalCaps, setMultimodalCaps] = useState<{
@@ -284,12 +284,20 @@ function useMultimodalCapabilities(
     fetchMultimodalCaps();
   }, [fetchMultimodalCaps, refreshKey]);
 
-  // Also poll caps when navigating back to chat
+  // Re-sync caps only when navigating FROM a non-chat page back to chat.
+  // Do NOT re-fetch when switching between sessions (e.g. /chat/A → /chat/B)
+  // because the agent/model config hasn't changed — avoids unnecessary
+  // models + active API calls on every session switch.
+  const prevChatPathRef = useRef(locationPathname);
   useEffect(() => {
-    if (isChatActive()) {
+    const prev = prevChatPathRef.current;
+    prevChatPathRef.current = locationPathname;
+    const wasOutsideChat = !prev.startsWith("/chat");
+    const isNowInChat = locationPathname.startsWith("/chat");
+    if (wasOutsideChat && isNowInChat) {
       fetchMultimodalCaps();
     }
-  }, [locationPathname, fetchMultimodalCaps, isChatActive]);
+  }, [locationPathname, fetchMultimodalCaps]);
 
   // Listen for model-switched event from ModelSelector
   useEffect(() => {
@@ -779,6 +787,12 @@ export default function ChatPage() {
       realId: string | null,
     ) => {
       if (!isChatActiveRef.current) return;
+
+      // Issue #4557: When a user-initiated session switch is in progress,
+      // handleSessionClick owns the navigate call. Do NOT navigate here
+      // to avoid race conditions and infinite loops.
+      if (sessionApi.isSessionSwitching) return;
+
       // Update URL when session is selected and different from current
       const targetId = realId || sessionId;
       if (!targetId) return;
@@ -808,6 +822,7 @@ export default function ChatPage() {
 
       if (targetId !== lastSessionIdRef.current) {
         lastSessionIdRef.current = targetId;
+        sessionApi.lastNavigatedChatId = targetId;
         navigateRef.current(`/chat/${targetId}`, { replace: true });
       }
     };

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -406,9 +406,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    * Used by handleSessionClick to load data BEFORE setting currentSessionId,
    * so the library's automatic getSession call hits the result cache.
    */
-  async preloadSession(
-    sessionId: string,
-  ): Promise<{
+  async preloadSession(sessionId: string): Promise<{
     session: IAgentScopeRuntimeWebUISession;
     realId: string | null;
   }> {

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -386,6 +386,61 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    */
   preferredChatId: string | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Session switch lock (issue #4557)
+  // Prevents rapid session switching from causing infinite loops by blocking
+  // all clicks until the current switch completes (data loaded + URL updated).
+  // ---------------------------------------------------------------------------
+
+  /** Whether a session switch is currently in progress. */
+  isSessionSwitching = false;
+
+  /** Short-lived result cache so the library's subsequent getSession call
+   *  (triggered by setCurrentSessionId → useAsyncEffect) can reuse the
+   *  already-fetched session without making another network request. */
+  private sessionResultCache: Map<string, IAgentScopeRuntimeWebUISession> =
+    new Map();
+
+  /**
+   * Pre-load a session's data. Returns the session with its realId resolved.
+   * Used by handleSessionClick to load data BEFORE setting currentSessionId,
+   * so the library's automatic getSession call hits the result cache.
+   */
+  async preloadSession(
+    sessionId: string,
+  ): Promise<{
+    session: IAgentScopeRuntimeWebUISession;
+    realId: string | null;
+  }> {
+    this.isSessionSwitching = true;
+    try {
+      const session = await this.getSession(sessionId);
+      const extendedSession = session as ExtendedSession;
+      const realId = extendedSession.realId || null;
+
+      // Cache the result so subsequent getSession calls return immediately.
+      this.sessionResultCache.set(sessionId, session);
+      if (realId) {
+        this.sessionResultCache.set(realId, session);
+      }
+      // Clear cache after 3s (enough for the library's useAsyncEffect to fire).
+      setTimeout(() => {
+        this.sessionResultCache.delete(sessionId);
+        if (realId) this.sessionResultCache.delete(realId);
+      }, 3000);
+
+      return { session, realId };
+    } catch (error) {
+      this.isSessionSwitching = false;
+      throw error;
+    }
+  }
+
+  /** Called after navigate + setCurrentSessionId are both done. */
+  finishSessionSwitch(): void {
+    this.isSessionSwitching = false;
+  }
+
   /**
    * Cache the latest user message for a chat so it can be patched into
    * history during reconnect (the backend only persists it after generation
@@ -432,6 +487,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   onSessionSelected:
     | ((sessionId: string | null | undefined, realId: string | null) => void)
     | null = null;
+
+  /**
+   * The last chatId that onSessionSelected navigated to. ChatSessionInitializer
+   * checks this to avoid re-triggering setCurrentSessionId for a URL change
+   * that was already handled by onSessionSelected (issue #4557).
+   */
+  lastNavigatedChatId: string | null = null;
 
   /**
    * Called when a new session is created.
@@ -595,10 +657,18 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     return this.sessionListRequest;
   }
 
-  /** Track the last session ID that triggered onSessionSelected to avoid duplicate calls. */
-  private lastSelectedSessionId: string | null = null;
+  /**
+   * Track both displayId and realId of the last selected session to avoid
+   * duplicate onSessionSelected calls when the same session is loaded via
+   * either its displayId or realId (issue #4557).
+   */
+  private lastSelectedIds: Set<string> = new Set();
 
   async getSession(sessionId: string) {
+    // Check short-lived result cache first (populated by preloadSession).
+    const cached = this.sessionResultCache.get(sessionId);
+    if (cached) return cached;
+
     const existingRequest = this.sessionRequests.get(sessionId);
     if (existingRequest) return existingRequest;
 
@@ -607,11 +677,16 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     try {
       const session = await requestPromise;
-      // Trigger onSessionSelected only when session actually changes
-      if (sessionId !== this.lastSelectedSessionId) {
-        this.lastSelectedSessionId = sessionId;
-        const extendedSession = session as ExtendedSession;
-        const realId = extendedSession.realId || null;
+      const extendedSession = session as ExtendedSession;
+      const realId = extendedSession.realId || null;
+
+      // Only trigger onSessionSelected if neither the displayId nor the
+      // realId has already been selected. This prevents the infinite loop
+      // where displayId and realId alternate triggering onSessionSelected.
+      if (!this.lastSelectedIds.has(sessionId)) {
+        this.lastSelectedIds.clear();
+        this.lastSelectedIds.add(sessionId);
+        if (realId) this.lastSelectedIds.add(realId);
         this.onSessionSelected?.(sessionId, realId);
       }
       return session;


### PR DESCRIPTION
## Description

Infinite Loop: Internally, the `useChatAnywhereSessionLoader` uses `useAsyncEffect([currentSessionId])` to automatically call `getSession`. The same session has two IDs: `displayId` (timestamp ID) and `realId` (backend UUID). This triggers an alternating loop: `onSessionSelected → navigate → ChatSessionInitializer → setCurrentSessionId → getSession again → infinite loop`.

Redundant API Requests: The `useMultimodalCapabilities` hook has an effect that depends on `locationPathname`. Every time the URL changes from `/chat/A` to `/chat/B` (session switching), it triggers a `models + active` request. However, the agent/model configuration remains unchanged when switching sessions, so no new requests are needed.

## Sloution

The `handleSessionClick` function overrides the synchronous locking mechanism on click, setting `isSessionSwitching=true`. It first loads the `preloadSession` to obtain the `realId`, then manually navigates to the correct URL, and finally sets the `setCurrentSessionId`. Unlock after two rAFs.

If `onSessionSelected` checks `isSessionSwitching` as true, return directly without triggering `navigate`.

`sessionResultCache` is a short-term cache. The result is cached for 3 seconds after `preloadSession` completes. Subsequent `getSession` calls from the library will return directly if the cache is hit, without triggering `onSessionSelected`.

`lastSelectedIds` sets duplicates and remembers both `displayId` and `realId` to prevent alternating triggering of dual IDs.

`lastNavigatedChatId` is checked by `ChatSessionInitializer` to skip processed URL changes.

`ChatSessionInitializer` lock checks `isSessionSwitching` to prevent URL changes from being handled.

List container pointer-events: none disables mouse events for the entire list container during the lock period.

`ChatSessionItem disabled` sets the style of a single item to disabled.

The `useMultimodalCapabilities` effect has been changed to only request `models + active` when returning to `/chat` from a page other than `/chat`, and will no longer be triggered when switching sessions within `chat`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

Fixes #4557

