### PR TITLE
fix(WeChat): fix message dedup bypass and infinite retry on expired context_token

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -22,6 +22,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -52,6 +53,9 @@ logger = logging.getLogger(__name__)
 
 # Max dedup set size
 _WECHAT_PROCESSED_IDS_MAX = 2000
+
+# Time window (seconds) for content-based dedup (same user + same text)
+_TEXT_DEDUP_TTL = 30.0
 
 # Default token file path
 _DEFAULT_TOKEN_FILE = WORKING_DIR / "wechat_bot_token"
@@ -145,6 +149,9 @@ class WeChatChannel(BaseChannel):
         # Message dedup (context_token or derived id)
         self._processed_ids: OrderedDict[str, None] = OrderedDict()
         self._processed_ids_lock = threading.Lock()
+
+        # Content-based dedup: {user_id:content_hash -> timestamp}
+        self._text_dedup: OrderedDict[str, float] = OrderedDict()
 
         # Cache last context_token per user for proactive sends
         self._user_context_tokens: Dict[str, str] = {}
@@ -437,6 +444,26 @@ class WeChatChannel(BaseChannel):
                 self._processed_ids.popitem(last=False)
         return False
 
+    def _is_text_duplicate(self, from_user_id: str, text: str) -> bool:
+        """Content-based dedup within a short time window.
+
+        Catches duplicates that slip past ``_is_duplicate`` when the iLink
+        API delivers the same message across two polls with different
+        ``context_token`` / ``msg_id`` values.
+        """
+        content_hash = hashlib.md5(text.encode()).hexdigest()[:16]
+        key = f"{from_user_id}:{content_hash}"
+        now = time.time()
+        with self._processed_ids_lock:
+            prev_time = self._text_dedup.get(key)
+            if prev_time is not None and now - prev_time < _TEXT_DEDUP_TTL:
+                return True
+            self._text_dedup[key] = now
+            # Evict old entries to bound memory
+            while len(self._text_dedup) > _WECHAT_PROCESSED_IDS_MAX:
+                self._text_dedup.popitem(last=False)
+        return False
+
     # ------------------------------------------------------------------
     # QR code login
     # ------------------------------------------------------------------
@@ -609,6 +636,22 @@ class WeChatChannel(BaseChannel):
                 logger.debug(
                     "wechat: duplicate message skipped: %s",
                     dedup_key[:40],
+                )
+                return
+
+            # Content-based dedup: catch duplicates that arrive with
+            # different context_token / msg_id across separate polls.
+            raw_text = "".join(
+                (item.get("text_item") or {}).get("text", "")
+                for item in (msg.get("item_list") or [])
+                if item.get("type", 0) == 1
+            ).strip()
+            if raw_text and self._is_text_duplicate(from_user_id, raw_text):
+                logger.debug(
+                    "wechat: content-duplicate message skipped: "
+                    "user=%s text_len=%d",
+                    from_user_id[:12],
+                    len(raw_text),
                 )
                 return
 
@@ -1059,19 +1102,31 @@ class WeChatChannel(BaseChannel):
             return
         try:
             resp = await _client.send_text(to_user_id, text, context_token)
-            if isinstance(resp, dict):
-                ret = resp.get("ret", 0)
-                errcode = resp.get("errcode", 0)
-                if ret != 0 or errcode != 0:
-                    logger.warning(
-                        "wechat send_text rejected: "
-                        "ret=%s errcode=%s to_user_id=%s",
-                        ret,
-                        errcode,
-                        to_user_id,
-                    )
         except Exception:
             logger.exception("wechat _send_text_direct failed")
+            return
+
+        if isinstance(resp, dict):
+            ret = resp.get("ret", 0)
+            errcode = resp.get("errcode", 0)
+            if ret != 0 or errcode != 0:
+                logger.warning(
+                    "wechat send_text rejected: "
+                    "ret=%s errcode=%s to_user_id=%s",
+                    ret,
+                    errcode,
+                    to_user_id,
+                )
+                # ret=-2 means context_token is expired/consumed;
+                # continuing to retry is pointless and floods logs.
+                if ret == -2:
+                    raise ChannelError(
+                        channel_name="wechat",
+                        message=(
+                            f"context_token expired (ret=-2) "
+                            f"for user {to_user_id}"
+                        ),
+                    )
 
     async def _send_media_file(
         self,
@@ -1443,8 +1498,6 @@ class WeChatChannel(BaseChannel):
         Returns:
             Typing ticket string (empty if failed)
         """
-        import time
-
         now = time.time()
         cache_ttl = 24 * 3600  # 24 hours
 


### PR DESCRIPTION
## Description

### Question 1 – Message dedup bypass

- iLink getupdates may deliver the same message across two polls with different context_token / msg_id, causing the existing dedup to miss duplicates entirely.
- Added a secondary content-based dedup (_is_text_duplicate) using from_user_id + text_hash with a 30-second sliding window.

### Question 2 – Infinite retry on ret=-2

- _send_text_direct only logged a warning on ret=-2 (expired context_token), allowing callers to keep sending — all failing and flooding logs.
- Now raises ChannelError on ret=-2 to stop the send loop immediately.

**Related Issue:** Fixes #4546 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
