### PR TITLE
fix(skill): complete skill validatoin

### DIFF
--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -193,6 +193,9 @@ class SkillPoolService:
                 )
             )
             for skill_dir, skill_name in found:
+                validate_skill_content(
+                    (skill_dir / "SKILL.md").read_text(encoding="utf-8"),
+                )
                 scan_skill_dir_or_raise(skill_dir, skill_name)
             conflicts: list[dict[str, Any]] = []
             planned: list[tuple[Path, str]] = []
@@ -332,11 +335,11 @@ class SkillPoolService:
     ) -> dict[str, Any]:
         try:
             skill_name = normalize_skill_dir_name(skill_name)
-            normalized_target = normalize_skill_dir_name(
-                target_name or skill_name,
-            )
         except SkillsError:
             return {"success": False, "reason": "not_found"}
+        normalized_target = normalize_skill_dir_name(
+            target_name or skill_name,
+        )
         manifest = read_skill_pool_manifest()
         entry = manifest.get("skills", {}).get(skill_name)
         if entry is None:

--- a/src/qwenpaw/agents/skill_system/workspace_service.py
+++ b/src/qwenpaw/agents/skill_system/workspace_service.py
@@ -211,11 +211,12 @@ class SkillService:
         overwrite: bool = False,
     ) -> dict[str, Any]:
         """Edit-in-place or rename-save a workspace skill."""
+        validate_skill_content(content)
         try:
             skill_name = normalize_skill_dir_name(skill_name)
-            final_name = normalize_skill_dir_name(target_name or skill_name)
         except SkillsError:
             return {"success": False, "reason": "not_found"}
+        final_name = normalize_skill_dir_name(target_name or skill_name)
         manifest = self._read_manifest()
         old_entry = manifest.get("skills", {}).get(skill_name)
         if old_entry is None:
@@ -443,6 +444,9 @@ class SkillService:
             planned: list[tuple[Path, str]] = []
             seen_names: set[str] = set()
             for skill_dir, skill_name in found:
+                validate_skill_content(
+                    (skill_dir / "SKILL.md").read_text(encoding="utf-8"),
+                )
                 scan_skill_dir_or_raise(skill_dir, skill_name)
                 if skill_name in seen_names:
                     conflicts.append(


### PR DESCRIPTION
## Description

Add frontmatter validation to workspace save and both ZIP import paths, and propagate invalid target_name errors as 400 instead of masking them as 404, so create and save now return consistent error codes.    

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
