### PR TITLE
fix(WeChat): report send failure for API-initiated messages

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1113,7 +1113,6 @@ class WeChatChannel(BaseChannel):
             if raise_on_error:
                 raise
             return
-
         if isinstance(resp, dict):
             ret = resp.get("ret", 0)
             errcode = resp.get("errcode", 0)
@@ -1428,7 +1427,9 @@ class WeChatChannel(BaseChannel):
         api_send = bool(m.get("_api_send"))
         for chunk in split_text(body):
             await self._send_text_direct(
-                to_user_id, chunk, context_token,
+                to_user_id,
+                chunk,
+                context_token,
                 raise_on_error=api_send,
             )
 

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1095,8 +1095,14 @@ class WeChatChannel(BaseChannel):
         text: str,
         context_token: str,
         client: Optional[ILinkClient] = None,
+        raise_on_error: bool = False,
     ) -> None:
-        """Send text using the shared ILinkClient (or create a temp one)."""
+        """Send text using the shared ILinkClient (or create a temp one).
+
+        Args:
+            raise_on_error: If True, raise ChannelError on API rejection
+                instead of only logging. Used by API-initiated sends.
+        """
         _client = client or self._client
         if not _client or not to_user_id or not text:
             return
@@ -1104,6 +1110,8 @@ class WeChatChannel(BaseChannel):
             resp = await _client.send_text(to_user_id, text, context_token)
         except Exception:
             logger.exception("wechat _send_text_direct failed")
+            if raise_on_error:
+                raise
             return
 
         if isinstance(resp, dict):
@@ -1119,12 +1127,12 @@ class WeChatChannel(BaseChannel):
                 )
                 # ret=-2 means context_token is expired/consumed;
                 # continuing to retry is pointless and floods logs.
-                if ret == -2:
+                if ret == -2 or raise_on_error:
                     raise ChannelError(
                         channel_name="wechat",
                         message=(
-                            f"context_token expired (ret=-2) "
-                            f"for user {to_user_id}"
+                            f"iLink API rejected: ret={ret} "
+                            f"errcode={errcode} response={resp}"
                         ),
                     )
 
@@ -1417,8 +1425,12 @@ class WeChatChannel(BaseChannel):
         if not body:
             return
 
+        api_send = bool(m.get("_api_send"))
         for chunk in split_text(body):
-            await self._send_text_direct(to_user_id, chunk, context_token)
+            await self._send_text_direct(
+                to_user_id, chunk, context_token,
+                raise_on_error=api_send,
+            )
 
     async def _on_process_completed(
         self,

--- a/src/qwenpaw/app/routers/messages.py
+++ b/src/qwenpaw/app/routers/messages.py
@@ -153,12 +153,15 @@ async def send_message(
 
     # Send the message via channel manager
     try:
+        meta: dict = {"_api_send": True}
+        if x_agent_id:
+            meta["agent_id"] = x_agent_id
         await channel_manager.send_text(
             channel=request.channel,
             user_id=request.target_user,
             session_id=request.target_session,
             text=request.text,
-            meta={"agent_id": x_agent_id} if x_agent_id else None,
+            meta=meta,
         )
 
         return SendMessageResponse(


### PR DESCRIPTION
## Description

The /api/messages/send endpoint always returned {"success": true} for WeChat even when the iLink API rejected the message (e.g. expired or exhausted context_token).

Added _api_send flag in meta at the API router layer. WeChat channel now raises ChannelError on iLink API rejection only when this flag is set, so the HTTP endpoint can return an accurate failure response. Normal conversation flows and cron tasks are not affected.

**Related Issue:** Fixes #4521 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
